### PR TITLE
Remove superfluous addManaCost method

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArwenMortalQueen.java
+++ b/Mage.Sets/src/mage/cards/a/ArwenMortalQueen.java
@@ -46,7 +46,7 @@ public final class ArwenMortalQueen extends CardImpl {
                 new GainAbilityTargetEffect(IndestructibleAbility.getInstance()),
                 new RemoveCountersSourceCost(CounterType.INDESTRUCTIBLE.createInstance())
         );
-        ability.addManaCost(new GenericManaCost(1));
+        ability.addCost(new GenericManaCost(1));
         ability.addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance())
                 .setText("Put a +1/+1 counter"));
         ability.addEffect(new AddCountersTargetEffect(CounterType.LIFELINK.createInstance())

--- a/Mage.Sets/src/mage/cards/c/CateranBrute.java
+++ b/Mage.Sets/src/mage/cards/c/CateranBrute.java
@@ -42,7 +42,7 @@ public final class CateranBrute extends CardImpl {
 	
         // {2}, {T}: Search your library for a Mercenary permanent card with converted mana cost 2 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(2));
+        ability.addCost(new GenericManaCost(2));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CateranEnforcer.java
+++ b/Mage.Sets/src/mage/cards/c/CateranEnforcer.java
@@ -46,7 +46,7 @@ public final class CateranEnforcer extends CardImpl {
         
         // {4}, {T}: Search your library for a Mercenary permanent card with converted mana cost 4 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(4));
+        ability.addCost(new GenericManaCost(4));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CateranKidnappers.java
+++ b/Mage.Sets/src/mage/cards/c/CateranKidnappers.java
@@ -41,7 +41,7 @@ public final class CateranKidnappers extends CardImpl {
 
         // {3}, {T}: Search your library for a Mercenary permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(3));
+        ability.addCost(new GenericManaCost(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CateranOverlord.java
+++ b/Mage.Sets/src/mage/cards/c/CateranOverlord.java
@@ -49,7 +49,7 @@ public final class CateranOverlord extends CardImpl {
 
         // {6}, {T}: Search your library for a Mercenary permanent card with converted mana cost 6 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(6));
+        ability.addCost(new GenericManaCost(6));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CateranPersuader.java
+++ b/Mage.Sets/src/mage/cards/c/CateranPersuader.java
@@ -42,7 +42,7 @@ public final class CateranPersuader extends CardImpl {
 
         // {1}, {T}: Search your library for a Mercenary permanent card with converted mana cost 1 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(1));
+        ability.addCost(new GenericManaCost(1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CateranSlaver.java
+++ b/Mage.Sets/src/mage/cards/c/CateranSlaver.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.c;
 
 import java.util.UUID;
@@ -30,7 +28,7 @@ public final class CateranSlaver extends CardImpl {
 
     static {
         filter.add(SubType.MERCENARY.getPredicate());
-	filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 6));
+        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 6));
     }
 
     public CateranSlaver(UUID ownerId, CardSetInfo setInfo) {
@@ -46,7 +44,7 @@ public final class CateranSlaver extends CardImpl {
 
         // {5}, {T}: Search your library for a Mercenary permanent card with converted mana cost 5 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(5));
+        ability.addCost(new GenericManaCost(5));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrystalBall.java
+++ b/Mage.Sets/src/mage/cards/c/CrystalBall.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.c;
 
 import java.util.UUID;
@@ -22,7 +20,7 @@ public final class CrystalBall extends CardImpl {
     public CrystalBall(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{3}");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ScryEffect(2), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(1));
+        ability.addCost(new GenericManaCost(1));
         this.addAbility(ability);
     }
 
@@ -36,4 +34,3 @@ public final class CrystalBall extends CardImpl {
     }
 
 }
-

--- a/Mage.Sets/src/mage/cards/d/DroidFactory.java
+++ b/Mage.Sets/src/mage/cards/d/DroidFactory.java
@@ -1,22 +1,20 @@
-
 package mage.cards.d;
 
-import mage.MageObject;
-import mage.abilities.ActivatedAbilityImpl;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCardInLibrary;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -25,6 +23,16 @@ import java.util.UUID;
  */
 public final class DroidFactory extends CardImpl {
 
+    private static final FilterCard filter = new FilterCard("basic Plains, Island or Swamp card");
+    static {
+        filter.add(SuperType.BASIC.getPredicate());
+        filter.add(Predicates.or(
+                SubType.PLAINS.getPredicate(),
+                SubType.ISLAND.getPredicate(),
+                SubType.SWAMP.getPredicate()
+        ));
+    }
+
     public DroidFactory(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
 
@@ -32,7 +40,9 @@ public final class DroidFactory extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // {T}, Sacrifice Droid Factor: Search your library for a basic Plains, Island or Swamp card and put it onto the battlefield tapped. Then shuffle your library.
-        this.addAbility(new DroidFactoryAbility());
+        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true), new TapSourceCost());
+        ability.addCost(new SacrificeSourceCost());
+        this.addAbility(ability);
 
     }
 
@@ -45,31 +55,4 @@ public final class DroidFactory extends CardImpl {
         return new DroidFactory(this);
     }
 
-    public final class DroidFactoryAbility extends ActivatedAbilityImpl {
-
-        private DroidFactoryAbility(final DroidFactoryAbility ability) {
-            super(ability);
-        }
-
-        public DroidFactoryAbility() {
-            super(Zone.BATTLEFIELD, null);
-            addCost(new TapSourceCost());
-            addCost(new SacrificeSourceCost());
-            FilterCard filter = new FilterCard("basic Plains, Island or Swamp");
-            filter.add(CardType.LAND.getPredicate());
-            List<Predicate<MageObject>> subtypePredicates = new ArrayList<>();
-            subtypePredicates.add(SubType.SWAMP.getPredicate());
-            subtypePredicates.add(SubType.PLAINS.getPredicate());
-            subtypePredicates.add(SubType.ISLAND.getPredicate());
-            filter.add(Predicates.or(subtypePredicates));
-            filter.add(SuperType.BASIC.getPredicate());
-            TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true));
-        }
-
-        @Override
-        public DroidFactoryAbility copy() {
-            return new DroidFactoryAbility(this);
-        }
-    }
 }

--- a/Mage.Sets/src/mage/cards/e/ElixirOfImmortality.java
+++ b/Mage.Sets/src/mage/cards/e/ElixirOfImmortality.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.e;
 
 import java.util.UUID;
@@ -27,7 +25,7 @@ public final class ElixirOfImmortality extends CardImpl {
     public ElixirOfImmortality(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ElixerOfImmortalityEffect(), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(2));
+        ability.addCost(new GenericManaCost(2));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FirecatBlitz.java
+++ b/Mage.Sets/src/mage/cards/f/FirecatBlitz.java
@@ -42,7 +42,7 @@ public final class FirecatBlitz extends CardImpl {
 
         // Flashback-{R}{R}, Sacrifice X Mountains.
         Ability ability = new FlashbackAbility(this, new SacrificeXTargetCost(filter));
-        ability.addManaCost(new ManaCostsImpl<>("{R}{R}"));
+        ability.addCost(new ManaCostsImpl<>("{R}{R}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JediEnclave.java
+++ b/Mage.Sets/src/mage/cards/j/JediEnclave.java
@@ -1,22 +1,20 @@
-
 package mage.cards.j;
 
-import mage.MageObject;
-import mage.abilities.ActivatedAbilityImpl;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCardInLibrary;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -25,6 +23,16 @@ import java.util.UUID;
  */
 public final class JediEnclave extends CardImpl {
 
+    private static final FilterCard filter = new FilterCard("basic Forest, Plains, or Island card");
+    static {
+        filter.add(SuperType.BASIC.getPredicate());
+        filter.add(Predicates.or(
+                SubType.FOREST.getPredicate(),
+                SubType.PLAINS.getPredicate(),
+                SubType.ISLAND.getPredicate()
+        ));
+    }
+
     public JediEnclave(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
 
@@ -32,7 +40,9 @@ public final class JediEnclave extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // {T}, Sacrifice Jedi Enclave: Search your library for a basic Forest, Plains or Island card and put it onto the battlefield tapped. Then shuffle your library.
-        this.addAbility(new JediEnclaveAbility());
+        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true), new TapSourceCost());
+        ability.addCost(new SacrificeSourceCost());
+        this.addAbility(ability);
 
     }
 
@@ -45,31 +55,4 @@ public final class JediEnclave extends CardImpl {
         return new JediEnclave(this);
     }
 
-    public static class JediEnclaveAbility extends ActivatedAbilityImpl {
-
-        private JediEnclaveAbility(final JediEnclaveAbility ability) {
-            super(ability);
-        }
-
-        public JediEnclaveAbility() {
-            super(Zone.BATTLEFIELD, null);
-            addCost(new TapSourceCost());
-            addCost(new SacrificeSourceCost());
-            FilterCard filter = new FilterCard("basic Forest, Plains or Island");
-            filter.add(CardType.LAND.getPredicate());
-            List<Predicate<MageObject>> subtypePredicates = new ArrayList<>();
-            subtypePredicates.add(SubType.FOREST.getPredicate());
-            subtypePredicates.add(SubType.PLAINS.getPredicate());
-            subtypePredicates.add(SubType.ISLAND.getPredicate());
-            filter.add(Predicates.or(subtypePredicates));
-            filter.add(SuperType.BASIC.getPredicate());
-            TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true));
-        }
-
-        @Override
-        public JediEnclaveAbility copy() {
-            return new JediEnclaveAbility(this);
-        }
-    }
 }

--- a/Mage.Sets/src/mage/cards/j/JungleVillage.java
+++ b/Mage.Sets/src/mage/cards/j/JungleVillage.java
@@ -1,22 +1,20 @@
-
 package mage.cards.j;
 
-import mage.MageObject;
-import mage.abilities.ActivatedAbilityImpl;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCardInLibrary;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -25,6 +23,16 @@ import java.util.UUID;
  */
 public final class JungleVillage extends CardImpl {
 
+    private static final FilterCard filter = new FilterCard("basic Mountain, Forest, or Plains card");
+    static {
+        filter.add(SuperType.BASIC.getPredicate());
+        filter.add(Predicates.or(
+                SubType.MOUNTAIN.getPredicate(),
+                SubType.FOREST.getPredicate(),
+                SubType.PLAINS.getPredicate()
+        ));
+    }
+
     public JungleVillage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
 
@@ -32,7 +40,9 @@ public final class JungleVillage extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // {T}, Sacrifice Jungle Village: Search your library for a basic Mountain, Forest or Plains card and put it onto the battlefield tapped. Then shuffle your library.
-        this.addAbility(new JungleVillageAbility());
+        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true), new TapSourceCost());
+        ability.addCost(new SacrificeSourceCost());
+        this.addAbility(ability);
 
     }
 
@@ -45,31 +55,4 @@ public final class JungleVillage extends CardImpl {
         return new JungleVillage(this);
     }
 
-    public final class JungleVillageAbility extends ActivatedAbilityImpl {
-
-        private JungleVillageAbility(final JungleVillageAbility ability) {
-            super(ability);
-        }
-
-        public JungleVillageAbility() {
-            super(Zone.BATTLEFIELD, null);
-            addCost(new TapSourceCost());
-            addCost(new SacrificeSourceCost());
-            FilterCard filter = new FilterCard("basic Mountain, Forest or Plains");
-            filter.add(CardType.LAND.getPredicate());
-            List<Predicate<MageObject>> subtypePredicates = new ArrayList<>();
-            subtypePredicates.add(SubType.PLAINS.getPredicate());
-            subtypePredicates.add(SubType.MOUNTAIN.getPredicate());
-            subtypePredicates.add(SubType.FOREST.getPredicate());
-            filter.add(Predicates.or(subtypePredicates));
-            filter.add(SuperType.BASIC.getPredicate());
-            TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true));
-        }
-
-        @Override
-        public JungleVillageAbility copy() {
-            return new JungleVillageAbility(this);
-        }
-    }
 }

