### PR TITLE
Adds two tests on Transform+card changing effects

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DisturbTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DisturbTest.java
@@ -6,6 +6,7 @@ import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.stack.Spell;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -236,6 +237,27 @@ public class DisturbTest extends CardTestPlayerBase {
         execute();
         assertPermanentCount(playerA, "Sinner's Judgment", 1);
         assertTappedCount("Plains", true, 5);
+    }
+
+    //Currently failing: Transform SpellAbilityCastMode.getTypeModifiedCardObjectCopy destroys existing modifications
+    @Ignore
+    @Test
+    public void test_SpellAttributesIndirectCostModifications() {
+        // Disturb {1}{U}
+        // Hook-Haunt Drifter
+        addCard(Zone.GRAVEYARD, playerA, "Baithook Angler", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Maskwood Nexus", 1);
+        //Dragonlord's Servant : Dragon spells you cast cost {1} less to cast.
+        addCard(Zone.BATTLEFIELD, playerA, "Dragonlord's Servant", 1);
+        // Transform's copy effect must not override other spell modifications
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Hook-Haunt Drifter using Disturb");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertPermanentCount(playerA, "Hook-Haunt Drifter", 1);
+        assertTappedCount("Island", true, 1);
     }
 
     /**

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/TransformTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/TransformTest.java
@@ -494,4 +494,31 @@ public class TransformTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Delver of Secrets", 1);
         assertPermanentCount(playerA, "Insectile Aberration", 0);
     }
+
+    @Test
+    public void testMoonmistHuntmasterDressdown() {
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 6);
+        addCard(Zone.BATTLEFIELD, playerA, "Huntmaster of the Fells"); //Has on-transform triggers
+        addCard(Zone.BATTLEFIELD, playerA, "Maskwood Nexus"); //Make back side human
+
+
+        addCard(Zone.HAND, playerA, "Dress Down"); //Creatures lose all abilities
+        addCard(Zone.HAND, playerA, "Moonmist", 2);
+
+        castSpell(1, PhaseStep.UPKEEP, playerA, "Dress Down");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Moonmist");
+
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Moonmist");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertGraveyardCount(playerA, "Dress Down", 1);
+        assertPermanentCount(playerA, "Huntmaster of the Fells", 1);
+        assertPermanentCount(playerA, 6+1+1);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/TransformTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/TransformTest.java
@@ -508,7 +508,7 @@ public class TransformTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.UPKEEP, playerA, "Dress Down");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Moonmist");
-
+        checkPermanentCount("Huntmaster flipped", 1, PhaseStep.BEGIN_COMBAT, playerA, "Ravager of the Fells", 1);
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Moonmist");
 
         setStrictChooseMode(true);


### PR DESCRIPTION
Testing edge cases for #11302 led to it failing the TransformTest with no easy solution to the problem, so I will be closing that PR. Perhaps some sort of batching of transforms would be possible, but the approach there seems nonviable currently.

That edge case also led me to realize that my prior work with SpellAbilityCastMode.getTypeModifiedCardObjectCopy also fell victim to a similar issue. While those changes were improvements in more common situations, it was a regression in this exact situation.