### PR TITLE
add checkbox in tournament settings to host and not play

### DIFF
--- a/Mage.Client/src/main/java/mage/client/SessionHandler.java
+++ b/Mage.Client/src/main/java/mage/client/SessionHandler.java
@@ -25,9 +25,9 @@ import java.util.*;
 
 /**
  * Network: client side session
- *
+ * <p>
  * Only one session/server per GUI's client
- *
+ * <p>
  * Created by IGOUDT on 15-9-2016.
  */
 public final class SessionHandler {
@@ -38,7 +38,7 @@ public final class SessionHandler {
     private static Session session;
     private static String lastConnectError = "";
 
-    private SessionHandler(){
+    private SessionHandler() {
     }
 
     public static void startSession(MageFrame mageFrame) {
@@ -125,8 +125,16 @@ public final class SessionHandler {
         return session.getPlayerTypes();
     }
 
-    public static boolean joinTournamentTable(UUID roomId, UUID tableId, String text, PlayerType selectedItem, Integer integer, DeckCardLists deckCardLists, String s) {
-        return session.joinTournamentTable(roomId, tableId, text, selectedItem, integer, deckCardLists, s);
+    public static boolean hostTournamentTable(UUID roomId, UUID tableId, String hostName, boolean joinAsPlayer, PlayerType playerType,
+                                              Integer skill, DeckCardLists deckCardLists, String password
+    ) {
+        return session.hostTournamentTable(roomId, tableId, hostName, joinAsPlayer, playerType, skill, deckCardLists, password);
+    }
+
+    public static boolean joinTournamentTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType,
+                                              Integer skill, DeckCardLists deckCardLists, String password
+    ) {
+        return session.joinTournamentTable(roomId, tableId, playerName, playerType, skill, deckCardLists, password);
     }
 
     public static void sendPlayerInteger(UUID gameId, int data) {
@@ -240,7 +248,7 @@ public final class SessionHandler {
 
     private static void autoSaveLimitedDeck(DeckCardLists deckList) {
         String autoSave = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_LIMITED_DECK_AUTO_SAVE, "true");
-        if(autoSave.equals("true")){
+        if (autoSave.equals("true")) {
             // Log the submitted deck in the log folder.
             SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
             String logFilename = sdf.format(new Date()) + "_limited" + ".dck";
@@ -254,7 +262,7 @@ public final class SessionHandler {
 
     public static boolean submitDeck(DeckEditorMode mode, UUID tableId, DeckCardLists deckCardLists) {
         boolean success = session.submitDeck(tableId, deckCardLists);
-        if(DeckEditorMode.LIMITED_BUILDING.equals(mode)) {
+        if (DeckEditorMode.LIMITED_BUILDING.equals(mode)) {
             // AutoSaving is done after submitting, to not let the server wait.
             autoSaveLimitedDeck(deckCardLists);
         }

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
@@ -113,11 +113,14 @@
                               <Component id="spnNumSeats" min="-2" pref="46" max="-2" attributes="0"/>
                           </Group>
                           <Component id="lblPacks" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="lblPlayer1" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Component id="lblPlayer1" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                              <Component id="chkHostPlaying" min="-2" max="-2" attributes="0"/>
+                          </Group>
                       </Group>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" attributes="0">
-                              <EmptySpace min="-2" pref="28" max="-2" attributes="0"/>
                               <Component id="pnlDraftOptions" min="-2" max="-2" attributes="0"/>
                               <EmptySpace max="32767" attributes="0"/>
                               <Component id="lblNumRounds" min="-2" max="-2" attributes="0"/>
@@ -290,7 +293,7 @@
                   <Group type="102" attributes="0">
                       <Component id="pnlPacks" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="pnlRandomPacks" pref="9" max="32767" attributes="0"/>
+                      <Component id="pnlRandomPacks" pref="12" max="32767" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="1" max="-2" attributes="0">
                           <Group type="103" alignment="1" groupAlignment="3" attributes="0">
@@ -307,7 +310,10 @@
                           <Component id="spnNumSeats" alignment="1" max="32767" attributes="1"/>
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="lblPlayer1" min="-2" pref="25" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="lblPlayer1" alignment="3" min="-2" pref="25" max="-2" attributes="0"/>
+                          <Component id="chkHostPlaying" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
                   </Group>
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="spnConstructTime" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -618,7 +624,7 @@
         </DimensionLayout>
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
-              <Component id="pnlOtherPlayers" alignment="0" pref="8" max="32767" attributes="0"/>
+              <Component id="pnlOtherPlayers" alignment="0" pref="9" max="32767" attributes="0"/>
           </Group>
         </DimensionLayout>
       </Layout>
@@ -726,6 +732,16 @@
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnCustomOptionsActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="chkHostPlaying">
+      <Properties>
+        <Property name="selected" type="boolean" value="true"/>
+        <Property name="text" type="java.lang.String" value="Playing"/>
+        <Property name="toolTipText" type="java.lang.String" value="If checked, you are playing in the tournament"/>
+      </Properties>
+      <Events>
+        <EventHandler event="stateChanged" listener="javax.swing.event.ChangeListener" parameters="javax.swing.event.ChangeEvent" handler="chkHostPlayingStateChanged"/>
       </Events>
     </Component>
   </SubComponents>

--- a/Mage.Common/src/main/java/mage/interfaces/MageServer.java
+++ b/Mage.Common/src/main/java/mage/interfaces/MageServer.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public interface MageServer {
@@ -64,6 +63,8 @@ public interface MageServer {
     TableView createTournamentTable(String sessionId, UUID roomId, TournamentOptions tournamentOptions) throws MageException;
 
     boolean joinTable(String sessionId, UUID roomId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws MageException, GameException;
+
+    boolean hostTournamentTable(String sessionId, UUID roomId, UUID tableId, String name, boolean joinAsPlayer, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws MageException, GameException;
 
     boolean joinTournamentTable(String sessionId, UUID roomId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws MageException, GameException;
 
@@ -183,7 +184,7 @@ public interface MageServer {
     void lockUser(String sessionId, String userName, long durationMinutes) throws MageException;
 
     void setActivation(String sessionId, String userName, boolean active) throws MageException;
-    
+
     void toggleActivation(String sessionId, String userName) throws MageException;
 
     void removeTable(String sessionId, UUID tableId) throws MageException;

--- a/Mage.Common/src/main/java/mage/remote/SessionImpl.java
+++ b/Mage.Common/src/main/java/mage/remote/SessionImpl.java
@@ -764,7 +764,33 @@ public class SessionImpl implements Session {
     }
 
     @Override
-    public boolean joinTournamentTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType, int skill, DeckCardLists deckList, String password) {
+    public boolean hostTournamentTable(UUID roomId, UUID tableId, String playerName, boolean joinAsPlayer, PlayerType playerType,
+                                       int skill, DeckCardLists deckList, String password) {
+        try {
+            if (isConnected()) {
+                // Workaround to fix Can't join table problem
+                if (deckList != null) {
+                    deckList.setCardLayout(null);
+                    deckList.setSideboardLayout(null);
+                }
+                return server.hostTournamentTable(
+                        sessionId, roomId, tableId, playerName, joinAsPlayer,
+                        playerType, skill, deckList, password
+                );
+            }
+        } catch (GameException ex) {
+            handleGameException(ex);
+        } catch (MageException ex) {
+            handleMageException(ex);
+        } catch (Throwable t) {
+            handleThrowable(t);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean joinTournamentTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType,
+                                       int skill, DeckCardLists deckList, String password) {
         try {
             if (isConnected()) {
                 // Workaround to fix Can't join table problem
@@ -997,7 +1023,7 @@ public class SessionImpl implements Session {
         }
         return null;
     }
-    
+
     @Override
     public boolean setBoosterLoaded(UUID draftId) {
         try {

--- a/Mage.Common/src/main/java/mage/remote/interfaces/PlayerActions.java
+++ b/Mage.Common/src/main/java/mage/remote/interfaces/PlayerActions.java
@@ -39,13 +39,18 @@ public interface PlayerActions {
 
     // boolean startChallenge(UUID roomId, UUID tableId, UUID challengeId);
 
-    boolean joinTournamentTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType, int skill, DeckCardLists deckList, String password);
+    boolean hostTournamentTable(UUID roomId, UUID tableId, String hostName, boolean joinAsPlayer, PlayerType playerType,
+                                int skill, DeckCardLists deckList, String password);
+
+    boolean joinTournamentTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType,
+                                int skill, DeckCardLists deckList, String password);
 
     boolean watchTable(UUID roomId, UUID tableId);
 
     boolean watchTournamentTable(UUID tableId);
 
-    boolean joinTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType, int skill, DeckCardLists deckList, String password);
+    boolean joinTable(UUID roomId, UUID tableId, String playerName, PlayerType playerType,
+                      int skill, DeckCardLists deckList, String password);
 
     Optional<TableView> getTable(UUID roomId, UUID tableId);
 

--- a/Mage.Server/src/main/java/mage/server/MageServerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/MageServerImpl.java
@@ -310,6 +310,38 @@ public class MageServerImpl implements MageServer {
     }
 
     @Override
+    public boolean hostTournamentTable(
+            final String sessionId, final UUID roomId, final UUID tableId, final String name,
+            final boolean joinAsPlayer, final PlayerType playerType, final int skill,
+            final DeckCardLists deckList, final String password
+    ) throws MageException {
+        return executeWithResult("hostTournamentTable", sessionId, new ActionWithBooleanResult() {
+            @Override
+            public Boolean execute() throws MageException {
+                Optional<Session> session = managerFactory.sessionManager().getSession(sessionId);
+                if (!session.isPresent()) {
+                    return false;
+                }
+                UUID userId = session.get().getUserId();
+                if (logger.isTraceEnabled()) {
+                    Optional<User> user = managerFactory.userManager().getUser(userId);
+                    user.ifPresent(user1 -> logger.trace("join tourn. tableId: " + tableId + ' ' + name));
+                }
+                if (userId == null) {
+                    logger.fatal("Got no userId from sessionId" + sessionId + " tableId" + tableId);
+                    return false;
+                }
+                Optional<GamesRoom> room = managerFactory.gamesRoomManager().getRoom(roomId);
+                if (room.isPresent()) {
+                    return room.get().hostTournamentTable(userId, tableId, name, joinAsPlayer, playerType, skill, deckList, password);
+                }
+                return null;
+
+            }
+        });
+    }
+
+    @Override
     public boolean joinTournamentTable(final String sessionId, final UUID roomId, final UUID tableId, final String name, final PlayerType playerType, final int skill, final DeckCardLists deckList, final String password) throws MageException {
         return executeWithResult("joinTournamentTable", sessionId, new ActionWithBooleanResult() {
             @Override
@@ -737,7 +769,7 @@ public class MageServerImpl implements MageServer {
             });
         });
     }
-    
+
     @Override
     public void setBoosterLoaded(final UUID draftId, final String sessionId) throws MageException {
         execute("setBoosterLoaded", sessionId, () -> {

--- a/Mage.Server/src/main/java/mage/server/TableManagerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/TableManagerImpl.java
@@ -165,7 +165,21 @@ public class TableManagerImpl implements TableManager {
     }
 
     @Override
-    public boolean joinTournament(UUID userId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException {
+    public boolean hostTournament(
+            UUID userId, UUID tableId, String name, boolean joinAsPlayer, PlayerType playerType,
+            int skill, DeckCardLists deckList, String password
+    ) throws GameException {
+        if (controllers.containsKey(tableId)) {
+            return controllers.get(tableId).hostTournament(userId, name, joinAsPlayer, playerType, skill, deckList, password);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean joinTournament(
+            UUID userId, UUID tableId, String name, PlayerType playerType,
+            int skill, DeckCardLists deckList, String password
+    ) throws GameException {
         if (controllers.containsKey(tableId)) {
             return controllers.get(tableId).joinTournament(userId, name, playerType, skill, deckList, password);
         }

--- a/Mage.Server/src/main/java/mage/server/User.java
+++ b/Mage.Server/src/main/java/mage/server/User.java
@@ -22,6 +22,7 @@ import mage.server.util.ServerMessagesUtil;
 import mage.server.util.SystemUtil;
 import mage.view.TableClientMessage;
 import org.apache.log4j.Logger;
+import org.jboss.util.collection.ConcurrentSet;
 
 import java.util.*;
 import java.util.Map.Entry;
@@ -47,6 +48,7 @@ public class User {
     private final String userName;
     private final String host;
     private final Date connectionTime;
+    private final Set<Table> hostTables; // tables for which the user is the host.
     private final Map<UUID, Table> tables;
     private final List<UUID> tablesToDelete;
     private final Map<UUID, GameSessionPlayer> gameSessions;
@@ -89,6 +91,7 @@ public class User {
             this.authorizedUser = null;
         }
 
+        this.hostTables = new ConcurrentSet<>();
         this.tables = new ConcurrentHashMap<>();
         this.gameSessions = new ConcurrentHashMap<>();
         this.draftSessions = new ConcurrentHashMap<>();
@@ -398,6 +401,17 @@ public class User {
 
     public void removeTournament(UUID playerId) {
         userTournaments.remove(playerId);
+    }
+
+    public void addHostTable(Table table) {
+        hostTables.add(table);
+    }
+
+    public void removeHostTable(UUID tableId) {
+        Optional<Table> tableToRemove = hostTables.stream().filter(t -> t.getId().equals(tableId)).findFirst();
+        if (tableToRemove.isPresent()) {
+            hostTables.remove(tableToRemove.get());
+        }
     }
 
     public void addTable(UUID playerId, Table table) {

--- a/Mage.Server/src/main/java/mage/server/game/GamesRoom.java
+++ b/Mage.Server/src/main/java/mage/server/game/GamesRoom.java
@@ -18,22 +18,34 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public interface GamesRoom extends Room {
 
     List<TableView> getTables();
+
     List<MatchView> getFinished();
+
     List<RoomUsersView> getRoomUsersInfo();
+
     boolean joinTable(UUID userId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws MageException;
+
+    boolean hostTournamentTable(UUID userId, UUID tableId, String name, boolean joinAsPlayer, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException;
+
     boolean joinTournamentTable(UUID userId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException;
+
     TableView createTable(UUID userId, MatchOptions options);
+
     TableView createTournamentTable(UUID userId, TournamentOptions options);
+
     void removeTable(UUID userId, UUID tableId);
+
     void removeTable(UUID tableId);
+
     Optional<TableView> getTable(UUID tableId);
+
     void leaveTable(UUID userId, UUID tableId);
+
     boolean watchTable(UUID userId, UUID tableId) throws MageException;
 
 }

--- a/Mage.Server/src/main/java/mage/server/game/GamesRoomImpl.java
+++ b/Mage.Server/src/main/java/mage/server/game/GamesRoomImpl.java
@@ -136,6 +136,15 @@ public class GamesRoomImpl extends RoomImpl implements GamesRoom, Serializable {
     }
 
     @Override
+    public boolean hostTournamentTable(UUID userId, UUID tableId, String name, boolean joinAsPlayer, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException {
+        if (tables.containsKey(tableId)) {
+            return managerFactory.tableManager().hostTournament(userId, tableId, name, joinAsPlayer, playerType, skill, deckList, password);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
     public boolean joinTournamentTable(UUID userId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException {
         if (tables.containsKey(tableId)) {
             return managerFactory.tableManager().joinTournament(userId, tableId, name, playerType, skill, deckList, password);

--- a/Mage.Server/src/main/java/mage/server/managers/TableManager.java
+++ b/Mage.Server/src/main/java/mage/server/managers/TableManager.java
@@ -36,6 +36,8 @@ public interface TableManager {
 
     boolean joinTable(UUID userId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws MageException;
 
+    boolean hostTournament(UUID userId, UUID tableId, String name, boolean joinAsPlayer, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException;
+
     boolean joinTournament(UUID userId, UUID tableId, String name, PlayerType playerType, int skill, DeckCardLists deckList, String password) throws GameException;
 
     boolean submitDeck(UUID userId, UUID tableId, DeckCardLists deckList) throws MageException;

--- a/Mage.Tests/src/test/java/org/mage/test/stub/TournamentStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/TournamentStub.java
@@ -1,10 +1,6 @@
 
 package org.mage.test.stub;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 import mage.cards.ExpansionSet;
 import mage.cards.decks.Deck;
 import mage.game.draft.Draft;
@@ -16,8 +12,12 @@ import mage.game.tournament.*;
 import mage.players.Player;
 import mage.players.PlayerType;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
 /**
- *
  * @author Quercitron
  */
 public class TournamentStub implements Tournament {
@@ -27,6 +27,11 @@ public class TournamentStub implements Tournament {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public void addHost(UUID hostId) {
+
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/tournament/Tournament.java
+++ b/Mage/src/main/java/mage/game/tournament/Tournament.java
@@ -1,12 +1,9 @@
 
 package mage.game.tournament;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 import mage.cards.ExpansionSet;
 import mage.cards.decks.Deck;
+import mage.game.GameException;
 import mage.game.draft.Draft;
 import mage.game.events.Listener;
 import mage.game.events.PlayerQueryEvent;
@@ -15,13 +12,19 @@ import mage.game.result.ResultProtos.TourneyProto;
 import mage.players.Player;
 import mage.players.PlayerType;
 
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public interface Tournament {
 
     UUID getId();
+
+    void addHost(UUID hostId) throws GameException;
 
     void addPlayer(Player player, PlayerType playerType);
 

--- a/Mage/src/main/java/mage/game/tournament/TournamentImpl.java
+++ b/Mage/src/main/java/mage/game/tournament/TournamentImpl.java
@@ -1,48 +1,33 @@
 package mage.game.tournament;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import mage.cards.ExpansionSet;
 import mage.cards.decks.Deck;
 import mage.constants.TournamentPlayerState;
+import mage.game.GameException;
 import mage.game.draft.Draft;
 import mage.game.draft.DraftCube;
-import mage.game.events.Listener;
-import mage.game.events.PlayerQueryEvent;
-import mage.game.events.PlayerQueryEventSource;
-import mage.game.events.TableEvent;
+import mage.game.events.*;
 import mage.game.events.TableEvent.EventType;
-import mage.game.events.TableEventSource;
 import mage.game.jumpstart.JumpstartPoolGenerator;
 import mage.game.match.Match;
 import mage.game.match.MatchPlayer;
-import mage.game.result.ResultProtos.MatchPlayerProto;
-import mage.game.result.ResultProtos.MatchProto;
-import mage.game.result.ResultProtos.MatchQuitStatus;
-import mage.game.result.ResultProtos.TourneyProto;
-import mage.game.result.ResultProtos.TourneyRoundProto;
+import mage.game.result.ResultProtos.*;
 import mage.players.Player;
 import mage.players.PlayerType;
 import mage.util.RandomUtil;
 import org.apache.log4j.Logger;
 
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public abstract class TournamentImpl implements Tournament {
 
     protected UUID id = UUID.randomUUID();
     protected List<Round> rounds = new CopyOnWriteArrayList<>();
+    protected UUID hostId;
     protected Map<UUID, TournamentPlayer> players = new HashMap<>();
     protected String matchName;
     protected TournamentOptions options;
@@ -70,6 +55,14 @@ public abstract class TournamentImpl implements Tournament {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public void addHost(UUID hostId) throws GameException {
+        if (this.hostId != null) {
+            throw new GameException("Tournament can only add host once. new one:" + hostId + ", while already set to:" + this.hostId);
+        }
+        this.hostId = hostId;
     }
 
     @Override


### PR DESCRIPTION
The point of this PR is to allow hosting tournaments, but not play in them.

Still a draft, I need to investigate more on if some of the addition is actually relevant. There was the notion of table 'owner', which may be duplicated by the extra host info added there.

Should probably ensure that at least one human player is there for the tournament settings to be valid. I don't think all computer is working correctly at the moment, but not sure we want to support that anyway.