--- a/Mage.Sets/src/mage/cards/k/KnotvineMystic.java
+++ b/Mage.Sets/src/mage/cards/k/KnotvineMystic.java
@@ -32,7 +32,7 @@ public final class KnotvineMystic extends CardImpl {
         
         // {1}, {T}: Add {R}{G}{W}.
         Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, new Mana(1, 0, 0, 1, 1, 0, 0, 0), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(1));
+        ability.addCost(new GenericManaCost(1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Moggcatcher.java
+++ b/Mage.Sets/src/mage/cards/m/Moggcatcher.java
@@ -38,7 +38,7 @@ public final class Moggcatcher extends CardImpl {
 
         // {3}, {T}: Search your library for a Goblin permanent card and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(3));
+        ability.addCost(new GenericManaCost(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamosianCaptain.java
+++ b/Mage.Sets/src/mage/cards/r/RamosianCaptain.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -30,7 +28,7 @@ public final class RamosianCaptain extends CardImpl {
 
     static {
         filter.add(SubType.REBEL.getPredicate());
-	filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 5));
+        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 5));
     }
 
     public RamosianCaptain(UUID ownerId, CardSetInfo setInfo) {
@@ -46,7 +44,7 @@ public final class RamosianCaptain extends CardImpl {
 
         // {5}, {T}: Search your library for a Rebel permanent card with converted mana cost 4 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(5));
+        ability.addCost(new GenericManaCost(5));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamosianCommander.java
+++ b/Mage.Sets/src/mage/cards/r/RamosianCommander.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -29,7 +27,7 @@ public final class RamosianCommander extends CardImpl {
 
     static {
         filter.add(SubType.REBEL.getPredicate());
-	filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 6));
+        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 6));
     }
 
     public RamosianCommander(UUID ownerId, CardSetInfo setInfo) {
@@ -42,7 +40,7 @@ public final class RamosianCommander extends CardImpl {
 
         // {6}, {T}: Search your library for a Rebel permanent card with converted mana cost 5 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(6));
+        ability.addCost(new GenericManaCost(6));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamosianLieutenant.java
+++ b/Mage.Sets/src/mage/cards/r/RamosianLieutenant.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -29,7 +27,7 @@ public final class RamosianLieutenant extends CardImpl {
 
     static {
         filter.add(SubType.REBEL.getPredicate());
-	filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 4));
+        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 4));
     }
 
     public RamosianLieutenant(UUID ownerId, CardSetInfo setInfo) {
@@ -42,7 +40,7 @@ public final class RamosianLieutenant extends CardImpl {
 
         // {4}, {T}: Search your library for a Rebel permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(4));
+        ability.addCost(new GenericManaCost(4));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamosianSergeant.java
+++ b/Mage.Sets/src/mage/cards/r/RamosianSergeant.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -41,7 +39,7 @@ public final class RamosianSergeant extends CardImpl {
 
         // {3}, {T}: Search your library for a Rebel permanent card with converted mana cost 2 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(3));
+        ability.addCost(new GenericManaCost(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RamosianSkyMarshal.java
+++ b/Mage.Sets/src/mage/cards/r/RamosianSkyMarshal.java
@@ -45,7 +45,7 @@ public final class RamosianSkyMarshal extends CardImpl {
 
         // {7}, {T}: Search your library for a Rebel permanent card with converted mana cost 6 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(7));
+        ability.addCost(new GenericManaCost(7));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RathiAssassin.java
+++ b/Mage.Sets/src/mage/cards/r/RathiAssassin.java
@@ -60,7 +60,7 @@ public final class RathiAssassin extends CardImpl {
         
         // {3}, {T}: Search your library for a Mercenary permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(3));
+        ability.addCost(new GenericManaCost(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RathiFiend.java
+++ b/Mage.Sets/src/mage/cards/r/RathiFiend.java
@@ -46,7 +46,7 @@ public final class RathiFiend extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new LoseLifeAllPlayersEffect(3), false));
         // {3}, {T}: Search your library for a Mercenary permanent card with converted mana cost 3 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(3));
+        ability.addCost(new GenericManaCost(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/RathiIntimidator.java
+++ b/Mage.Sets/src/mage/cards/r/RathiIntimidator.java
@@ -44,7 +44,7 @@ public final class RathiIntimidator extends CardImpl {
         this.addAbility(FearAbility.getInstance());
         // {2}, {T}: Search your library for a Mercenary permanent card with converted mana cost 2 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(2));
+        ability.addCost(new GenericManaCost(2));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/Seahunter.java
+++ b/Mage.Sets/src/mage/cards/s/Seahunter.java
@@ -38,7 +38,7 @@ public final class Seahunter extends CardImpl {
 
         // {3}, {T}: Search your library for a Merfolk permanent card and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(3));
+        ability.addCost(new GenericManaCost(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SithRuins.java
+++ b/Mage.Sets/src/mage/cards/s/SithRuins.java
@@ -1,22 +1,20 @@
-
 package mage.cards.s;
 
-import mage.MageObject;
-import mage.abilities.ActivatedAbilityImpl;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCardInLibrary;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -25,6 +23,16 @@ import java.util.UUID;
  */
 public final class SithRuins extends CardImpl {
 
+    private static final FilterCard filter = new FilterCard("basic Island, Swamp, or Mountain card");
+    static {
+        filter.add(SuperType.BASIC.getPredicate());
+        filter.add(Predicates.or(
+                SubType.ISLAND.getPredicate(),
+                SubType.SWAMP.getPredicate(),
+                SubType.MOUNTAIN.getPredicate()
+        ));
+    }
+
     public SithRuins(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
 
@@ -32,7 +40,9 @@ public final class SithRuins extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // {T}, Sacrifice Sith Ruins: Search your library for a basic Island, Swamp or Mountain card and put it onto the battlefield tapped. Then shuffle your library.
-        this.addAbility(new SithRuinsAbility());
+        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true), new TapSourceCost());
+        ability.addCost(new SacrificeSourceCost());
+        this.addAbility(ability);
 
     }
 
@@ -45,31 +55,4 @@ public final class SithRuins extends CardImpl {
         return new SithRuins(this);
     }
 
-    public static class SithRuinsAbility extends ActivatedAbilityImpl {
-
-        private SithRuinsAbility(final SithRuinsAbility ability) {
-            super(ability);
-        }
-
-        public SithRuinsAbility() {
-            super(Zone.BATTLEFIELD, null);
-            addCost(new TapSourceCost());
-            addCost(new SacrificeSourceCost());
-            FilterCard filter = new FilterCard("basic Island, Swamp or Mountain");
-            filter.add(CardType.LAND.getPredicate());
-            List<Predicate<MageObject>> subtypePredicates = new ArrayList<>();
-            subtypePredicates.add(SubType.SWAMP.getPredicate());
-            subtypePredicates.add(SubType.MOUNTAIN.getPredicate());
-            subtypePredicates.add(SubType.ISLAND.getPredicate());
-            filter.add(Predicates.or(subtypePredicates));
-            filter.add(SuperType.BASIC.getPredicate());
-            TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true));
-        }
-
-        @Override
-        public SithRuinsAbility copy() {
-            return new SithRuinsAbility(this);
-        }
-    }
 }

--- a/Mage.Sets/src/mage/cards/s/SoldierOfFortune.java
+++ b/Mage.Sets/src/mage/cards/s/SoldierOfFortune.java
@@ -31,7 +31,7 @@ public final class SoldierOfFortune extends CardImpl {
 		
 		// {R}, {T}: Target player shuffles their library.
 		Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShuffleLibraryTargetEffect(), new TapSourceCost());
-		ability.addManaCost(new ManaCostsImpl<>("{R}"));
+		ability.addCost(new ManaCostsImpl<>("{R}"));
 		ability.addTarget(new TargetPlayer());
 		this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SorcerersStrongbox.java
+++ b/Mage.Sets/src/mage/cards/s/SorcerersStrongbox.java
@@ -30,7 +30,7 @@ public final class SorcerersStrongbox extends CardImpl {
         effect.setText("and draw three cards");
         flipCoinEffect.addEffectWon(effect);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, flipCoinEffect, new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(2));
+        ability.addCost(new GenericManaCost(2));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TrigonOfCorruption.java
+++ b/Mage.Sets/src/mage/cards/t/TrigonOfCorruption.java
@@ -32,7 +32,7 @@ public final class TrigonOfCorruption extends CardImpl {
 
         // {B}{B}, {T}: Put a charge counter on Trigon of Corruption.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost());
-        ability2.addManaCost(new ManaCostsImpl<>("{B}{B}"));
+        ability2.addCost(new ManaCostsImpl<>("{B}{B}"));
         this.addAbility(ability2);
 
         // {2}, {T}, Remove a charge counter from Trigon of Corruption: Put a -1/-1 counter on target creature.

--- a/Mage.Sets/src/mage/cards/t/TrigonOfInfestation.java
+++ b/Mage.Sets/src/mage/cards/t/TrigonOfInfestation.java
@@ -30,7 +30,7 @@ public final class TrigonOfInfestation extends CardImpl {
 
         // {G}{G}, {T}: Put a charge counter on Trigon of Infestation.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost());
-        ability2.addManaCost(new ManaCostsImpl<>("{G}{G}"));
+        ability2.addCost(new ManaCostsImpl<>("{G}{G}"));
         this.addAbility(ability2);
 
         // {2}, {T}, Remove a charge counter from Trigon of Infestation: Create a 1/1 green Phyrexian Insect creature token with infect.

--- a/Mage.Sets/src/mage/cards/t/TrigonOfMending.java
+++ b/Mage.Sets/src/mage/cards/t/TrigonOfMending.java
@@ -30,7 +30,7 @@ public final class TrigonOfMending extends CardImpl {
 
         // {W}{W}, {T}: Put a charge counter on Trigon of Mending.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost());
-        ability2.addManaCost(new ManaCostsImpl<>("{W}{W}"));
+        ability2.addCost(new ManaCostsImpl<>("{W}{W}"));
         this.addAbility(ability2);
 
         // {2}, {T}, Remove a charge counter from Trigon of Mending: Target player gains 3 life.

--- a/Mage.Sets/src/mage/cards/t/TrigonOfRage.java
+++ b/Mage.Sets/src/mage/cards/t/TrigonOfRage.java
@@ -32,7 +32,7 @@ public final class TrigonOfRage extends CardImpl {
 
         // {R}{R}, {T}: Put a charge counter on Trigon of Rage.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost());
-        ability2.addManaCost(new ManaCostsImpl<>("{R}{R}"));
+        ability2.addCost(new ManaCostsImpl<>("{R}{R}"));
         this.addAbility(ability2);
 
         // {2}, {T}, Remove a charge counter from Trigon of Rage: Target creature gets +3/+0 until end of turn.

--- a/Mage.Sets/src/mage/cards/t/TrigonOfThought.java
+++ b/Mage.Sets/src/mage/cards/t/TrigonOfThought.java
@@ -29,7 +29,7 @@ public final class TrigonOfThought extends CardImpl {
 
         // {U}{U}, {T}: Put a charge counter on Trigon of Thought.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost());
-        ability2.addManaCost(new ManaCostsImpl<>("{U}{U}"));
+        ability2.addCost(new ManaCostsImpl<>("{U}{U}"));
         this.addAbility(ability2);
 
         // {2}, {T}, Remove a charge counter from Trigon of Thought: Draw a card.

--- a/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
+++ b/Mage.Sets/src/mage/cards/u/UnderworldSlums.java
@@ -1,22 +1,20 @@
-
 package mage.cards.u;
 
-import mage.MageObject;
-import mage.abilities.ActivatedAbilityImpl;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
 import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCardInLibrary;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -25,6 +23,16 @@ import java.util.UUID;
  */
 public final class UnderworldSlums extends CardImpl {
 
+    private static final FilterCard filter = new FilterCard("basic Swamp, Mountain, or Forest card");
+    static {
+        filter.add(SuperType.BASIC.getPredicate());
+        filter.add(Predicates.or(
+                SubType.SWAMP.getPredicate(),
+                SubType.MOUNTAIN.getPredicate(),
+                SubType.FOREST.getPredicate()
+        ));
+    }
+
     public UnderworldSlums(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.LAND},"");
 
@@ -32,7 +40,9 @@ public final class UnderworldSlums extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
 
         // {T}, Sacrifice Underworld Slums: Search your library for a basic Swamp, Mountain or Forest card and put it onto the battlefield tapped. Then shuffle your library.
-        this.addAbility(new UnderworldSlumsAbility());
+        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true), new TapSourceCost());
+        ability.addCost(new SacrificeSourceCost());
+        this.addAbility(ability);
 
     }
 
@@ -45,31 +55,4 @@ public final class UnderworldSlums extends CardImpl {
         return new UnderworldSlums(this);
     }
 
-    public static class UnderworldSlumsAbility extends ActivatedAbilityImpl {
-
-        private UnderworldSlumsAbility(final UnderworldSlumsAbility ability) {
-            super(ability);
-        }
-
-        public UnderworldSlumsAbility() {
-            super(Zone.BATTLEFIELD, null);
-            addCost(new TapSourceCost());
-            addCost(new SacrificeSourceCost());
-            FilterCard filter = new FilterCard("basic Swamp, Mountain or Forest");
-            filter.add(CardType.LAND.getPredicate());
-            List<Predicate<MageObject>> subtypePredicates = new ArrayList<>();
-            subtypePredicates.add(SubType.SWAMP.getPredicate());
-            subtypePredicates.add(SubType.MOUNTAIN.getPredicate());
-            subtypePredicates.add(SubType.FOREST.getPredicate());
-            filter.add(Predicates.or(subtypePredicates));
-            filter.add(SuperType.BASIC.getPredicate());
-            TargetCardInLibrary target = new TargetCardInLibrary(filter);
-            addEffect(new SearchLibraryPutInPlayEffect(target, true));
-        }
-
-        @Override
-        public UnderworldSlumsAbility copy() {
-            return new UnderworldSlumsAbility(this);
-        }
-    }
 }

--- a/Mage.Sets/src/mage/cards/v/VoltaicKey.java
+++ b/Mage.Sets/src/mage/cards/v/VoltaicKey.java
@@ -1,5 +1,3 @@
-
-
 package mage.cards.v;
 
 import java.util.UUID;
@@ -12,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.target.TargetPermanent;
+import mage.target.common.TargetArtifactPermanent;
 
 /**
  *
@@ -21,17 +18,11 @@ import mage.target.TargetPermanent;
  */
 public final class VoltaicKey extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact");
-
-    static {
-        filter.add(CardType.ARTIFACT.getPredicate());
-    }
-
     public VoltaicKey(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addManaCost(new GenericManaCost(1));
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addCost(new GenericManaCost(1));
+        ability.addTarget(new TargetArtifactPermanent());
         this.addAbility(ability);
     }
 

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -155,14 +155,6 @@ public interface Ability extends Controllable, Serializable {
      */
     ManaCosts<ManaCost> getManaCostsToPay();
 
-    /**
-     * Adds a {@link ManaCost} to this ability that must be paid before this
-     * ability is activated.
-     *
-     * @param cost The {@link ManaCost} to add.
-     */
-    void addManaCost(ManaCost cost);
-
     void addManaCostsToPay(ManaCost manaCost);
 
     /**

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -58,7 +58,7 @@ public abstract class AbilityImpl implements Ability {
     protected UUID sourceId;
     private final ManaCosts<ManaCost> manaCosts;
     private final ManaCosts<ManaCost> manaCostsToPay;
-    private Costs<Cost> costs;
+    private final Costs<Cost> costs;
     protected Modes modes; // access to it by GetModes only (it can be overridden by some abilities)
     protected Zone zone;
     protected String name;
@@ -855,7 +855,6 @@ public abstract class AbilityImpl implements Ability {
         if (cost == null) {
             return;
         }
-
         if (cost instanceof Costs) {
             // as list of costs
             Costs<Cost> list = (Costs<Cost>) cost;
@@ -865,11 +864,9 @@ public abstract class AbilityImpl implements Ability {
         } else {
             // as single cost
             if (cost instanceof ManaCost) {
-                addManaCost((ManaCost) cost);
+                manaCosts.add((ManaCost) cost);
+                manaCostsToPay.add((ManaCost) cost);
             } else {
-                if (costs == null) {
-                    costs = new CostsImpl<>();
-                }
                 costs.add(cost);
             }
         }
@@ -885,15 +882,6 @@ public abstract class AbilityImpl implements Ability {
         } else {
             manaCostsToPay.add(manaCost);
         }
-    }
-
-    @Override
-    public void addManaCost(ManaCost manaCost) {
-        if (manaCost == null) {
-            return;
-        }
-        manaCosts.add(manaCost);
-        manaCostsToPay.add(manaCost);
     }
 
     @Override
@@ -1141,10 +1129,10 @@ public abstract class AbilityImpl implements Ability {
         if (object == null) { // e.g. sacrificed token
             logger.warn("Could get no object: " + this);
         }
-        return new StringBuilder(" activates: ")
-                .append(object != null ? this.formatRule(getModes().getText(), object.getLogName()) : getModes().getText())
-                .append(" from ")
-                .append(getMessageText(game)).toString();
+        return " activates: " +
+                (object != null ? this.formatRule(getModes().getText(), object.getLogName()) : getModes().getText()) +
+                " from " +
+                getMessageText(game);
     }
 
     protected String getMessageText(Game game) {

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -56,13 +56,9 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
         condition = ability.condition;
     }
 
-    protected ActivatedAbilityImpl(Zone zone, Effect effect) {
+    protected ActivatedAbilityImpl(Zone zone, Effect effect, Cost cost) {
         super(AbilityType.ACTIVATED, zone);
         this.addEffect(effect);
-    }
-
-    protected ActivatedAbilityImpl(Zone zone, Effect effect, Cost cost) {
-        this(zone, effect);
         this.addCost(cost);
     }
 

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -4,7 +4,6 @@ import mage.ApprovingObject;
 import mage.MageObject;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
-import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.effects.Effect;
 import mage.abilities.mana.ManaOptions;
 import mage.cards.Card;
@@ -62,15 +61,8 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
         this.addEffect(effect);
     }
 
-    protected ActivatedAbilityImpl(Zone zone, Effect effect, ManaCosts cost) {
-        super(AbilityType.ACTIVATED, zone);
-        this.addEffect(effect);
-        this.addManaCost(cost);
-    }
-
     protected ActivatedAbilityImpl(Zone zone, Effect effect, Cost cost) {
-        super(AbilityType.ACTIVATED, zone);
-        this.addEffect(effect);
+        this(zone, effect);
         this.addCost(cost);
     }
 

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -45,7 +45,7 @@ public class SpellAbility extends ActivatedAbilityImpl {
         this.cardName = cardName;
         this.spellAbilityType = spellAbilityType;
         this.spellAbilityCastMode = spellAbilityCastMode;
-        this.addManaCost(cost);
+        this.addCost(cost);
         this.setIdentifier(MageIdentifier.Default);
         setSpellName();
     }

--- a/Mage/src/main/java/mage/abilities/abilityword/GrandeurAbility.java
+++ b/Mage/src/main/java/mage/abilities/abilityword/GrandeurAbility.java
@@ -1,5 +1,3 @@
-
-
 package mage.abilities.abilityword;
 
 import mage.abilities.ActivatedAbilityImpl;
@@ -18,11 +16,8 @@ import mage.target.common.TargetCardInHand;
 
 public class GrandeurAbility extends ActivatedAbilityImpl {
 
-    protected final String cardName;
-
     public GrandeurAbility(Effect effect, String cardName) {
-        super(Zone.BATTLEFIELD, effect);
-        this.cardName = cardName;
+        super(Zone.BATTLEFIELD, effect, null);
 
         FilterCard filter = new FilterCard("another card named " + cardName);
         filter.add(new NamePredicate(cardName));
@@ -33,7 +28,6 @@ public class GrandeurAbility extends ActivatedAbilityImpl {
 
     protected GrandeurAbility(final GrandeurAbility ability) {
         super(ability);
-        this.cardName = ability.cardName;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/FetchLandActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/FetchLandActivatedAbility.java
@@ -23,8 +23,7 @@ public class FetchLandActivatedAbility extends ActivatedAbilityImpl {
     }
 
     public FetchLandActivatedAbility(boolean withDamage, SubType subType1, SubType subType2) {
-        super(Zone.BATTLEFIELD, null);
-        addCost(new TapSourceCost());
+        super(Zone.BATTLEFIELD, null, new TapSourceCost());
         if (withDamage) {
             addCost(new PayLifeCost(1));
         }

--- a/Mage/src/main/java/mage/abilities/common/PassAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/PassAbility.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 public class PassAbility extends ActivatedAbilityImpl {
 
     public PassAbility() {
-        super(Zone.ALL, new PassEffect());
+        super(Zone.ALL, new PassEffect(), null);
         this.usesStack = false;
     }
 

--- a/Mage/src/main/java/mage/abilities/common/SimpleActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SimpleActivatedAbility.java
@@ -3,7 +3,6 @@ package mage.abilities.common;
 import mage.constants.Zone;
 import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.costs.Cost;
-import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.effects.Effect;
 
 /**
@@ -12,16 +11,8 @@ import mage.abilities.effects.Effect;
  */
 public class SimpleActivatedAbility extends ActivatedAbilityImpl {
 
-    public SimpleActivatedAbility(Effect effect, ManaCosts cost) {
-        super(Zone.BATTLEFIELD, effect, cost);
-    }
-
     public SimpleActivatedAbility(Effect effect, Cost cost) {
-        super(Zone.BATTLEFIELD, effect, cost);
-    }
-
-    public SimpleActivatedAbility(Zone zone, Effect effect, ManaCosts cost) {
-        super(zone, effect, cost);
+        this(Zone.BATTLEFIELD, effect, cost);
     }
 
     public SimpleActivatedAbility(Zone zone, Effect effect, Cost cost) {

--- a/Mage/src/main/java/mage/abilities/common/SpellTransformedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SpellTransformedAbility.java
@@ -32,7 +32,7 @@ public class SpellTransformedAbility extends SpellAbility {
         this.manaCost = manaCost;
         this.clearManaCosts();
         this.clearManaCostsToPay();
-        this.addManaCost(new ManaCostsImpl<>(manaCost));
+        this.addCost(new ManaCostsImpl<>(manaCost));
         this.addSubAbility(new TransformAbility());
     }
 

--- a/Mage/src/main/java/mage/abilities/common/TurnFaceUpAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/TurnFaceUpAbility.java
@@ -1,11 +1,9 @@
-
 package mage.abilities.common;
 
 import mage.abilities.Ability;
 import mage.abilities.SpecialAction;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.Costs;
-import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.constants.AbilityType;
@@ -28,14 +26,7 @@ public class TurnFaceUpAbility extends SpecialAction {
     public TurnFaceUpAbility(Costs<Cost> costs, boolean megamorph) {
         super(Zone.BATTLEFIELD);
         this.addEffect(new TurnFaceUpEffect(megamorph));
-        for (Cost cost : costs) {
-            if (cost instanceof ManaCost) {
-                this.addManaCost((ManaCost) cost);
-            } else {
-                this.addCost(cost);
-            }
-        }
-
+        this.addCost(costs);
         this.usesStack = false;
         this.abilityType = AbilityType.SPECIAL_ACTION;
         this.setRuleVisible(false); // will be made visible only to controller in CardView

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalActivatedAbility.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalActivatedAbility.java
@@ -3,7 +3,6 @@ package mage.abilities.decorator;
 import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
-import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.Effects;
 import mage.constants.EffectType;
@@ -29,15 +28,8 @@ public class ConditionalActivatedAbility extends ActivatedAbilityImpl {
         this.condition = condition;
     }
 
-    public ConditionalActivatedAbility(Zone zone, Effect effect, ManaCosts cost, Condition condition, String rule) {
-        super(zone, effect, cost);
-        this.condition = condition;
-        this.ruleText = rule;
-    }
-
     public ConditionalActivatedAbility(Zone zone, Effect effect, Cost cost, Condition condition, String rule) {
-        super(zone, effect, cost);
-        this.condition = condition;
+        this(zone, effect, cost, condition);
         this.ruleText = rule;
     }
 
@@ -70,10 +62,7 @@ public class ConditionalActivatedAbility extends ActivatedAbilityImpl {
             sb.append("as a sorcery and only ");
         }
         String conditionText = condition.toString();
-        if (conditionText.startsWith("during")
-                || conditionText.startsWith("before")
-                || conditionText.startsWith("if")) {
-        } else {
+        if (!conditionText.startsWith("during") && !conditionText.startsWith("before") && !conditionText.startsWith("if")) {
             sb.append("if ");
         }
         sb.append(conditionText);

--- a/Mage/src/main/java/mage/abilities/keyword/AwakenAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/AwakenAbility.java
@@ -31,10 +31,10 @@ public class AwakenAbility extends SpellAbility {
 
     private static final Logger logger = Logger.getLogger(AwakenAbility.class);
 
-    private static String filterMessage = "a land you control to awake";
+    private static final String filterMessage = "a land you control to awake";
 
-    private String rule;
-    private int awakenValue;
+    private final String rule;
+    private final int awakenValue;
 
     public AwakenAbility(Card card, int awakenValue, String awakenCosts) {
         super(card.getSpellAbility());
@@ -45,7 +45,7 @@ public class AwakenAbility extends SpellAbility {
 
         this.clearManaCosts();
         this.clearManaCostsToPay();
-        this.addManaCost(new ManaCostsImpl<>(awakenCosts));
+        this.addCost(new ManaCostsImpl<>(awakenCosts));
 
         this.addTarget(new TargetControlledPermanent(new FilterControlledLandPermanent(filterMessage)));
         this.addEffect(new AwakenEffect());

--- a/Mage/src/main/java/mage/abilities/keyword/EmergeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/EmergeAbility.java
@@ -37,7 +37,7 @@ public class EmergeAbility extends SpellAbility {
 
         this.clearManaCosts();
         this.clearManaCostsToPay();
-        this.addManaCost(emergeCost.copy());
+        this.addCost(emergeCost.copy());
 
         this.setRuleAtTheTop(true);
     }

--- a/Mage/src/main/java/mage/abilities/keyword/EscapeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/EscapeAbility.java
@@ -46,7 +46,7 @@ public class EscapeAbility extends SpellAbility {
         this.clearManaCostsToPay();
 
         String text = "Escape&mdash;" + manaCost;
-        this.addManaCost(new ManaCostsImpl<>(manaCost));
+        this.addCost(new ManaCostsImpl<>(manaCost));
         for (Cost cost : additionalCosts) {
             text += ", " + CardUtil.getTextWithFirstCharUpperCase(cost.getText());
             this.addCost(cost.copy().setText("")); // hide additional cost text from rules

--- a/Mage/src/main/java/mage/abilities/keyword/SpectacleAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SpectacleAbility.java
@@ -32,7 +32,7 @@ public class SpectacleAbility extends SpellAbility {
 
         this.clearManaCosts();
         this.clearManaCostsToPay();
-        this.addManaCost(spectacleCosts.copy());
+        this.addCost(spectacleCosts.copy());
 
         this.setRuleAtTheTop(true);
         this.rule = "Spectacle " + spectacleCosts.getText()
@@ -58,7 +58,7 @@ public class SpectacleAbility extends SpellAbility {
     @SuppressWarnings("unchecked")
     public boolean activate(Game game, boolean noMana) {
         if (super.activate(game, noMana)) {
-            List<Integer> spectacleActivations = (ArrayList) game.getState().getValue(SPECTACLE_ACTIVATION_VALUE_KEY + getSourceId());
+            List<Integer> spectacleActivations = (List<Integer>) game.getState().getValue(SPECTACLE_ACTIVATION_VALUE_KEY + getSourceId());
             if (spectacleActivations == null) {
                 spectacleActivations = new ArrayList<>(); // zoneChangeCounter
                 game.getState().setValue(SPECTACLE_ACTIVATION_VALUE_KEY + getSourceId(), spectacleActivations);

--- a/Mage/src/main/java/mage/abilities/keyword/SurgeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SurgeAbility.java
@@ -21,7 +21,7 @@ public class SurgeAbility extends SpellAbility {
 
     public static final String SURGE_ACTIVATION_VALUE_KEY = "surgeActivation";
 
-    private String rule;
+    private final String rule;
 
     public SurgeAbility(Card card, String surgeCosts) {
         super(card.getSpellAbility());
@@ -32,7 +32,7 @@ public class SurgeAbility extends SpellAbility {
 
         this.clearManaCosts();
         this.clearManaCostsToPay();
-        this.addManaCost(new ManaCostsImpl<>(surgeCosts));
+        this.addCost(new ManaCostsImpl<>(surgeCosts));
 
         this.setRuleAtTheTop(true);
         this.rule = "Surge " + surgeCosts

--- a/Mage/src/main/java/mage/abilities/keyword/SuspendAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SuspendAbility.java
@@ -132,7 +132,7 @@ public class SuspendAbility extends SpecialAction {
         if (suspend == Integer.MAX_VALUE) {
             VariableManaCost xCosts = new VariableManaCost(VariableCostType.ALTERNATIVE);
             xCosts.setMinX(1);
-            this.addManaCost(xCosts);
+            this.addCost(xCosts);
             cost = new ManaCostsImpl<>("{X}" + cost.getText());
         }
         StringBuilder sb = new StringBuilder("Suspend ");

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -394,11 +394,6 @@ public class StackAbility extends StackObjectImpl implements Ability {
     }
 
     @Override
-    public void addManaCost(ManaCost manaCost) {
-        // Do nothing
-    }
-
-    @Override
     public void addManaCostsToPay(ManaCost manaCost) {
         // Do nothing
     }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1113,9 +1113,6 @@ public abstract class PlayerImpl implements Player, Serializable {
                 .computeIfAbsent(sourceId, k -> new HashMap<>())
                 .put(identifier, costs != null ? costs.copy() : null);
 
-        if (identifier == null) {
-            boolean a = true;
-        }
     }
 
     @Override
@@ -1236,7 +1233,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                     } else {
                         spellAbility.clearManaCosts();
                         spellAbility.clearManaCostsToPay();
-                        spellAbility.addManaCost(alternateCosts.copy());
+                        spellAbility.addCost(alternateCosts.copy());
                     }
                     spellAbility.clearCosts();
                     spellAbility.addCost(costs);


### PR DESCRIPTION
This additional cleanup continues from #9625 and #11283, related to #11280. There's no longer any need to have a separate method or constructor parameter for ManaCost as it's automatically handled as part of Cost.

Refactored some Star Wars cards along the way.