### PR TITLE
Update MariTheKillingQuill.java

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MariTheKillingQuill.java
+++ b/Mage.Sets/src/mage/cards/m/MariTheKillingQuill.java
@@ -66,14 +66,12 @@ public class MariTheKillingQuill extends CardImpl {
         GainAbilityControlledEffect gainDeathTouchEffect = new GainAbilityControlledEffect(DeathtouchAbility.getInstance(), Duration.WhileOnBattlefield, filter);
         Ability mainAbility = new SimpleStaticAbility(Zone.BATTLEFIELD, gainDeathTouchEffect);
 
-        String abilityText = "Whenever this creature deals combat damage to a player, " +
-                "you may remove a hit counter from a card that player owns in exile. " +
-                "If you do, draw a card and create two Treasure tokens.";
-
         // NOTE: Optional part is handled inside the effect
-        Ability dealsDamageAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new MariTheKillingQuillDealsDamageEffect(), false, true).setTriggerPhrase(abilityText);
+        Ability dealsDamageAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new MariTheKillingQuillDealsDamageEffect(), false, true);
         Effect drawAndTreasureEffect = new GainAbilityControlledEffect(dealsDamageAbility, Duration.WhileOnBattlefield, filter);
-        drawAndTreasureEffect.setText("\"" + abilityText + "\"");
+        drawAndTreasureEffect.setText("\"Whenever this creature deals combat damage to a player, " +
+                "you may remove a hit counter from a card that player owns in exile. " +
+                "If you do, draw a card and create two Treasure tokens.\"");
         drawAndTreasureEffect.concatBy("and");
 
         mainAbility.addEffect(drawAndTreasureEffect);
@@ -95,6 +93,8 @@ class MariTheKillingQuillDealsDamageEffect extends OneShotEffect {
 
     MariTheKillingQuillDealsDamageEffect() {
         super(Outcome.Benefit);
+        staticText =  "you may remove a hit counter from a card that player owns in exile. " +
+                "If you do, draw a card and create two Treasure tokens.";
     }
 
     private MariTheKillingQuillDealsDamageEffect(final MariTheKillingQuillDealsDamageEffect effect) {

--- a/Mage.Sets/src/mage/cards/m/MariTheKillingQuill.java
+++ b/Mage.Sets/src/mage/cards/m/MariTheKillingQuill.java
@@ -66,12 +66,14 @@ public class MariTheKillingQuill extends CardImpl {
         GainAbilityControlledEffect gainDeathTouchEffect = new GainAbilityControlledEffect(DeathtouchAbility.getInstance(), Duration.WhileOnBattlefield, filter);
         Ability mainAbility = new SimpleStaticAbility(Zone.BATTLEFIELD, gainDeathTouchEffect);
 
+        String abilityText = "Whenever this creature deals combat damage to a player, " +
+                "you may remove a hit counter from a card that player owns in exile. " +
+                "If you do, draw a card and create two Treasure tokens.";
+
         // NOTE: Optional part is handled inside the effect
-        Ability dealsDamageAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new MariTheKillingQuillDealsDamageEffect(), false, true);
+        Ability dealsDamageAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new MariTheKillingQuillDealsDamageEffect(), false, true).setTriggerPhrase(abilityText);
         Effect drawAndTreasureEffect = new GainAbilityControlledEffect(dealsDamageAbility, Duration.WhileOnBattlefield, filter);
-        drawAndTreasureEffect.setText(
-                "\"Whenever this creature deals combat damage to a player, you may remove a hit counter from a card that player owns in exile. " +
-                "If you do, draw a card and create two Treasure tokens.\"");
+        drawAndTreasureEffect.setText("\"" + abilityText + "\"");
         drawAndTreasureEffect.concatBy("and");
 
         mainAbility.addEffect(drawAndTreasureEffect);


### PR DESCRIPTION
Updated the combat damage trigger text so it shows correctly on Mari as well as any other creatures that have the effect.

**Before:**
"Whenever this creature deals combat damage to a player, "
![Before_Mari](https://github.com/magefree/mage/assets/26773658/cb7b575f-10e1-4880-a056-2dfd38d91583)

**After:**
"Whenever this creature deals combat damage to a player, you may remove a hit counter from a card that player owns in exile. If you do, draw a card and create two Treasure tokens."
![After_Mari](https://github.com/magefree/mage/assets/26773658/20631c13-d297-4474-b222-4674f1bcdd2a)