### PR TITLE
[MIR] Implement Teferi's Imp

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TeferisImp.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisImp.java
@@ -1,0 +1,54 @@
+package mage.cards.t;
+
+import mage.MageInt;
+import mage.abilities.common.SourcePhaseInTriggeredAbility;
+import mage.abilities.common.SourcePhaseOutTriggeredAbility;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.discard.DiscardControllerEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.PhasingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public final class TeferisImp extends CardImpl {
+
+    public TeferisImp(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
+
+        this.subtype.add(SubType.IMP);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Phasing
+        this.addAbility(PhasingAbility.getInstance());
+
+        // Whenever Teferi's Imp phases out, discard a card.
+        this.addAbility(new SourcePhaseOutTriggeredAbility(
+                new DiscardControllerEffect(1), false)
+        );
+
+        // Whenever Teferi's Imp phases in, draw a card.
+        this.addAbility(new SourcePhaseInTriggeredAbility(
+                new DrawCardSourceControllerEffect(1), false)
+        );
+    }
+
+    private TeferisImp(final TeferisImp card) {
+        super(card);
+    }
+
+    @Override
+    public TeferisImp copy() {
+        return new TeferisImp(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Mirage.java
+++ b/Mage.Sets/src/mage/sets/Mirage.java
@@ -309,6 +309,7 @@ public final class Mirage extends ExpansionSet {
         cards.add(new SetCardInfo("Teeka's Dragon", 320, Rarity.RARE, mage.cards.t.TeekasDragon.class));
         cards.add(new SetCardInfo("Teferi's Curse", 96, Rarity.COMMON, mage.cards.t.TeferisCurse.class));
         cards.add(new SetCardInfo("Teferi's Drake", 97, Rarity.COMMON, mage.cards.t.TeferisDrake.class));
+        cards.add(new SetCardInfo("Teferi's Imp", 98, Rarity.RARE, mage.cards.t.TeferisImp.class));
         cards.add(new SetCardInfo("Teferi's Isle", 330, Rarity.RARE, mage.cards.t.TeferisIsle.class));
         cards.add(new SetCardInfo("Telim'Tor", 197, Rarity.RARE, mage.cards.t.TelimTor.class));
         cards.add(new SetCardInfo("Telim'Tor's Darts", 321, Rarity.UNCOMMON, mage.cards.t.TelimTorsDarts.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mir/TeferisImpTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mir/TeferisImpTest.java
@@ -10,6 +10,16 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class TeferisImpTest extends CardTestPlayerBase {
 
+    /**
+     * {@link mage.cards.t.TeferisImp} <br>
+     * Teferi's Imp {2}{U} <br>
+     * Creature — Imp <br>
+     * Flying <br>
+     * Phasing <br>
+     * Whenever Teferi’s Imp phases out, discard a card. <br>
+     * Whenever Teferi’s Imp phases in, draw a card. <br>
+     * 1/1
+     */
     private static final String imp = "Teferi's Imp";
 
     @Test

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mir/TeferisImpTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mir/TeferisImpTest.java
@@ -1,0 +1,41 @@
+package org.mage.test.cards.single.mir;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class TeferisImpTest extends CardTestPlayerBase {
+
+    private static final String imp = "Teferi's Imp";
+
+    @Test
+    public void test_Phasing_triggers() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.HAND, playerA, imp);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+        addCard(Zone.HAND, playerA, "Grizzly Bears", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, imp);
+
+        checkHandCount("before discard", 2, PhaseStep.END_TURN, playerA, 2);
+        // Beginning of turn 3 -- imp phases out. trigger to discard.
+        setChoice(playerA, "Grizzly Bears"); // choose to discard one of the Bears
+        waitStackResolved(3, PhaseStep.UPKEEP);
+        checkHandCount("after discard", 3, PhaseStep.UPKEEP, playerA, 1);
+
+        checkHandCount("before draw", 4, PhaseStep.END_TURN, playerA, 2);
+        // Beginning of turn 5 -- imp phases in. trigger to draw.
+        waitStackResolved(5, PhaseStep.UPKEEP);
+        checkHandCount("after draw", 5, PhaseStep.UPKEEP, playerA, 3);
+
+        setStopAt(5, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, "Grizzly Bears", 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -420,6 +420,22 @@ public interface Ability extends Controllable, Serializable {
     void setWorksFaceDown(boolean worksFaceDown);
 
     /**
+     * Returns true if this ability has to work also with phased out object.
+     *
+     * @return
+     */
+    boolean getWorksPhasedOut();
+
+    /**
+     * Sets the value for the worksPhasedOut flag
+     * <p>
+     * true = the ability works also if the object is phased out
+     *
+     * @param worksPhasedOut
+     */
+    void setWorksPhasedOut(boolean worksPhasedOut);
+
+    /**
      * Returns true if this ability's rule is visible on the card tooltip
      *
      * @return

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -70,6 +70,7 @@ public abstract class AbilityImpl implements Ability {
     protected boolean ruleAdditionalCostsVisible = true;
     protected boolean activated = false;
     protected boolean worksFaceDown = false;
+    protected boolean worksPhasedOut = false;
     protected int sourceObjectZoneChangeCounter;
     protected List<Watcher> watchers = new ArrayList<>(); // access to it by GetWatchers only (it can be overridden by some abilities)
     protected List<Ability> subAbilities = null;
@@ -121,6 +122,7 @@ public abstract class AbilityImpl implements Ability {
         this.ruleVisible = ability.ruleVisible;
         this.ruleAdditionalCostsVisible = ability.ruleAdditionalCostsVisible;
         this.worksFaceDown = ability.worksFaceDown;
+        this.worksPhasedOut = ability.worksPhasedOut;
         this.abilityWord = ability.abilityWord;
         this.flavorWord = ability.flavorWord;
         this.sourceObjectZoneChangeCounter = ability.sourceObjectZoneChangeCounter;
@@ -1051,7 +1053,7 @@ public abstract class AbilityImpl implements Ability {
         if (object != null) {
             if (object instanceof Permanent) {
                 return object.hasAbility(this, game) && (
-                        ((Permanent) object).isPhasedIn() ^ this.getZone() == Zone.PHASED_OUT
+                        ((Permanent) object).isPhasedIn() || this.getWorksPhasedOut()
                 );
             } else {
                 // cards and other objects
@@ -1270,6 +1272,16 @@ public abstract class AbilityImpl implements Ability {
     @Override
     public void setWorksFaceDown(boolean worksFaceDown) {
         this.worksFaceDown = worksFaceDown;
+    }
+
+    @Override
+    public boolean getWorksPhasedOut() {
+        return worksPhasedOut;
+    }
+
+    @Override
+    public void setWorksPhasedOut(boolean worksPhasedOut) {
+        this.worksPhasedOut = worksPhasedOut;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -1050,7 +1050,9 @@ public abstract class AbilityImpl implements Ability {
         }
         if (object != null) {
             if (object instanceof Permanent) {
-                return object.hasAbility(this, game) && ((Permanent) object).isPhasedIn();
+                return object.hasAbility(this, game) && (
+                        ((Permanent) object).isPhasedIn() ^ this.getZone() == Zone.PHASED_OUT
+                );
             } else {
                 // cards and other objects
                 return object.hasAbility(this, game);
@@ -1481,7 +1483,7 @@ public abstract class AbilityImpl implements Ability {
             // to change the zone of any existing singleton abilities
             return this;
         }
-        AbilityImpl copy = ((AbilityImpl)this.copy());
+        AbilityImpl copy = ((AbilityImpl) this.copy());
         copy.zone = zone;
         copy.newId();
         return copy;

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -325,7 +325,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
                 break;
             case PHASED_OUT:
                 source = game.getPermanent(getSourceId());
-                if (source != null && this.zone == Zone.PHASED_OUT) {
+                if (source != null && (this.zone == Zone.ALL || game.getLastKnownInformation(getSourceId(), zone) != null)) {
                     return this.hasSourceObjectAbility(game, source, event);
                 }
                 break;

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -323,12 +323,6 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
                     return this.hasSourceObjectAbility(game, source, event);
                 }
                 break;
-            case PHASED_OUT:
-                source = game.getPermanent(getSourceId());
-                if (source != null && (this.zone == Zone.ALL || game.getLastKnownInformation(getSourceId(), zone) != null)) {
-                    return this.hasSourceObjectAbility(game, source, event);
-                }
-                break;
         }
         return super.isInUseableZone(game, source, event);
     }

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -315,12 +315,17 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
                     source = game.getLastKnownInformation(getSourceId(), Zone.BATTLEFIELD);
                 }
                 break;
-            case PHASED_OUT:
             case PHASED_IN:
                 if (isLeavesTheBattlefieldTrigger()) {
                     source = game.getLastKnownInformation(getSourceId(), event.getZone());
                 }
                 if (this.zone == Zone.ALL || game.getLastKnownInformation(getSourceId(), zone) != null) {
+                    return this.hasSourceObjectAbility(game, source, event);
+                }
+                break;
+            case PHASED_OUT:
+                source = game.getPermanent(getSourceId());
+                if (source != null && this.zone == Zone.PHASED_OUT) {
                     return this.hasSourceObjectAbility(game, source, event);
                 }
                 break;

--- a/Mage/src/main/java/mage/abilities/common/SourcePhaseOutTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SourcePhaseOutTriggeredAbility.java
@@ -1,0 +1,37 @@
+package mage.abilities.common;
+
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+
+/**
+ * @author Susucr
+ */
+public class SourcePhaseOutTriggeredAbility extends TriggeredAbilityImpl {
+
+    public SourcePhaseOutTriggeredAbility(Effect effect, boolean optional) {
+        super(Zone.PHASED_OUT, effect, optional);
+        setTriggerPhrase("Whenever {this} phases out, ");
+    }
+
+    protected SourcePhaseOutTriggeredAbility(final SourcePhaseOutTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public SourcePhaseOutTriggeredAbility copy() {
+        return new SourcePhaseOutTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.PHASED_OUT;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        return getSourceId().equals(event.getTargetId());
+    }
+}

--- a/Mage/src/main/java/mage/abilities/common/SourcePhaseOutTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SourcePhaseOutTriggeredAbility.java
@@ -12,8 +12,9 @@ import mage.game.events.GameEvent;
 public class SourcePhaseOutTriggeredAbility extends TriggeredAbilityImpl {
 
     public SourcePhaseOutTriggeredAbility(Effect effect, boolean optional) {
-        super(Zone.PHASED_OUT, effect, optional);
+        super(Zone.BATTLEFIELD, effect, optional);
         setTriggerPhrase("Whenever {this} phases out, ");
+        setWorksPhasedOut(true);
     }
 
     protected SourcePhaseOutTriggeredAbility(final SourcePhaseOutTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/constants/Zone.java
+++ b/Mage/src/main/java/mage/constants/Zone.java
@@ -10,7 +10,6 @@ public enum Zone {
     GRAVEYARD(true),
     LIBRARY(false),
     BATTLEFIELD(true),
-    PHASED_OUT(true), // This is a fake zone for the phased out triggers to work.
     STACK(true),
     EXILED(true),
     ALL(false),

--- a/Mage/src/main/java/mage/constants/Zone.java
+++ b/Mage/src/main/java/mage/constants/Zone.java
@@ -2,7 +2,6 @@
 package mage.constants;
 
 /**
- *
  * @author North
  */
 public enum Zone {
@@ -11,6 +10,7 @@ public enum Zone {
     GRAVEYARD(true),
     LIBRARY(false),
     BATTLEFIELD(true),
+    PHASED_OUT(true), // This is a fake zone for the phased out triggers to work.
     STACK(true),
     EXILED(true),
     ALL(false),

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -541,6 +541,16 @@ public class StackAbility extends StackObjectImpl implements Ability {
     }
 
     @Override
+    public boolean getWorksPhasedOut() {
+        return this.ability.getWorksPhasedOut();
+    }
+
+    @Override
+    public void setWorksPhasedOut(boolean worksPhasedOut) {
+        this.ability.setWorksPhasedOut(worksPhasedOut);
+    }
+
+    @Override
     public List<Watcher> getWatchers() {
         return this.ability.getWatchers();
     }


### PR DESCRIPTION
So the phases out trigger needed some work, as triggers on phased out permanents were never considered enabled (and that makes a lot of sense for all the Zone.ALL triggers)

Adding `Zone.PHASED_OUT` is not elegant, but the trigger needs to be active when the Imp is already phased out. I'm open for suggestion on another way to make that particular trigger work out.