### PR TITLE
dev: improved test logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ git:
   submodules: false
 before_install:
   - echo "MAVEN_OPTS='-Xmx2g'" > ~/.mavenrc
+script:
+  - mvn test -B
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
 before_install:
   - echo "MAVEN_OPTS='-Xmx2g'" > ~/.mavenrc
 script:
-  - mvn test -B
+  - mvn test -B -Dlog4j.configuration=file:${TRAVIS_BUILD_DIR}/.travis/log4j.properties
 cache:
   directories:
     - $HOME/.m2

--- a/.travis/log4j.properties
+++ b/.travis/log4j.properties
@@ -1,0 +1,14 @@
+# logs settings for github/travis ci builds, used by travis.yml
+
+# 1. Only console logs
+log4j.rootLogger=info, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p %d{yyyy-MM-dd HH:mm:ss,SSS} %-90m =>[%t] %C{1}.%M %n
+log4j.appender.console.Threshold=info
+
+# 2. Hide db/sql logs
+log4j.logger.com.j256.ormlite=warn
+
+# 3. Hide AI decision logs ("info" to enable and "warn" to disable)
+log4j.logger.mage.player.ai=warn

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,18 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
+                    <dependencies>
+                        <!-- tree reporter deps -->
+                        <dependency>
+                            <groupId>me.fabriciorby</groupId>
+                            <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+                            <version>1.2.1</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
+                        <!-- ******************** -->
+                        <!-- default plain report -->
+                        <!-- ******************** -->
                         <!--
                             printSummary: print elapsed time and other stats per test file
                             - if you disable this, you will not be able to trace the name of the test
@@ -115,6 +126,28 @@
                             - useless, so disable it for more performance
                         -->
                         <useFile>false</useFile>
+
+                        <!-- **************** -->
+                        <!-- tree view report -->
+                        <!-- **************** -->
+                        <consoleOutputReporter>
+                            <disable>true</disable>
+                        </consoleOutputReporter>
+                        <statelessTestsetInfoReporter
+                                implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                            <theme>ASCII</theme>
+                            <!-- print stack -->
+                            <printStacktraceOnError>true</printStacktraceOnError>
+                            <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                            <!-- print standard output -->
+                            <printStdoutOnError>true</printStdoutOnError>
+                            <printStdoutOnFailure>true</printStdoutOnFailure>
+                            <printStdoutOnSuccess>false</printStdoutOnSuccess>
+                            <!-- print error output -->
+                            <printStderrOnError>true</printStderrOnError>
+                            <printStderrOnFailure>true</printStderrOnFailure>
+                            <printStderrOnSuccess>false</printStderrOnSuccess>
+                        </statelessTestsetInfoReporter>
 
                         <!-- for compatible with jacoco code coverage - argLine moved to properties section
                         <argLine>-Dfile.encoding=UTF-8</argLine>
@@ -225,8 +258,7 @@
 
         <!-- Sonar settings for code coverage. Must be only one report for all modules (use report-aggregate goal report from JaCoCo) -->
         <aggregate.report.dir>Mage.Verify/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}
-        </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <!-- tests runner -->
+                    <!-- test runner for maven, travis-ci (IDE uses own test runner) -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
@@ -130,23 +130,23 @@
                         <!-- **************** -->
                         <!-- tree view report -->
                         <!-- **************** -->
+                        <!-- for full logs: use xmage.build.tests.treeViewRunnerShowAllLogs -->
+                        <!-- for ai logs in ci build: use .travis/log4j.properties -->
+                        <!-- for default maven logs: delete or comment all settings below -->
                         <consoleOutputReporter>
                             <disable>true</disable>
                         </consoleOutputReporter>
                         <statelessTestsetInfoReporter
                                 implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
                             <theme>ASCII</theme>
-                            <!-- print stack -->
                             <printStacktraceOnError>true</printStacktraceOnError>
                             <printStacktraceOnFailure>true</printStacktraceOnFailure>
