### PR TITLE
Refactor SVG css file URIs to comply with library change

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/SvgUtils.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/SvgUtils.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Base64;
 
 import static org.mage.plugins.card.utils.CardImageUtils.getImagesDir;
 
@@ -111,7 +113,8 @@ public class SvgUtils {
         // css settings for svg
         SvgUtils.prepareCss(cssFileName, cssAdditionalSettings, false);
         File cssFile = new File(SvgUtils.getSvgTempFile(cssFileName));
-
+        byte[] cssFileContent = Files.readAllBytes(cssFile.toPath());
+        String cssDataURI = "data:text/css;base64," + Base64.getEncoder().encodeToString(cssFileContent);
         TranscodingHints transcoderHints = new TranscodingHints();
 
         // resize
@@ -138,7 +141,7 @@ public class SvgUtils {
         transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT_NAMESPACE_URI,
                 SVGConstants.SVG_NAMESPACE_URI);
         transcoderHints.put(ImageTranscoder.KEY_DOCUMENT_ELEMENT, "svg");
-        transcoderHints.put(ImageTranscoder.KEY_USER_STYLESHEET_URI, cssFile.toURI().toString());
+        transcoderHints.put(ImageTranscoder.KEY_USER_STYLESHEET_URI, cssDataURI);
 
         try {
             TranscoderInput input = new TranscoderInput(svgFile);


### PR DESCRIPTION
As per #11241, our SVGs are currently loading CSS styles via a file URI pointing to a folder with temp files. Recent Batik transcoder changes have made that method start to fail, as it wants file URIs to originate from the same path. Since the use of temp files makes sense here, as CSS theme changes can happen asynchonously, I've modified the CSS loading code to load from a data URI and the raw bytes of the CSS file, rather than attempting to load it via Batik. This has been tested locally, and has also been tested with #10968 and should unblock that dependency upgrade from being merged.