### PR TITLE
Refactor self-suspend cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArcBlade.java
+++ b/Mage.Sets/src/mage/cards/a/ArcBlade.java
@@ -3,7 +3,7 @@ package mage.cards.a;
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DamageTargetEffect;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -22,7 +22,7 @@ public final class ArcBlade extends CardImpl {
         // Arc Blade deals 2 damage to any target. Exile Arc Blade with three time counters on it.
         this.getSpellAbility().addEffect(new DamageTargetEffect(2));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
-        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        this.getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{2}{R}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{R}"), this));

--- a/Mage.Sets/src/mage/cards/a/ArcBlade.java
+++ b/Mage.Sets/src/mage/cards/a/ArcBlade.java
@@ -1,18 +1,13 @@
-
 package mage.cards.a;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
-import mage.abilities.effects.common.ExileSpellEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.target.common.TargetAnyTarget;
 
 /**
@@ -24,17 +19,12 @@ public final class ArcBlade extends CardImpl {
     public ArcBlade(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{R}{R}");
 
-        // Arc Blade deals 2 damage to any target.
+        // Arc Blade deals 2 damage to any target. Exile Arc Blade with three time counters on it.
         this.getSpellAbility().addEffect(new DamageTargetEffect(2));
-        // Exile Arc Blade
-        this.getSpellAbility().addEffect(new ExileSpellEffect());
-        // with three time counters on it.
-        Effect effect = new AddCountersSourceEffect(CounterType.TIME.createInstance(), StaticValue.get(3), false, true);
-        effect.setText("with three time counters on it");
-        this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTarget());
+        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
-        // Suspend 3-{2}{R}
+        // Suspend 3—{2}{R}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{R}"), this));
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChronomanticEscape.java
+++ b/Mage.Sets/src/mage/cards/c/ChronomanticEscape.java
@@ -2,7 +2,7 @@ package mage.cards.c;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.effects.common.combat.CantAttackYouAllEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
@@ -22,7 +22,7 @@ public final class ChronomanticEscape extends CardImpl {
 
         // Until your next turn, creatures can't attack you. Exile Chronomantic Escape with three time counters on it.
         getSpellAbility().addEffect(new CantAttackYouAllEffect(Duration.UntilYourNextTurn, StaticFilters.FILTER_PERMANENT_CREATURES));
-        getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{2}{W}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{W}"), this));

--- a/Mage.Sets/src/mage/cards/c/ChronomanticEscape.java
+++ b/Mage.Sets/src/mage/cards/c/ChronomanticEscape.java
@@ -1,19 +1,14 @@
-
 package mage.cards.c;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.ExileSpellEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.effects.common.combat.CantAttackYouAllEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 
 /**
@@ -22,18 +17,14 @@ import mage.filter.StaticFilters;
  */
 public final class ChronomanticEscape extends CardImpl {
 
-
     public ChronomanticEscape(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{W}{W}");
 
         // Until your next turn, creatures can't attack you. Exile Chronomantic Escape with three time counters on it.
         getSpellAbility().addEffect(new CantAttackYouAllEffect(Duration.UntilYourNextTurn, StaticFilters.FILTER_PERMANENT_CREATURES));
-        getSpellAbility().addEffect(new ExileSpellEffect());
-        Effect effect = new AddCountersSourceEffect(CounterType.TIME.createInstance(), StaticValue.get(3), true, true);
-        effect.setText("with three time counters on it");
-        getSpellAbility().addEffect(effect);
+        getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
-        // Suspend 3-{2}{W}
+        // Suspend 3—{2}{W}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{W}"), this));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CyclicalEvolution.java
+++ b/Mage.Sets/src/mage/cards/c/CyclicalEvolution.java
@@ -1,19 +1,14 @@
-
 package mage.cards.c;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.ExileSpellEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -28,12 +23,9 @@ public final class CyclicalEvolution extends CardImpl {
         // Target creature gets +3/+3 until end of turn. Exile Cyclical Evolution with three time counters on it.
         getSpellAbility().addEffect(new BoostTargetEffect(3, 3, Duration.EndOfTurn));
         getSpellAbility().addTarget(new TargetCreaturePermanent());
-        getSpellAbility().addEffect(new ExileSpellEffect());
-        Effect effect = new AddCountersSourceEffect(CounterType.TIME.createInstance(), StaticValue.get(3), true, true);
-        effect.setText("with three time counters on it");
-        getSpellAbility().addEffect(effect);
+        getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
-        // Suspend 3-{2}{G}
+        // Suspend 3—{2}{G}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{G}"), this));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CyclicalEvolution.java
+++ b/Mage.Sets/src/mage/cards/c/CyclicalEvolution.java
@@ -2,7 +2,7 @@ package mage.cards.c;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
@@ -23,7 +23,7 @@ public final class CyclicalEvolution extends CardImpl {
         // Target creature gets +3/+3 until end of turn. Exile Cyclical Evolution with three time counters on it.
         getSpellAbility().addEffect(new BoostTargetEffect(3, 3, Duration.EndOfTurn));
         getSpellAbility().addTarget(new TargetCreaturePermanent());
-        getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{2}{G}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{G}"), this));

--- a/Mage.Sets/src/mage/cards/f/FesteringMarch.java
+++ b/Mage.Sets/src/mage/cards/f/FesteringMarch.java
@@ -2,7 +2,7 @@ package mage.cards.f;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.effects.common.continuous.BoostOpponentsEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
@@ -21,7 +21,7 @@ public final class FesteringMarch extends CardImpl {
 
         // Creatures your opponents control get -1/-1 until end of turn. Exile Festering March with three time counters on it.
         this.getSpellAbility().addEffect(new BoostOpponentsEffect(-1, -1, Duration.EndOfTurn));
-        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        this.getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{2}{B}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{B}"), this));

--- a/Mage.Sets/src/mage/cards/f/FesteringMarch.java
+++ b/Mage.Sets/src/mage/cards/f/FesteringMarch.java
@@ -1,19 +1,14 @@
-
 package mage.cards.f;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.ExileSpellEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.effects.common.continuous.BoostOpponentsEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
 
 /**
  *
@@ -24,16 +19,11 @@ public final class FesteringMarch extends CardImpl {
     public FesteringMarch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}{B}");
 
-        // Creatures your opponents control get -1/-1 until end of turn.
+        // Creatures your opponents control get -1/-1 until end of turn. Exile Festering March with three time counters on it.
         this.getSpellAbility().addEffect(new BoostOpponentsEffect(-1, -1, Duration.EndOfTurn));
-        // Exile Festering March
-        this.getSpellAbility().addEffect(new ExileSpellEffect());
-        // with three time counters on it.
-        Effect effect = new AddCountersSourceEffect(CounterType.TIME.createInstance(), StaticValue.get(3), false, true);
-        effect.setText("with three time counters on it");
-        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
-        // Suspend 3-{2}{B}
+        // Suspend 3—{2}{B}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{B}"), this));
     }
 

--- a/Mage.Sets/src/mage/cards/i/InspiringRefrain.java
+++ b/Mage.Sets/src/mage/cards/i/InspiringRefrain.java
@@ -1,15 +1,12 @@
 package mage.cards.i;
 
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.effects.common.ExileSpellEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 
 import java.util.UUID;
 
@@ -23,10 +20,7 @@ public final class InspiringRefrain extends CardImpl {
 
         // Draw two cards. Exile Inspiring Refrain with three time counters on it.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
-        this.getSpellAbility().addEffect(new ExileSpellEffect());
-        this.getSpellAbility().addEffect(new AddCountersSourceEffect(
-                CounterType.TIME.createInstance(), StaticValue.get(3), false, true
-        ).setText("with three time counters on it"));
+        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
         // Suspend 3—{2}{U}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{U}"), this));

--- a/Mage.Sets/src/mage/cards/i/InspiringRefrain.java
+++ b/Mage.Sets/src/mage/cards/i/InspiringRefrain.java
@@ -2,7 +2,7 @@ package mage.cards.i;
 
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -20,7 +20,7 @@ public final class InspiringRefrain extends CardImpl {
 
         // Draw two cards. Exile Inspiring Refrain with three time counters on it.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
-        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        this.getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{2}{U}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{U}"), this));

--- a/Mage.Sets/src/mage/cards/r/RealityStrobe.java
+++ b/Mage.Sets/src/mage/cards/r/RealityStrobe.java
@@ -1,18 +1,13 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.ExileSpellEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.effects.common.ReturnToHandTargetEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.target.TargetPermanent;
 
 /**
@@ -24,18 +19,12 @@ public final class RealityStrobe extends CardImpl {
     public RealityStrobe(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{U}{U}");
 
-
-        // Return target permanent to its owner's hand.
+        // Return target permanent to its owner's hand. Exile Reality Strobe with three time counters on it.
         this.getSpellAbility().addEffect(new ReturnToHandTargetEffect());
-        // Exile Reality Strobe
-        this.getSpellAbility().addEffect(new ExileSpellEffect());
-        // with three time counters on it.
-        Effect effect = new AddCountersSourceEffect(CounterType.TIME.createInstance(), StaticValue.get(3), false, true);
-        effect.setText("with three time counters on it");
-        this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetPermanent());
+        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
         
-        // Suspend 3-{2}{U}
+        // Suspend 3—{2}{U}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{U}"), this));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RealityStrobe.java
+++ b/Mage.Sets/src/mage/cards/r/RealityStrobe.java
@@ -2,7 +2,7 @@ package mage.cards.r;
 
 import java.util.UUID;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
@@ -22,7 +22,7 @@ public final class RealityStrobe extends CardImpl {
         // Return target permanent to its owner's hand. Exile Reality Strobe with three time counters on it.
         this.getSpellAbility().addEffect(new ReturnToHandTargetEffect());
         this.getSpellAbility().addTarget(new TargetPermanent());
-        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        this.getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
         
         // Suspend 3—{2}{U}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{2}{U}"), this));

--- a/Mage.Sets/src/mage/cards/r/RousingRefrain.java
+++ b/Mage.Sets/src/mage/cards/r/RousingRefrain.java
@@ -3,17 +3,14 @@ package mage.cards.r;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileSpellEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ManaType;
 import mage.constants.Outcome;
-import mage.counters.CounterType;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetOpponent;
@@ -30,11 +27,8 @@ public final class RousingRefrain extends CardImpl {
 
         // Add {R} for each card in target opponent's hand. Until end of turn, you don't lose this mana as steps and phases end. Exile Rousing Refrain with three time counters on it.
         this.getSpellAbility().addEffect(new RousingRefrainEffect());
-        this.getSpellAbility().addEffect(new ExileSpellEffect());
-        this.getSpellAbility().addEffect(new AddCountersSourceEffect(
-                CounterType.TIME.createInstance(), StaticValue.get(3), false, true
-        ).setText("with three time counters on it"));
         this.getSpellAbility().addTarget(new TargetOpponent());
+        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
         // Suspend 3—{1}{R}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{1}{R}"), this));

--- a/Mage.Sets/src/mage/cards/r/RousingRefrain.java
+++ b/Mage.Sets/src/mage/cards/r/RousingRefrain.java
@@ -4,7 +4,7 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -28,7 +28,7 @@ public final class RousingRefrain extends CardImpl {
         // Add {R} for each card in target opponent's hand. Until end of turn, you don't lose this mana as steps and phases end. Exile Rousing Refrain with three time counters on it.
         this.getSpellAbility().addEffect(new RousingRefrainEffect());
         this.getSpellAbility().addTarget(new TargetOpponent());
-        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        this.getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{1}{R}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{1}{R}"), this));

--- a/Mage.Sets/src/mage/cards/v/VentureForth.java
+++ b/Mage.Sets/src/mage/cards/v/VentureForth.java
@@ -3,7 +3,7 @@ package mage.cards.v;
 import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileWithTimeCountersEffect;
+import mage.abilities.effects.common.ExileSpellWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.*;
 import mage.constants.CardType;
@@ -24,7 +24,7 @@ public final class VentureForth extends CardImpl {
 
         // Exile cards from the top of your library until you exile a land card. Put that onto the battlefield and the rest on the bottom of your library in a random order. Exile Venture Forth with three time counters on it.
         this.getSpellAbility().addEffect(new VentureForthEffect());
-        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
+        this.getSpellAbility().addEffect(new ExileSpellWithTimeCountersEffect(3));
 
         // Suspend 3—{1}{G}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{1}{G}"), this));

--- a/Mage.Sets/src/mage/cards/v/VentureForth.java
+++ b/Mage.Sets/src/mage/cards/v/VentureForth.java
@@ -2,16 +2,13 @@ package mage.cards.v;
 
 import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileSpellEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.ExileWithTimeCountersEffect;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
-import mage.counters.CounterType;
 import mage.game.Game;
 import mage.players.Player;
 
@@ -27,10 +24,7 @@ public final class VentureForth extends CardImpl {
 
         // Exile cards from the top of your library until you exile a land card. Put that onto the battlefield and the rest on the bottom of your library in a random order. Exile Venture Forth with three time counters on it.
         this.getSpellAbility().addEffect(new VentureForthEffect());
-        this.getSpellAbility().addEffect(new ExileSpellEffect());
-        this.getSpellAbility().addEffect(new AddCountersSourceEffect(
-                CounterType.TIME.createInstance(), StaticValue.get(3), false, true
-        ).setText("with three time counters on it"));
+        this.getSpellAbility().addEffect(new ExileWithTimeCountersEffect(3));
 
         // Suspend 3—{1}{G}
         this.addAbility(new SuspendAbility(3, new ManaCostsImpl<>("{1}{G}"), this));

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileSpellWithTimeCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileSpellWithTimeCountersEffect.java
@@ -15,24 +15,24 @@ import java.util.UUID;
 /**
  * @author PurpleCrowbar
  */
-public class ExileWithTimeCountersEffect extends OneShotEffect {
+public class ExileSpellWithTimeCountersEffect extends OneShotEffect {
 
     private final int counters;
 
-    public ExileWithTimeCountersEffect(int counters) {
+    public ExileSpellWithTimeCountersEffect(int counters) {
         super(Outcome.Exile);
         this.counters = counters;
         this.staticText = "Exile {this} with " + CardUtil.numberToText(this.counters) + " time counters on it";
     }
 
-    private ExileWithTimeCountersEffect(final ExileWithTimeCountersEffect effect) {
+    private ExileSpellWithTimeCountersEffect(final ExileSpellWithTimeCountersEffect effect) {
         super(effect);
         this.counters = effect.counters;
     }
 
     @Override
-    public ExileWithTimeCountersEffect copy() {
-        return new ExileWithTimeCountersEffect(this);
+    public ExileSpellWithTimeCountersEffect copy() {
+        return new ExileSpellWithTimeCountersEffect(this);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileWithTimeCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileWithTimeCountersEffect.java
@@ -1,0 +1,52 @@
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.SuspendAbility;
+import mage.cards.Card;
+import mage.constants.Outcome;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public class ExileWithTimeCountersEffect extends OneShotEffect {
+
+    private final int counters;
+
+    public ExileWithTimeCountersEffect(int counters) {
+        super(Outcome.Exile);
+        this.counters = counters;
+        this.staticText = "Exile {this} with " + CardUtil.numberToText(this.counters) + " time counters on it";
+    }
+
+    private ExileWithTimeCountersEffect(final ExileWithTimeCountersEffect effect) {
+        super(effect);
+        this.counters = effect.counters;
+    }
+
+    @Override
+    public ExileWithTimeCountersEffect copy() {
+        return new ExileWithTimeCountersEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Card card = game.getStack().getSpell(source.getId()).getCard();
+        if (controller == null || card == null) {
+            return true;
+        }
+        UUID exileId = SuspendAbility.getSuspendExileId(controller.getId(), game);
+        if (!card.isCopy() && controller.moveCardsToExile(card, source, game, true, exileId, "Suspended cards of " + controller.getName())) {
+            card.addCounters(CounterType.TIME.createInstance(3), source.getControllerId(), source, game);
+            game.informPlayers(controller.getLogName() + " exiles " + card.getLogName() + " with " + counters + " time counters on it");
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Adds a common effect for cards which exile themselves with time counters on resolution. Also fixes an issue wherein cards suspending themselves in this way wouldn't appear in the "Suspended cards of \<player name>" window. Affects [these cards](https://scryfall.com/search?q=o%3A%22exile+%7E+with%22+o%3A%22time+counters%22&unique=cards&as=grid&order=name).