-                            <!-- print standard output -->
                             <printStdoutOnError>true</printStdoutOnError>
                             <printStdoutOnFailure>true</printStdoutOnFailure>
-                            <printStdoutOnSuccess>false</printStdoutOnSuccess>
-                            <!-- print error output -->
+                            <printStdoutOnSuccess>${xmage.build.tests.treeViewRunnerShowAllLogs}</printStdoutOnSuccess>
                             <printStderrOnError>true</printStderrOnError>
                             <printStderrOnFailure>true</printStderrOnFailure>
-                            <printStderrOnSuccess>false</printStderrOnSuccess>
+                            <printStderrOnSuccess>${xmage.build.tests.treeViewRunnerShowAllLogs}</printStderrOnSuccess>
                         </statelessTestsetInfoReporter>
 
                         <!-- for compatible with jacoco code coverage - argLine moved to properties section
@@ -244,6 +244,9 @@
         <argLine>-Dfile.encoding=UTF-8</argLine>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
+
+        <!-- logs settings for maven tests and travis ci builds -->
+        <xmage.build.tests.treeViewRunnerShowAllLogs>false</xmage.build.tests.treeViewRunnerShowAllLogs>
 
         <!--
             JaCoCo code coverage disabled by default. If you need to generate

--- a/pom.xml
+++ b/pom.xml
@@ -90,15 +90,36 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <!-- tests runner -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
-                    <!--
-                    for compatible with jacoco code coverage - argLine moved to properties section
+                    <version>3.1.2</version>
                     <configuration>
+                        <!--
+                            printSummary: print elapsed time and other stats per test file
+                            - if you disable this, you will not be able to trace the name of the test
+                              from where the logs are printed
+                            - failed tests will be shown anyway
+                        -->
+                        <printSummary>true</printSummary>
+
+                        <!--
+                            reportFormat: summary format
+                            - brief: print total elapsed time only
+                            - plain: print brief + elapsed time for each test name
+                        -->
+                        <reportFormat>brief</reportFormat>
+
+                        <!--
+                            useFile: enable txt and xml reports in .\target\surefire-reports
+                            - useless, so disable it for more performance
+                        -->
+                        <useFile>false</useFile>
+
+                        <!-- for compatible with jacoco code coverage - argLine moved to properties section
                         <argLine>-Dfile.encoding=UTF-8</argLine>
+                        -->
                     </configuration>
-                    -->
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -204,7 +225,8 @@
 
         <!-- Sonar settings for code coverage. Must be only one report for all modules (use report-aggregate goal report from JaCoCo) -->
         <aggregate.report.dir>Mage.Verify/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}
+        </sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Travis-ci build logs are bloated and hard to read. That PR improved some logs and introduced additional tools for a developers.

If you used unit tests for errors check only then nothing changes.
But if you use unit tests for looking into additional info and "warning" messages like card stats, rules text compare, etc then:
* IDE test runner: nothing changes;
* maven test runner (command line): must use additional param to watch a non-error logs from successful test, see below;
* travis-ci test runner: you can't watch such logs now. If you can't develop without travis's logs then create new issue or report here -- I'll look for some workaround to enable such logs in a specific tests;

What's new:
1. Added logs config for travis-ci builds: `/.travis/log4j.properties`
2. AI decision logs hidden for travis-ci builds by default, but it still visible for local runs by maven or IDE;
3. Failed test logs visible all the time;
4. Successful test logs hidden by default:
    * app runs (client/server): logs visible;
    * IDE runs (tests): logs visible;
    * travis-ci runs (tests): logs hidden;
    * maven runs (tests): logs hidden by default, but can be enabled by additional command line param `treeViewRunnerShowAllLogs`:
```
mvn install test "-Dsurefire.failIfNoSpecifiedTests=false" "-Dxmage.build.tests.treeViewRunnerShowAllLogs=true" -Dtest=VerifyCardDataTest#test_showCardInfo
```
5. Logs shows after all tests done;
6. Updated wiki page about testing tools and actual settings:
    * https://github.com/magefree/mage/wiki/Development-Testing-Tools