### PR TITLE
[don't merge] Transform efficiency

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
@@ -6,6 +6,8 @@ import mage.constants.Zone;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
+import java.util.stream.Collectors;
+
 /**
  * @author xenohedron
  */
@@ -44,18 +46,22 @@ public class OptimusPrimeTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, Sacrifice"); // gain 2 life
         setChoice(playerA, optimus); // sac, returns transformed
-
+        showBattlefield("part 1", 1, PhaseStep.BEGIN_COMBAT, playerA);
         attack(1, playerA, ghoul, playerB);
         addTarget(playerA, ghoul); // choice for bolster, becomes a 4/4 with trample
         block(1, playerB, centaur, ghoul);
         setChoice(playerA, "X=3"); // assign 3 damage to centaur, 1 damage tramples over
+        showBattlefield("part 2", 1, PhaseStep.END_COMBAT, playerA);
         // optimus triggers and transforms
         // at end step, bolster 1, only target is myr
-
-        setStopAt(2, PhaseStep.UPKEEP);
+        showBattlefield("part 3", 2, PhaseStep.UPKEEP, playerA);
+        setStopAt(2, PhaseStep.BEGIN_COMBAT);
         setStrictChooseMode(true);
         execute();
 
+        currentGame.debugMessage(getBattlefieldCards(playerA).stream().map(
+                (x) -> "\n"+x.getName()+": "+x.getPower()+"/"+x.getToughness()+" - "+x.isTransformed()
+        ).collect(Collectors.toList()).toString());
         assertLife(playerA, 20 + 2);
         assertLife(playerB, 20 - 1);
         assertGraveyardCount(playerB, centaur, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
@@ -6,8 +6,6 @@ import mage.constants.Zone;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
-import java.util.stream.Collectors;
-
 /**
  * @author xenohedron
  */
@@ -52,7 +50,7 @@ public class OptimusPrimeTest extends CardTestPlayerBase {
         setChoice(playerA, "X=3"); // assign 3 damage to centaur, 1 damage tramples over
         // optimus triggers and transforms
         // at end step, bolster 1, only target is myr
-        setStopAt(2, PhaseStep.BEGIN_COMBAT);
+        setStopAt(2, PhaseStep.UPKEEP);
         setStrictChooseMode(true);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
@@ -44,12 +44,14 @@ public class OptimusPrimeTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, Sacrifice"); // gain 2 life
         setChoice(playerA, optimus); // sac, returns transformed
+
         attack(1, playerA, ghoul, playerB);
         addTarget(playerA, ghoul); // choice for bolster, becomes a 4/4 with trample
         block(1, playerB, centaur, ghoul);
         setChoice(playerA, "X=3"); // assign 3 damage to centaur, 1 damage tramples over
         // optimus triggers and transforms
         // at end step, bolster 1, only target is myr
+
         setStopAt(2, PhaseStep.UPKEEP);
         setStrictChooseMode(true);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/bot/OptimusPrimeTest.java
@@ -46,22 +46,16 @@ public class OptimusPrimeTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, Sacrifice"); // gain 2 life
         setChoice(playerA, optimus); // sac, returns transformed
-        showBattlefield("part 1", 1, PhaseStep.BEGIN_COMBAT, playerA);
         attack(1, playerA, ghoul, playerB);
         addTarget(playerA, ghoul); // choice for bolster, becomes a 4/4 with trample
         block(1, playerB, centaur, ghoul);
         setChoice(playerA, "X=3"); // assign 3 damage to centaur, 1 damage tramples over
-        showBattlefield("part 2", 1, PhaseStep.END_COMBAT, playerA);
         // optimus triggers and transforms
         // at end step, bolster 1, only target is myr
-        showBattlefield("part 3", 2, PhaseStep.UPKEEP, playerA);
         setStopAt(2, PhaseStep.BEGIN_COMBAT);
         setStrictChooseMode(true);
         execute();
 
-        currentGame.debugMessage(getBattlefieldCards(playerA).stream().map(
-                (x) -> "\n"+x.getName()+": "+x.getPower()+"/"+x.getToughness()+" - "+x.isTransformed()
-        ).collect(Collectors.toList()).toString());
         assertLife(playerA, 20 + 2);
         assertLife(playerB, 20 - 1);
         assertGraveyardCount(playerB, centaur, 1);

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -178,7 +178,7 @@ class TransformEffect extends ContinuousEffectImpl {
 
         MageObject card;
         boolean transformed = permanent.isTransformed();
-        if (permanent.isTransformed()) {
+        if (transformed) {
             if (permanent instanceof PermanentToken) {
                 card = ((PermanentToken) permanent).getToken().getBackFace();
             } else {
@@ -188,7 +188,7 @@ class TransformEffect extends ContinuousEffectImpl {
             if (permanent instanceof PermanentToken) {
                 card = ((PermanentToken) permanent).getToken();
             } else if (permanent instanceof PermanentCard){
-                card = ((PermanentCard)permanent).getCard();
+                card = ((PermanentCard) permanent).getCard();
             } else {
                 throw new IllegalArgumentException("Force transform on non-token non-card permanent");
             }

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -160,7 +160,6 @@ class TransformEffect extends ContinuousEffectImpl {
         }
 
         TransformAbility.transformPermanent(permanent, card, game, source);
-
         return true;
 
     }
@@ -178,6 +177,7 @@ class TransformEffect extends ContinuousEffectImpl {
         }
 
         MageObject card;
+        boolean transformed = permanent.isTransformed();
         if (permanent.isTransformed()) {
             if (permanent instanceof PermanentToken) {
                 card = ((PermanentToken) permanent).getToken().getBackFace();
@@ -193,13 +193,12 @@ class TransformEffect extends ContinuousEffectImpl {
                 throw new IllegalArgumentException("Force transform on non-token non-card permanent");
             }
         }
-        game.debugMessage("Applying force "+(permanent.isTransformed()?"Transform":"Untransform")+" to "+permanent.getName());
-
         if (card == null) {
             return false;
         }
 
         TransformAbility.transformPermanent(permanent, card, game, source);
+        permanent.setTransformed(transformed);
 
         return true;
 

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -10,6 +10,7 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.game.MageObjectAttribute;
 import mage.game.permanent.Permanent;
+import mage.game.permanent.PermanentCard;
 import mage.game.permanent.PermanentToken;
 import mage.game.stack.Spell;
 import mage.util.CardUtil;
@@ -114,6 +115,9 @@ public class TransformAbility extends SimpleStaticAbility {
             game.getState().addOtherAbility(spell.getCard(), ability);
         }
     }
+    public void force_apply(Game game){
+        getEffects().forEach((effect) -> ((TransformEffect)effect).apply_force(game, this));
+    }
 }
 
 class TransformEffect extends ContinuousEffectImpl {
@@ -150,6 +154,46 @@ class TransformEffect extends ContinuousEffectImpl {
         } else {
             card = permanent.getSecondCardFace();
         }
+
+        if (card == null) {
+            return false;
+        }
+
+        TransformAbility.transformPermanent(permanent, card, game, source);
+
+        return true;
+
+    }
+
+    //apply but also applies from back side to front, so that we don't need to reset
+    public boolean apply_force(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getSourceId());
+
+        if (permanent == null) {
+            return false;
+        }
+
+        if (permanent.isCopy()) { // copies can't transform
+            return true;
+        }
+
+        MageObject card;
+        if (permanent.isTransformed()) {
+            if (permanent instanceof PermanentToken) {
+                card = ((PermanentToken) permanent).getToken().getBackFace();
+            } else {
+                card = permanent.getSecondCardFace();
+            }
+        } else {
+            if (permanent instanceof PermanentToken) {
+                card = ((PermanentToken) permanent).getToken();
+            } else if (permanent instanceof PermanentCard){
+                card = ((PermanentCard)permanent).getCard();
+            } else {
+                throw new IllegalArgumentException("Force transform on non-token non-card permanent");
+            }
+        }
+        game.debugMessage("Applying force "+(permanent.isTransformed()?"Transform":"Untransform")+" to "+permanent.getName());
 
         if (card == null) {
             return false;

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -640,9 +640,9 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 ((TransformAbility) a).force_apply(game);
             }
         }
-        //game.applyEffects();
+        //Old code did game.applyEffects() instead of this force_apply, but this should be much more efficient
         this.replaceEvent(EventType.TRANSFORMING, game);
-        game.addSimultaneousEvent(GameEvent.getEvent(EventType.TRANSFORMED, this.getId(), this.getControllerId()));
+        game.addSimultaneousEvent(GameEvent.getEvent(EventType.TRANSFORMED, this.getId(), source, this.getControllerId()));
         return true;
     }
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -633,7 +633,14 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 + CardUtil.getSourceLogName(game, source, this.getId()));
         this.setTransformed(!this.transformed);
         this.transformCount++;
-        game.applyEffects();
+        Abilities<Ability> abilities = this.getAbilities(game);
+        this.reset(game);
+        for (Ability a : abilities){
+            if (a instanceof TransformAbility){
+                ((TransformAbility) a).force_apply(game);
+            }
+        }
+        //game.applyEffects();
         this.replaceEvent(EventType.TRANSFORMING, game);
         game.addSimultaneousEvent(GameEvent.getEvent(EventType.TRANSFORMED, this.getId(), this.getControllerId()));
         return true;


### PR DESCRIPTION
#11285 noted that transform calls were eating a significant amount of resources because every creature that transformed required a full recalculation of the game state via `game.applyEffects()`. This attempts to do the minimal amount of work possible instead.

While it passes all the current tests, I'm worried that this workaround may have undesirable side effects when combined with other continuous effects that must be applied above the transform effect. I'm trying to figure out if there are additional tests that should be added to check against that.