### PR TITLE
Fix tournament new settings causing NPE

### DIFF
--- a/Mage.Common/src/main/java/mage/view/TableView.java
+++ b/Mage.Common/src/main/java/mage/view/TableView.java
@@ -174,11 +174,11 @@ public class TableView implements Serializable {
                     if (tourneyMatchOptions.getFreeMulligans() > 0) {
                         infoText.append(" FM: ").append(tourneyMatchOptions.getFreeMulligans());
                     }
-                    if (table.getMatch().getOptions().isCustomStartLifeEnabled()) {
-                        infoText.append(" StartLife: ").append(table.getMatch().getOptions().getCustomStartLife());
+                    if (tourneyMatchOptions.isCustomStartLifeEnabled()) {
+                        infoText.append(" StartLife: ").append(tourneyMatchOptions.getCustomStartLife());
                     }
-                    if (table.getMatch().getOptions().isCustomStartHandSizeEnabled()) {
-                        infoText.append(" StartHandSize: ").append(table.getMatch().getOptions().getCustomStartHandSize());
+                    if (tourneyMatchOptions.isCustomStartHandSizeEnabled()) {
+                        infoText.append(" StartHandSize: ").append(tourneyMatchOptions.getCustomStartHandSize());
                     }
                     if (table.getTournament().getTournamentType().isLimited()) {
                         infoText.append(" Constr.: ").append(table.getTournament().getOptions().getLimitedOptions().getConstructionTime() / 60).append(" Min.");


### PR DESCRIPTION
Big thanks to @phughk for noticing the issue and reporting it.

A bug was introduced with the additions of new options https://github.com/magefree/mage/pull/11259, that would have been part of next release. A NPE on tournament display due to a confusion on my part between the getMatch and getTournament of TableViews, having one of the two.