### PR TITLE
[LEA] Implement Chaos Orb (Errated to be reasonable)

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChaosOrb.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosOrb.java
@@ -1,0 +1,110 @@
+package mage.cards.c;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DestroySourceEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.permanent.TokenPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+/**
+ * Heavily errated version of Chaos Orb, as it is not
+ * realistic to implement any kind of fall simulation.
+ * No dexterity, a single destroyed permanent at most,
+ * and a randomized (not a dice roll) chance to destroy
+ * the other permanent.
+ *
+ * @author Susucr
+ */
+public final class ChaosOrb extends CardImpl {
+
+    public ChaosOrb(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
+
+        // {1}, {T}: Choose a nontoken permanent. A number between 1 and 20 is generated at random. If the number is 4 or more, destroy the chosen permanent. Then destroy Chaos Orb.
+        Ability ability = new SimpleActivatedAbility(
+                new ChaosOrbEffect(),
+                new GenericManaCost(1)
+        );
+        ability.addCost(new TapSourceCost());
+        ability.addEffect(new DestroySourceEffect().concatBy("Then"));
+        this.addAbility(ability);
+    }
+
+    private ChaosOrb(final ChaosOrb card) {
+        super(card);
+    }
+
+    @Override
+    public ChaosOrb copy() {
+        return new ChaosOrb(this);
+    }
+}
+
+class ChaosOrbEffect extends OneShotEffect {
+
+    private static final FilterPermanent filter = new FilterPermanent("nontoken permanent");
+
+    static {
+        filter.add(TokenPredicate.FALSE);
+    }
+
+    ChaosOrbEffect() {
+        super(Outcome.DestroyPermanent);
+        staticText = "choose a nontoken permanent. "
+                + "A number between 1 and 20 is generated at random. "
+                + "If the number is 4 or more, destroy the chosen permanent";
+    }
+
+    private ChaosOrbEffect(final ChaosOrbEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public ChaosOrbEffect copy() {
+        return new ChaosOrbEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+
+        TargetPermanent target = new TargetPermanent(filter);
+        target.withNotTarget(true);
+        Permanent chosen = null;
+        if (target.choose(outcome, player.getId(), source.getSourceId(), source, game)) {
+            chosen = game.getPermanent(target.getFirstTarget());
+        }
+        if (chosen != null) {
+            game.informPlayers(player.getLogName() + " has chosen " + chosen.getLogName() + CardUtil.getSourceLogName(game, source));
+
+            // roll a 20 side dice without any roll interaction.
+            int result = player.rollDieResult(20, game);
+            game.informPlayers("The random number is " + result + CardUtil.getSourceLogName(game, source));
+
+            // 3/20 chance of failure.
+            if (result >= 4) {
+                chosen.destroy(source, game);
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/c/ChaosOrb.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosOrb.java
@@ -34,7 +34,7 @@ public final class ChaosOrb extends CardImpl {
     public ChaosOrb(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
-        // {1}, {T}: Choose a nontoken permanent. A number between 1 and 20 is generated at random. If the number is 4 or more, destroy the chosen permanent. Then destroy Chaos Orb.
+        // {1}, {T}: If Chaos Orb is on the battlefield, choose a nontoken permanent, then a number between 1 and 20 is generated at random. If the number is 4 or more, destroy the chosen permanent. Then destroy Chaos Orb.
         Ability ability = new SimpleActivatedAbility(
                 new ChaosOrbEffect(),
                 new GenericManaCost(1)
@@ -64,8 +64,8 @@ class ChaosOrbEffect extends OneShotEffect {
 
     ChaosOrbEffect() {
         super(Outcome.DestroyPermanent);
-        staticText = "choose a nontoken permanent. "
-                + "A number between 1 and 20 is generated at random. "
+        staticText = "if {this} is on the battlefield, choose a nontoken permanent, "
+                + "then a number between 1 and 20 is generated at random. "
                 + "If the number is 4 or more, destroy the chosen permanent";
     }
 
@@ -81,7 +81,8 @@ class ChaosOrbEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
-        if (player == null) {
+        Permanent orb = source.getSourcePermanentIfItStillExists(game);
+        if (player == null || orb == null) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionAlpha.java
@@ -57,6 +57,7 @@ public final class LimitedEditionAlpha extends ExpansionSet {
         cards.add(new SetCardInfo("Castle", 9, Rarity.UNCOMMON, mage.cards.c.Castle.class));
         cards.add(new SetCardInfo("Celestial Prism", 234, Rarity.UNCOMMON, mage.cards.c.CelestialPrism.class));
         cards.add(new SetCardInfo("Channel", 188, Rarity.UNCOMMON, mage.cards.c.Channel.class));
+        cards.add(new SetCardInfo("Chaos Orb", 235, Rarity.RARE, mage.cards.c.ChaosOrb.class));
         cards.add(new SetCardInfo("Chaoslace", 139, Rarity.RARE, mage.cards.c.Chaoslace.class));
         cards.add(new SetCardInfo("Circle of Protection: Blue", 10, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlue.class));
         cards.add(new SetCardInfo("Circle of Protection: Green", 11, Rarity.COMMON, mage.cards.c.CircleOfProtectionGreen.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -57,6 +57,7 @@ public final class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Castle", 9, Rarity.UNCOMMON, mage.cards.c.Castle.class));
         cards.add(new SetCardInfo("Celestial Prism", 235, Rarity.UNCOMMON, mage.cards.c.CelestialPrism.class));
         cards.add(new SetCardInfo("Channel", 189, Rarity.UNCOMMON, mage.cards.c.Channel.class));
+        cards.add(new SetCardInfo("Chaos Orb", 237, Rarity.RARE, mage.cards.c.ChaosOrb.class));
         cards.add(new SetCardInfo("Chaoslace", 140, Rarity.RARE, mage.cards.c.Chaoslace.class));
         cards.add(new SetCardInfo("Circle of Protection: Black", 10, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlack.class));
         cards.add(new SetCardInfo("Circle of Protection: Blue", 11, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlue.class));

--- a/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
+++ b/Mage.Sets/src/mage/sets/LimitedEditionBeta.java
@@ -7,7 +7,6 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 /**
- *
  * @author North
  */
 public final class LimitedEditionBeta extends ExpansionSet {
@@ -57,7 +56,7 @@ public final class LimitedEditionBeta extends ExpansionSet {
         cards.add(new SetCardInfo("Castle", 9, Rarity.UNCOMMON, mage.cards.c.Castle.class));
         cards.add(new SetCardInfo("Celestial Prism", 235, Rarity.UNCOMMON, mage.cards.c.CelestialPrism.class));
         cards.add(new SetCardInfo("Channel", 189, Rarity.UNCOMMON, mage.cards.c.Channel.class));
-        cards.add(new SetCardInfo("Chaos Orb", 237, Rarity.RARE, mage.cards.c.ChaosOrb.class));
+        cards.add(new SetCardInfo("Chaos Orb", 236, Rarity.RARE, mage.cards.c.ChaosOrb.class));
         cards.add(new SetCardInfo("Chaoslace", 140, Rarity.RARE, mage.cards.c.Chaoslace.class));
         cards.add(new SetCardInfo("Circle of Protection: Black", 10, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlack.class));
         cards.add(new SetCardInfo("Circle of Protection: Blue", 11, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlue.class));

--- a/Mage.Sets/src/mage/sets/UnlimitedEdition.java
+++ b/Mage.Sets/src/mage/sets/UnlimitedEdition.java
@@ -57,6 +57,7 @@ public final class UnlimitedEdition extends ExpansionSet {
         cards.add(new SetCardInfo("Castle", 9, Rarity.UNCOMMON, mage.cards.c.Castle.class));
         cards.add(new SetCardInfo("Celestial Prism", 235, Rarity.UNCOMMON, mage.cards.c.CelestialPrism.class));
         cards.add(new SetCardInfo("Channel", 189, Rarity.UNCOMMON, mage.cards.c.Channel.class));
+        cards.add(new SetCardInfo("Chaos Orb", 236, Rarity.RARE, mage.cards.c.ChaosOrb.class));
         cards.add(new SetCardInfo("Chaoslace", 140, Rarity.RARE, mage.cards.c.Chaoslace.class));
         cards.add(new SetCardInfo("Circle of Protection: Black", 10, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlack.class));
         cards.add(new SetCardInfo("Circle of Protection: Blue", 11, Rarity.COMMON, mage.cards.c.CircleOfProtectionBlue.class));


### PR DESCRIPTION
From #5954, Chaos Orb is a staple of the Old School format (https://www.eternalcentral.com/9394rules/ ), so here is a reasonable implementation for Chaos Orb for that purpose.

The errated version from this PR has the following text:
> {1}, {T}: If Chaos Orb is on the battlefield, choose a nontoken permanent, then a number between 1 and 20 is generated at random. If the number is 4 or more, destroy the chosen permanent. Then destroy Chaos Orb.

Choosing a permanent is already in the errata from the Old School format, so I only removed any dexterity and used a probability to destroy instead. Avoided any interaction with cards that do care about rolling dice.

closes #5954