### PR TITLE
Fix Feast of the Victorious Dead and 4 others distributing counters without targetting

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
@@ -115,6 +115,8 @@ class AwakenTheMaelstromEffect extends OneShotEffect {
             return;
         }
         TargetPermanentAmount target = new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURE);
+        target.setMinNumberOfTargets(1);
+        target.setMaxNumberOfTargets(3);
         target.withNotTarget(true);
         target.withChooseHint("to distribute counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
@@ -77,8 +77,10 @@ class BlessingOfFrostEffect extends OneShotEffect {
             return false;
         }
         int snow = ManaPaidSourceWatcher.getSnowPaid(source.getId(), game);
-        if (snow > 0) {
+        int potentialTarget = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game);
+        if (snow > 0 && potentialTarget > 0) {
             TargetAmount target = new TargetCreaturePermanentAmount(snow, StaticFilters.FILTER_CONTROLLED_CREATURE);
+            target.setMinNumberOfTargets(1);
             target.withNotTarget(true);
             target.chooseTarget(outcome, player.getId(), source, game);
             for (UUID targetId : target.getTargets()) {

--- a/Mage.Sets/src/mage/cards/f/FeastOfTheVictoriousDead.java
+++ b/Mage.Sets/src/mage/cards/f/FeastOfTheVictoriousDead.java
@@ -4,18 +4,21 @@ import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.dynamicvalue.common.CreaturesDiedThisTurnCount;
+import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.GainLifeEffect;
-import mage.abilities.effects.common.counter.DistributeCountersEffect;
 import mage.abilities.hint.common.CreaturesDiedThisTurnHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Outcome;
 import mage.constants.TargetController;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
-import mage.target.Target;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
 import mage.target.common.TargetCreaturePermanentAmount;
+import mage.target.common.TargetPermanentAmount;
 
 import java.util.UUID;
 
@@ -33,11 +36,7 @@ public final class FeastOfTheVictoriousDead extends CardImpl {
                         .setText("you gain that much life"),
                 TargetController.YOU, FeastOfTheVictoriousDeadCondition.instance, false
         );
-        ability.addEffect(new DistributeCountersEffect(CounterType.P1P1, 1, "")
-                .setText("and distribute that many +1/+1 counters among creatures you control"));
-        Target target = new TargetCreaturePermanentAmount(CreaturesDiedThisTurnCount.instance, StaticFilters.FILTER_CONTROLLED_CREATURES);
-        target.withNotTarget(true);
-        ability.addTarget(target);
+        ability.addEffect(new FeastOfTheVictoriousDeadEffect());
         this.addAbility(ability.addHint(CreaturesDiedThisTurnHint.instance));
     }
 
@@ -49,6 +48,49 @@ public final class FeastOfTheVictoriousDead extends CardImpl {
     public FeastOfTheVictoriousDead copy() {
         return new FeastOfTheVictoriousDead(this);
     }
+}
+
+class FeastOfTheVictoriousDeadEffect extends OneShotEffect {
+
+    FeastOfTheVictoriousDeadEffect() {
+        super(Outcome.BoostCreature);
+        staticText = "and distribute that many +1/+1 counters among creatures you control";
+    }
+
+    private FeastOfTheVictoriousDeadEffect(final FeastOfTheVictoriousDeadEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public FeastOfTheVictoriousDeadEffect copy() {
+        return new FeastOfTheVictoriousDeadEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        int amount = CreaturesDiedThisTurnCount.instance.calculate(game, source, this);
+        if (amount <= 0) {
+            return false;
+        }
+
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null || game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game) < 1) {
+            return false;
+        }
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, StaticFilters.FILTER_CONTROLLED_CREATURE);
+        target.setMinNumberOfTargets(1);
+        target.withNotTarget(true);
+        target.withChooseHint("to distribute " + amount + " counters");
+        target.chooseTarget(outcome, player.getId(), source, game);
+        for (UUID targetId : target.getTargets()) {
+            Permanent permanent = game.getPermanent(targetId);
+            if (permanent != null) {
+                permanent.addCounters(CounterType.P1P1.createInstance(target.getTargetAmount(targetId)), source, game);
+            }
+        }
+        return true;
+    }
+
 }
 
 enum FeastOfTheVictoriousDeadCondition implements Condition {

--- a/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
+++ b/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
@@ -92,12 +92,14 @@ class StumpsquallHydraEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         int xValue = ManacostVariableValue.ETB.calculate(game, source, this);
-        if (player == null || xValue < 1) {
+        if (player == null || xValue < 1 || game.getBattlefield().count(filter, player.getId(), source, game) < 1) {
             return false;
         }
+
         TargetAmount targetAmount = new TargetCreatureOrPlaneswalkerAmount(xValue, filter);
+        targetAmount.setMinNumberOfTargets(1);
         targetAmount.withNotTarget(true);
-        player.choose(outcome, targetAmount, source, game);
+        targetAmount.chooseTarget(outcome, player.getId(), source, game);
         for (UUID targetId : targetAmount.getTargets()) {
             Permanent permanent = game.getPermanent(targetId);
             if (permanent == null) {

--- a/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
@@ -1,7 +1,6 @@
 
 package mage.cards.v;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DiesSourceTriggeredAbility;
@@ -12,18 +11,21 @@ import mage.abilities.effects.common.EntersBattlefieldWithXCountersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.counters.CounterType;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.target.Target;
+import mage.players.Player;
 import mage.target.common.TargetCreaturePermanentAmount;
+import mage.target.common.TargetPermanentAmount;
+
+import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class VastwoodHydra extends CardImpl {
@@ -35,7 +37,7 @@ public final class VastwoodHydra extends CardImpl {
     }
 
     public VastwoodHydra(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{X}{G}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{X}{G}{G}");
         this.subtype.add(SubType.HYDRA);
 
         this.power = new MageInt(0);
@@ -45,9 +47,7 @@ public final class VastwoodHydra extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new EntersBattlefieldWithXCountersEffect(CounterType.P1P1.createInstance())));
 
         // When Vastwood Hydra dies, you may distribute a number of +1/+1 counters equal to the number of +1/+1 counters on Vastwood Hydra among any number of creatures you control.
-        Ability ability = new DiesSourceTriggeredAbility(new VastwoodHydraDistributeEffect(), true);
-        ability.addTarget(new TargetCreaturePermanentAmount(new CountersSourceCount(CounterType.P1P1), filter).withNotTarget(true));
-        this.addAbility(ability);
+        this.addAbility(new DiesSourceTriggeredAbility(new VastwoodHydraDistributeEffect(), true));
     }
 
     private VastwoodHydra(final VastwoodHydra card) {
@@ -78,13 +78,25 @@ class VastwoodHydraDistributeEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (!source.getTargets().isEmpty()) {
-            Target multiTarget = source.getTargets().get(0);
-            for (UUID target : multiTarget.getTargets()) {
-                Permanent permanent = game.getPermanent(target);
-                if (permanent != null) {
-                    permanent.addCounters(CounterType.P1P1.createInstance(multiTarget.getTargetAmount(target)), source.getControllerId(), source, game);
-                }
+        int amount = new CountersSourceCount(CounterType.P1P1).calculate(game, source, this);
+        if (amount <= 0) {
+            return false;
+        }
+
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null || game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game) < 1) {
+            return false;
+        }
+
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, StaticFilters.FILTER_CONTROLLED_CREATURE);
+        target.setMinNumberOfTargets(1);
+        target.withNotTarget(true);
+        target.withChooseHint("to distribute " + amount + " counters");
+        target.chooseTarget(outcome, player.getId(), source, game);
+        for (UUID targetId : target.getTargets()) {
+            Permanent permanent = game.getPermanent(targetId);
+            if (permanent != null) {
+                permanent.addCounters(CounterType.P1P1.createInstance(target.getTargetAmount(targetId)), source, game);
             }
         }
         return true;

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/FeastOfTheVictoriousDeadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/FeastOfTheVictoriousDeadTest.java
@@ -1,0 +1,100 @@
+package org.mage.test.cards.single.mat;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class FeastOfTheVictoriousDeadTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.f.FeastOfTheVictoriousDead}
+     * Feast of the Victorious Dead
+     * {W}{B}
+     * Enchantment
+     * At the beginning of your end step, if one or more creatures died this turn, you gain that much life and distribute that many +1/+1 counters among creatures you control.
+     */
+    private static final String feast = "Feast of the Victorious Dead";
+
+    /**
+     * {@link mage.cards.f.FanaticalFirebrand}
+     * <p>
+     * {T}, Sacrifice Fanatical Firebrand: It deals 1 damage to any target.
+     * 1/1
+     */
+    private static final String firebrand = "Fanatical Firebrand";
+
+    private static final String memnite = "Memnite"; // vanilla 1/1
+    private static final String bears = "Grizzly Bears";  // vanilla 2/2
+    private static final String seeker = "Glory Seeker";  // vanilla 2/2
+
+    @Test
+    public void noDistribution() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, feast);
+        addCard(Zone.BATTLEFIELD, playerA, firebrand);
+        addCard(Zone.BATTLEFIELD, playerB, memnite);
+
+        activateAbility(1, PhaseStep.UPKEEP, playerA, "{T}, Sacrifice", memnite);
+
+        setStopAt(2, PhaseStep.UPKEEP);
+        execute();
+
+        assertLife(playerA, 20 + 2);
+        assertPermanentCount(playerA, 1);
+        assertPermanentCount(playerB, 0);
+    }
+
+    @Test
+    public void distributeOn1() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, feast);
+        addCard(Zone.BATTLEFIELD, playerA, firebrand);
+        addCard(Zone.BATTLEFIELD, playerA, bears);
+        addCard(Zone.BATTLEFIELD, playerA, seeker);
+        addCard(Zone.BATTLEFIELD, playerB, memnite);
+
+        activateAbility(1, PhaseStep.UPKEEP, playerA, "{T}, Sacrifice", memnite);
+
+        addTargetAmount(playerA, seeker, 2);
+
+        setStopAt(2, PhaseStep.UPKEEP);
+        execute();
+
+        assertLife(playerA, 20 + 2);
+        assertPermanentCount(playerA, 3);
+        assertPowerToughness(playerA, seeker, 2 + 2, 2 + 2);
+        assertPowerToughness(playerA, bears, 2 + 0, 2 + 0);
+        assertPermanentCount(playerB, 0);
+    }
+
+    @Test
+    public void distributeAmong2() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, feast);
+        addCard(Zone.BATTLEFIELD, playerA, firebrand);
+        addCard(Zone.BATTLEFIELD, playerA, bears);
+        addCard(Zone.BATTLEFIELD, playerA, seeker);
+        addCard(Zone.BATTLEFIELD, playerB, memnite);
+
+        activateAbility(1, PhaseStep.UPKEEP, playerA, "{T}, Sacrifice", memnite);
+
+        addTargetAmount(playerA, seeker, 1);
+        addTargetAmount(playerA, bears, 1);
+
+        setStopAt(2, PhaseStep.UPKEEP);
+        execute();
+
+        assertLife(playerA, 20 + 2);
+        assertPermanentCount(playerA, 3);
+        assertPowerToughness(playerA, seeker, 2 + 1, 2 + 1);
+        assertPowerToughness(playerA, bears, 2 + 1, 2 + 1);
+        assertPermanentCount(playerB, 0);
+    }
+}


### PR DESCRIPTION
A couple fix on counter distribution:
- Feast of the Victorious Dead was incorrect on situations where there is no creatures to distribute counters onto (the life was not gained), and incorrectly allowed the player to not distribute although it is mandatory if there is at least one creature to distribute onto.
- Awaken the Maelstrom was incorrectly allowing to not distribute although the player should if there is at least one creature to distribute onto.