### PR TITLE
cleanup EntersBattlefieldAllTriggeredAbility and subclasses

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AetherFlash.java
+++ b/Mage.Sets/src/mage/cards/a/AetherFlash.java
@@ -25,7 +25,7 @@ public final class AetherFlash extends CardImpl {
                 Zone.BATTLEFIELD,
                 new DamageTargetEffect(2).setText("{this} deals 2 damage to it"),
                 StaticFilters.FILTER_PERMANENT_A_CREATURE,
-                false, SetTargetPointer.PERMANENT, null));
+                false, SetTargetPointer.PERMANENT));
     }
 
     private AetherFlash(final AetherFlash card) {

--- a/Mage.Sets/src/mage/cards/a/AjanisChosen.java
+++ b/Mage.Sets/src/mage/cards/a/AjanisChosen.java
@@ -34,7 +34,7 @@ public final class AjanisChosen extends CardImpl {
         // Whenever an enchantment enters the battlefield under your control, create a 2/2 white Cat creature token. If that enchantment is an Aura, you may attach it to the token.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AjanisChosenEffect(), filter,
-                false, SetTargetPointer.PERMANENT, null));
+                false, SetTargetPointer.PERMANENT));
     }
 
     private AjanisChosen(final AjanisChosen card) {

--- a/Mage.Sets/src/mage/cards/a/AltarOfTheBrood.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfTheBrood.java
@@ -1,7 +1,7 @@
 package mage.cards.a;
 
 import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.MillCardsEachPlayerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -27,8 +27,8 @@ public final class AltarOfTheBrood extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}");
 
         // Whenever another permanent enters the battlefield under your control, each opponent mills a card.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new MillCardsEachPlayerEffect(1, TargetController.OPPONENT), filter, false, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new MillCardsEachPlayerEffect(1, TargetController.OPPONENT), filter, false));
     }
 
     private AltarOfTheBrood(final AltarOfTheBrood card) {

--- a/Mage.Sets/src/mage/cards/a/AltarOfTheBrood.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfTheBrood.java
@@ -28,7 +28,7 @@ public final class AltarOfTheBrood extends CardImpl {
 
         // Whenever another permanent enters the battlefield under your control, each opponent mills a card.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new MillCardsEachPlayerEffect(1, TargetController.OPPONENT), filter, false, null, true));
+                new MillCardsEachPlayerEffect(1, TargetController.OPPONENT), filter, false, null));
     }
 
     private AltarOfTheBrood(final AltarOfTheBrood card) {

--- a/Mage.Sets/src/mage/cards/a/AuraShards.java
+++ b/Mage.Sets/src/mage/cards/a/AuraShards.java
@@ -24,9 +24,8 @@ public final class AuraShards extends CardImpl {
         // Whenever a creature enters the battlefield under your control, 
         // you may destroy target artifact or enchantment.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                new DestroyTargetEffect(), StaticFilters.FILTER_PERMANENT_CREATURE, true,
-                "Whenever a creature enters the battlefield under your control, "
-                + "you may destroy target artifact or enchantment");
+                new DestroyTargetEffect(), StaticFilters.FILTER_PERMANENT_CREATURE, true
+        );
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/AuthorityOfTheConsuls.java
+++ b/Mage.Sets/src/mage/cards/a/AuthorityOfTheConsuls.java
@@ -1,6 +1,6 @@
 package mage.cards.a;
 
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.effects.common.PermanentsEnterBattlefieldTappedEffect;
@@ -23,9 +23,8 @@ public final class AuthorityOfTheConsuls extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new PermanentsEnterBattlefieldTappedEffect(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURES)));
 
         // Whenever a creature enters the battlefield under an opponent's control, you gain 1 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                new GainLifeEffect(1), StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURES,
-                "Whenever a creature enters the battlefield under an opponent's control, you gain 1 life."
+        this.addAbility(new EntersBattlefieldOpponentTriggeredAbility(
+                new GainLifeEffect(1), StaticFilters.FILTER_PERMANENT_A_CREATURE, false
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BaruFistOfKrosa.java
+++ b/Mage.Sets/src/mage/cards/b/BaruFistOfKrosa.java
@@ -1,4 +1,3 @@
-
 package mage.cards.b;
 
 import java.util.UUID;
@@ -29,12 +28,10 @@ import mage.game.permanent.token.Token;
  */
 public final class BaruFistOfKrosa extends CardImpl {
 
-    private static final FilterLandPermanent forestFilter = new FilterLandPermanent("Forest");
-    private static final FilterCreaturePermanent greenCreatureFilter = new FilterCreaturePermanent("green creatures you control");
+    private static final FilterLandPermanent forestFilter = new FilterLandPermanent(SubType.FOREST, "a Forest");
+    private static final FilterCreaturePermanent greenCreatureFilter = new FilterCreaturePermanent("green creatures");
 
     static {
-        forestFilter.add(SubType.FOREST.getPredicate());
-        greenCreatureFilter.add(TargetController.YOU.getControllerPredicate());
         greenCreatureFilter.add(new ColorPredicate(ObjectColor.GREEN));
     }
 
@@ -47,8 +44,10 @@ public final class BaruFistOfKrosa extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever a Forest enters the battlefield, green creatures you control get +1/+1 and gain trample until end of turn.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(new BoostControlledEffect(1, 1, Duration.EndOfTurn, greenCreatureFilter), forestFilter, "Whenever a Forest enters the battlefield, green creatures you control get +1/+1 and gain trample until end of turn.");
-        ability.addEffect(new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.EndOfTurn, greenCreatureFilter));
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(new BoostControlledEffect(1, 1, Duration.EndOfTurn, greenCreatureFilter)
+                .setText("green creatures you control get +1/+1"), forestFilter);
+        ability.addEffect(new GainAbilityControlledEffect(TrampleAbility.getInstance(), Duration.EndOfTurn, greenCreatureFilter)
+                .setText("and gain trample until end of turn"));
         this.addAbility(ability);
 
         // Grandeur - Discard another card named Baru, Fist of Krosa: Create an X/X green Wurm creature token, where X is the number of lands you control.

--- a/Mage.Sets/src/mage/cards/b/BindingMummy.java
+++ b/Mage.Sets/src/mage/cards/b/BindingMummy.java
@@ -36,7 +36,7 @@ public final class BindingMummy extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another Zombie enters the battlefield under your control, you may tap target artifact or creature.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, true, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, true);
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BindingMummy.java
+++ b/Mage.Sets/src/mage/cards/b/BindingMummy.java
@@ -37,7 +37,7 @@ public final class BindingMummy extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another Zombie enters the battlefield under your control, you may tap target artifact or creature.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, true, null, true);
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, true, null);
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BindingMummy.java
+++ b/Mage.Sets/src/mage/cards/b/BindingMummy.java
@@ -1,10 +1,9 @@
-
 package mage.cards.b;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -37,7 +36,7 @@ public final class BindingMummy extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another Zombie enters the battlefield under your control, you may tap target artifact or creature.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, true, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, true, null);
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BrainstealerDragon.java
+++ b/Mage.Sets/src/mage/cards/b/BrainstealerDragon.java
@@ -49,7 +49,7 @@ public final class BrainstealerDragon extends CardImpl {
         // Whenever a nonland permanent an opponent owns enters the battlefield under your control, they lose life equal to its mana value.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new BrainstealerDragonLifeEffect(), filter,
-                false, SetTargetPointer.PERMANENT, null
+                false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
+++ b/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
@@ -27,7 +27,7 @@ import mage.game.permanent.Permanent;
  */
 public final class BrambleSovereign extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("nontoken creature");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another nontoken creature");
 
     static {
         filter.add(TokenPredicate.FALSE);
@@ -45,9 +45,7 @@ public final class BrambleSovereign extends CardImpl {
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new DoIfCostPaid(new BrambleSovereignEffect(), new ManaCostsImpl<>("{1}{G}")),
-                filter, false, SetTargetPointer.PERMANENT,
-                "Whenever another nontoken creature enters the battlefield, you may pay {1}{G}. "
-                + "If you do, that creature's controller creates a token that's a copy of that creature."
+                filter, false, SetTargetPointer.PERMANENT, null
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
+++ b/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
@@ -45,7 +45,7 @@ public final class BrambleSovereign extends CardImpl {
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new DoIfCostPaid(new BrambleSovereignEffect(), new ManaCostsImpl<>("{1}{G}")),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
+++ b/Mage.Sets/src/mage/cards/b/BrambleSovereign.java
@@ -63,7 +63,7 @@ class BrambleSovereignEffect extends OneShotEffect {
 
     BrambleSovereignEffect() {
         super(Outcome.PutCardInPlay);
-        this.staticText = "its controller creates a token that's a copy of that creature";
+        this.staticText = "that creature's controller creates a token that's a copy of that creature";
     }
 
     private BrambleSovereignEffect(final BrambleSovereignEffect effect) {

--- a/Mage.Sets/src/mage/cards/c/CarnivalOfSouls.java
+++ b/Mage.Sets/src/mage/cards/c/CarnivalOfSouls.java
@@ -26,7 +26,7 @@ public final class CarnivalOfSouls extends CardImpl {
 
         // Whenever a creature enters the battlefield, you lose 1 life and add {B}.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeSourceControllerEffect(1),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null);
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT);
         Effect effect = new AddManaToManaPoolSourceControllerEffect(Mana.BlackMana(1));
         effect.setText("and add {B}.");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/c/CarnivalOfSouls.java
+++ b/Mage.Sets/src/mage/cards/c/CarnivalOfSouls.java
@@ -26,7 +26,7 @@ public final class CarnivalOfSouls extends CardImpl {
 
         // Whenever a creature enters the battlefield, you lose 1 life and add {B}.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeSourceControllerEffect(1),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null, false);
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null);
         Effect effect = new AddManaToManaPoolSourceControllerEffect(Mana.BlackMana(1));
         effect.setText("and add {B}.");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
+++ b/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
@@ -4,7 +4,7 @@ import mage.MageInt;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.LimitedTimesPerTurnActivatedAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.effects.AsThoughEffectImpl;
@@ -15,8 +15,7 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.util.CardUtil;
@@ -127,7 +126,6 @@ class ChainerNightmareAdeptWatcher extends Watcher {
             }
             morMap.computeIfAbsent(event.getAdditionalReference().getApprovingMageObjectReference(), m -> new HashMap<>())
                     .compute(event.getPlayerId(), (u, i) -> i == null ? 0 : Integer.sum(i, -1));
-            return;
         }
     }
 
@@ -156,25 +154,17 @@ class ChainerNightmareAdeptWatcher extends Watcher {
     }
 }
 
-class ChainerNightmareAdeptTriggeredAbility extends EntersBattlefieldAllTriggeredAbility {
+class ChainerNightmareAdeptTriggeredAbility extends EntersBattlefieldControlledTriggeredAbility {
 
-    private static final String abilityText = "Whenever a nontoken creature "
-            + "enters the battlefield under your control, "
-            + "if you didn't cast it from your hand, it gains haste until your next turn.";
     private static final ContinuousEffect gainHasteUntilNextTurnEffect
             = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.UntilYourNextTurn);
-    private static final FilterControlledCreaturePermanent filter
-            = new FilterControlledCreaturePermanent("nontoken creature");
-
-    static {
-        filter.add(TokenPredicate.FALSE);
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
 
     ChainerNightmareAdeptTriggeredAbility() {
-        super(Zone.BATTLEFIELD, gainHasteUntilNextTurnEffect, filter, false,
-                SetTargetPointer.PERMANENT, abilityText);
+        super(Zone.BATTLEFIELD, gainHasteUntilNextTurnEffect, StaticFilters.FILTER_CREATURE_NON_TOKEN, false,
+                SetTargetPointer.PERMANENT, null);
         this.addWatcher(new CastFromHandWatcher());
+        setTriggerPhrase("Whenever a nontoken creature enters the battlefield under your control, "
+                + "if you didn't cast it from your hand, ");
     }
 
     private ChainerNightmareAdeptTriggeredAbility(final ChainerNightmareAdeptTriggeredAbility effect) {
@@ -188,11 +178,9 @@ class ChainerNightmareAdeptTriggeredAbility extends EntersBattlefieldAllTriggere
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (!super.checkTrigger(event, game)) {
-            return false;
-        }
-
         CastFromHandWatcher watcher = game.getState().getWatcher(CastFromHandWatcher.class);
-        return watcher != null && !watcher.spellWasCastFromHand(event.getTargetId());
+        return watcher != null && !watcher.spellWasCastFromHand(event.getTargetId())
+                && super.checkTrigger(event, game);
     }
+
 }

--- a/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
+++ b/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
@@ -161,7 +161,7 @@ class ChainerNightmareAdeptTriggeredAbility extends EntersBattlefieldControlledT
 
     ChainerNightmareAdeptTriggeredAbility() {
         super(Zone.BATTLEFIELD, gainHasteUntilNextTurnEffect, StaticFilters.FILTER_CREATURE_NON_TOKEN, false,
-                SetTargetPointer.PERMANENT, null);
+                SetTargetPointer.PERMANENT);
         this.addWatcher(new CastFromHandWatcher());
         setTriggerPhrase("Whenever a nontoken creature enters the battlefield under your control, "
                 + "if you didn't cast it from your hand, ");

--- a/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
+++ b/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
@@ -35,7 +35,7 @@ public final class ChampionOfLambholt extends CardImpl {
         // Whenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, null));
+                StaticFilters.FILTER_ANOTHER_CREATURE, false));
     }
 
     private ChampionOfLambholt(final ChampionOfLambholt card) {

--- a/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
+++ b/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
@@ -41,7 +41,7 @@ public final class ChampionOfLambholt extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ChampionOfLambholtEffect()));
 
         // Whenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, false, null, true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, false, null));
 
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
+++ b/Mage.Sets/src/mage/cards/c/ChampionOfLambholt.java
@@ -2,7 +2,7 @@ package mage.cards.c;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.RestrictionEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
@@ -10,8 +10,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -21,13 +20,6 @@ import java.util.UUID;
  * @author noxx
  */
 public final class ChampionOfLambholt extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
 
     public ChampionOfLambholt(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}{G}");
@@ -41,8 +33,9 @@ public final class ChampionOfLambholt extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ChampionOfLambholtEffect()));
 
         // Whenever another creature enters the battlefield under your control, put a +1/+1 counter on Champion of Lambholt.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, false, null));
-
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, null));
     }
 
     private ChampionOfLambholt(final ChampionOfLambholt card) {

--- a/Mage.Sets/src/mage/cards/c/CloakAndDagger.java
+++ b/Mage.Sets/src/mage/cards/c/CloakAndDagger.java
@@ -37,7 +37,7 @@ public final class CloakAndDagger extends CardImpl {
         // Whenever a Rogue creature enters the battlefield, you may attach Cloak and Dagger to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                filter, true, SetTargetPointer.PERMANENT));
         // Equip {3}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(3), new TargetControlledCreaturePermanent(), false));
     }

--- a/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
+++ b/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
@@ -32,7 +32,7 @@ public final class CloudstoneCurio extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // Whenever a nonartifact permanent enters the battlefield under your control, you may return another permanent you control that shares a card type with it to its owner's hand.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new CloudstoneCurioEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new CloudstoneCurioEffect(), filter, true, SetTargetPointer.PERMANENT));
 
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
+++ b/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
@@ -33,7 +33,7 @@ public final class CloudstoneCurio extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // Whenever a nonartifact permanent enters the battlefield under your control, you may return another permanent you control that shares a card type with it to its owner's hand.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new CloudstoneCurioEffect(), filter, true, SetTargetPointer.PERMANENT, "", true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new CloudstoneCurioEffect(), filter, true, SetTargetPointer.PERMANENT, ""));
 
     }
 

--- a/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
+++ b/Mage.Sets/src/mage/cards/c/CloudstoneCurio.java
@@ -1,7 +1,7 @@
 package mage.cards.c;
 
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -26,14 +26,13 @@ public final class CloudstoneCurio extends CardImpl {
 
     static {
         filter.add(Predicates.not(CardType.ARTIFACT.getPredicate()));
-        filter.add(TargetController.YOU.getControllerPredicate());
     }
 
     public CloudstoneCurio(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // Whenever a nonartifact permanent enters the battlefield under your control, you may return another permanent you control that shares a card type with it to its owner's hand.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new CloudstoneCurioEffect(), filter, true, SetTargetPointer.PERMANENT, ""));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new CloudstoneCurioEffect(), filter, true, SetTargetPointer.PERMANENT, null));
 
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConfoundingConundrum.java
+++ b/Mage.Sets/src/mage/cards/c/ConfoundingConundrum.java
@@ -46,7 +46,7 @@ public final class ConfoundingConundrum extends CardImpl {
         // Whenever a land enters the battlefield under an opponent's control, if that player had another land enter the battlefield under their control this turn, they return a land they control to its owner's hand.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new ConfoundingConundrumEffect(), filter,
-                false, SetTargetPointer.PLAYER, ""
+                false, SetTargetPointer.PLAYER
         ), ConfoundingConundrumCondition.instance, "Whenever a land enters the battlefield under " +
                 "an opponent's control, if that player had another land enter the battlefield " +
                 "under their control this turn, they return a land they control to its owner's hand."

--- a/Mage.Sets/src/mage/cards/c/ConfusionInTheRanks.java
+++ b/Mage.Sets/src/mage/cards/c/ConfusionInTheRanks.java
@@ -49,7 +49,7 @@ public final class ConfusionInTheRanks extends CardImpl {
                                 + "another player controls that shares a card type with it. "
                                 + "Exchange control of those permanents"
                 ),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         );
         ability.addTarget(new TargetPermanent());
         ability.setTargetAdjuster(ConfusionInTheRanksAdjuster.instance);

--- a/Mage.Sets/src/mage/cards/c/CourtStreetDenizen.java
+++ b/Mage.Sets/src/mage/cards/c/CourtStreetDenizen.java
@@ -37,7 +37,7 @@ public final class CourtStreetDenizen extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, false, null, true);
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, false, null);
         ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CourtStreetDenizen.java
+++ b/Mage.Sets/src/mage/cards/c/CourtStreetDenizen.java
@@ -37,7 +37,7 @@ public final class CourtStreetDenizen extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, false);
         ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CourtStreetDenizen.java
+++ b/Mage.Sets/src/mage/cards/c/CourtStreetDenizen.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -37,7 +37,7 @@ public final class CourtStreetDenizen extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another white creature enters the battlefield under your control, tap target creature an opponent controls.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(), filter, false, null);
         ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CreamOfTheCrop.java
+++ b/Mage.Sets/src/mage/cards/c/CreamOfTheCrop.java
@@ -31,12 +31,8 @@ public final class CreamOfTheCrop extends CardImpl {
         // library and the rest on the bottom of your library in any order.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new CreamOfTheCropEffect(),
-                StaticFilters.FILTER_PERMANENT_CREATURE, true, SetTargetPointer.PERMANENT,
-                "Whenever a creature enters the battlefield under your control, "
-                + "you may look at the top X cards of your library, where X "
-                + "is that creature's power. If you do, put one of those cards "
-                + "on top of your library and the rest on the bottom of "
-                + "your library in any order."));
+                StaticFilters.FILTER_PERMANENT_CREATURE, true, SetTargetPointer.PERMANENT
+        ));
     }
 
     private CreamOfTheCrop(final CreamOfTheCrop card) {

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheRestlessDead.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheRestlessDead.java
@@ -44,10 +44,9 @@ public final class CurseOfTheRestlessDead extends CardImpl {
 
         // Whenever a land enters the battlefield under enchanted player's control, you create a 2/2 black Zombie creature token with decayed.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                new CreateTokenEffect(new ZombieDecayedToken()),
-                filter, "Whenever a land enters the battlefield under enchanted player's control, " +
-                "you create a 2/2 black Zombie creature token with decayed."
-        ));
+                new CreateTokenEffect(new ZombieDecayedToken()).setText("you create a 2/2 black Zombie creature token with decayed."),
+                filter
+        ).setTriggerPhrase("Whenever a land enters the battlefield under enchanted player's control, "));
     }
 
     private CurseOfTheRestlessDead(final CurseOfTheRestlessDead card) {

--- a/Mage.Sets/src/mage/cards/d/DeathMatch.java
+++ b/Mage.Sets/src/mage/cards/d/DeathMatch.java
@@ -27,7 +27,7 @@ public final class DeathMatch extends CardImpl {
         // Whenever a creature enters the battlefield, that creature's controller may have target creature of their choice get -3/-3 until end of turn.
         // NOTE: The ability being optional is implemented in the subclass to give the choice to correct player.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new DeathMatchEffect(),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PLAYER, "");
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PLAYER);
         ability.addTarget(new TargetCreaturePermanent());
         ability.setTargetAdjuster(DeathMatchAdjuster.instance);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DecoratedChampion.java
+++ b/Mage.Sets/src/mage/cards/d/DecoratedChampion.java
@@ -35,9 +35,7 @@ public final class DecoratedChampion extends CardImpl {
 
         // Whenever another Warrior enters the battlefield under your team's control, put a +1/+1 counter on Decorated Champion.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter,
-                "Whenever another Warrior enters the battlefield under your team's control,"
-                + " put a +1/+1 counter on {this}"
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DecoratedChampion.java
+++ b/Mage.Sets/src/mage/cards/d/DecoratedChampion.java
@@ -1,4 +1,3 @@
-
 package mage.cards.d;
 
 import java.util.UUID;
@@ -36,7 +35,7 @@ public final class DecoratedChampion extends CardImpl {
         // Whenever another Warrior enters the battlefield under your team's control, put a +1/+1 counter on Decorated Champion.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter
-        ));
+        ).setTriggerPhrase("Whenever another Warrior enters the battlefield under your team's control, "));
     }
 
     private DecoratedChampion(final DecoratedChampion card) {

--- a/Mage.Sets/src/mage/cards/d/DireUndercurrents.java
+++ b/Mage.Sets/src/mage/cards/d/DireUndercurrents.java
@@ -1,20 +1,19 @@
-
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.DrawCardTargetEffect;
 import mage.abilities.effects.common.discard.DiscardTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterControlledPermanent;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.target.TargetPlayer;
+
+import java.util.UUID;
 
 /**
  *
@@ -22,11 +21,8 @@ import mage.target.TargetPlayer;
  */
 public final class DireUndercurrents extends CardImpl {
 
-    private static final String rule1 = "Whenever a blue creature enters the battlefield under your control, you may have target player draw a card.";
-    private static final String rule2 = "Whenever a black creature enters the battlefield under your control, you may have target player discard a card.";
-
-    private static final FilterControlledPermanent filterBlue = new FilterControlledCreaturePermanent();
-    private static final FilterControlledPermanent filterBlack = new FilterControlledCreaturePermanent();
+    private static final FilterCreaturePermanent filterBlue = new FilterCreaturePermanent("a blue creature");
+    private static final FilterCreaturePermanent filterBlack = new FilterCreaturePermanent("a black creature");
 
     static {
         filterBlue.add(new ColorPredicate(ObjectColor.BLUE));
@@ -36,14 +32,13 @@ public final class DireUndercurrents extends CardImpl {
     public DireUndercurrents(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{3}{U/B}{U/B}");
 
-
         // Whenever a blue creature enters the battlefield under your control, you may have target player draw a card.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new DrawCardTargetEffect(1), filterBlue, true, rule1);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DrawCardTargetEffect(1), filterBlue, true);
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
 
         // Whenever a black creature enters the battlefield under your control, you may have target player discard a card.
-        Ability ability2 = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new DiscardTargetEffect(1), filterBlack, true, rule2);
+        Ability ability2 = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DiscardTargetEffect(1), filterBlack, true);
         ability2.addTarget(new TargetPlayer());
         this.addAbility(ability2);
 

--- a/Mage.Sets/src/mage/cards/d/DireUndercurrents.java
+++ b/Mage.Sets/src/mage/cards/d/DireUndercurrents.java
@@ -33,7 +33,8 @@ public final class DireUndercurrents extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{3}{U/B}{U/B}");
 
         // Whenever a blue creature enters the battlefield under your control, you may have target player draw a card.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DrawCardTargetEffect(1), filterBlue, true);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DrawCardTargetEffect(1)
+                .setText("you may have target player draw a card"), filterBlue, true);
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/d/DivinersWand.java
+++ b/Mage.Sets/src/mage/cards/d/DivinersWand.java
@@ -52,7 +52,7 @@ public final class DivinersWand extends CardImpl {
         // Whenever a Wizard creature enters the battlefield, you may attach Diviner's Wand to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                filter, true, SetTargetPointer.PERMANENT));
 
         // Equip {3}
         this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(3), false));

--- a/Mage.Sets/src/mage/cards/d/DragonBreath.java
+++ b/Mage.Sets/src/mage/cards/d/DragonBreath.java
@@ -54,7 +54,7 @@ public final class DragonBreath extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(1, 0, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.R)));
         
         // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Breath from your graveyard to the battlefield attached to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonBreathEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonBreathEffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private DragonBreath(final DragonBreath card) {

--- a/Mage.Sets/src/mage/cards/d/DragonFangs.java
+++ b/Mage.Sets/src/mage/cards/d/DragonFangs.java
@@ -50,7 +50,7 @@ public final class DragonFangs extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(TrampleAbility.getInstance(), AttachmentType.AURA)));
                
         // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Fangs from your graveyard to the battlefield attached to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonFangsEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonFangsEffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private DragonFangs(final DragonFangs card) {
@@ -94,4 +94,3 @@ class DragonFangsEffect extends OneShotEffect {
         return false;
     }
 }
-

--- a/Mage.Sets/src/mage/cards/d/DragonScales.java
+++ b/Mage.Sets/src/mage/cards/d/DragonScales.java
@@ -50,7 +50,7 @@ public final class DragonScales extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(VigilanceAbility.getInstance(), AttachmentType.AURA)));
         
         // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Scales from your graveyard to the battlefield attached to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonScalesEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonScalesEffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private DragonScales(final DragonScales card) {

--- a/Mage.Sets/src/mage/cards/d/DragonShadow.java
+++ b/Mage.Sets/src/mage/cards/d/DragonShadow.java
@@ -50,7 +50,7 @@ public final class DragonShadow extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(FearAbility.getInstance(), AttachmentType.AURA)));
                
          // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Breath from your graveyard to the battlefield attached to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonShadowEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonShadowEffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private DragonShadow(final DragonShadow card) {

--- a/Mage.Sets/src/mage/cards/d/DragonTempest.java
+++ b/Mage.Sets/src/mage/cards/d/DragonTempest.java
@@ -37,7 +37,7 @@ public final class DragonTempest extends CardImpl {
         // Whenever a creature with flying enters the battlefield under your control, it gains haste until the end of turn.
         Effect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("it gains haste until end of turn");
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filterFlying, false, SetTargetPointer.PERMANENT, ""));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filterFlying, false, SetTargetPointer.PERMANENT));
 
         // Whenever a Dragon enters the battlefield under your control, it deals X damage to any target, where X is the number of Dragons you control.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
@@ -45,8 +45,7 @@ public final class DragonTempest extends CardImpl {
                 new DragonTempestDamageEffect(),
                 new FilterCreaturePermanent(SubType.DRAGON, "a Dragon"),
                 false,
-                SetTargetPointer.NONE,
-                ""
+                SetTargetPointer.NONE
         );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DragonWings.java
+++ b/Mage.Sets/src/mage/cards/d/DragonWings.java
@@ -52,7 +52,7 @@ public final class DragonWings extends CardImpl {
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{1}{U}")));
         
         // When a creature with converted mana cost 6 or greater enters the battlefield, you may return Dragon Breath from your graveyard to the battlefield attached to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonWingsEffect(), filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new DragonWingsEffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private DragonWings(final DragonWings card) {
@@ -96,4 +96,3 @@ class DragonWingsEffect extends OneShotEffect {
         return false;
     }
 }
-

--- a/Mage.Sets/src/mage/cards/d/DualNature.java
+++ b/Mage.Sets/src/mage/cards/d/DualNature.java
@@ -44,8 +44,7 @@ public final class DualNature extends CardImpl {
 
         // Whenever a nontoken creature enters the battlefield, its controller creates a token that's a copy of that creature.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new DualNatureCreateTokenEffect(), filter, false, SetTargetPointer.PERMANENT,
-                "Whenever a nontoken creature enters the battlefield, its controller creates a token that's a copy of that creature."
+                Zone.BATTLEFIELD, new DualNatureCreateTokenEffect(), filter, false, SetTargetPointer.PERMANENT
         ));
 
         // Whenever a nontoken creature leaves the battlefield, exile all tokens with the same name as that creature.

--- a/Mage.Sets/src/mage/cards/d/DurableHandicraft.java
+++ b/Mage.Sets/src/mage/cards/d/DurableHandicraft.java
@@ -35,7 +35,7 @@ public final class DurableHandicraft extends CardImpl {
                                 .setText("put a +1/+1 counter on that creature"),
                         new GenericManaCost(1)
                 ), StaticFilters.FILTER_PERMANENT_A_CREATURE,
-                false, SetTargetPointer.PERMANENT, null
+                false, SetTargetPointer.PERMANENT
         ));
 
         // {5}{G}, Sacrifice Durable Handicraft: Put a +1/+1 counter on each creature you control.

--- a/Mage.Sets/src/mage/cards/e/EldraziMimic.java
+++ b/Mage.Sets/src/mage/cards/e/EldraziMimic.java
@@ -39,7 +39,7 @@ public final class EldraziMimic extends CardImpl {
 
         // Whenever another colorless creature enters the battlefield under your control, you may have the base power and toughness of Eldrazi Mimic
         // become that creature's power and toughness until end of turn.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new EldraziMimicEffect(), FILTER, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new EldraziMimicEffect(), FILTER, true, SetTargetPointer.PERMANENT));
     }
 
     private EldraziMimic(final EldraziMimic card) {

--- a/Mage.Sets/src/mage/cards/e/EmielTheBlessed.java
+++ b/Mage.Sets/src/mage/cards/e/EmielTheBlessed.java
@@ -42,7 +42,7 @@ public final class EmielTheBlessed extends CardImpl {
         // If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new DoIfCostPaid(new EmielTheBlessedEffect(), new ManaCostsImpl<>("{G/W}")),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmielTheBlessed.java
+++ b/Mage.Sets/src/mage/cards/e/EmielTheBlessed.java
@@ -42,9 +42,7 @@ public final class EmielTheBlessed extends CardImpl {
         // If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new DoIfCostPaid(new EmielTheBlessedEffect(), new ManaCostsImpl<>("{G/W}")),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT,
-                "Whenever another creature enters the battlefield under your control, you may pay {G/W}. "
-                        + "If you do, put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead."
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
         ));
     }
 
@@ -62,6 +60,7 @@ class EmielTheBlessedEffect extends OneShotEffect {
 
     EmielTheBlessedEffect() {
         super(Outcome.Benefit);
+        staticText = "put a +1/+1 counter on it. If it's a Unicorn, put two +1/+1 counters on it instead.";
     }
 
     private EmielTheBlessedEffect(final EmielTheBlessedEffect effect) {

--- a/Mage.Sets/src/mage/cards/e/EssenceWarden.java
+++ b/Mage.Sets/src/mage/cards/e/EssenceWarden.java
@@ -33,7 +33,7 @@ public final class EssenceWarden extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever another creature enters the battlefield, you gain 1 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), filter, false, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), filter, false));
     }
 
     private EssenceWarden(final EssenceWarden card) {

--- a/Mage.Sets/src/mage/cards/f/FaerieArtisans.java
+++ b/Mage.Sets/src/mage/cards/f/FaerieArtisans.java
@@ -1,10 +1,8 @@
 package mage.cards.f;
 
-import java.util.StringTokenizer;
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -13,24 +11,19 @@ import mage.cards.CardSetInfo;
 import mage.cards.Cards;
 import mage.cards.CardsImpl;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.StringTokenizer;
+import java.util.UUID;
+
 /**
  * @author LevelX2
  */
 public final class FaerieArtisans extends CardImpl {
-
-    private static final FilterCreaturePermanent filterNontoken = new FilterCreaturePermanent("nontoken creature");
-
-    static {
-        filterNontoken.add(TokenPredicate.FALSE);
-        filterNontoken.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public FaerieArtisans(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
@@ -44,8 +37,8 @@ public final class FaerieArtisans extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever a nontoken creature enters the battlefield under an opponent's control, create a token that's a copy of that creature except it's an artifact in addition to its other types. Then exile all other tokens created with Faerie Artisans.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new FaerieArtisansEffect(), filterNontoken, false, SetTargetPointer.PERMANENT,
-                "Whenever a nontoken creature enters the battlefield under an opponent's control, create a token that's a copy of that creature except it's an artifact in addition to its other types. Then exile all other tokens created with {this}.");
+        Ability ability = new EntersBattlefieldOpponentTriggeredAbility(Zone.BATTLEFIELD,
+                new FaerieArtisansEffect(), StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlameKinWarScout.java
+++ b/Mage.Sets/src/mage/cards/f/FlameKinWarScout.java
@@ -33,7 +33,7 @@ public final class FlameKinWarScout extends CardImpl {
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
             Zone.BATTLEFIELD, new FlameKinWarScourEffect(),
             StaticFilters.FILTER_ANOTHER_CREATURE, false,
-            SetTargetPointer.PERMANENT, null
+            SetTargetPointer.PERMANENT
         ));
 
     }

--- a/Mage.Sets/src/mage/cards/f/FlameshadowConjuring.java
+++ b/Mage.Sets/src/mage/cards/f/FlameshadowConjuring.java
@@ -34,7 +34,7 @@ public final class FlameshadowConjuring extends CardImpl {
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new DoIfCostPaid(new FlameshadowConjuringEffect(), new ManaCostsImpl<>("{R}"),
                         "Pay {R} to create a token that's a copy of that creature that entered the battlefield?"),
-                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, null);
+                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FlameshadowConjuring.java
+++ b/Mage.Sets/src/mage/cards/f/FlameshadowConjuring.java
@@ -1,4 +1,3 @@
-
 package mage.cards.f;
 
 import java.util.UUID;
@@ -18,8 +17,6 @@ import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
@@ -34,12 +31,10 @@ public final class FlameshadowConjuring extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{R}");
 
         // Whenever a nontoken creature enters the battlefield under your control, you may pay {R}. If you do, create a token that's a copy of that creature. That token gains haste. Exile it at the beginning of the next end step.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DoIfCostPaid(
-                new FlameshadowConjuringEffect(), new ManaCostsImpl<>("{R}"), "Pay {R} to create a token that's a copy of that creature that entered the battlefield?"),
-                StaticFilters.FILTER_CONTROLLED_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT,
-                "Whenever a nontoken creature enters the battlefield under your control, "
-                + "you may pay {R}. If you do, create a token that's a copy of that creature. "
-                + "That token gains haste. Exile it at the beginning of the next end step.");
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new DoIfCostPaid(new FlameshadowConjuringEffect(), new ManaCostsImpl<>("{R}"),
+                        "Pay {R} to create a token that's a copy of that creature that entered the battlefield?"),
+                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, null);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FoundryStreetDenizen.java
+++ b/Mage.Sets/src/mage/cards/f/FoundryStreetDenizen.java
@@ -3,7 +3,7 @@ package mage.cards.f;
 import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -36,7 +36,8 @@ public final class FoundryStreetDenizen extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), filter, false, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new BoostSourceEffect(1, 0, Duration.EndOfTurn), filter, false, null));
     }
 
     private FoundryStreetDenizen(final FoundryStreetDenizen card) {

--- a/Mage.Sets/src/mage/cards/f/FoundryStreetDenizen.java
+++ b/Mage.Sets/src/mage/cards/f/FoundryStreetDenizen.java
@@ -36,7 +36,7 @@ public final class FoundryStreetDenizen extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), filter, false, null, true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), filter, false, null));
     }
 
     private FoundryStreetDenizen(final FoundryStreetDenizen card) {

--- a/Mage.Sets/src/mage/cards/f/FoundryStreetDenizen.java
+++ b/Mage.Sets/src/mage/cards/f/FoundryStreetDenizen.java
@@ -37,7 +37,7 @@ public final class FoundryStreetDenizen extends CardImpl {
 
         // Whenever another red creature enters the battlefield under your control, Foundry Street Denizen gets +1/+0 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                new BoostSourceEffect(1, 0, Duration.EndOfTurn), filter, false, null));
+                new BoostSourceEffect(1, 0, Duration.EndOfTurn), filter, false));
     }
 
     private FoundryStreetDenizen(final FoundryStreetDenizen card) {

--- a/Mage.Sets/src/mage/cards/f/FrontierSiege.java
+++ b/Mage.Sets/src/mage/cards/f/FrontierSiege.java
@@ -54,7 +54,7 @@ public final class FrontierSiege extends CardImpl {
 
         // * Dragons - Whenever a creature with flying enters the battlefield under your control, you may have it fight target creature you don't control.
         Ability ability2 = new ConditionalTriggeredAbility(
-                new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new FrontierSiegeFightEffect(), filter, true, SetTargetPointer.PERMANENT, ""),
+                new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new FrontierSiegeFightEffect(), filter, true, SetTargetPointer.PERMANENT),
                 new ModeChoiceSourceCondition("Dragons"),
                 ruleTrigger2);
         ability2.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL));

--- a/Mage.Sets/src/mage/cards/g/GamorreanPrisonGuard.java
+++ b/Mage.Sets/src/mage/cards/g/GamorreanPrisonGuard.java
@@ -36,7 +36,7 @@ public final class GamorreanPrisonGuard extends CardImpl {
 
         // Whenever a creature enters the battlefield under an opponent's control, Gamorrean Prison Guard fights that creature.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new GamorreanPrisonGuardEffect(), filter, false, SetTargetPointer.PERMANENT, "Whenever a creature enters the battlefield under an opponent's control, Gamorrean Prison Guard fights that creature."));
+                Zone.BATTLEFIELD, new GamorreanPrisonGuardEffect(), filter, false, SetTargetPointer.PERMANENT));
 
     }
 

--- a/Mage.Sets/src/mage/cards/g/GenesisChamber.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisChamber.java
@@ -13,8 +13,6 @@ import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.token.MyrToken;
@@ -30,7 +28,7 @@ public final class GenesisChamber extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // Whenever a nontoken creature enters the battlefield, if Genesis Chamber is untapped, that creature's controller creates a 1/1 colorless Myr artifact creature token.
-        TriggeredAbility ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GenesisChamberEffect(), StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, "");
+        TriggeredAbility ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GenesisChamberEffect(), StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability,
                 SourceUntappedCondition.instance,
                 "Whenever a nontoken creature enters the battlefield, "

--- a/Mage.Sets/src/mage/cards/g/GlassdustHulk.java
+++ b/Mage.Sets/src/mage/cards/g/GlassdustHulk.java
@@ -1,4 +1,3 @@
-
 package mage.cards.g;
 
 import java.util.UUID;
@@ -14,7 +13,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterArtifactPermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
@@ -28,7 +26,6 @@ public final class GlassdustHulk extends CardImpl {
     private static final FilterPermanent filter = new FilterArtifactPermanent("another artifact");
 
     static {
-        filter.add(TargetController.YOU.getControllerPredicate());
         filter.add(AnotherPredicate.instance);
     }
 
@@ -40,9 +37,8 @@ public final class GlassdustHulk extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever another artifact enters the battlefield under your control, Glassdust Hulk gets +1/+1 until end of turn and can't be blocked this turn.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter,
-                "Whenever another artifact enters the battlefield under your control, {this} gets +1/+1 until end of turn and can't be blocked this turn.");
-        ability.addEffect(new CantBeBlockedSourceEffect(Duration.EndOfTurn));
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, null);
+        ability.addEffect(new CantBeBlockedSourceEffect(Duration.EndOfTurn).setText("and can't be blocked this turn"));
         this.addAbility(ability);
 
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{W/U}")));

--- a/Mage.Sets/src/mage/cards/g/GlassdustHulk.java
+++ b/Mage.Sets/src/mage/cards/g/GlassdustHulk.java
@@ -37,7 +37,7 @@ public final class GlassdustHulk extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever another artifact enters the battlefield under your control, Glassdust Hulk gets +1/+1 until end of turn and can't be blocked this turn.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter);
         ability.addEffect(new CantBeBlockedSourceEffect(Duration.EndOfTurn).setText("and can't be blocked this turn"));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/g/GoblinAssassin.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinAssassin.java
@@ -35,7 +35,7 @@ public final class GoblinAssassin extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever Goblin Assassin or another Goblin enters the battlefield, each player flips a coin. Each player whose coin comes up tails sacrifices a creature.
-        this.addAbility(new EntersBattlefieldThisOrAnotherTriggeredAbility(new GoblinAssassinTriggeredEffect(), filter));
+        this.addAbility(new EntersBattlefieldThisOrAnotherTriggeredAbility(new GoblinAssassinTriggeredEffect(), filter, false, false));
     }
 
     private GoblinAssassin(final GoblinAssassin card) {

--- a/Mage.Sets/src/mage/cards/g/GodtrackerOfJund.java
+++ b/Mage.Sets/src/mage/cards/g/GodtrackerOfJund.java
@@ -36,7 +36,7 @@ public final class GodtrackerOfJund extends CardImpl {
 
         // Whenever a creature with power 5 or greater enters the battlefield under your control, you may put a +1/+1 counter on Godtracker of Jund.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, true, null));
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, true));
     }
 
     private GodtrackerOfJund(final GodtrackerOfJund card) {

--- a/Mage.Sets/src/mage/cards/g/GodtrackerOfJund.java
+++ b/Mage.Sets/src/mage/cards/g/GodtrackerOfJund.java
@@ -1,9 +1,8 @@
-
 package mage.cards.g;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -12,7 +11,7 @@ import mage.constants.SubType;
 import mage.constants.ComparisonType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
 
 /**
@@ -21,26 +20,23 @@ import mage.filter.predicate.mageobject.PowerPredicate;
  */
 public final class GodtrackerOfJund extends CardImpl {
     
-    final private static FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("a creature with power 5 or greater");
     
     static {
         filter.add(new PowerPredicate(ComparisonType.MORE_THAN, 4));
     }
-    
-    private static final String rule = "Whenever a creature with power 5 or greater enters the battlefield under your control, you may put a +1/+1 counter on {this}.";
 
     public GodtrackerOfJund(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{R}{G}");
         this.subtype.add(SubType.ELF);
         this.subtype.add(SubType.SHAMAN);
 
-
-
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
 
         // Whenever a creature with power 5 or greater enters the battlefield under your control, you may put a +1/+1 counter on Godtracker of Jund.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, true, rule));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, true, null));
     }
 
     private GodtrackerOfJund(final GodtrackerOfJund card) {

--- a/Mage.Sets/src/mage/cards/g/GodtrackerOfJund.java
+++ b/Mage.Sets/src/mage/cards/g/GodtrackerOfJund.java
@@ -40,7 +40,7 @@ public final class GodtrackerOfJund extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever a creature with power 5 or greater enters the battlefield under your control, you may put a +1/+1 counter on Godtracker of Jund.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, true, rule, true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, true, rule));
     }
 
     private GodtrackerOfJund(final GodtrackerOfJund card) {

--- a/Mage.Sets/src/mage/cards/g/GoldnightCommander.java
+++ b/Mage.Sets/src/mage/cards/g/GoldnightCommander.java
@@ -1,9 +1,8 @@
-
 package mage.cards.g;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -28,7 +27,7 @@ public final class GoldnightCommander extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new BoostControlledEffect(1, 1, Duration.EndOfTurn), StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldnightCommander.java
+++ b/Mage.Sets/src/mage/cards/g/GoldnightCommander.java
@@ -28,7 +28,7 @@ public final class GoldnightCommander extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                new BoostControlledEffect(1, 1, Duration.EndOfTurn), StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
+                new BoostControlledEffect(1, 1, Duration.EndOfTurn), StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false));
     }
 
     private GoldnightCommander(final GoldnightCommander card) {

--- a/Mage.Sets/src/mage/cards/g/GoldnightCommander.java
+++ b/Mage.Sets/src/mage/cards/g/GoldnightCommander.java
@@ -29,7 +29,7 @@ public final class GoldnightCommander extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, creatures you control get +1/+1 until end of turn.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new BoostControlledEffect(1, 1, Duration.EndOfTurn), StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null, true));
+                new BoostControlledEffect(1, 1, Duration.EndOfTurn), StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
     }
 
     private GoldnightCommander(final GoldnightCommander card) {

--- a/Mage.Sets/src/mage/cards/g/GoodFortuneUnicorn.java
+++ b/Mage.Sets/src/mage/cards/g/GoodFortuneUnicorn.java
@@ -29,9 +29,7 @@ public final class GoodFortuneUnicorn extends CardImpl {
         // Whenever another creature enters the battlefield under your control, put a +1/+1 counter on that creature.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT,
-                "Whenever another creature enters the battlefield under your control, " +
-                        "put a +1/+1 counter on that creature."
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GravePeril.java
+++ b/Mage.Sets/src/mage/cards/g/GravePeril.java
@@ -26,7 +26,7 @@ public final class GravePeril extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{B}");
 
         // When a nonblack creature enters the battlefield, sacrifice Grave Peril. If you do, destroy that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GravePerilEffect(), StaticFilters.FILTER_PERMANENT_CREATURE_NON_BLACK, false, SetTargetPointer.PERMANENT, null).setTriggerPhrase("When a nonblack creature enters the battlefield, "));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GravePerilEffect(), StaticFilters.FILTER_PERMANENT_CREATURE_NON_BLACK, false, SetTargetPointer.PERMANENT).setTriggerPhrase("When a nonblack creature enters the battlefield, "));
     }
 
     private GravePeril(final GravePeril card) {

--- a/Mage.Sets/src/mage/cards/g/GriffinProtector.java
+++ b/Mage.Sets/src/mage/cards/g/GriffinProtector.java
@@ -1,9 +1,8 @@
-
 package mage.cards.g;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -31,8 +30,8 @@ public final class GriffinProtector extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, null));
 
     }
 

--- a/Mage.Sets/src/mage/cards/g/GriffinProtector.java
+++ b/Mage.Sets/src/mage/cards/g/GriffinProtector.java
@@ -31,7 +31,7 @@ public final class GriffinProtector extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, null));
+                StaticFilters.FILTER_ANOTHER_CREATURE, false));
 
     }
 

--- a/Mage.Sets/src/mage/cards/g/GriffinProtector.java
+++ b/Mage.Sets/src/mage/cards/g/GriffinProtector.java
@@ -32,7 +32,7 @@ public final class GriffinProtector extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, Griffin Protector gets +1/+1 until end of turn.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null, true));
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
 
     }
 

--- a/Mage.Sets/src/mage/cards/h/HalanaKessigRanger.java
+++ b/Mage.Sets/src/mage/cards/h/HalanaKessigRanger.java
@@ -42,7 +42,7 @@ public final class HalanaKessigRanger extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new DoIfCostPaid(new HalanaKessigRangerTriggerEffect(), new GenericManaCost(2))
                         .setText("you may pay {2}. When you do, that creature deals damage equal to its power to target creature."),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT
         ));
 
         // Partner

--- a/Mage.Sets/src/mage/cards/h/HalanaKessigRanger.java
+++ b/Mage.Sets/src/mage/cards/h/HalanaKessigRanger.java
@@ -39,11 +39,10 @@ public final class HalanaKessigRanger extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
 
         // Whenever another creature enters the battlefield under your control, you may pay {2}. When you do, that creature deals damage equal to its power to target creature.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new DoIfCostPaid(new HalanaKessigRangerTriggerEffect(), new GenericManaCost(2)),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT,
-                "Whenever another creature enters the battlefield under your control, you may pay {2}. " +
-                        "When you do, that creature deals damage equal to its power to target creature."
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new DoIfCostPaid(new HalanaKessigRangerTriggerEffect(), new GenericManaCost(2))
+                        .setText("you may pay {2}. When you do, that creature deals damage equal to its power to target creature."),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
         ));
 
         // Partner

--- a/Mage.Sets/src/mage/cards/h/HealerOfThePride.java
+++ b/Mage.Sets/src/mage/cards/h/HealerOfThePride.java
@@ -1,9 +1,8 @@
-
 package mage.cards.h;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -27,8 +26,8 @@ public final class HealerOfThePride extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield under your control, you gain 2 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(2),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(2),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, null));
 
     }
 

--- a/Mage.Sets/src/mage/cards/h/HealerOfThePride.java
+++ b/Mage.Sets/src/mage/cards/h/HealerOfThePride.java
@@ -28,7 +28,7 @@ public final class HealerOfThePride extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, you gain 2 life.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(2),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null, true));
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, null));
 
     }
 

--- a/Mage.Sets/src/mage/cards/h/HealerOfThePride.java
+++ b/Mage.Sets/src/mage/cards/h/HealerOfThePride.java
@@ -27,7 +27,7 @@ public final class HealerOfThePride extends CardImpl {
 
         // Whenever another creature enters the battlefield under your control, you gain 2 life.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new GainLifeEffect(2),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, null));
+                StaticFilters.FILTER_ANOTHER_CREATURE, false));
 
     }
 

--- a/Mage.Sets/src/mage/cards/h/HerosBlade.java
+++ b/Mage.Sets/src/mage/cards/h/HerosBlade.java
@@ -37,7 +37,7 @@ public final class HerosBlade extends CardImpl {
         // Whenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null, true));
+                filter, true, SetTargetPointer.PERMANENT, null));
 
         // Equip {4}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(4)));

--- a/Mage.Sets/src/mage/cards/h/HerosBlade.java
+++ b/Mage.Sets/src/mage/cards/h/HerosBlade.java
@@ -1,8 +1,7 @@
-
 package mage.cards.h;
 
 import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.AttachEffect;
@@ -35,7 +34,7 @@ public final class HerosBlade extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(3, 2)));
 
         // Whenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
                 filter, true, SetTargetPointer.PERMANENT, null));
 

--- a/Mage.Sets/src/mage/cards/h/HerosBlade.java
+++ b/Mage.Sets/src/mage/cards/h/HerosBlade.java
@@ -36,7 +36,7 @@ public final class HerosBlade extends CardImpl {
         // Whenever a legendary creature enters the battlefield under your control, you may attach Hero's Blade to it.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                filter, true, SetTargetPointer.PERMANENT));
 
         // Equip {4}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(4)));

--- a/Mage.Sets/src/mage/cards/h/HungryDragonsnake.java
+++ b/Mage.Sets/src/mage/cards/h/HungryDragonsnake.java
@@ -40,7 +40,7 @@ public final class HungryDragonsnake extends CardImpl {
         // Whenever a creature enters the battlefield under an opponents's control, put a +1/+1 counter on Hungry Dragonsnake.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, false,
-                "Whenever a creature enters the battlefield under an opponents's control, put a +1/+1 counter on {this}.", false));
+                "Whenever a creature enters the battlefield under an opponents's control, put a +1/+1 counter on {this}."));
     }
 
     private HungryDragonsnake(final HungryDragonsnake card) {

--- a/Mage.Sets/src/mage/cards/h/HungryDragonsnake.java
+++ b/Mage.Sets/src/mage/cards/h/HungryDragonsnake.java
@@ -39,8 +39,8 @@ public final class HungryDragonsnake extends CardImpl {
 
         // Whenever a creature enters the battlefield under an opponents's control, put a +1/+1 counter on Hungry Dragonsnake.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, false,
-                "Whenever a creature enters the battlefield under an opponents's control, put a +1/+1 counter on {this}."));
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter, false
+        ));
     }
 
     private HungryDragonsnake(final HungryDragonsnake card) {

--- a/Mage.Sets/src/mage/cards/i/IcebergCancrix.java
+++ b/Mage.Sets/src/mage/cards/i/IcebergCancrix.java
@@ -21,7 +21,7 @@ import java.util.UUID;
  */
 public final class IcebergCancrix extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent();
+    private static final FilterPermanent filter = new FilterPermanent("another snow permanent");
 
     static {
         filter.add(AnotherPredicate.instance);
@@ -38,9 +38,7 @@ public final class IcebergCancrix extends CardImpl {
 
         // Whenever another snow permanent enters the battlefield under your control, you may have target player put the top two cards of their library into their graveyard.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter,
-                true, "Whenever another snow permanent enters the battlefield under your control, " +
-                "you may have target player mill two cards."
+                Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, true, null
         );
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/i/IcebergCancrix.java
+++ b/Mage.Sets/src/mage/cards/i/IcebergCancrix.java
@@ -38,7 +38,7 @@ public final class IcebergCancrix extends CardImpl {
 
         // Whenever another snow permanent enters the battlefield under your control, you may have target player put the top two cards of their library into their graveyard.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, true, null
+                Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, true
         );
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/i/IllusoryGains.java
+++ b/Mage.Sets/src/mage/cards/i/IllusoryGains.java
@@ -1,9 +1,7 @@
-
 package mage.cards.i;
 
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.AttachEffect;
@@ -11,31 +9,21 @@ import mage.abilities.effects.common.continuous.ControlEnchantedEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Outcome;
-import mage.constants.SetTargetPointer;
-import mage.constants.TargetController;
-import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
  *
  * @author fireshoes
  */
 public final class IllusoryGains extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterCreaturePermanent("a creature");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public IllusoryGains(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{U}{U}");
@@ -52,8 +40,8 @@ public final class IllusoryGains extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ControlEnchantedEffect()));
 
         // Whenever a creature enters the battlefield under an opponent's control, attach Illusory Gains to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new IllusoryGainsEffect(), filter, false, SetTargetPointer.PERMANENT, "Whenever a creature enters the battlefield under an opponent's control, attach Illusory Gains to that creature."));
+        this.addAbility(new EntersBattlefieldOpponentTriggeredAbility(
+                Zone.BATTLEFIELD, new IllusoryGainsEffect(), StaticFilters.FILTER_PERMANENT_CREATURE, false, SetTargetPointer.PERMANENT));
     }
 
     private IllusoryGains(final IllusoryGains card) {
@@ -68,8 +56,9 @@ public final class IllusoryGains extends CardImpl {
 
 class IllusoryGainsEffect extends OneShotEffect {
 
-    public IllusoryGainsEffect() {
+    IllusoryGainsEffect() {
         super(Outcome.Detriment);
+        staticText = "attach {this} to that creature";
     }
 
     private IllusoryGainsEffect(final IllusoryGainsEffect effect) {

--- a/Mage.Sets/src/mage/cards/i/InTheWebOfWar.java
+++ b/Mage.Sets/src/mage/cards/i/InTheWebOfWar.java
@@ -15,7 +15,6 @@ import mage.constants.Duration;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 
 /**
  *
@@ -29,7 +28,7 @@ public final class InTheWebOfWar extends CardImpl {
         // Whenever a creature enters the battlefield under your control, it gets +2/+0 and gains haste until end of turn.
         Effect effect = new BoostTargetEffect(2,0, Duration.EndOfTurn);
         effect.setText("it gets +2/+0");
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT);
         effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains haste until end of turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/i/InallaArchmageRitualist.java
+++ b/Mage.Sets/src/mage/cards/i/InallaArchmageRitualist.java
@@ -66,7 +66,7 @@ public final class InallaArchmageRitualist extends CardImpl {
         Ability ability = new ConditionalInterveningIfTriggeredAbility(
                 new EntersBattlefieldControlledTriggeredAbility(Zone.ALL, new DoIfCostPaid(
                         new InallaArchmageRitualistEffect(), new ManaCostsImpl<>("{1}"), "Pay {1} to create a token copy?"),
-                        filter, false, SetTargetPointer.PERMANENT, ""),
+                        filter, false, SetTargetPointer.PERMANENT),
                 SourceOnBattlefieldOrCommandZoneCondition.instance,
                 "Whenever another nontoken Wizard enters the battlefield under your control, "
                 + "{this} is in the command zone or on the battlefield, "

--- a/Mage.Sets/src/mage/cards/i/InventorsGoggles.java
+++ b/Mage.Sets/src/mage/cards/i/InventorsGoggles.java
@@ -30,7 +30,7 @@ public final class InventorsGoggles extends CardImpl {
         // Whenever an Artificer enters the battlefield under your control, you may attach Inventor's Goggles to it.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.BoostCreature, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null
+                filter, true, SetTargetPointer.PERMANENT
         ));
 
         // Equip {2}

--- a/Mage.Sets/src/mage/cards/i/IvyLaneDenizen.java
+++ b/Mage.Sets/src/mage/cards/i/IvyLaneDenizen.java
@@ -41,7 +41,7 @@ public final class IvyLaneDenizen extends CardImpl {
         Ability ability = new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
-                filter, false, null, true);
+                filter, false, null);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/i/IvyLaneDenizen.java
+++ b/Mage.Sets/src/mage/cards/i/IvyLaneDenizen.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.counter.AddCountersTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -38,7 +38,7 @@ public final class IvyLaneDenizen extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on target creature.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
                 filter, false, null);

--- a/Mage.Sets/src/mage/cards/i/IvyLaneDenizen.java
+++ b/Mage.Sets/src/mage/cards/i/IvyLaneDenizen.java
@@ -41,7 +41,7 @@ public final class IvyLaneDenizen extends CardImpl {
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
-                filter, false, null);
+                filter, false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/j/JuniperOrderRanger.java
+++ b/Mage.Sets/src/mage/cards/j/JuniperOrderRanger.java
@@ -32,7 +32,7 @@ public final class JuniperOrderRanger extends CardImpl {
         // Whenever another creature enters the battlefield under your control, put a +1/+1 counter on that creature and a +1/+1 counter on Juniper Order Ranger.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT
         );
         ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance())
                 .setText("and a +1/+1 counter on {this}"));

--- a/Mage.Sets/src/mage/cards/j/JuniperOrderRanger.java
+++ b/Mage.Sets/src/mage/cards/j/JuniperOrderRanger.java
@@ -13,8 +13,6 @@ import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
 
 import java.util.UUID;
 
@@ -22,12 +20,6 @@ import java.util.UUID;
  * @author emerald000
  */
 public final class JuniperOrderRanger extends CardImpl {
-
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
 
     public JuniperOrderRanger(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}{W}");
@@ -40,11 +32,10 @@ public final class JuniperOrderRanger extends CardImpl {
         // Whenever another creature enters the battlefield under your control, put a +1/+1 counter on that creature and a +1/+1 counter on Juniper Order Ranger.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false,
-                SetTargetPointer.PERMANENT, "Whenever another creature enters the battlefield " +
-                "under your control, put a +1/+1 counter on that creature and a +1/+1 counter on {this}."
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
         );
-        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance()));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance())
+                .setText("and a +1/+1 counter on {this}"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JunkWinder.java
+++ b/Mage.Sets/src/mage/cards/j/JunkWinder.java
@@ -17,6 +17,7 @@ import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterNonlandPermanent;
 import mage.filter.predicate.permanent.TokenPredicate;
@@ -51,12 +52,10 @@ public final class JunkWinder extends CardImpl {
 
         // Whenever a token enters the battlefield under your control, tap target nonland permanent an opponent controls. It doesn't untap during its controller's next untap step.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
-                new TapTargetEffect(), filter, "Whenever a token enters the battlefield " +
-                "under your control, tap target nonland permanent an opponent controls. " +
-                "It doesn't untap during its controller's next untap step."
+                new TapTargetEffect(), StaticFilters.FILTER_PERMANENT_TOKEN
         );
-        ability.addEffect(new DontUntapInControllersNextUntapStepTargetEffect());
-        ability.addTarget(new TargetPermanent(filter2));
+        ability.addEffect(new DontUntapInControllersNextUntapStepTargetEffect("It"));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_NON_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KavuLair.java
+++ b/Mage.Sets/src/mage/cards/k/KavuLair.java
@@ -30,7 +30,8 @@ public final class KavuLair extends CardImpl {
 
         // Whenever a creature with power 4 or greater enters the battlefield, its controller draws a card.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new DrawCardTargetEffect(1), filter, false, SetTargetPointer.PLAYER
+                new DrawCardTargetEffect(1).setText("its controller draws a card"),
+                filter, false, SetTargetPointer.PLAYER
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KavuLair.java
+++ b/Mage.Sets/src/mage/cards/k/KavuLair.java
@@ -30,8 +30,8 @@ public final class KavuLair extends CardImpl {
 
         // Whenever a creature with power 4 or greater enters the battlefield, its controller draws a card.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new DrawCardTargetEffect(1), filter, false, SetTargetPointer.PLAYER,
-                "Whenever a creature with power 4 or greater enters the battlefield, its controller draws a card."));        
+                new DrawCardTargetEffect(1), filter, false, SetTargetPointer.PLAYER
+        ));
     }
 
     private KavuLair(final KavuLair card) {

--- a/Mage.Sets/src/mage/cards/k/KruinStriker.java
+++ b/Mage.Sets/src/mage/cards/k/KruinStriker.java
@@ -1,10 +1,9 @@
-
 package mage.cards.k;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.keyword.TrampleAbility;
@@ -30,9 +29,11 @@ public final class KruinStriker extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever another creature enters the battlefield under your control, Kruin Striker gets +1/+0 and gains trample until end of turn.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(new BoostSourceEffect(1, 0, Duration.EndOfTurn), StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE,
-                "Whenever another creature enters the battlefield under your control, Kruin Striker gets +1/+0 and gains trample until end of turn.");
-        ability.addEffect(new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.EndOfTurn));
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(
+                new BoostSourceEffect(1, 0, Duration.EndOfTurn).setText("{this} gets +1/+0"),
+                StaticFilters.FILTER_ANOTHER_CREATURE);
+        ability.addEffect(new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.EndOfTurn).
+                setText("and gains trample until end of turn"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LethalVapors.java
+++ b/Mage.Sets/src/mage/cards/l/LethalVapors.java
@@ -31,7 +31,7 @@ public final class LethalVapors extends CardImpl {
                 Zone.BATTLEFIELD,
                 new DestroyTargetEffect().setText("destroy it"),
                 StaticFilters.FILTER_PERMANENT_A_CREATURE,
-                false, SetTargetPointer.PERMANENT, null));
+                false, SetTargetPointer.PERMANENT));
 
         // {0}: Destroy Lethal Vapors. You skip your next turn. Any player may activate this ability.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroySourceEffect(), new ManaCostsImpl<>("{0}"));

--- a/Mage.Sets/src/mage/cards/l/LlanowarStalker.java
+++ b/Mage.Sets/src/mage/cards/l/LlanowarStalker.java
@@ -28,7 +28,7 @@ public final class LlanowarStalker extends CardImpl {
         // Whenever another creature enters the battlefield under your control, Llanowar Stalker gets +1/+0 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 new BoostSourceEffect(1, 0, Duration.EndOfTurn),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, null
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LonisCryptozoologist.java
+++ b/Mage.Sets/src/mage/cards/l/LonisCryptozoologist.java
@@ -3,7 +3,7 @@ package mage.cards.l;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeXTargetCost;
 import mage.abilities.costs.common.TapSourceCost;
@@ -12,8 +12,8 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.keyword.InvestigateEffect;
 import mage.cards.*;
 import mage.constants.*;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterControlledPermanent;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.common.FilterPermanentCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AnotherPredicate;
@@ -30,7 +30,7 @@ import mage.target.common.TargetOpponent;
  */
 public final class LonisCryptozoologist extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("another nontoken creature");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another nontoken creature");
     private static final FilterControlledPermanent filter2 = new FilterControlledPermanent(SubType.CLUE, "Clues");
 
     static {
@@ -49,7 +49,7 @@ public final class LonisCryptozoologist extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another nontoken creature enters the battlefield under your control, investigate.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new InvestigateEffect(), filter, false, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new InvestigateEffect(), filter));
 
         // {T}, Sacrifice X Clues: Target opponent reveals the top X cards of their library.
         // You may put a nonland permanent card with mana value X or less from among them onto the battlefield under your control.

--- a/Mage.Sets/src/mage/cards/l/LonisCryptozoologist.java
+++ b/Mage.Sets/src/mage/cards/l/LonisCryptozoologist.java
@@ -49,7 +49,7 @@ public final class LonisCryptozoologist extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another nontoken creature enters the battlefield under your control, investigate.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new InvestigateEffect(), filter, false, null, true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new InvestigateEffect(), filter, false, null));
 
         // {T}, Sacrifice X Clues: Target opponent reveals the top X cards of their library.
         // You may put a nonland permanent card with mana value X or less from among them onto the battlefield under your control.

--- a/Mage.Sets/src/mage/cards/m/ManaEchoes.java
+++ b/Mage.Sets/src/mage/cards/m/ManaEchoes.java
@@ -28,7 +28,7 @@ public final class ManaEchoes extends CardImpl {
 
         // Whenever a creature enters the battlefield, you may add X mana of {C}, where X is the number of creatures you control that share a creature type with it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new ManaEchoesEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, ""));
+                new ManaEchoesEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT));
     }
 
     private ManaEchoes(final ManaEchoes card) {

--- a/Mage.Sets/src/mage/cards/m/MaraudingRaptor.java
+++ b/Mage.Sets/src/mage/cards/m/MaraudingRaptor.java
@@ -38,7 +38,7 @@ public final class MaraudingRaptor extends CardImpl {
         // Whenever another creature enters the battlefield under your control, Marauding Raptor deals 2 damage to it. If a Dinosaur is dealt damage this way, Marauding Raptor gets +2/+0 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new MaraudingRaptorEffect(),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaraudingRaptor.java
+++ b/Mage.Sets/src/mage/cards/m/MaraudingRaptor.java
@@ -11,10 +11,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterCard;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreatureCard;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -26,11 +24,6 @@ import java.util.UUID;
 public final class MaraudingRaptor extends CardImpl {
 
     private static final FilterCard filter = new FilterCreatureCard("creature spells");
-    private static final FilterPermanent filter2 = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter2.add(AnotherPredicate.instance);
-    }
 
     public MaraudingRaptor(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{R}");
@@ -45,10 +38,7 @@ public final class MaraudingRaptor extends CardImpl {
         // Whenever another creature enters the battlefield under your control, Marauding Raptor deals 2 damage to it. If a Dinosaur is dealt damage this way, Marauding Raptor gets +2/+0 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new MaraudingRaptorEffect(),
-                filter2, false, SetTargetPointer.PERMANENT,
-                "Whenever another creature enters the battlefield under your control, " +
-                        "{this} deals 2 damage to it. If a Dinosaur is dealt damage this way, " +
-                        "{this} gets +2/+0 until end of turn."
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null
         ));
     }
 
@@ -66,6 +56,7 @@ class MaraudingRaptorEffect extends OneShotEffect {
 
     MaraudingRaptorEffect() {
         super(Outcome.Benefit);
+        staticText = "{this} deals 2 damage to it. If a Dinosaur is dealt damage this way, {this} gets +2/+0 until end of turn";
     }
 
     private MaraudingRaptorEffect(final MaraudingRaptorEffect effect) {

--- a/Mage.Sets/src/mage/cards/m/MightyEmergence.java
+++ b/Mage.Sets/src/mage/cards/m/MightyEmergence.java
@@ -33,7 +33,7 @@ public final class MightyEmergence extends CardImpl {
         // Whenever a creature with power 5 or greater enters the battlefield under your control, you may put two +1/+1 counters on it.
         Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(2));
         effect.setText("you may put two +1/+1 counters on it");
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true, SetTargetPointer.PERMANENT, "", true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true, SetTargetPointer.PERMANENT, ""));
     }
 
     private MightyEmergence(final MightyEmergence card) {

--- a/Mage.Sets/src/mage/cards/m/MightyEmergence.java
+++ b/Mage.Sets/src/mage/cards/m/MightyEmergence.java
@@ -32,7 +32,7 @@ public final class MightyEmergence extends CardImpl {
         // Whenever a creature with power 5 or greater enters the battlefield under your control, you may put two +1/+1 counters on it.
         Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(2));
         effect.setText("you may put two +1/+1 counters on it");
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true, SetTargetPointer.PERMANENT));
     }
 
     private MightyEmergence(final MightyEmergence card) {

--- a/Mage.Sets/src/mage/cards/m/MightyEmergence.java
+++ b/Mage.Sets/src/mage/cards/m/MightyEmergence.java
@@ -1,8 +1,7 @@
-
 package mage.cards.m;
 
 import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.counter.AddCountersTargetEffect;
 import mage.cards.CardImpl;
@@ -33,7 +32,7 @@ public final class MightyEmergence extends CardImpl {
         // Whenever a creature with power 5 or greater enters the battlefield under your control, you may put two +1/+1 counters on it.
         Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(2));
         effect.setText("you may put two +1/+1 counters on it");
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true, SetTargetPointer.PERMANENT, ""));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, true, SetTargetPointer.PERMANENT, null));
     }
 
     private MightyEmergence(final MightyEmergence card) {

--- a/Mage.Sets/src/mage/cards/m/MiirymSentinelWyrm.java
+++ b/Mage.Sets/src/mage/cards/m/MiirymSentinelWyrm.java
@@ -47,7 +47,7 @@ public final class MiirymSentinelWyrm extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new CreateTokenCopyTargetEffect(true).setIsntLegendary(true)
                 .setText("create a token that's a copy of it, except the token isn't legendary"),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MiirymSentinelWyrm.java
+++ b/Mage.Sets/src/mage/cards/m/MiirymSentinelWyrm.java
@@ -21,7 +21,7 @@ import java.util.UUID;
  */
 public final class MiirymSentinelWyrm extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterControlledPermanent(SubType.DRAGON);
+    private static final FilterPermanent filter = new FilterControlledPermanent(SubType.DRAGON, "another nontoken Dragon");
 
     static {
         filter.add(AnotherPredicate.instance);
@@ -45,10 +45,9 @@ public final class MiirymSentinelWyrm extends CardImpl {
 
         // Whenever another nontoken Dragon enters the battlefield under your control, create a token that's a copy of it, except the token isn't legendary if that Dragon is legendary.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new CreateTokenCopyTargetEffect(true).setIsntLegendary(true),
-                filter, false, SetTargetPointer.PERMANENT, "Whenever another nontoken Dragon " +
-                "enters the battlefield under your control, create a token that's a copy of it, " +
-                "except the token isn't legendary."
+                Zone.BATTLEFIELD, new CreateTokenCopyTargetEffect(true).setIsntLegendary(true)
+                .setText("create a token that's a copy of it, except the token isn't legendary"),
+                filter, false, SetTargetPointer.PERMANENT, null
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MinionReflector.java
+++ b/Mage.Sets/src/mage/cards/m/MinionReflector.java
@@ -14,8 +14,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
@@ -37,7 +35,7 @@ public final class MinionReflector extends CardImpl {
                         new MinionReflectorEffect(), new ManaCostsImpl<>("{2}"), "Pay {2} " +
                         "to create a token that's a copy of that creature that entered the battlefield?"
                 ),
-                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorMarch.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorMarch.java
@@ -27,7 +27,7 @@ public final class MirrorMarch extends CardImpl {
         // Whenever a nontoken creature enters the battlefield under your control, flip a coin until you lose a flip. For each flip you won, create a token that's a copy of that creature. Those tokens gain haste. Exile them at the beginning of the next end step.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new MirrorMarchEffect(), StaticFilters.FILTER_CREATURE_NON_TOKEN,
-                false, SetTargetPointer.PERMANENT, null
+                false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrorMarch.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorMarch.java
@@ -10,10 +10,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.players.Player;
 
@@ -29,11 +26,8 @@ public final class MirrorMarch extends CardImpl {
 
         // Whenever a nontoken creature enters the battlefield under your control, flip a coin until you lose a flip. For each flip you won, create a token that's a copy of that creature. Those tokens gain haste. Exile them at the beginning of the next end step.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new MirrorMarchEffect(), StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT,
-                "Whenever a nontoken creature enters the battlefield under your control, " +
-                        "flip a coin until you lose a flip. For each flip you won, " +
-                        "create a token that's a copy of that creature. Those tokens gain haste. " +
-                        "Exile them at the beginning of the next end step."
+                Zone.BATTLEFIELD, new MirrorMarchEffect(), StaticFilters.FILTER_CREATURE_NON_TOKEN,
+                false, SetTargetPointer.PERMANENT, null
         ));
     }
 
@@ -51,6 +45,9 @@ class MirrorMarchEffect extends OneShotEffect {
 
     MirrorMarchEffect() {
         super(Outcome.Benefit);
+        staticText = "flip a coin until you lose a flip. For each flip you won, " +
+                "create a token that's a copy of that creature. Those tokens gain haste. " +
+                "Exile them at the beginning of the next end step.";
     }
 
     private MirrorMarchEffect(final MirrorMarchEffect effect) {

--- a/Mage.Sets/src/mage/cards/m/Mirrorworks.java
+++ b/Mage.Sets/src/mage/cards/m/Mirrorworks.java
@@ -37,7 +37,7 @@ public final class Mirrorworks extends CardImpl {
         Effect effect = new DoIfCostPaid(new CreateTokenCopyTargetEffect(true),
                 new ManaCostsImpl<>("{2}"), "Create a token that's a copy of that artifact?");
         effect.setText("you may pay {2}. If you do, create a token that's a copy of that artifact");
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, SetTargetPointer.PERMANENT));
     }
 
     private Mirrorworks(final Mirrorworks card) {

--- a/Mage.Sets/src/mage/cards/m/MoggBombers.java
+++ b/Mage.Sets/src/mage/cards/m/MoggBombers.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
@@ -20,8 +19,6 @@ import mage.target.common.TargetPlayerOrPlaneswalker;
  * @author jeffwadsworth
  */
 public final class MoggBombers extends CardImpl {
-    
-    private static final String rule = "When another creature enters the battlefield, sacrifice {this} and it deals 3 damage to target player or planeswalker.";
 
     public MoggBombers(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}");
@@ -31,15 +28,9 @@ public final class MoggBombers extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When another creature enters the battlefield, sacrifice Mogg Bombers and it deals 3 damage to target player.
-        Effect sacrificeMoggBombers = new SacrificeSourceEffect();
-        Effect damageTargetPlayer = new DamageTargetEffect(3);
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD,
-                sacrificeMoggBombers,
-                StaticFilters.FILTER_ANOTHER_CREATURE,
-                false
-        );
-        ability.addEffect(damageTargetPlayer);
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
+                new SacrificeSourceEffect(), StaticFilters.FILTER_ANOTHER_CREATURE, false);
+        ability.addEffect(new DamageTargetEffect(3, "it").concatBy("and"));
         ability.addTarget(new TargetPlayerOrPlaneswalker());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/m/MoggBombers.java
+++ b/Mage.Sets/src/mage/cards/m/MoggBombers.java
@@ -13,7 +13,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.target.TargetPlayer;
 import mage.target.common.TargetPlayerOrPlaneswalker;
 
 /**
@@ -38,8 +37,8 @@ public final class MoggBombers extends CardImpl {
                 Zone.BATTLEFIELD,
                 sacrificeMoggBombers,
                 StaticFilters.FILTER_ANOTHER_CREATURE,
-                false,
-                rule);
+                false
+        );
         ability.addEffect(damageTargetPlayer);
         ability.addTarget(new TargetPlayerOrPlaneswalker());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/m/MoltenEchoes.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenEchoes.java
@@ -42,10 +42,8 @@ public final class MoltenEchoes extends CardImpl {
         filter.add(ChosenSubtypePredicate.TRUE);
 
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new MoltenEchoesEffect(),
-                filter, false, SetTargetPointer.PERMANENT,
-                "Whenever a nontoken creature of the chosen type enters the battlefield under your control, "
-                        + "create a token that's a copy of that creature. "
-                        + "That token gains haste. Exile it at the beginning of the next end step.");
+                filter, false, SetTargetPointer.PERMANENT
+        );
         this.addAbility(ability);
     }
 
@@ -95,4 +93,3 @@ class MoltenEchoesEffect extends OneShotEffect {
         return false;
     }
 }
-

--- a/Mage.Sets/src/mage/cards/m/MonkeyCage.java
+++ b/Mage.Sets/src/mage/cards/m/MonkeyCage.java
@@ -28,7 +28,7 @@ public final class MonkeyCage extends CardImpl {
         // When a creature enters the battlefield, sacrifice Monkey Cage and create X 2/2 green Monkey creature tokens, where X is that creature's converted mana cost.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new SacrificeSourceEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE,
-                false, SetTargetPointer.PERMANENT, null
+                false, SetTargetPointer.PERMANENT
         ).setTriggerPhrase("When a creature enters the battlefield, ");
         ability.addEffect(new MonkeyCageEffect());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/n/NaturesWrath.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesWrath.java
@@ -45,16 +45,16 @@ public final class NaturesWrath extends CardImpl {
                 Zone.BATTLEFIELD,
                 new SacrificeEffect(filterBlue, 1, ""),
                 filterBlue,
-                false, SetTargetPointer.PLAYER, 
-                "Whenever a player puts an Island or blue permanent onto the battlefield, they sacrifice an Island or blue permanent."));
+                false, SetTargetPointer.PLAYER
+        ));
 
         // Whenever a player puts a Swamp or black permanent onto the battlefield, they sacrifice a Swamp or black permanent.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new SacrificeEffect(filterBlack, 1, ""),
                 filterBlack,
-                false, SetTargetPointer.PLAYER, 
-                "Whenever a player puts a Swamp or black permanent onto the battlefield, they sacrifice a Swamp or black permanent."));
+                false, SetTargetPointer.PLAYER
+        ));
     }
 
     private NaturesWrath(final NaturesWrath card) {

--- a/Mage.Sets/src/mage/cards/n/NaturesWrath.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesWrath.java
@@ -1,4 +1,3 @@
-
 package mage.cards.n;
 
 import java.util.UUID;
@@ -43,18 +42,18 @@ public final class NaturesWrath extends CardImpl {
         // Whenever a player puts an Island or blue permanent onto the battlefield, they sacrifice an Island or blue permanent.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
-                new SacrificeEffect(filterBlue, 1, ""),
+                new SacrificeEffect(filterBlue, 1, "that player"),
                 filterBlue,
                 false, SetTargetPointer.PLAYER
-        ));
+        ).setTriggerPhrase("Whenever a player puts an Island or blue permanent onto the battlefield, "));
 
         // Whenever a player puts a Swamp or black permanent onto the battlefield, they sacrifice a Swamp or black permanent.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
-                new SacrificeEffect(filterBlack, 1, ""),
+                new SacrificeEffect(filterBlack, 1, "that player"),
                 filterBlack,
                 false, SetTargetPointer.PLAYER
-        ));
+        ).setTriggerPhrase("Whenever a player puts a Swamp or black permanent onto the battlefield, "));
     }
 
     private NaturesWrath(final NaturesWrath card) {

--- a/Mage.Sets/src/mage/cards/n/Necroduality.java
+++ b/Mage.Sets/src/mage/cards/n/Necroduality.java
@@ -19,7 +19,7 @@ import java.util.UUID;
  */
 public final class Necroduality extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent(SubType.ZOMBIE);
+    private static final FilterPermanent filter = new FilterControlledCreaturePermanent(SubType.ZOMBIE, "a nontoken Zombie");
 
     static {
         filter.add(TokenPredicate.FALSE);
@@ -29,11 +29,9 @@ public final class Necroduality extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{U}");
 
         // Whenever a nontoken Zombie enters the battlefield under your control, create a token that's a copy of that creature.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new CreateTokenCopyTargetEffect(true), filter, false,
-                SetTargetPointer.PERMANENT, "Whenever a nontoken Zombie enters the battlefield " +
-                "under your control, create a token that's a copy of that creature."
-        ));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new CreateTokenCopyTargetEffect(true).setText("create a token that's a copy of that creature"),
+                filter, false, SetTargetPointer.PERMANENT, null));
     }
 
     private Necroduality(final Necroduality card) {

--- a/Mage.Sets/src/mage/cards/n/Necroduality.java
+++ b/Mage.Sets/src/mage/cards/n/Necroduality.java
@@ -31,7 +31,7 @@ public final class Necroduality extends CardImpl {
         // Whenever a nontoken Zombie enters the battlefield under your control, create a token that's a copy of that creature.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new CreateTokenCopyTargetEffect(true).setText("create a token that's a copy of that creature"),
-                filter, false, SetTargetPointer.PERMANENT, null));
+                filter, false, SetTargetPointer.PERMANENT));
     }
 
     private Necroduality(final Necroduality card) {

--- a/Mage.Sets/src/mage/cards/n/NightshadeHarvester.java
+++ b/Mage.Sets/src/mage/cards/n/NightshadeHarvester.java
@@ -2,14 +2,14 @@ package mage.cards.n;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.effects.common.LoseLifeTargetEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.filter.common.FilterLandPermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -17,12 +17,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class NightshadeHarvester extends CardImpl {
-
-    private static final FilterLandPermanent filter = new FilterLandPermanent();
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public NightshadeHarvester(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}");
@@ -33,10 +27,9 @@ public final class NightshadeHarvester extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever a land enters the battlefield under an opponent's control, that player loses 1 life. Put a +1/+1 counter on Nightshade Harvester.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false,
-                SetTargetPointer.PLAYER, "Whenever a land enters the battlefield under an opponent's control, " +
-                "that player loses 1 life. Put a +1/+1 counter on {this}."
+        Ability ability = new EntersBattlefieldOpponentTriggeredAbility(
+                Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), StaticFilters.FILTER_LAND_A, false,
+                SetTargetPointer.PLAYER
         );
         ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance()));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/n/NoxiousGhoul.java
+++ b/Mage.Sets/src/mage/cards/n/NoxiousGhoul.java
@@ -36,7 +36,7 @@ public final class NoxiousGhoul extends CardImpl {
         // Whenever Noxious Ghoul or another Zombie enters the battlefield, all non-Zombie creatures get -1/-1 until end of turn.
         this.addAbility(new EntersBattlefieldThisOrAnotherTriggeredAbility(new BoostAllEffect(
                 -1, -1, Duration.EndOfTurn, filter, false
-        ), filter2));
+        ), filter2, false, false));
     }
 
     private NoxiousGhoul(final NoxiousGhoul card) {

--- a/Mage.Sets/src/mage/cards/o/ObsidianBattleAxe.java
+++ b/Mage.Sets/src/mage/cards/o/ObsidianBattleAxe.java
@@ -37,7 +37,7 @@ public final class ObsidianBattleAxe extends CardImpl {
         // Whenever a Warrior creature enters the battlefield, you may attach Obsidian Battle-Axe to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                filter, true, SetTargetPointer.PERMANENT));
         // Equip {3}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(3), new TargetControlledCreaturePermanent(), false));
     }

--- a/Mage.Sets/src/mage/cards/o/OgreBattledriver.java
+++ b/Mage.Sets/src/mage/cards/o/OgreBattledriver.java
@@ -30,7 +30,7 @@ public final class OgreBattledriver extends CardImpl {
         // Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new BoostTargetEffect(2, 0, Duration.EndOfTurn).setText("that creature gets +2/+0"),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null);
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT);
         ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn)
                 .setText("and gains haste until end of turn"));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/o/OgreBattledriver.java
+++ b/Mage.Sets/src/mage/cards/o/OgreBattledriver.java
@@ -1,38 +1,23 @@
-
 package mage.cards.o;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.SetTargetPointer;
-import mage.constants.TargetController;
-import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.constants.*;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
  *
  * @author jeffwadsworth
  */
 public final class OgreBattledriver extends CardImpl {
-    
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-    
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(AnotherPredicate.instance);
-    }
-    
-    private static final String rule = "Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn.";
 
     public OgreBattledriver(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{R}{R}");
@@ -43,8 +28,11 @@ public final class OgreBattledriver extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostTargetEffect(2, 0, Duration.EndOfTurn), filter, false, SetTargetPointer.PERMANENT, rule);
-        ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new BoostTargetEffect(2, 0, Duration.EndOfTurn).setText("that creature gets +2/+0"),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null);
+        ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn)
+                .setText("and gains haste until end of turn"));
         this.addAbility(ability);
         
     }

--- a/Mage.Sets/src/mage/cards/o/OgreBattledriver.java
+++ b/Mage.Sets/src/mage/cards/o/OgreBattledriver.java
@@ -43,7 +43,7 @@ public final class OgreBattledriver extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield under your control, that creature gets +2/+0 and gains haste until end of turn.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostTargetEffect(2, 0, Duration.EndOfTurn), filter, false, SetTargetPointer.PERMANENT, rule, true);
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostTargetEffect(2, 0, Duration.EndOfTurn), filter, false, SetTargetPointer.PERMANENT, rule);
         ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
         this.addAbility(ability);
         

--- a/Mage.Sets/src/mage/cards/o/OliviaMobilizedForWar.java
+++ b/Mage.Sets/src/mage/cards/o/OliviaMobilizedForWar.java
@@ -46,7 +46,7 @@ public final class OliviaMobilizedForWar extends CardImpl {
         effect.setText("and it becomes a Vampire in addition to its other types");
         doIfCostPaid.addEffect(effect);
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, doIfCostPaid,
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT));
     }
 
     private OliviaMobilizedForWar(final OliviaMobilizedForWar card) {

--- a/Mage.Sets/src/mage/cards/o/OnduSpiritdancer.java
+++ b/Mage.Sets/src/mage/cards/o/OnduSpiritdancer.java
@@ -29,7 +29,7 @@ public final class OnduSpiritdancer extends CardImpl {
         // Whenever an enchantment enters the battlefield under your control, you may create a token that's a copy of it. Do this only once each turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new CreateTokenCopyTargetEffect().setText("create a token that's a copy of it"),
-                StaticFilters.FILTER_PERMANENT_ENCHANTMENT, true, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_PERMANENT_ENCHANTMENT, true, SetTargetPointer.PERMANENT
         ).setDoOnlyOnceEachTurn(true).setTriggerPhrase("Whenever an enchantment enters the battlefield under your control, "));
     }
 

--- a/Mage.Sets/src/mage/cards/o/OrchardWarden.java
+++ b/Mage.Sets/src/mage/cards/o/OrchardWarden.java
@@ -36,7 +36,7 @@ public final class OrchardWarden extends CardImpl {
         this.toughness = new MageInt(6);
 
         // Whenever another Treefolk creature enters the battlefield under your control, you may gain life equal to that creature's toughness.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new OrchardWardenffect(), filter, true, SetTargetPointer.PERMANENT, ""));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new OrchardWardenffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private OrchardWarden(final OrchardWarden card) {

--- a/Mage.Sets/src/mage/cards/o/OvalchaseDaredevil.java
+++ b/Mage.Sets/src/mage/cards/o/OvalchaseDaredevil.java
@@ -32,7 +32,7 @@ public final class OvalchaseDaredevil extends CardImpl {
         // Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), filter,
-                true, SetTargetPointer.NONE, null, true
+                true, SetTargetPointer.NONE, null
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/o/OvalchaseDaredevil.java
+++ b/Mage.Sets/src/mage/cards/o/OvalchaseDaredevil.java
@@ -25,7 +25,7 @@ public final class OvalchaseDaredevil extends CardImpl {
         // Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), StaticFilters.FILTER_PERMANENT_ARTIFACT,
-                true, SetTargetPointer.NONE, null
+                true, SetTargetPointer.NONE
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/o/OvalchaseDaredevil.java
+++ b/Mage.Sets/src/mage/cards/o/OvalchaseDaredevil.java
@@ -1,13 +1,12 @@
 package mage.cards.o;
 
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.ReturnSourceFromGraveyardToHandEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterArtifactPermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -15,12 +14,6 @@ import java.util.UUID;
  * @author fireshoes
  */
 public final class OvalchaseDaredevil extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterArtifactPermanent("an artifact");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
 
     public OvalchaseDaredevil(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}");
@@ -30,8 +23,8 @@ public final class OvalchaseDaredevil extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever an artifact enters the battlefield under your control, you may return Ovalchase Daredevil from your graveyard to your hand.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), filter,
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
+                Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), StaticFilters.FILTER_PERMANENT_ARTIFACT,
                 true, SetTargetPointer.NONE, null
         ));
     }

--- a/Mage.Sets/src/mage/cards/o/Overburden.java
+++ b/Mage.Sets/src/mage/cards/o/Overburden.java
@@ -11,8 +11,6 @@ import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.TokenPredicate;
 
 /**
  *
@@ -31,9 +29,8 @@ public final class Overburden extends CardImpl {
                 new ReturnToHandChosenPermanentEffect(RETURN_FILTER),
                 StaticFilters.FILTER_CREATURE_NON_TOKEN,
                 false,
-                SetTargetPointer.PLAYER,
-                "Whenever a player puts a nontoken creature onto the battlefield,"
-                + " that player returns a land they control to its owner's hand."));
+                SetTargetPointer.PLAYER
+        ));
     }
 
     private Overburden(final Overburden card) {

--- a/Mage.Sets/src/mage/cards/o/Overburden.java
+++ b/Mage.Sets/src/mage/cards/o/Overburden.java
@@ -1,4 +1,3 @@
-
 package mage.cards.o;
 
 import java.util.UUID;
@@ -30,7 +29,7 @@ public final class Overburden extends CardImpl {
                 StaticFilters.FILTER_CREATURE_NON_TOKEN,
                 false,
                 SetTargetPointer.PLAYER
-        ));
+        ).setTriggerPhrase("Whenever a player puts a nontoken creature onto the battlefield, "));
     }
 
     private Overburden(final Overburden card) {

--- a/Mage.Sets/src/mage/cards/p/Paleoloth.java
+++ b/Mage.Sets/src/mage/cards/p/Paleoloth.java
@@ -40,7 +40,7 @@ public final class Paleoloth extends CardImpl {
         this.toughness = new MageInt(5);
 
         // Whenever another creature with power 5 or greater enters the battlefield under your control, you may return target creature card from your graveyard to your hand.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new ReturnFromGraveyardToHandTargetEffect(), filter, true, rule);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new ReturnFromGraveyardToHandTargetEffect(), filter, true);
         ability.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/p/Pandemonium.java
+++ b/Mage.Sets/src/mage/cards/p/Pandemonium.java
@@ -30,7 +30,7 @@ public final class Pandemonium extends CardImpl {
         Ability ability = new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new PandemoniumEffect(),
                 StaticFilters.FILTER_PERMANENT_A_CREATURE,
-                false, SetTargetPointer.PERMANENT, ""
+                false, SetTargetPointer.PERMANENT
         );
         ability.addTarget(new TargetAnyTarget());
         ability.setTargetAdjuster(PandemoniumAdjuster.instance);

--- a/Mage.Sets/src/mage/cards/p/PathOfDiscovery.java
+++ b/Mage.Sets/src/mage/cards/p/PathOfDiscovery.java
@@ -23,7 +23,7 @@ public final class PathOfDiscovery extends CardImpl {
         // Whenever a creature enters the battlefield under your control, it explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new ExploreTargetEffect(),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT));
 
     }
 

--- a/Mage.Sets/src/mage/cards/p/PiousEvangel.java
+++ b/Mage.Sets/src/mage/cards/p/PiousEvangel.java
@@ -1,11 +1,8 @@
-
 package mage.cards.p;
-
-import java.util.UUID;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldThisOrAnotherTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.costs.common.TapSourceCost;
@@ -18,18 +15,18 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.target.common.TargetControlledPermanent;
+
+import java.util.UUID;
 
 /**
  * @author fireshoes
  */
 public final class PiousEvangel extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent("{this} or another creature");
     private static final FilterControlledPermanent filter2 = new FilterControlledPermanent("another permanent");
 
     static {
@@ -46,7 +43,8 @@ public final class PiousEvangel extends CardImpl {
         this.secondSideCardClazz = mage.cards.w.WaywardDisciple.class;
 
         // Whenever Pious Evangel or another creature enters the battlefield under your control, you gain 1 life.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new GainLifeEffect(1), filter));
+        this.addAbility(new EntersBattlefieldThisOrAnotherTriggeredAbility(new GainLifeEffect(1),
+                StaticFilters.FILTER_PERMANENT_CREATURE, false, true));
 
         // {2}, {T}, Sacrifice another permanent: Transform Pious Evangel.
         this.addAbility(new TransformAbility());

--- a/Mage.Sets/src/mage/cards/p/PoisonbellyOgre.java
+++ b/Mage.Sets/src/mage/cards/p/PoisonbellyOgre.java
@@ -1,4 +1,3 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
@@ -24,9 +23,7 @@ public final class PoisonbellyOgre extends CardImpl {
     static {
         filter.add(AnotherPredicate.instance);
     }
-    
-    private static final String RULE = "Whenever another creature enters the battlefield, its controller loses 1 life.";
-    
+
     public PoisonbellyOgre(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{B}");
         this.subtype.add(SubType.OGRE);
@@ -35,8 +32,9 @@ public final class PoisonbellyOgre extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield, its controller loses 1 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, SetTargetPointer.PLAYER));
-        
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
+                new LoseLifeTargetEffect(1).setText("its controller loses 1 life"),
+                filter, false, SetTargetPointer.PLAYER));
     }
 
     private PoisonbellyOgre(final PoisonbellyOgre card) {

--- a/Mage.Sets/src/mage/cards/p/PoisonbellyOgre.java
+++ b/Mage.Sets/src/mage/cards/p/PoisonbellyOgre.java
@@ -35,7 +35,7 @@ public final class PoisonbellyOgre extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield, its controller loses 1 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, SetTargetPointer.PLAYER, RULE, false));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, SetTargetPointer.PLAYER, RULE));
         
     }
 

--- a/Mage.Sets/src/mage/cards/p/PoisonbellyOgre.java
+++ b/Mage.Sets/src/mage/cards/p/PoisonbellyOgre.java
@@ -35,7 +35,7 @@ public final class PoisonbellyOgre extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield, its controller loses 1 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, SetTargetPointer.PLAYER, RULE));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, SetTargetPointer.PLAYER));
         
     }
 

--- a/Mage.Sets/src/mage/cards/p/PollutedBonds.java
+++ b/Mage.Sets/src/mage/cards/p/PollutedBonds.java
@@ -1,44 +1,30 @@
-
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.effects.common.LoseLifeTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SetTargetPointer;
-import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterLandPermanent;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
- *
  * @author jeffwadsworth
- *
  */
 public final class PollutedBonds extends CardImpl {
-
-    private static final FilterLandPermanent filter = new FilterLandPermanent("a land");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public PollutedBonds(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{B}{B}");
 
         // Whenever a land enters the battlefield under an opponent's control, that player loses 2 life and you gain 2 life.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, 
-                new LoseLifeTargetEffect(2), 
-                filter, 
-                false, 
-                SetTargetPointer.PLAYER, 
-                "Whenever a land enters the battlefield under an opponent's control, that player loses 2 life and you gain 2 life.");
-        ability.addEffect(new GainLifeEffect(2));
+        Ability ability = new EntersBattlefieldOpponentTriggeredAbility(Zone.BATTLEFIELD,
+                new LoseLifeTargetEffect(2), StaticFilters.FILTER_LAND_A, false, SetTargetPointer.PLAYER);
+        ability.addEffect(new GainLifeEffect(2).concatBy("and"));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/p/Portcullis.java
+++ b/Mage.Sets/src/mage/cards/p/Portcullis.java
@@ -38,7 +38,7 @@ public final class Portcullis extends CardImpl {
         String rule = "Whenever a creature enters the battlefield, if there are two or more other creatures on the battlefield, exile that creature.";
         String rule2 = " Return that card to the battlefield under its owner's control when {this} leaves the battlefield.";
         TriggeredAbility ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new PortcullisExileEffect(),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, rule);
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT);
         MoreThanXCreaturesOnBFCondition condition = new MoreThanXCreaturesOnBFCondition(2);
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, condition, rule + rule2));
 

--- a/Mage.Sets/src/mage/cards/p/PrestonTheVanisher.java
+++ b/Mage.Sets/src/mage/cards/p/PrestonTheVanisher.java
@@ -1,4 +1,3 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
@@ -58,11 +57,8 @@ public final class PrestonTheVanisher extends CardImpl {
         effect.setOnlyColor(ObjectColor.WHITE);
         effect.setOnlySubType(SubType.ILLUSION);
         effect.setText("create a token that's a copy of that creature, except it's a 0/1 white Illusion");
-        this.addAbility(
-                new EntersBattlefieldCastTriggeredAbility(Zone.BATTLEFIELD, effect, triggerFilter, false, false,
-                        SetTargetPointer.PERMANENT, null,
-                        true));
-
+        this.addAbility(new EntersBattlefieldCastTriggeredAbility(Zone.BATTLEFIELD, effect, triggerFilter,
+                false, SetTargetPointer.PERMANENT, false));
         // {1}{W}, Sacrifice five Illusions: Exile target nonland permanent.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ExileTargetEffect(),
                 new ManaCostsImpl<>("{1}{W}"));

--- a/Mage.Sets/src/mage/cards/p/PrimalForcemage.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalForcemage.java
@@ -42,7 +42,7 @@ public final class PrimalForcemage extends CardImpl {
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new BoostTargetEffect(3, 3, Duration.EndOfTurn),
-                filter, false, SetTargetPointer.PERMANENT, rule, true));
+                filter, false, SetTargetPointer.PERMANENT, rule));
     }
 
     private PrimalForcemage(final PrimalForcemage card) {

--- a/Mage.Sets/src/mage/cards/p/PrimalForcemage.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalForcemage.java
@@ -40,7 +40,7 @@ public final class PrimalForcemage extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
                 new BoostTargetEffect(3, 3, Duration.EndOfTurn).setText("that creature gets +3/+3 until end of turn"),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT));
     }
 
     private PrimalForcemage(final PrimalForcemage card) {

--- a/Mage.Sets/src/mage/cards/p/PrimalForcemage.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalForcemage.java
@@ -1,9 +1,8 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -13,6 +12,7 @@ import mage.constants.Duration;
 import mage.constants.SetTargetPointer;
 import mage.constants.TargetController;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 
@@ -29,8 +29,6 @@ public final class PrimalForcemage extends CardImpl {
         filter.add(AnotherPredicate.instance);
     }
 
-    private static final String rule = "Whenever another creature enters the battlefield under your control, that creature gets +3/+3 until end of turn.";
-
     public PrimalForcemage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}");
         this.subtype.add(SubType.ELF);
@@ -39,10 +37,10 @@ public final class PrimalForcemage extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another creature enters the battlefield under your control, that creature gets +3/+3 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD,
-                new BoostTargetEffect(3, 3, Duration.EndOfTurn),
-                filter, false, SetTargetPointer.PERMANENT, rule));
+                new BoostTargetEffect(3, 3, Duration.EndOfTurn).setText("that creature gets +3/+3 until end of turn"),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null));
     }
 
     private PrimalForcemage(final PrimalForcemage card) {

--- a/Mage.Sets/src/mage/cards/p/PrisonTerm.java
+++ b/Mage.Sets/src/mage/cards/p/PrisonTerm.java
@@ -1,9 +1,8 @@
-
 package mage.cards.p;
 
 import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.AttachEffect;
@@ -18,6 +17,7 @@ import mage.constants.SetTargetPointer;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -53,8 +53,8 @@ public final class PrisonTerm extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBlockAttackActivateAttachedEffect()));
 
         // Whenever a creature enters the battlefield under an opponent's control, you may attach Prison Term to that creature.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new PrisonTermEffect(), filter, true, SetTargetPointer.PERMANENT, "Whenever a creature enters the battlefield under an opponent's control, you may attach Prison Term to that creature."));
+        this.addAbility(new EntersBattlefieldOpponentTriggeredAbility(
+                Zone.BATTLEFIELD, new PrisonTermEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT));
     }
 
     private PrisonTerm(final PrisonTerm card) {
@@ -69,8 +69,9 @@ public final class PrisonTerm extends CardImpl {
 
 class PrisonTermEffect extends OneShotEffect {
 
-    public PrisonTermEffect() {
+    PrisonTermEffect() {
         super(Outcome.Detriment);
+        staticText = "attach {this} to that creature";
     }
 
     private PrisonTermEffect(final PrisonTermEffect effect) {

--- a/Mage.Sets/src/mage/cards/q/QuicksmithGenius.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksmithGenius.java
@@ -1,7 +1,7 @@
 package mage.cards.q;
 
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
@@ -10,7 +10,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledArtifactPermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -27,8 +27,9 @@ public final class QuicksmithGenius extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever an artifact enters the battlefield under your control, you may discard a card. If you do, draw a card.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()), new FilterControlledArtifactPermanent("an artifact"), false, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()),
+                StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null));
     }
 
     private QuicksmithGenius(final QuicksmithGenius card) {

--- a/Mage.Sets/src/mage/cards/q/QuicksmithGenius.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksmithGenius.java
@@ -29,7 +29,7 @@ public final class QuicksmithGenius extends CardImpl {
         // Whenever an artifact enters the battlefield under your control, you may discard a card. If you do, draw a card.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
                 new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()),
-                StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null));
+                StaticFilters.FILTER_PERMANENT_ARTIFACT, false));
     }
 
     private QuicksmithGenius(final QuicksmithGenius card) {

--- a/Mage.Sets/src/mage/cards/q/QuicksmithGenius.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksmithGenius.java
@@ -28,7 +28,7 @@ public final class QuicksmithGenius extends CardImpl {
 
         // Whenever an artifact enters the battlefield under your control, you may discard a card. If you do, draw a card.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()), new FilterControlledArtifactPermanent("an artifact"), false, null, true));
+                Zone.BATTLEFIELD, new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()), new FilterControlledArtifactPermanent("an artifact"), false, null));
     }
 
     private QuicksmithGenius(final QuicksmithGenius card) {

--- a/Mage.Sets/src/mage/cards/r/RampagingFerocidon.java
+++ b/Mage.Sets/src/mage/cards/r/RampagingFerocidon.java
@@ -44,7 +44,7 @@ public final class RampagingFerocidon extends CardImpl {
 
         // Whenever another creature enters the battlefield, Rampaging Ferocidon deals 1 damage to that creature's controller.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new DamageTargetEffect(1, true, "that creature's controller"), filter, false, SetTargetPointer.PLAYER, ""));
+                Zone.BATTLEFIELD, new DamageTargetEffect(1, true, "that creature's controller"), filter, false, SetTargetPointer.PLAYER));
     }
 
     private RampagingFerocidon(final RampagingFerocidon card) {

--- a/Mage.Sets/src/mage/cards/r/ReachOfBranches.java
+++ b/Mage.Sets/src/mage/cards/r/ReachOfBranches.java
@@ -34,7 +34,7 @@ public final class ReachOfBranches extends CardImpl {
         // Create a 2/5 green Treefolk Shaman creature token.
         this.getSpellAbility().addEffect(new CreateTokenEffect(new TreefolkShamanToken()));
         // Whenever a Forest enters the battlefield under your control, you may return Reach of Branches from your graveyard to your hand.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), filter, true, "", true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), filter, true, ""));
     }
 
     private ReachOfBranches(final ReachOfBranches card) {

--- a/Mage.Sets/src/mage/cards/r/ReachOfBranches.java
+++ b/Mage.Sets/src/mage/cards/r/ReachOfBranches.java
@@ -1,15 +1,13 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.ReturnSourceFromGraveyardToHandEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.common.FilterLandPermanent;
 import mage.game.permanent.token.TreefolkShamanToken;
@@ -20,12 +18,7 @@ import mage.game.permanent.token.TreefolkShamanToken;
  */
 public final class ReachOfBranches extends CardImpl {
 
-    private static final FilterLandPermanent filter = new FilterLandPermanent("a Forest");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-        filter.add(SubType.FOREST.getPredicate());
-    }
+    private static final FilterLandPermanent filter = new FilterLandPermanent(SubType.FOREST, "a Forest");
 
     public ReachOfBranches(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.TRIBAL, CardType.INSTANT}, "{4}{G}");
@@ -33,8 +26,10 @@ public final class ReachOfBranches extends CardImpl {
 
         // Create a 2/5 green Treefolk Shaman creature token.
         this.getSpellAbility().addEffect(new CreateTokenEffect(new TreefolkShamanToken()));
+
         // Whenever a Forest enters the battlefield under your control, you may return Reach of Branches from your graveyard to your hand.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), filter, true, ""));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.GRAVEYARD,
+                new ReturnSourceFromGraveyardToHandEffect(), filter, true, null));
     }
 
     private ReachOfBranches(final ReachOfBranches card) {

--- a/Mage.Sets/src/mage/cards/r/ReachOfBranches.java
+++ b/Mage.Sets/src/mage/cards/r/ReachOfBranches.java
@@ -29,7 +29,7 @@ public final class ReachOfBranches extends CardImpl {
 
         // Whenever a Forest enters the battlefield under your control, you may return Reach of Branches from your graveyard to your hand.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.GRAVEYARD,
-                new ReturnSourceFromGraveyardToHandEffect(), filter, true, null));
+                new ReturnSourceFromGraveyardToHandEffect(), filter, true));
     }
 
     private ReachOfBranches(final ReachOfBranches card) {

--- a/Mage.Sets/src/mage/cards/r/RecklessFireweaver.java
+++ b/Mage.Sets/src/mage/cards/r/RecklessFireweaver.java
@@ -27,7 +27,7 @@ public final class RecklessFireweaver extends CardImpl {
 
         // Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DamagePlayersEffect(1, TargetController.OPPONENT),
-                StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null));
+                StaticFilters.FILTER_PERMANENT_ARTIFACT, false));
     }
 
     private RecklessFireweaver(final RecklessFireweaver card) {

--- a/Mage.Sets/src/mage/cards/r/RecklessFireweaver.java
+++ b/Mage.Sets/src/mage/cards/r/RecklessFireweaver.java
@@ -1,9 +1,8 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.DamagePlayersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -11,7 +10,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledArtifactPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -27,9 +26,8 @@ public final class RecklessFireweaver extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new DamagePlayersEffect(1, TargetController.OPPONENT),
-                new FilterControlledArtifactPermanent(), false,
-            "Whenever an artifact enters the battlefield under your control, Reckless Fireweaver deals 1 damage to each opponent."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new DamagePlayersEffect(1, TargetController.OPPONENT),
+                StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null));
     }
 
     private RecklessFireweaver(final RecklessFireweaver card) {

--- a/Mage.Sets/src/mage/cards/r/RedtoothVanguard.java
+++ b/Mage.Sets/src/mage/cards/r/RedtoothVanguard.java
@@ -32,7 +32,7 @@ public final class RedtoothVanguard extends CardImpl {
         // Whenever an enchantment enters the battlefield under your control, you may pay 2. If you do, return Redtooth Vanguard from your graveyard to your hand.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.GRAVEYARD,
                 new DoIfCostPaid(new ReturnSourceFromGraveyardToHandEffect(), new GenericManaCost(2)),
-                StaticFilters.FILTER_PERMANENT_ENCHANTMENT, false, SetTargetPointer.NONE, null
+                StaticFilters.FILTER_PERMANENT_ENCHANTMENT, false, SetTargetPointer.NONE
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RedtoothVanguard.java
+++ b/Mage.Sets/src/mage/cards/r/RedtoothVanguard.java
@@ -42,7 +42,7 @@ public final class RedtoothVanguard extends CardImpl {
                         new ReturnSourceFromGraveyardToHandEffect(),
                         new GenericManaCost(2)
                 ),
-                filter, false, SetTargetPointer.NONE, null, true
+                filter, false, SetTargetPointer.NONE, null
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RedtoothVanguard.java
+++ b/Mage.Sets/src/mage/cards/r/RedtoothVanguard.java
@@ -1,7 +1,7 @@
 package mage.cards.r;
 
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.ReturnSourceFromGraveyardToHandEffect;
@@ -9,7 +9,7 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterEnchantmentPermanent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -17,12 +17,6 @@ import java.util.UUID;
  * @author Susucr
  */
 public final class RedtoothVanguard extends CardImpl {
-
-    private static final FilterEnchantmentPermanent filter = new FilterEnchantmentPermanent("an enchantment");
-
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
 
     public RedtoothVanguard(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
@@ -36,13 +30,9 @@ public final class RedtoothVanguard extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever an enchantment enters the battlefield under your control, you may pay 2. If you do, return Redtooth Vanguard from your graveyard to your hand.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.GRAVEYARD,
-                new DoIfCostPaid(
-                        new ReturnSourceFromGraveyardToHandEffect(),
-                        new GenericManaCost(2)
-                ),
-                filter, false, SetTargetPointer.NONE, null
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.GRAVEYARD,
+                new DoIfCostPaid(new ReturnSourceFromGraveyardToHandEffect(), new GenericManaCost(2)),
+                StaticFilters.FILTER_PERMANENT_ENCHANTMENT, false, SetTargetPointer.NONE, null
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReplicationSpecialist.java
+++ b/Mage.Sets/src/mage/cards/r/ReplicationSpecialist.java
@@ -47,7 +47,7 @@ public final class ReplicationSpecialist extends CardImpl {
                         new CreateTokenCopyTargetEffect()
                                 .setText("create a token that's a copy of that artifact"),
                         new ManaCostsImpl<>("{1}{U}")
-                ), filter, false, SetTargetPointer.PERMANENT, null
+                ), filter, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RikuOfTwoReflections.java
+++ b/Mage.Sets/src/mage/cards/r/RikuOfTwoReflections.java
@@ -56,7 +56,7 @@ public final class RikuOfTwoReflections extends CardImpl {
         effect = new DoIfCostPaid(new CreateTokenCopyTargetEffect(true),
                 new ManaCostsImpl<>("{G}{U}"), "Create a token that's a copy of that creature?");
         effect.setText("you may pay {G}{U}. If you do, create a token that's a copy of that creature");
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filterPermanent, false, SetTargetPointer.PERMANENT, null));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filterPermanent, false, SetTargetPointer.PERMANENT));
     }
 
     private RikuOfTwoReflections(final RikuOfTwoReflections card) {

--- a/Mage.Sets/src/mage/cards/r/RiverSneak.java
+++ b/Mage.Sets/src/mage/cards/r/RiverSneak.java
@@ -42,7 +42,7 @@ public final class RiverSneak extends CardImpl {
         this.addAbility(new CantBeBlockedSourceAbility());
 
         // Whenever another Merfolk enters the battlefield under your control, River sneak gets +1/+1 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, false, null, true));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, false, null));
     }
 
     private RiverSneak(final RiverSneak card) {

--- a/Mage.Sets/src/mage/cards/r/RiverSneak.java
+++ b/Mage.Sets/src/mage/cards/r/RiverSneak.java
@@ -40,7 +40,7 @@ public final class RiverSneak extends CardImpl {
 
         // Whenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, false, null));
+                new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, false));
     }
 
     private RiverSneak(final RiverSneak card) {

--- a/Mage.Sets/src/mage/cards/r/RiverSneak.java
+++ b/Mage.Sets/src/mage/cards/r/RiverSneak.java
@@ -1,9 +1,8 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.keyword.CantBeBlockedSourceAbility;
 import mage.constants.SubType;
@@ -11,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
@@ -26,7 +24,6 @@ public final class RiverSneak extends CardImpl {
 
     static {
         filter.add(AnotherPredicate.instance);
-        filter.add(TargetController.YOU.getControllerPredicate());
         filter.add(SubType.MERFOLK.getPredicate());
     }
 
@@ -41,8 +38,9 @@ public final class RiverSneak extends CardImpl {
         // River Sneak can't be blocked.
         this.addAbility(new CantBeBlockedSourceAbility());
 
-        // Whenever another Merfolk enters the battlefield under your control, River sneak gets +1/+1 until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, false, null));
+        // Whenever another Merfolk enters the battlefield under your control, River Sneak gets +1/+1 until end of turn.
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                new BoostSourceEffect(1, 1, Duration.EndOfTurn), filter, false, null));
     }
 
     private RiverSneak(final RiverSneak card) {

--- a/Mage.Sets/src/mage/cards/r/RoninWarclub.java
+++ b/Mage.Sets/src/mage/cards/r/RoninWarclub.java
@@ -28,7 +28,7 @@ public final class RoninWarclub extends CardImpl {
         // Whenever a creature enters the battlefield under your control, attach Ronin Warclub to that creature.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.BoostCreature, "attach {this} to that creature"),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, false, SetTargetPointer.PERMANENT));
 
         // Equip {5} ({5}: Attach to target creature you control. Equip only as a sorcery.)
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(5)));

--- a/Mage.Sets/src/mage/cards/s/SagesRowDenizen.java
+++ b/Mage.Sets/src/mage/cards/s/SagesRowDenizen.java
@@ -38,7 +38,7 @@ public final class SagesRowDenizen extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, false, null, true);
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, false, null);
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SagesRowDenizen.java
+++ b/Mage.Sets/src/mage/cards/s/SagesRowDenizen.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.MillCardsTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -38,7 +38,7 @@ public final class SagesRowDenizen extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, false, null);
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SagesRowDenizen.java
+++ b/Mage.Sets/src/mage/cards/s/SagesRowDenizen.java
@@ -38,7 +38,7 @@ public final class SagesRowDenizen extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another blue creature enters the battlefield under your control, target player puts the top two cards of their library into their graveyard.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new MillCardsTargetEffect(2), filter, false);
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SaiOfTheShinobi.java
+++ b/Mage.Sets/src/mage/cards/s/SaiOfTheShinobi.java
@@ -39,7 +39,7 @@ public final class SaiOfTheShinobi extends CardImpl {
         // Whenever a creature enters the battlefield under your control, you may attach Sai of the Shinobi to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null, true));
+                filter, true, SetTargetPointer.PERMANENT, null));
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));
     }

--- a/Mage.Sets/src/mage/cards/s/SaiOfTheShinobi.java
+++ b/Mage.Sets/src/mage/cards/s/SaiOfTheShinobi.java
@@ -1,8 +1,6 @@
-
 package mage.cards.s;
 
-import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.AttachEffect;
@@ -10,14 +8,10 @@ import mage.abilities.effects.common.continuous.BoostEquippedEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Outcome;
-import mage.constants.SetTargetPointer;
-import mage.constants.TargetController;
-import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.constants.*;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
  *
@@ -25,21 +19,18 @@ import mage.filter.common.FilterCreaturePermanent;
  */
 public final class SaiOfTheShinobi extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent("a creature");
-    static {
-        filter.add(TargetController.YOU.getControllerPredicate());
-    }
-
     public SaiOfTheShinobi(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
         this.subtype.add(SubType.EQUIPMENT);
 
         // Equipped creature gets +1/+1.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(1, 1)));
+
         // Whenever a creature enters the battlefield under your control, you may attach Sai of the Shinobi to it.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null));
+
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));
     }

--- a/Mage.Sets/src/mage/cards/s/SaiOfTheShinobi.java
+++ b/Mage.Sets/src/mage/cards/s/SaiOfTheShinobi.java
@@ -29,7 +29,7 @@ public final class SaiOfTheShinobi extends CardImpl {
         // Whenever a creature enters the battlefield under your control, you may attach Sai of the Shinobi to it.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT));
 
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));

--- a/Mage.Sets/src/mage/cards/s/SalivatingGremlins.java
+++ b/Mage.Sets/src/mage/cards/s/SalivatingGremlins.java
@@ -1,10 +1,9 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
@@ -15,7 +14,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledArtifactPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -32,9 +31,8 @@ public final class SalivatingGremlins extends CardImpl {
         // Whenever an artifact enters the battlefield under your control, Salivating Gremlins gets +2/+0 and gains trample until end of turn.
         Effect effect = new BoostSourceEffect(2, 0, Duration.EndOfTurn);
         effect.setText("{this} gets +2/+0");
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                effect,
-                new FilterControlledArtifactPermanent("an artifact"), false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                effect, StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null);
         effect = new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains trample until end of turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/s/SalivatingGremlins.java
+++ b/Mage.Sets/src/mage/cards/s/SalivatingGremlins.java
@@ -34,7 +34,7 @@ public final class SalivatingGremlins extends CardImpl {
         effect.setText("{this} gets +2/+0");
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
                 effect,
-                new FilterControlledArtifactPermanent("an artifact"), false, null, true);
+                new FilterControlledArtifactPermanent("an artifact"), false, null);
         effect = new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains trample until end of turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/s/SalivatingGremlins.java
+++ b/Mage.Sets/src/mage/cards/s/SalivatingGremlins.java
@@ -32,7 +32,7 @@ public final class SalivatingGremlins extends CardImpl {
         Effect effect = new BoostSourceEffect(2, 0, Duration.EndOfTurn);
         effect.setText("{this} gets +2/+0");
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                effect, StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null);
+                effect, StaticFilters.FILTER_PERMANENT_ARTIFACT, false);
         effect = new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("and gains trample until end of turn");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/s/SeedTheLand.java
+++ b/Mage.Sets/src/mage/cards/s/SeedTheLand.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -23,7 +22,8 @@ public final class SeedTheLand extends CardImpl {
 
         // Whenever a land enters the battlefield, its controller creates a 1/1 green Snake creature token.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new CreateTokenTargetEffect(new SnakeToken()), StaticFilters.FILTER_LAND, false, SetTargetPointer.PLAYER
+                new CreateTokenTargetEffect(new SnakeToken()).setText("its controller creates a 1/1 green Snake creature token"),
+                StaticFilters.FILTER_LAND, false, SetTargetPointer.PLAYER
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SeedTheLand.java
+++ b/Mage.Sets/src/mage/cards/s/SeedTheLand.java
@@ -23,8 +23,8 @@ public final class SeedTheLand extends CardImpl {
 
         // Whenever a land enters the battlefield, its controller creates a 1/1 green Snake creature token.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new CreateTokenTargetEffect(new SnakeToken()), StaticFilters.FILTER_LAND, false, SetTargetPointer.PLAYER,
-                "Whenever a land enters the battlefield, its controller creates a 1/1 green Snake creature token."));
+                new CreateTokenTargetEffect(new SnakeToken()), StaticFilters.FILTER_LAND, false, SetTargetPointer.PLAYER
+        ));
     }
 
     private SeedTheLand(final SeedTheLand card) {

--- a/Mage.Sets/src/mage/cards/s/SelvalaHeartOfTheWilds.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalaHeartOfTheWilds.java
@@ -17,7 +17,6 @@ import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicate;
-import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -28,14 +27,6 @@ import mage.players.Player;
  */
 public final class SelvalaHeartOfTheWilds extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature");
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
-    private static final String rule = "Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.";
-
     public SelvalaHeartOfTheWilds(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}{G}");
         this.supertype.add(SuperType.LEGENDARY);
@@ -45,7 +36,8 @@ public final class SelvalaHeartOfTheWilds extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SelvalaHeartOfTheWildsEffect(), filter, false, SetTargetPointer.PERMANENT, rule));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SelvalaHeartOfTheWildsEffect(),
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null));
 
         // {G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.
         ManaEffect manaEffect = new AddManaInAnyCombinationEffect(
@@ -75,9 +67,9 @@ class SelvalaHeartOfTheWildsEffect extends OneShotEffect {
         filter2.add(new GreatestPowerPredicate());
     }
 
-    public SelvalaHeartOfTheWildsEffect() {
+    SelvalaHeartOfTheWildsEffect() {
         super(Outcome.Benefit);
-        this.staticText = "that creature's controller may draw a card";
+        this.staticText = "its controller may draw a card if its power is greater than each other creature's power";
     }
 
     private SelvalaHeartOfTheWildsEffect(final SelvalaHeartOfTheWildsEffect effect) {

--- a/Mage.Sets/src/mage/cards/s/SelvalaHeartOfTheWilds.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalaHeartOfTheWilds.java
@@ -37,7 +37,7 @@ public final class SelvalaHeartOfTheWilds extends CardImpl {
 
         // Whenever another creature enters the battlefield, its controller may draw a card if its power is greater than each other creature's power.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SelvalaHeartOfTheWildsEffect(),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_ANOTHER_CREATURE, false, SetTargetPointer.PERMANENT));
 
         // {G}, {T}: Add X mana in any combination of colors, where X is the greatest power among creatures you control.
         ManaEffect manaEffect = new AddManaInAnyCombinationEffect(

--- a/Mage.Sets/src/mage/cards/s/SerraRedeemer.java
+++ b/Mage.Sets/src/mage/cards/s/SerraRedeemer.java
@@ -42,7 +42,7 @@ public final class SerraRedeemer extends CardImpl {
         // Whenever another creature with power 2 or less enters the battlefield under your control, put two +1/+1 counters on that creature.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance(2)),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SerumTank.java
+++ b/Mage.Sets/src/mage/cards/s/SerumTank.java
@@ -26,7 +26,7 @@ public final class SerumTank extends CardImpl {
 
         // Whenever {this} or another artifact comes into play, put a charge counter on {this}.
         this.addAbility(new EntersBattlefieldThisOrAnotherTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), StaticFilters.FILTER_PERMANENT_ARTIFACT
+                new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), StaticFilters.FILTER_PERMANENT_ARTIFACT, false, false
         ));
 
         // {3}, {tap}, Remove a charge counter from {this}: Draw a card.

--- a/Mage.Sets/src/mage/cards/s/ShadowAlleyDenizen.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowAlleyDenizen.java
@@ -43,7 +43,7 @@ public final class ShadowAlleyDenizen extends CardImpl {
         // Whenever another black creature enters the battlefield under your control, target creature gains intimidate until end of turn.
         Effect effect = new GainAbilityTargetEffect(IntimidateAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("target creature gains intimidate until end of turn. <i>(It can't be blocked except by artifact creatures and/or creatures that share a color with it.)</i>");
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/ShadowAlleyDenizen.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowAlleyDenizen.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.keyword.IntimidateAbility;
@@ -43,7 +43,7 @@ public final class ShadowAlleyDenizen extends CardImpl {
         // Whenever another black creature enters the battlefield under your control, target creature gains intimidate until end of turn.
         Effect effect = new GainAbilityTargetEffect(IntimidateAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("target creature gains intimidate until end of turn. <i>(It can't be blocked except by artifact creatures and/or creatures that share a color with it.)</i>");
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, null);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/ShadowAlleyDenizen.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowAlleyDenizen.java
@@ -43,7 +43,7 @@ public final class ShadowAlleyDenizen extends CardImpl {
         // Whenever another black creature enters the battlefield under your control, target creature gains intimidate until end of turn.
         Effect effect = new GainAbilityTargetEffect(IntimidateAbility.getInstance(), Duration.EndOfTurn);
         effect.setText("target creature gains intimidate until end of turn. <i>(It can't be blocked except by artifact creatures and/or creatures that share a color with it.)</i>");
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, null, true);
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, effect, filter, false, null);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/ShatteredAngel.java
+++ b/Mage.Sets/src/mage/cards/s/ShatteredAngel.java
@@ -1,31 +1,22 @@
-
-
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterLandPermanent;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
  *
  * @author Loki
  */
 public final class ShatteredAngel extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterLandPermanent("a land");
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public ShatteredAngel (UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{W}{W}");
@@ -37,9 +28,9 @@ public final class ShatteredAngel extends CardImpl {
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());
+
         // Whenever a land enters the battlefield under an opponent's control, you may gain 3 life.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new GainLifeEffect(3), filter, true, "Whenever a land enters the battlefield under an opponent's control, you may gain 3 life."));
+        this.addAbility(new EntersBattlefieldOpponentTriggeredAbility(new GainLifeEffect(3), StaticFilters.FILTER_LAND_A, true));
     }
 
     private ShatteredAngel(final ShatteredAngel card) {

--- a/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
@@ -48,7 +48,7 @@ public final class ShieldedByFaith extends CardImpl {
         // Whenever a creature enters the battlefield, you may attach Shielded by Faith to that creature.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Benefit, "attach {this} to that creature"),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT));
     }
 
     private ShieldedByFaith(final ShieldedByFaith card) {

--- a/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
@@ -48,7 +48,7 @@ public final class ShieldedByFaith extends CardImpl {
         // Whenever a creature enters the battlefield, you may attach Shielded by Faith to that creature.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Benefit, "attach {this} to that creature"),
-                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null, false));
+                StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null));
     }
 
     private ShieldedByFaith(final ShieldedByFaith card) {

--- a/Mage.Sets/src/mage/cards/s/SigardasAid.java
+++ b/Mage.Sets/src/mage/cards/s/SigardasAid.java
@@ -39,7 +39,7 @@ public final class SigardasAid extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CastAsThoughItHadFlashAllEffect(Duration.WhileOnBattlefield, filterCard, false)));
 
         // Whenever an Equipment enters the battlefield under your control, you may attach it to target creature you control.
-        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new SigardasAidEffect(), filter, true, SetTargetPointer.PERMANENT, "");
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD, new SigardasAidEffect(), filter, true, SetTargetPointer.PERMANENT);
         ability.addTarget(new TargetControlledCreaturePermanent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/s/SireOfStagnation.java
+++ b/Mage.Sets/src/mage/cards/s/SireOfStagnation.java
@@ -1,34 +1,26 @@
-
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldOpponentTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.ExileCardsFromTopOfLibraryTargetEffect;
 import mage.abilities.keyword.DevoidAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.SetTargetPointer;
-import mage.constants.TargetController;
+import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterLandPermanent;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
  *
  * @author fireshoes
  */
 public final class SireOfStagnation extends CardImpl {
-
-    private static final FilterLandPermanent filter = new FilterLandPermanent();
-    private static final String rule = "Whenever a land enters the battlefield under an opponent's control, that player exiles the top two cards of their library and you draw two cards.";
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
 
     public SireOfStagnation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{U}{B}");
@@ -40,9 +32,9 @@ public final class SireOfStagnation extends CardImpl {
         this.addAbility(new DevoidAbility(this.color));
 
         // Whenever a land enters the battlefield under an opponent's control, that player exiles the top two cards of their library and you draw two cards.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                new ExileCardsFromTopOfLibraryTargetEffect(2), filter, false, SetTargetPointer.PLAYER, rule, false);
-        ability.addEffect(new DrawCardSourceControllerEffect(2));
+        Ability ability = new EntersBattlefieldOpponentTriggeredAbility(Zone.BATTLEFIELD,
+                new ExileCardsFromTopOfLibraryTargetEffect(2), StaticFilters.FILTER_LAND_A, false, SetTargetPointer.PLAYER);
+        ability.addEffect(new DrawCardSourceControllerEffect(2).concatBy("and you"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SmokeShroud.java
+++ b/Mage.Sets/src/mage/cards/s/SmokeShroud.java
@@ -52,7 +52,7 @@ public final class SmokeShroud extends CardImpl {
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.GRAVEYARD, new SmokeShroudEffect(), filter, true,
                 SetTargetPointer.PERMANENT, null
-        ));
+        ).setTriggerPhrase("When a Ninja enters the battlefield under your control, "));
     }
 
     private SmokeShroud(final SmokeShroud card) {

--- a/Mage.Sets/src/mage/cards/s/SmokeShroud.java
+++ b/Mage.Sets/src/mage/cards/s/SmokeShroud.java
@@ -27,7 +27,7 @@ import java.util.UUID;
  */
 public final class SmokeShroud extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent(SubType.NINJA, "");
+    private static final FilterPermanent filter = new FilterPermanent(SubType.NINJA, "a Ninja");
 
     public SmokeShroud(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{U}");
@@ -51,8 +51,7 @@ public final class SmokeShroud extends CardImpl {
         // When a Ninja enters the battlefield under your control, you may return Smoke Shroud from your graveyard to the battlefield attached to that creature.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.GRAVEYARD, new SmokeShroudEffect(), filter, true,
-                SetTargetPointer.PERMANENT, "When a Ninja enters the battlefield under your control, " +
-                "you may return {this} from your graveyard to the battlefield attached to that creature."
+                SetTargetPointer.PERMANENT, null
         ));
     }
 
@@ -70,6 +69,7 @@ class SmokeShroudEffect extends OneShotEffect {
 
     SmokeShroudEffect() {
         super(Outcome.Benefit);
+        staticText = "return {this} from your graveyard to the battlefield attached to that creature";
     }
 
     private SmokeShroudEffect(final SmokeShroudEffect effect) {
@@ -96,4 +96,3 @@ class SmokeShroudEffect extends OneShotEffect {
         return false;
     }
 }
-

--- a/Mage.Sets/src/mage/cards/s/SmokeShroud.java
+++ b/Mage.Sets/src/mage/cards/s/SmokeShroud.java
@@ -51,7 +51,7 @@ public final class SmokeShroud extends CardImpl {
         // When a Ninja enters the battlefield under your control, you may return Smoke Shroud from your graveyard to the battlefield attached to that creature.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.GRAVEYARD, new SmokeShroudEffect(), filter, true,
-                SetTargetPointer.PERMANENT, null
+                SetTargetPointer.PERMANENT
         ).setTriggerPhrase("When a Ninja enters the battlefield under your control, "));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpreadingPlague.java
+++ b/Mage.Sets/src/mage/cards/s/SpreadingPlague.java
@@ -24,8 +24,6 @@ import mage.game.permanent.Permanent;
  */
 public final class SpreadingPlague extends CardImpl {
 
-    private static final String RULE = "Whenever a creature enters the battlefield, destroy all other creatures that share a color with it. They can't be regenerated.";
-
     public SpreadingPlague(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{4}{B}");
 

--- a/Mage.Sets/src/mage/cards/s/SpreadingPlague.java
+++ b/Mage.Sets/src/mage/cards/s/SpreadingPlague.java
@@ -30,7 +30,7 @@ public final class SpreadingPlague extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{4}{B}");
 
         // Whenever a creature enters the battlefield, destroy all other creatures that share a color with it. They can't be regenerated.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SpreadingPlagueEffect(), StaticFilters.FILTER_PERMANENT_CREATURE, false, SetTargetPointer.PERMANENT, RULE));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SpreadingPlagueEffect(), StaticFilters.FILTER_PERMANENT_CREATURE, false, SetTargetPointer.PERMANENT));
 
     }
 

--- a/Mage.Sets/src/mage/cards/s/StormriderRig.java
+++ b/Mage.Sets/src/mage/cards/s/StormriderRig.java
@@ -33,7 +33,7 @@ public final class StormriderRig extends CardImpl {
         // Whenever a creature enters the battlefield under your control, you may attach Stormrider Rig to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, true, SetTargetPointer.PERMANENT, null, true));
+                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, true, SetTargetPointer.PERMANENT, null));
 
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));

--- a/Mage.Sets/src/mage/cards/s/StormriderRig.java
+++ b/Mage.Sets/src/mage/cards/s/StormriderRig.java
@@ -32,7 +32,7 @@ public final class StormriderRig extends CardImpl {
         // Whenever a creature enters the battlefield under your control, you may attach Stormrider Rig to it.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                StaticFilters.FILTER_PERMANENT_CREATURE, true, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_CREATURE, true, SetTargetPointer.PERMANENT));
 
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));

--- a/Mage.Sets/src/mage/cards/s/StormriderRig.java
+++ b/Mage.Sets/src/mage/cards/s/StormriderRig.java
@@ -1,8 +1,7 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.AttachEffect;
@@ -31,9 +30,9 @@ public final class StormriderRig extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(1, 1)));
 
         // Whenever a creature enters the battlefield under your control, you may attach Stormrider Rig to it.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, true, SetTargetPointer.PERMANENT, null));
+                StaticFilters.FILTER_PERMANENT_CREATURE, true, SetTargetPointer.PERMANENT, null));
 
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));

--- a/Mage.Sets/src/mage/cards/s/SuleimansLegacy.java
+++ b/Mage.Sets/src/mage/cards/s/SuleimansLegacy.java
@@ -1,4 +1,3 @@
-
 package mage.cards.s;
 
 import java.util.UUID;
@@ -38,9 +37,9 @@ public final class SuleimansLegacy extends CardImpl {
 
         // Whenever a Djinn or Efreet enters the battlefield, destroy it. It can't be regenerated.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new DestroyTargetEffect(true), filter, false, SetTargetPointer.PERMANENT,
-                "Whenever a Djinn or Efreet enters the battlefield, destroy it. It can't be regenerated."
-        ));
+                Zone.BATTLEFIELD, new DestroyTargetEffect("destroy it. It can't be regenerated.", true),
+                filter, false, SetTargetPointer.PERMANENT, null
+        ).setTriggerPhrase("Whenever a Djinn or Efreet enters the battlefield, "));
     }
 
     private SuleimansLegacy(final SuleimansLegacy card) {

--- a/Mage.Sets/src/mage/cards/s/SuleimansLegacy.java
+++ b/Mage.Sets/src/mage/cards/s/SuleimansLegacy.java
@@ -38,7 +38,7 @@ public final class SuleimansLegacy extends CardImpl {
         // Whenever a Djinn or Efreet enters the battlefield, destroy it. It can't be regenerated.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new DestroyTargetEffect("destroy it. It can't be regenerated.", true),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         ).setTriggerPhrase("Whenever a Djinn or Efreet enters the battlefield, "));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SunstrikeLegionnaire.java
+++ b/Mage.Sets/src/mage/cards/s/SunstrikeLegionnaire.java
@@ -46,7 +46,7 @@ public final class SunstrikeLegionnaire extends CardImpl {
         // Sunstrike Legionnaire doesn't untap during your untap step.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new DontUntapInControllersUntapStepSourceEffect()));
         // Whenever another creature enters the battlefield, untap Sunstrike Legionnaire.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new UntapSourceEffect(), untapFilter, false, null));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new UntapSourceEffect(), untapFilter, false));
         // {tap}: Tap target creature with converted mana cost 3 or less.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TapTargetEffect(), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent(tapFilter));

--- a/Mage.Sets/src/mage/cards/s/SurrakAndGoreclaw.java
+++ b/Mage.Sets/src/mage/cards/s/SurrakAndGoreclaw.java
@@ -56,7 +56,7 @@ public final class SurrakAndGoreclaw extends CardImpl {
                 Zone.BATTLEFIELD,
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance())
                         .setText("put a +1/+1 counter on it"),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         );
         ability.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance())
                 .setText("it gains haste until end of turn"));

--- a/Mage.Sets/src/mage/cards/s/SwordOfTheMeek.java
+++ b/Mage.Sets/src/mage/cards/s/SwordOfTheMeek.java
@@ -42,7 +42,7 @@ public final class SwordOfTheMeek extends CardImpl {
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));
         // Whenever a 1/1 creature enters the battlefield under your control, you may return Sword of the Meek from your graveyard to the battlefield, then attach it to that creature.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.GRAVEYARD, new SwordOfTheMeekEffect(), filter, true, SetTargetPointer.PERMANENT, ""));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.GRAVEYARD, new SwordOfTheMeekEffect(), filter, true, SetTargetPointer.PERMANENT));
     }
 
     private SwordOfTheMeek(final SwordOfTheMeek card) {

--- a/Mage.Sets/src/mage/cards/t/TaintedAether.java
+++ b/Mage.Sets/src/mage/cards/t/TaintedAether.java
@@ -1,4 +1,3 @@
-
 package mage.cards.t;
 
 import java.util.UUID;
@@ -16,23 +15,24 @@ import mage.filter.predicate.Predicates;
 /**
  *
  * @author LoneFox
-
  */
 public final class TaintedAether extends CardImpl {
 
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("a creature or a land");
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("a creature or land");
 
     static {
-        filter.add(Predicates.or(CardType.CREATURE.getPredicate(), CardType.LAND.getPredicate()));
+        filter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                CardType.LAND.getPredicate()
+        ));
     }
 
     public TaintedAether(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{B}{B}");
 
         // Whenever a creature enters the battlefield, its controller sacrifices a creature or land.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SacrificeEffect(filter, 1, ""),
-                StaticFilters.FILTER_PERMANENT_CREATURES, false, SetTargetPointer.PLAYER,
-            "Whenever a creature enters the battlefield, its controller sacrifices a creature or land."));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SacrificeEffect(filter, 1, "its controller"),
+                StaticFilters.FILTER_PERMANENT_CREATURE, false, SetTargetPointer.PLAYER, null));
     }
 
     private TaintedAether(final TaintedAether card) {

--- a/Mage.Sets/src/mage/cards/t/TaintedAether.java
+++ b/Mage.Sets/src/mage/cards/t/TaintedAether.java
@@ -32,7 +32,7 @@ public final class TaintedAether extends CardImpl {
 
         // Whenever a creature enters the battlefield, its controller sacrifices a creature or land.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new SacrificeEffect(filter, 1, "its controller"),
-                StaticFilters.FILTER_PERMANENT_CREATURE, false, SetTargetPointer.PLAYER, null));
+                StaticFilters.FILTER_PERMANENT_CREATURE, false, SetTargetPointer.PLAYER));
     }
 
     private TaintedAether(final TaintedAether card) {

--- a/Mage.Sets/src/mage/cards/t/TectonicInstability.java
+++ b/Mage.Sets/src/mage/cards/t/TectonicInstability.java
@@ -22,8 +22,8 @@ public final class TectonicInstability extends CardImpl {
 
         // Whenever a land enters the battlefield, tap all lands its controller controls.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-            new TapAllTargetPlayerControlsEffect(StaticFilters.FILTER_LANDS), StaticFilters.FILTER_LAND,
-            false, SetTargetPointer.PLAYER));
+                new TapAllTargetPlayerControlsEffect(StaticFilters.FILTER_LANDS).setText("tap all lands its controller controls"),
+                StaticFilters.FILTER_LAND, false, SetTargetPointer.PLAYER));
     }
 
     private TectonicInstability(final TectonicInstability card) {

--- a/Mage.Sets/src/mage/cards/t/TectonicInstability.java
+++ b/Mage.Sets/src/mage/cards/t/TectonicInstability.java
@@ -23,7 +23,7 @@ public final class TectonicInstability extends CardImpl {
         // Whenever a land enters the battlefield, tap all lands its controller controls.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
             new TapAllTargetPlayerControlsEffect(StaticFilters.FILTER_LANDS), StaticFilters.FILTER_LAND,
-            false, SetTargetPointer.PLAYER, null));
+            false, SetTargetPointer.PLAYER));
     }
 
     private TectonicInstability(final TectonicInstability card) {

--- a/Mage.Sets/src/mage/cards/t/TectonicInstability.java
+++ b/Mage.Sets/src/mage/cards/t/TectonicInstability.java
@@ -1,4 +1,3 @@
-
 package mage.cards.t;
 
 import java.util.UUID;
@@ -10,7 +9,6 @@ import mage.constants.CardType;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterLandPermanent;
 
 /**
  *
@@ -24,8 +22,8 @@ public final class TectonicInstability extends CardImpl {
 
         // Whenever a land enters the battlefield, tap all lands its controller controls.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-            new TapAllTargetPlayerControlsEffect(new FilterLandPermanent()), StaticFilters.FILTER_LANDS,
-            false, SetTargetPointer.PLAYER, "Whenever a land enters the battlefield, tap all lands its controller controls."));
+            new TapAllTargetPlayerControlsEffect(StaticFilters.FILTER_LANDS), StaticFilters.FILTER_LAND,
+            false, SetTargetPointer.PLAYER, null));
     }
 
     private TectonicInstability(final TectonicInstability card) {

--- a/Mage.Sets/src/mage/cards/t/TerrorOfThePeaks.java
+++ b/Mage.Sets/src/mage/cards/t/TerrorOfThePeaks.java
@@ -46,7 +46,7 @@ public final class TerrorOfThePeaks extends CardImpl {
         // Whenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 new DamageTargetEffect(TerrorOfThePeaksValue.instance).setText("{this} deals damage equal to that creature's power to any target"),
-                StaticFilters.FILTER_ANOTHER_CREATURE, null
+                StaticFilters.FILTER_ANOTHER_CREATURE
         );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/t/TerrorOfThePeaks.java
+++ b/Mage.Sets/src/mage/cards/t/TerrorOfThePeaks.java
@@ -3,7 +3,7 @@ package mage.cards.t;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -44,11 +44,9 @@ public final class TerrorOfThePeaks extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new TerrorOfThePeaksCostIncreaseEffect()));
 
         // Whenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(
-                new DamageTargetEffect(TerrorOfThePeaksValue.instance),
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE,
-                "Whenever another creature enters the battlefield under your control, " +
-                        "{this} deals damage equal to that creature's power to any target."
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(
+                new DamageTargetEffect(TerrorOfThePeaksValue.instance).setText("{this} deals damage equal to that creature's power to any target"),
+                StaticFilters.FILTER_ANOTHER_CREATURE, null
         );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
@@ -104,7 +102,6 @@ class TerrorOfThePeaksCostIncreaseEffect extends CostModificationEffectImpl {
             if (allTargets.stream().anyMatch(target -> !isTargetCompatible(target, source, game))) {
                 return false;
             }
-            ;
         }
 
         return allTargets.stream().anyMatch(target -> isTargetCompatible(target, source, game));

--- a/Mage.Sets/src/mage/cards/t/TheGreatHenge.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatHenge.java
@@ -43,11 +43,10 @@ public final class TheGreatHenge extends CardImpl {
 
         // Whenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.
         ability = new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()),
-                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, "Whenever a nontoken creature " +
-                "enters the battlefield under your control, put a +1/+1 counter on it and draw a card."
+                Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()).setText("put a +1/+1 counter on it"),
+                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, null
         );
-        ability.addEffect(new DrawCardSourceControllerEffect(1));
+        ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy("and"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGreatHenge.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatHenge.java
@@ -44,7 +44,7 @@ public final class TheGreatHenge extends CardImpl {
         // Whenever a nontoken creature enters the battlefield under your control, put a +1/+1 counter on it and draw a card.
         ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()).setText("put a +1/+1 counter on it"),
-                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT, null
+                StaticFilters.FILTER_CREATURE_NON_TOKEN, false, SetTargetPointer.PERMANENT
         );
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy("and"));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/t/TheIrencrag.java
+++ b/Mage.Sets/src/mage/cards/t/TheIrencrag.java
@@ -42,7 +42,7 @@ public final class TheIrencrag extends CardImpl {
         // Whenever a legendary creature enters the battlefield under your control, you may have The Irencrag become a legendary Equipment artifact named Everflame, Heroes' Legacy. If you do, it gains equip {3} and "Equipped creature gets +3/+3" and loses all other abilities.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new AddContinuousEffectToGame(new TheIrencragBecomesContinuousEffect()),
-                filter, true, SetTargetPointer.NONE, null
+                filter, true, SetTargetPointer.NONE
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThelonsChant.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonsChant.java
@@ -37,7 +37,7 @@ public final class ThelonsChant extends CardImpl {
 
         // Whenever a player puts a Swamp onto the battlefield, Thelon's Chant deals 3 damage to that player unless they put a -1/-1 counter on a creature they control.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new ThelonsChantEffect(), filter, false, SetTargetPointer.PLAYER
-        ));
+        ).setTriggerPhrase("Whenever a player puts a Swamp onto the battlefield, "));
     }
 
     private ThelonsChant(final ThelonsChant card) {
@@ -52,7 +52,7 @@ public final class ThelonsChant extends CardImpl {
 
 class ThelonsChantEffect extends OneShotEffect {
 
-    public ThelonsChantEffect() {
+    ThelonsChantEffect() {
         super(Outcome.Damage);
         staticText = "{this} deals 3 damage to that player unless they put a -1/-1 counter on a creature they control";
     }

--- a/Mage.Sets/src/mage/cards/t/ThelonsChant.java
+++ b/Mage.Sets/src/mage/cards/t/ThelonsChant.java
@@ -36,8 +36,8 @@ public final class ThelonsChant extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new SacrificeSourceUnlessPaysEffect(new ManaCostsImpl<>("{G}")), TargetController.YOU, false));
 
         // Whenever a player puts a Swamp onto the battlefield, Thelon's Chant deals 3 damage to that player unless they put a -1/-1 counter on a creature they control.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new ThelonsChantEffect(), filter, false, SetTargetPointer.PLAYER,
-                "Whenever a player puts a Swamp onto the battlefield, {this} deals 3 damage to that player unless they put a -1/-1 counter on a creature they control."));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new ThelonsChantEffect(), filter, false, SetTargetPointer.PLAYER
+        ));
     }
 
     private ThelonsChant(final ThelonsChant card) {

--- a/Mage.Sets/src/mage/cards/t/ThornbiteStaff.java
+++ b/Mage.Sets/src/mage/cards/t/ThornbiteStaff.java
@@ -49,7 +49,7 @@ public final class ThornbiteStaff extends CardImpl {
         // Whenever a Shaman creature enters the battlefield, you may attach Thornbite Staff to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                filter, true, SetTargetPointer.PERMANENT));
         // Equip {4}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(4), new TargetControlledCreaturePermanent(), false));
     }

--- a/Mage.Sets/src/mage/cards/t/ThrasherBrute.java
+++ b/Mage.Sets/src/mage/cards/t/ThrasherBrute.java
@@ -34,7 +34,7 @@ public final class ThrasherBrute extends CardImpl {
 
         // Whenever Thrasher Brute or another Warrior enters the battlefield under your team's control, target opponent loses 1 life and you gain 1 life.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, null
+                Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false
         ).setTriggerPhrase("Whenever {this} or another Warrior enters the battlefield under your team's control, ");
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         ability.addTarget(new TargetOpponent());

--- a/Mage.Sets/src/mage/cards/t/ThrasherBrute.java
+++ b/Mage.Sets/src/mage/cards/t/ThrasherBrute.java
@@ -1,4 +1,3 @@
-
 package mage.cards.t;
 
 import mage.MageInt;
@@ -35,11 +34,9 @@ public final class ThrasherBrute extends CardImpl {
 
         // Whenever Thrasher Brute or another Warrior enters the battlefield under your team's control, target opponent loses 1 life and you gain 1 life.
         Ability ability = new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false,
-                "Whenever {this} or another Warrior enters the battlefield under your team's control, "
-                        + "target opponent loses 1 life and you gain 1 life."
-        );
-        ability.addEffect(new GainLifeEffect(1));
+                Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), filter, false, null
+        ).setTriggerPhrase("Whenever {this} or another Warrior enters the battlefield under your team's control, ");
+        ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/t/TillerEngine.java
+++ b/Mage.Sets/src/mage/cards/t/TillerEngine.java
@@ -37,7 +37,7 @@ public final class TillerEngine extends CardImpl {
         // • Untap that land.
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new UntapTargetEffect().setText("Untap that land"),
-                filter, false, SetTargetPointer.PERMANENT, null
+                filter, false, SetTargetPointer.PERMANENT
         ).setTriggerPhrase("Whenever a land enters the battlefield tapped and under your control, ");
 
         // • Tap target nonland permanent an opponent controls.

--- a/Mage.Sets/src/mage/cards/t/TimidDrake.java
+++ b/Mage.Sets/src/mage/cards/t/TimidDrake.java
@@ -31,8 +31,7 @@ public final class TimidDrake extends CardImpl {
         // When another creature enters the battlefield, return Timid Drake to its owner's hand.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new ReturnToHandSourceEffect(true),
-                StaticFilters.FILTER_ANOTHER_CREATURE, false,
-                "When another creature enters the battlefield, return {this} to its owner's hand."
+                StaticFilters.FILTER_ANOTHER_CREATURE, false
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TourachsChant.java
+++ b/Mage.Sets/src/mage/cards/t/TourachsChant.java
@@ -36,8 +36,8 @@ public final class TourachsChant extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new SacrificeSourceUnlessPaysEffect(new ManaCostsImpl<>("{B}")), TargetController.YOU, false));
 
         // Whenever a player puts a Forest onto the battlefield, Tourach's Chant deals 3 damage to that player unless they put a -1/-1 counter on a creature they control.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TourachsChantEffect(), filter, false, SetTargetPointer.PLAYER,
-                "Whenever a player puts a Forest onto the battlefield, {this} deals 3 damage to that player unless they put a -1/-1 counter on a creature they control."));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TourachsChantEffect(), filter, false, SetTargetPointer.PLAYER
+        ));
     }
 
     private TourachsChant(final TourachsChant card) {

--- a/Mage.Sets/src/mage/cards/t/TourachsChant.java
+++ b/Mage.Sets/src/mage/cards/t/TourachsChant.java
@@ -37,7 +37,7 @@ public final class TourachsChant extends CardImpl {
 
         // Whenever a player puts a Forest onto the battlefield, Tourach's Chant deals 3 damage to that player unless they put a -1/-1 counter on a creature they control.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new TourachsChantEffect(), filter, false, SetTargetPointer.PLAYER
-        ));
+        ).setTriggerPhrase("Whenever a player puts a Forest onto the battlefield, "));
     }
 
     private TourachsChant(final TourachsChant card) {
@@ -52,7 +52,7 @@ public final class TourachsChant extends CardImpl {
 
 class TourachsChantEffect extends OneShotEffect {
 
-    public TourachsChantEffect() {
+    TourachsChantEffect() {
         super(Outcome.Damage);
         staticText = "{this} deals 3 damage to that player unless they put a -1/-1 counter on a creature they control";
     }

--- a/Mage.Sets/src/mage/cards/t/TrialOfAmbition.java
+++ b/Mage.Sets/src/mage/cards/t/TrialOfAmbition.java
@@ -36,8 +36,8 @@ public final class TrialOfAmbition extends CardImpl {
         this.addAbility(ability);
 
         // When a Cartouche enters the battlefield under your control, return Trial of Ambition to its owner's hand.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter,
-                "When a Cartouche enters the battlefield under your control, return {this} to its owner's hand."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter
+        ));
     }
 
     private TrialOfAmbition(final TrialOfAmbition card) {

--- a/Mage.Sets/src/mage/cards/t/TrialOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/t/TrialOfKnowledge.java
@@ -31,8 +31,8 @@ public final class TrialOfKnowledge extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawDiscardControllerEffect(3, 1), false));
 
         // When a Cartouche enters the battlefield under your control, return Trial of Knowledge to its owner's hand.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter,
-                "When a Cartouche enters the battlefield under your control, return {this} to its owner's hand."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter
+        ));
     }
 
     private TrialOfKnowledge(final TrialOfKnowledge card) {

--- a/Mage.Sets/src/mage/cards/t/TrialOfSolidarity.java
+++ b/Mage.Sets/src/mage/cards/t/TrialOfSolidarity.java
@@ -43,8 +43,8 @@ public final class TrialOfSolidarity extends CardImpl {
         this.addAbility(ability);
 
         // When a Cartouche enters the battlefield under you control, return Trial of Solidarity to its owner's hand.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter,
-                "When a Cartouche enters the battlefield under your control, return {this} to its owner's hand."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter
+        ));
     }
 
     private TrialOfSolidarity(final TrialOfSolidarity card) {

--- a/Mage.Sets/src/mage/cards/t/TrialOfStrength.java
+++ b/Mage.Sets/src/mage/cards/t/TrialOfStrength.java
@@ -32,8 +32,8 @@ public final class TrialOfStrength extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new BeastToken3())));
 
         // When a Cartouche enters the battlefield under your control, return Trial of Strength to its owner's hand.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter,
-                "When a Cartouche enters the battlefield under your control, return {this} to its owner's hand."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter
+        ));
     }
 
     private TrialOfStrength(final TrialOfStrength card) {

--- a/Mage.Sets/src/mage/cards/t/TrialOfZeal.java
+++ b/Mage.Sets/src/mage/cards/t/TrialOfZeal.java
@@ -35,8 +35,8 @@ public final class TrialOfZeal extends CardImpl {
         this.addAbility(ability);
 
         // When a Cartouche enters the battlefield under your control, return Trial of Zeal to its owner's hand.
-        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter,
-                "When a Cartouche enters the battlefield under your control, return {this} to its owner's hand."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new ReturnToHandSourceEffect(), filter
+        ));
     }
 
     private TrialOfZeal(final TrialOfZeal card) {

--- a/Mage.Sets/src/mage/cards/t/TrooperArmor.java
+++ b/Mage.Sets/src/mage/cards/t/TrooperArmor.java
@@ -34,8 +34,8 @@ public final class TrooperArmor extends CardImpl {
                 new AttachEffect(Outcome.BoostCreature, "attach {this} to it"),
                 new FilterPermanent(SubType.TROOPER, "Trooper"),
                 true,
-                SetTargetPointer.PERMANENT,
-                null));
+                SetTargetPointer.PERMANENT
+        ));
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2)));
     }

--- a/Mage.Sets/src/mage/cards/u/UnderhandedDesigns.java
+++ b/Mage.Sets/src/mage/cards/u/UnderhandedDesigns.java
@@ -35,7 +35,7 @@ public final class UnderhandedDesigns extends CardImpl {
         DoIfCostPaid doIfCostPaid = new DoIfCostPaid(new LoseLifeOpponentsEffect(1), new GenericManaCost(1));
         doIfCostPaid.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
-                doIfCostPaid, StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null));
+                doIfCostPaid, StaticFilters.FILTER_PERMANENT_ARTIFACT, false));
 
         // {1}{B}, Sacrifice Underhanded Designs: Destroy target creature. Activate this ability only if you control two or more artifacts.
         Ability ability = new ActivateIfConditionActivatedAbility(Zone.BATTLEFIELD,

--- a/Mage.Sets/src/mage/cards/u/UnderhandedDesigns.java
+++ b/Mage.Sets/src/mage/cards/u/UnderhandedDesigns.java
@@ -4,12 +4,11 @@ package mage.cards.u;
 import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.ActivateIfConditionActivatedAbility;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.GainLifeEffect;
@@ -19,6 +18,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledArtifactPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -33,10 +33,9 @@ public final class UnderhandedDesigns extends CardImpl {
 
         // Whenever an artifact enters the battlefield under your control, you may pay {1}. If you do, each opponent loses 1 life and you gain 1 life.
         DoIfCostPaid doIfCostPaid = new DoIfCostPaid(new LoseLifeOpponentsEffect(1), new GenericManaCost(1));
-        Effect effect = new GainLifeEffect(1);
-        doIfCostPaid.addEffect(effect);
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, doIfCostPaid, new FilterControlledArtifactPermanent("an artifact"), false,
-                "Whenever an artifact enters the battlefield under your control, you may pay {1}. If you do, each opponent loses 1 life and you gain 1 life."));
+        doIfCostPaid.addEffect(new GainLifeEffect(1).concatBy("and"));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(Zone.BATTLEFIELD,
+                doIfCostPaid, StaticFilters.FILTER_PERMANENT_ARTIFACT, false, null));
 
         // {1}{B}, Sacrifice Underhanded Designs: Destroy target creature. Activate this ability only if you control two or more artifacts.
         Ability ability = new ActivateIfConditionActivatedAbility(Zone.BATTLEFIELD,

--- a/Mage.Sets/src/mage/cards/u/UnstableShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/u/UnstableShapeshifter.java
@@ -41,7 +41,7 @@ public final class UnstableShapeshifter extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Whenever another creature enters the battlefield, Unstable Shapeshifter becomes a copy of that creature, except it has this ability.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new UnstableShapeshifterEffect(), filterAnotherCreature, false, SetTargetPointer.PERMANENT, ""));
+        this.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD, new UnstableShapeshifterEffect(), filterAnotherCreature, false, SetTargetPointer.PERMANENT));
     }
 
     private UnstableShapeshifter(final UnstableShapeshifter card) {
@@ -77,7 +77,7 @@ class UnstableShapeshifterEffect extends OneShotEffect {
         if (targetCreature != null && permanent != null) {
             Permanent blueprintPermanent = game.copyPermanent(Duration.Custom, targetCreature, permanent.getId(), source, new EmptyCopyApplier());
             blueprintPermanent.addAbility(new EntersBattlefieldAllTriggeredAbility(Zone.BATTLEFIELD,
-                    new UnstableShapeshifterEffect(), filterAnotherCreature, false, SetTargetPointer.PERMANENT, ""), source.getSourceId(), game);
+                    new UnstableShapeshifterEffect(), filterAnotherCreature, false, SetTargetPointer.PERMANENT), source.getSourceId(), game);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/v/VeteransArmaments.java
+++ b/Mage.Sets/src/mage/cards/v/VeteransArmaments.java
@@ -44,7 +44,7 @@ public final class VeteransArmaments extends CardImpl {
         // Whenever a Soldier creature enters the battlefield, you may attach Veteran's Armaments to it.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
                 Zone.BATTLEFIELD, new AttachEffect(Outcome.Detriment, "attach {this} to it"),
-                filter, true, SetTargetPointer.PERMANENT, null));
+                filter, true, SetTargetPointer.PERMANENT));
 
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), new TargetControlledCreaturePermanent(), false));

--- a/Mage.Sets/src/mage/cards/v/VildinPackAlpha.java
+++ b/Mage.Sets/src/mage/cards/v/VildinPackAlpha.java
@@ -35,7 +35,7 @@ public final class VildinPackAlpha extends CardImpl {
         // Whenever a Werewolf enters the battlefield under your control, you may transform it.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
                 Zone.BATTLEFIELD, new VildinPackAlphaEffect(), filter,
-                true, SetTargetPointer.PERMANENT, null
+                true, SetTargetPointer.PERMANENT
         ));
 
         // At the beginning of each upkeep, if a player cast two or more spells last turn, transform Vildin-Pack Alpha.

--- a/Mage.Sets/src/mage/cards/w/WaywardServant.java
+++ b/Mage.Sets/src/mage/cards/w/WaywardServant.java
@@ -1,11 +1,9 @@
-
 package mage.cards.w;
 
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
-import mage.abilities.effects.Effect;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.effects.common.LoseLifeOpponentsEffect;
 import mage.cards.CardImpl;
@@ -28,8 +26,6 @@ public final class WaywardServant extends CardImpl {
         filter.add(AnotherPredicate.instance);
     }
 
-    private static final String rule = "Whenever another Zombie enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.";
-
     public WaywardServant(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{W}{B}");
 
@@ -38,10 +34,8 @@ public final class WaywardServant extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Whenever another Zombie enters the battlefield under your control, each opponent loses 1 life and you gain 1 life.
-        Effect effect = new LoseLifeOpponentsEffect(1);
-        Effect effect2 = new GainLifeEffect(1);
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(effect, filter, rule);
-        ability.addEffect(effect2);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(new LoseLifeOpponentsEffect(1), filter);
+        ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/w/WeldfastWingsmith.java
+++ b/Mage.Sets/src/mage/cards/w/WeldfastWingsmith.java
@@ -3,7 +3,7 @@ package mage.cards.w;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -11,7 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.filter.common.FilterControlledArtifactPermanent;
+import mage.filter.StaticFilters;
 
 /**
  *
@@ -27,8 +27,8 @@ public final class WeldfastWingsmith extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever an artifact enters the battlefield under your control, Weldfast Wingsmith gains flying until end of turn.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn),
-                new FilterControlledArtifactPermanent(), "Whenever an artifact enters the battlefield under your control, {this} gains flying until end of turn."));
+        this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
+                new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn), StaticFilters.FILTER_PERMANENT_ARTIFACT));
     }
 
     private WeldfastWingsmith(final WeldfastWingsmith card) {

--- a/Mage.Sets/src/mage/cards/w/WildPair.java
+++ b/Mage.Sets/src/mage/cards/w/WildPair.java
@@ -39,7 +39,7 @@ public final class WildPair extends CardImpl {
 
         // Whenever a creature enters the battlefield, if you cast it from your hand, you may search your library for a creature card with the same total power and toughness and put it onto the battlefield. If you do, shuffle your library.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new WildPairEffect(), filter, true, SetTargetPointer.PERMANENT, null
+                Zone.BATTLEFIELD, new WildPairEffect(), filter, true, SetTargetPointer.PERMANENT
         ).setTriggerPhrase("Whenever a creature enters the battlefield, if you cast it from your hand, "), new CastFromHandWatcher());
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildPair.java
+++ b/Mage.Sets/src/mage/cards/w/WildPair.java
@@ -26,7 +26,7 @@ import java.util.UUID;
  */
 public final class WildPair extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent();
+    private static final FilterPermanent filter = new FilterCreaturePermanent("a creature");
 
     static {
         // TODO: This should check who cast the spell, not who controls the permanent
@@ -39,11 +39,8 @@ public final class WildPair extends CardImpl {
 
         // Whenever a creature enters the battlefield, if you cast it from your hand, you may search your library for a creature card with the same total power and toughness and put it onto the battlefield. If you do, shuffle your library.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new WildPairEffect(), filter, true,
-                SetTargetPointer.PERMANENT, "Whenever a creature enters the battlefield, " +
-                "if you cast it from your hand, you may search your library for a creature card " +
-                "with the same total power and toughness, put it onto the battlefield, then shuffle."
-        ), new CastFromHandWatcher());
+                Zone.BATTLEFIELD, new WildPairEffect(), filter, true, SetTargetPointer.PERMANENT, null
+        ).setTriggerPhrase("Whenever a creature enters the battlefield, if you cast it from your hand, "), new CastFromHandWatcher());
     }
 
     private WildPair(final WildPair card) {
@@ -58,7 +55,7 @@ public final class WildPair extends CardImpl {
 
 class WildPairEffect extends OneShotEffect {
 
-    public WildPairEffect() {
+    WildPairEffect() {
         super(Outcome.PutCreatureInPlay);
         this.staticText = "search your library for a creature card with the same total power and toughness and put it onto the battlefield";
     }
@@ -94,7 +91,7 @@ class WildPairEffect extends OneShotEffect {
 
 class WildPairPowerToughnessPredicate extends IntComparePredicate<MageObject> {
 
-    public WildPairPowerToughnessPredicate(int value) {
+    WildPairPowerToughnessPredicate(int value) {
         super(ComparisonType.EQUAL_TO, value);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WildPair.java
+++ b/Mage.Sets/src/mage/cards/w/WildPair.java
@@ -57,7 +57,7 @@ class WildPairEffect extends OneShotEffect {
 
     WildPairEffect() {
         super(Outcome.PutCreatureInPlay);
-        this.staticText = "search your library for a creature card with the same total power and toughness and put it onto the battlefield";
+        this.staticText = "search your library for a creature card with the same total power and toughness, put it onto the battlefield, then shuffle";
     }
 
     private WildPairEffect(final WildPairEffect effect) {

--- a/Mage.Sets/src/mage/cards/w/WolverineRiders.java
+++ b/Mage.Sets/src/mage/cards/w/WolverineRiders.java
@@ -26,7 +26,7 @@ import java.util.UUID;
  */
 public final class WolverineRiders extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent(SubType.ELF, "");
+    private static final FilterPermanent filter = new FilterPermanent(SubType.ELF, "another Elf");
 
     static {
         filter.add(AnotherPredicate.instance);
@@ -47,8 +47,7 @@ public final class WolverineRiders extends CardImpl {
 
         // Whenever another Elf enters the battlefield under your control, you gain life equal to its toughness.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                new GainLifeEffect(WolverineRidersValue.instance), filter, "Whenever another Elf " +
-                "enters the battlefield under your control, you gain life equal to its toughness."
+                new GainLifeEffect(WolverineRidersValue.instance, "you gain life equal to its toughness"), filter
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
@@ -49,7 +49,7 @@ public final class YorvoLordOfGarenbrig extends CardImpl {
 
         // Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on Yorvo. Then if that creature's power is greater than Yorvo's power, put another +1/+1 counter on Yorvo.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new YorvoLordOfGarenbrigEffect(), filter, false, SetTargetPointer.PERMANENT, null
+                Zone.BATTLEFIELD, new YorvoLordOfGarenbrigEffect(), filter, false, SetTargetPointer.PERMANENT
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
@@ -25,7 +25,7 @@ import java.util.UUID;
  */
 public final class YorvoLordOfGarenbrig extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterCreaturePermanent();
+    private static final FilterPermanent filter = new FilterCreaturePermanent("another green creature");
 
     static {
         filter.add(AnotherPredicate.instance);
@@ -49,10 +49,7 @@ public final class YorvoLordOfGarenbrig extends CardImpl {
 
         // Whenever another green creature enters the battlefield under your control, put a +1/+1 counter on Yorvo. Then if that creature's power is greater than Yorvo's power, put another +1/+1 counter on Yorvo.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(
-                Zone.BATTLEFIELD, new YorvoLordOfGarenbrigEffect(), filter, false, SetTargetPointer.PERMANENT,
-                "Whenever another green creature enters the battlefield under your control, " +
-                        "put a +1/+1 counter on {this}. Then if that creature's power is greater than {this}'s power, " +
-                        "put another +1/+1 counter on {this}."
+                Zone.BATTLEFIELD, new YorvoLordOfGarenbrigEffect(), filter, false, SetTargetPointer.PERMANENT, null
         ));
     }
 
@@ -70,6 +67,8 @@ class YorvoLordOfGarenbrigEffect extends OneShotEffect {
 
     YorvoLordOfGarenbrigEffect() {
         super(Outcome.Benefit);
+        staticText = "put a +1/+1 counter on {this}. Then if that creature's power is greater than {this}'s power, " +
+                "put another +1/+1 counter on {this}.";
     }
 
     private YorvoLordOfGarenbrigEffect(final YorvoLordOfGarenbrigEffect effect) {

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -2,7 +2,7 @@ package mage.abilities;
 
 import mage.MageObject;
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.*;
 import mage.constants.AbilityType;
 import mage.constants.AbilityWord;
 import mage.constants.Zone;
@@ -255,6 +255,19 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
                 || ruleLow.startsWith("turn")
                 || ruleLow.startsWith("tap")
                 || ruleLow.startsWith("untap");
+    }
+
+    /**
+     * For use in generating trigger phrases with correct text
+     * @return "When " for an effect that always removes the source from the battlefield, otherwise "Whenever "
+     */
+    protected final String getWhen() {
+        return (!optional && getAllEffects().stream().anyMatch(
+                effect -> effect instanceof SacrificeSourceEffect
+                        || effect instanceof ReturnToHandSourceEffect
+                        || effect instanceof ShuffleIntoLibrarySourceEffect
+                        || effect instanceof ExileSourceEffect
+        ) ? "When " : "Whenever ");
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/BecomesTargetSourceTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTargetSourceTriggeredAbility.java
@@ -2,10 +2,6 @@ package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.ExileSourceEffect;
-import mage.abilities.effects.common.ReturnToHandSourceEffect;
-import mage.abilities.effects.common.SacrificeSourceEffect;
-import mage.abilities.effects.common.ShuffleIntoLibrarySourceEffect;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.FilterStackObject;
@@ -36,11 +32,7 @@ public class BecomesTargetSourceTriggeredAbility extends TriggeredAbilityImpl {
         super(Zone.BATTLEFIELD, effect, optional);
         this.filter = filter;
         this.setTargetPointer = setTargetPointer;
-        boolean textWhen = !optional && (effect instanceof SacrificeSourceEffect
-                || effect instanceof ReturnToHandSourceEffect
-                || effect instanceof ShuffleIntoLibrarySourceEffect
-                || effect instanceof ExileSourceEffect);
-        setTriggerPhrase((textWhen ? "When" : "Whenever") + " {this} becomes the target of " + filter.getMessage() + ", ");
+        setTriggerPhrase(getWhen() + "{this} becomes the target of " + filter.getMessage() + ", ");
         this.replaceRuleText = true; // default true to replace "{this}" with "it"
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -58,7 +58,7 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         this.rule = rule;
         this.controlledText = controlledText;
         this.setTargetPointer = setTargetPointer;
-        setTriggerPhrase(generateTriggerPhrase());
+        setTriggerPhrase("Whenever " + getMessageFromFilter() + ", ");
     }
 
     protected EntersBattlefieldAllTriggeredAbility(final EntersBattlefieldAllTriggeredAbility ability) {
@@ -102,6 +102,12 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
 //        }
 //        return super.getRule();
 //    }
+
+    protected String getMessageFromFilter() {
+        return filter.getMessage().startsWith("one or more")
+                ? filter.getMessage() + " enter the battlefield"
+                : filter.getMessage() + " enters the battlefield";
+    }
 
     protected String generateTriggerPhrase() {
         StringBuilder sb = new StringBuilder("Whenever ");

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -9,6 +9,7 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -90,9 +91,11 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
 //    }
 
     protected String getMessageFromFilter() {
-        return filter.getMessage().startsWith("one or more")
-                ? filter.getMessage() + " enter the battlefield"
-                : filter.getMessage() + " enters the battlefield";
+        String filterMessage = filter.getMessage();
+        if (filterMessage.startsWith("one or more")) {
+            return filterMessage + " enter the battlefield";
+        }
+        return CardUtil.addArticle(filterMessage) + " enters the battlefield";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -2,8 +2,6 @@ package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.ReturnToHandSourceEffect;
-import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -12,8 +10,6 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
-
-import java.util.UUID;
 
 /**
  * @author LevelX2
@@ -54,8 +50,7 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        UUID targetId = event.getTargetId();
-        Permanent permanent = game.getPermanent(targetId);
+        Permanent permanent = game.getPermanent(event.getTargetId());
         if (!filter.match(permanent, getControllerId(), this, game)) {
             return false;
         }
@@ -73,15 +68,12 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         return true;
     }
 
-    protected String getTriggerPhraseFromFilter() {
-        String when = (!optional && getAllEffects().stream().anyMatch(
-                e -> e instanceof ReturnToHandSourceEffect || e instanceof SacrificeSourceEffect
-        ) ? "When " : "Whenever ");
+    protected final String getTriggerPhraseFromFilter() {
         String filterMessage = filter.getMessage();
         if (filterMessage.startsWith("one or more")) {
-            return when + filterMessage + " enter the battlefield";
+            return getWhen() + filterMessage + " enter the battlefield";
         }
-        return when + CardUtil.addArticle(filterMessage) + " enters the battlefield";
+        return getWhen() + CardUtil.addArticle(filterMessage) + " enters the battlefield";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -19,14 +19,10 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
 
     protected FilterPermanent filter;
     protected String rule;
-    protected boolean controlledText;
     protected SetTargetPointer setTargetPointer;
 
     /**
      * zone = BATTLEFIELD optional = false
-     *
-     * @param effect
-     * @param filter
      */
     public EntersBattlefieldAllTriggeredAbility(Effect effect, FilterPermanent filter) {
         this(Zone.BATTLEFIELD, effect, filter, false);
@@ -37,26 +33,17 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
     }
 
     public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional) {
-        this(zone, effect, filter, optional, SetTargetPointer.NONE, null, false);
+        this(zone, effect, filter, optional, SetTargetPointer.NONE, null);
     }
 
     public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, String rule) {
-        this(zone, effect, filter, optional, rule, false);
-    }
-
-    public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, String rule, boolean controlledText) {
-        this(zone, effect, filter, optional, SetTargetPointer.NONE, rule, controlledText);
+        this(zone, effect, filter, optional, SetTargetPointer.NONE, rule);
     }
 
     public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule) {
-        this(zone, effect, filter, optional, setTargetPointer, rule, false);
-    }
-
-    public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule, boolean controlledText) {
         super(zone, effect, optional);
         this.filter = filter;
         this.rule = rule;
-        this.controlledText = controlledText;
         this.setTargetPointer = setTargetPointer;
         setTriggerPhrase("Whenever " + getMessageFromFilter() + ", ");
     }
@@ -65,7 +52,6 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         super(ability);
         this.filter = ability.filter;
         this.rule = ability.rule;
-        this.controlledText = ability.controlledText;
         this.setTargetPointer = ability.setTargetPointer;
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -2,6 +2,8 @@ package mage.abilities.common;
 
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.ReturnToHandSourceEffect;
+import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
@@ -46,7 +48,7 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         this.filter = filter;
         this.rule = rule;
         this.setTargetPointer = setTargetPointer;
-        setTriggerPhrase("Whenever " + getMessageFromFilter() + ", ");
+        setTriggerPhrase(getTriggerPhraseFromFilter() + ", ");
     }
 
     protected EntersBattlefieldAllTriggeredAbility(final EntersBattlefieldAllTriggeredAbility ability) {
@@ -82,20 +84,15 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         return true;
     }
 
-//    @Override
-//    public String getRule() {
-//        if (rule != null && !rule.isEmpty()) {
-//            return rule;
-//        }
-//        return super.getRule();
-//    }
-
-    protected String getMessageFromFilter() {
+    protected String getTriggerPhraseFromFilter() {
+        String when = (getAllEffects().stream().allMatch(
+                e -> e instanceof ReturnToHandSourceEffect || e instanceof SacrificeSourceEffect
+        ) ? "When " : "Whenever ");
         String filterMessage = filter.getMessage();
         if (filterMessage.startsWith("one or more")) {
-            return filterMessage + " enter the battlefield";
+            return when + filterMessage + " enter the battlefield";
         }
-        return CardUtil.addArticle(filterMessage) + " enters the battlefield";
+        return when + CardUtil.addArticle(filterMessage) + " enters the battlefield";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -74,7 +74,7 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
     }
 
     protected String getTriggerPhraseFromFilter() {
-        String when = (getAllEffects().stream().allMatch(
+        String when = (!optional && getAllEffects().stream().anyMatch(
                 e -> e instanceof ReturnToHandSourceEffect || e instanceof SacrificeSourceEffect
         ) ? "When " : "Whenever ");
         String filterMessage = filter.getMessage();

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -95,13 +95,13 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         return true;
     }
 
-    @Override
-    public String getRule() {
-        if (rule != null && !rule.isEmpty()) {
-            return rule;
-        }
-        return super.getRule();
-    }
+//    @Override
+//    public String getRule() {
+//        if (rule != null && !rule.isEmpty()) {
+//            return rule;
+//        }
+//        return super.getRule();
+//    }
 
     protected String generateTriggerPhrase() {
         StringBuilder sb = new StringBuilder("Whenever ");

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -109,22 +109,6 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
                 : filter.getMessage() + " enters the battlefield";
     }
 
-    protected String generateTriggerPhrase() {
-        StringBuilder sb = new StringBuilder("Whenever ");
-        sb.append(filter.getMessage());
-        if (filter.getMessage().startsWith("one or more")) {
-            sb.append(" enter the battlefield");
-        } else {
-            sb.append(" enters the battlefield");
-        }
-        if (controlledText) {
-            sb.append(" under your control, ");
-        } else {
-            sb.append(", ");
-        }
-        return sb.toString();
-    }
-
     @Override
     public EntersBattlefieldAllTriggeredAbility copy() {
         return new EntersBattlefieldAllTriggeredAbility(this);

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldAllTriggeredAbility.java
@@ -21,7 +21,6 @@ import java.util.UUID;
 public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
 
     protected FilterPermanent filter;
-    protected String rule;
     protected SetTargetPointer setTargetPointer;
 
     /**
@@ -31,22 +30,13 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
         this(Zone.BATTLEFIELD, effect, filter, false);
     }
 
-    public EntersBattlefieldAllTriggeredAbility(Effect effect, FilterPermanent filter, String rule) {
-        this(Zone.BATTLEFIELD, effect, filter, false, rule);
-    }
-
     public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional) {
-        this(zone, effect, filter, optional, SetTargetPointer.NONE, null);
+        this(zone, effect, filter, optional, SetTargetPointer.NONE);
     }
 
-    public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, String rule) {
-        this(zone, effect, filter, optional, SetTargetPointer.NONE, rule);
-    }
-
-    public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule) {
+    public EntersBattlefieldAllTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
         super(zone, effect, optional);
         this.filter = filter;
-        this.rule = rule;
         this.setTargetPointer = setTargetPointer;
         setTriggerPhrase(getTriggerPhraseFromFilter() + ", ");
     }
@@ -54,7 +44,6 @@ public class EntersBattlefieldAllTriggeredAbility extends TriggeredAbilityImpl {
     protected EntersBattlefieldAllTriggeredAbility(final EntersBattlefieldAllTriggeredAbility ability) {
         super(ability);
         this.filter = ability.filter;
-        this.rule = ability.rule;
         this.setTargetPointer = ability.setTargetPointer;
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldCastTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldCastTriggeredAbility.java
@@ -1,7 +1,5 @@
 package mage.abilities.common;
 
-import java.util.UUID;
-
 import mage.abilities.effects.Effect;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
@@ -12,82 +10,31 @@ import mage.watchers.common.PermanentWasCastWatcher;
 
 /**
  * An extension of triggered abilities that trigger when permanents enter the
- * battlefield, but this time they either must be cast or must not be cast.
+ * battlefield under your control, but this time they either must be cast or must not be cast.
  *
  * @author alexander-novo
  */
-public class EntersBattlefieldCastTriggeredAbility extends EntersBattlefieldAllTriggeredAbility {
+public class EntersBattlefieldCastTriggeredAbility extends EntersBattlefieldControlledTriggeredAbility {
     private final boolean mustCast;
 
-    /**
-     * zone = BATTLEFIELD optional = false
-     *
-     * @param effect
-     * @param filter
-     */
-    public EntersBattlefieldCastTriggeredAbility(Effect effect, FilterPermanent filter, boolean mustCast) {
-        this(Zone.BATTLEFIELD, effect, filter, mustCast, false);
-    }
-
-    public EntersBattlefieldCastTriggeredAbility(Effect effect, FilterPermanent filter, boolean mustCast, String rule) {
-        this(Zone.BATTLEFIELD, effect, filter, mustCast, false, rule);
-    }
-
-    public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean mustCast,
-                                                 boolean optional) {
-        this(zone, effect, filter, mustCast, optional, SetTargetPointer.NONE, null, false);
-    }
-
-    public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean mustCast,
-                                                 boolean optional,
-                                                 String rule) {
-        this(zone, effect, filter, mustCast, optional, rule, false);
-    }
-
-    public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean mustCast,
-                                                 boolean optional,
-                                                 String rule, boolean controlledText) {
-        this(zone, effect, filter, mustCast, optional, SetTargetPointer.NONE, rule, controlledText);
-    }
-
-    public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean mustCast,
-                                                 boolean optional,
-                                                 SetTargetPointer setTargetPointer, String rule) {
-        this(zone, effect, filter, mustCast, optional, setTargetPointer, rule, false);
-    }
-
-    public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean mustCast,
-                                                 boolean optional,
-                                                 SetTargetPointer setTargetPointer, String rule, boolean controlledText) {
-        super(zone, effect, filter, optional, setTargetPointer, rule, controlledText);
-
+    public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional,
+                                                 SetTargetPointer setTargetPointer, boolean mustCast) {
+        super(zone, effect, filter, optional, setTargetPointer, null);
         this.mustCast = mustCast;
         this.addWatcher(new PermanentWasCastWatcher());
-
-        StringBuilder triggerPhrase = new StringBuilder(this.generateTriggerPhrase());
-        if (mustCast) {
-            triggerPhrase.append("if it was cast, ");
-        } else {
-            triggerPhrase.append("if it wasn't cast, ");
-        }
-        this.setTriggerPhrase(triggerPhrase.toString());
+        setTriggerPhrase("Whenever " + getMessageFromFilter() + " under your control, if it " + (mustCast ? "was" : "wasn't") + " cast, " );
     }
 
     protected EntersBattlefieldCastTriggeredAbility(final EntersBattlefieldCastTriggeredAbility ability) {
         super(ability);
-
         this.mustCast = ability.mustCast;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        if (!super.checkTrigger(event, game))
-            return false;
-
         PermanentWasCastWatcher watcher = game.getState().getWatcher(PermanentWasCastWatcher.class);
-        UUID targetId = event.getTargetId();
-
-        return watcher.wasPermanentCastThisTurn(targetId) == this.mustCast;
+        return watcher != null && watcher.wasPermanentCastThisTurn(event.getTargetId()) == this.mustCast
+                && super.checkTrigger(event, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldCastTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldCastTriggeredAbility.java
@@ -19,7 +19,7 @@ public class EntersBattlefieldCastTriggeredAbility extends EntersBattlefieldCont
 
     public EntersBattlefieldCastTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional,
                                                  SetTargetPointer setTargetPointer, boolean mustCast) {
-        super(zone, effect, filter, optional, setTargetPointer, null);
+        super(zone, effect, filter, optional, setTargetPointer);
         this.mustCast = mustCast;
         this.addWatcher(new PermanentWasCastWatcher());
         setTriggerPhrase(getTriggerPhraseFromFilter() + " under your control, if it " + (mustCast ? "was" : "wasn't") + " cast, " );

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldCastTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldCastTriggeredAbility.java
@@ -22,7 +22,7 @@ public class EntersBattlefieldCastTriggeredAbility extends EntersBattlefieldCont
         super(zone, effect, filter, optional, setTargetPointer, null);
         this.mustCast = mustCast;
         this.addWatcher(new PermanentWasCastWatcher());
-        setTriggerPhrase("Whenever " + getMessageFromFilter() + " under your control, if it " + (mustCast ? "was" : "wasn't") + " cast, " );
+        setTriggerPhrase(getTriggerPhraseFromFilter() + " under your control, if it " + (mustCast ? "was" : "wasn't") + " cast, " );
     }
 
     protected EntersBattlefieldCastTriggeredAbility(final EntersBattlefieldCastTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
@@ -36,7 +36,7 @@ public class EntersBattlefieldControlledTriggeredAbility extends EntersBattlefie
 
     public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule) {
         super(zone, effect, filter, optional, setTargetPointer, rule);
-        setTriggerPhrase("Whenever " + getMessageFromFilter() + " under your control, ");
+        setTriggerPhrase(getTriggerPhraseFromFilter() + " under your control, ");
     }
 
     protected EntersBattlefieldControlledTriggeredAbility(final EntersBattlefieldControlledTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
@@ -15,12 +15,7 @@ import mage.game.permanent.Permanent;
 public class EntersBattlefieldControlledTriggeredAbility extends EntersBattlefieldAllTriggeredAbility {
 
     /**
-     * zone     = BATTLEFIELD
-     * optional = false
-     * rule     = null
-     *
-     * @param effect
-     * @param filter
+     * zone = BATTLEFIELD, optional = false
      */
     public EntersBattlefieldControlledTriggeredAbility(Effect effect, FilterPermanent filter) {
         this(Zone.BATTLEFIELD, effect, filter, false);
@@ -40,7 +35,7 @@ public class EntersBattlefieldControlledTriggeredAbility extends EntersBattlefie
     }
 
     public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule) {
-        super(zone, effect, filter, optional, setTargetPointer, rule, true);
+        super(zone, effect, filter, optional, setTargetPointer, rule);
         setTriggerPhrase("Whenever " + getMessageFromFilter() + " under your control, ");
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
@@ -21,21 +21,12 @@ public class EntersBattlefieldControlledTriggeredAbility extends EntersBattlefie
         this(Zone.BATTLEFIELD, effect, filter, false);
     }
 
-    public EntersBattlefieldControlledTriggeredAbility(Effect effect, FilterPermanent filter, String rule) {
-        this(Zone.BATTLEFIELD, effect, filter, false, rule);
-    }
-
     public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional) {
-        this(zone, effect, filter, optional, null);
-        this.filter = filter;
+        this(zone, effect, filter, optional, SetTargetPointer.NONE);
     }
 
-    public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, String rule) {
-        this(zone, effect, filter, optional, SetTargetPointer.NONE, rule);
-    }
-
-    public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule) {
-        super(zone, effect, filter, optional, setTargetPointer, rule);
+    public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
+        super(zone, effect, filter, optional, setTargetPointer);
         setTriggerPhrase(getTriggerPhraseFromFilter() + " under your control, ");
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldControlledTriggeredAbility.java
@@ -1,5 +1,3 @@
-
-
 package mage.abilities.common;
 
 import mage.abilities.effects.Effect;
@@ -43,6 +41,7 @@ public class EntersBattlefieldControlledTriggeredAbility extends EntersBattlefie
 
     public EntersBattlefieldControlledTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, String rule) {
         super(zone, effect, filter, optional, setTargetPointer, rule, true);
+        setTriggerPhrase("Whenever " + getMessageFromFilter() + " under your control, ");
     }
 
     protected EntersBattlefieldControlledTriggeredAbility(final EntersBattlefieldControlledTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
@@ -18,7 +18,7 @@ public class EntersBattlefieldOpponentTriggeredAbility extends EntersBattlefield
     }
 
     public EntersBattlefieldOpponentTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
-        super(zone, effect, filter, optional, setTargetPointer, null, true);
+        super(zone, effect, filter, optional, setTargetPointer, null);
         setTriggerPhrase("Whenever " + getMessageFromFilter() + " under an opponent's control, ");
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
@@ -18,7 +18,7 @@ public class EntersBattlefieldOpponentTriggeredAbility extends EntersBattlefield
     }
 
     public EntersBattlefieldOpponentTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
-        super(zone, effect, filter, optional, setTargetPointer, null);
+        super(zone, effect, filter, optional, setTargetPointer);
         setTriggerPhrase(getTriggerPhraseFromFilter() + " under an opponent's control, ");
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
@@ -19,7 +19,7 @@ public class EntersBattlefieldOpponentTriggeredAbility extends EntersBattlefield
 
     public EntersBattlefieldOpponentTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
         super(zone, effect, filter, optional, setTargetPointer, null);
-        setTriggerPhrase("Whenever " + getMessageFromFilter() + " under an opponent's control, ");
+        setTriggerPhrase(getTriggerPhraseFromFilter() + " under an opponent's control, ");
     }
 
     protected EntersBattlefieldOpponentTriggeredAbility(final EntersBattlefieldOpponentTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
@@ -1,0 +1,41 @@
+package mage.abilities.common;
+
+import mage.abilities.effects.Effect;
+import mage.constants.SetTargetPointer;
+import mage.constants.Zone;
+import mage.filter.FilterPermanent;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ * @author xenohedron
+ */
+public class EntersBattlefieldOpponentTriggeredAbility extends EntersBattlefieldAllTriggeredAbility {
+
+    public EntersBattlefieldOpponentTriggeredAbility(Effect effect, FilterPermanent filter, boolean optional) {
+        this(Zone.BATTLEFIELD, effect, filter, optional, SetTargetPointer.NONE);
+    }
+
+    public EntersBattlefieldOpponentTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
+        super(zone, effect, filter, optional, setTargetPointer, null, true);
+    }
+
+    protected EntersBattlefieldOpponentTriggeredAbility(final EntersBattlefieldOpponentTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        if (permanent == null || !game.getOpponents(this.getControllerId()).contains(permanent.getControllerId())) {
+            return false;
+        }
+        return super.checkTrigger(event, game);
+    }
+
+    @Override
+    public EntersBattlefieldOpponentTriggeredAbility copy() {
+        return new EntersBattlefieldOpponentTriggeredAbility(this);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldOpponentTriggeredAbility.java
@@ -19,6 +19,7 @@ public class EntersBattlefieldOpponentTriggeredAbility extends EntersBattlefield
 
     public EntersBattlefieldOpponentTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer) {
         super(zone, effect, filter, optional, setTargetPointer, null, true);
+        setTriggerPhrase("Whenever " + getMessageFromFilter() + " under an opponent's control, ");
     }
 
     protected EntersBattlefieldOpponentTriggeredAbility(final EntersBattlefieldOpponentTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldThisOrAnotherTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldThisOrAnotherTriggeredAbility.java
@@ -11,22 +11,13 @@ import mage.filter.FilterPermanentThisOrAnother;
  */
 public class EntersBattlefieldThisOrAnotherTriggeredAbility extends EntersBattlefieldAllTriggeredAbility {
 
-    public EntersBattlefieldThisOrAnotherTriggeredAbility(Effect effect, FilterPermanent filter) {
-        this(effect, filter, false, false);
-    }
-
     public EntersBattlefieldThisOrAnotherTriggeredAbility(Effect effect, FilterPermanent filter, boolean optional, boolean onlyControlled) {
         this(effect, filter, optional, SetTargetPointer.NONE, onlyControlled);
     }
 
     public EntersBattlefieldThisOrAnotherTriggeredAbility(Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, boolean onlyControlled) {
-        this(Zone.BATTLEFIELD, effect, filter, optional, setTargetPointer, onlyControlled);
-    }
-
-    public EntersBattlefieldThisOrAnotherTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, boolean onlyControlled) {
-        super(zone, effect,
-                new FilterPermanentThisOrAnother(filter, onlyControlled),
-                optional, setTargetPointer, null);
+        super(Zone.BATTLEFIELD, effect, new FilterPermanentThisOrAnother(filter, onlyControlled), optional, setTargetPointer, null);
+        setTriggerPhrase("Whenever " + this.filter.getMessage() + " enters the battlefield" + (onlyControlled ? " under your control, " : ", "));
     }
 
     private EntersBattlefieldThisOrAnotherTriggeredAbility(final EntersBattlefieldThisOrAnotherTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldThisOrAnotherTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldThisOrAnotherTriggeredAbility.java
@@ -16,7 +16,7 @@ public class EntersBattlefieldThisOrAnotherTriggeredAbility extends EntersBattle
     }
 
     public EntersBattlefieldThisOrAnotherTriggeredAbility(Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, boolean onlyControlled) {
-        super(Zone.BATTLEFIELD, effect, new FilterPermanentThisOrAnother(filter, onlyControlled), optional, setTargetPointer, null);
+        super(Zone.BATTLEFIELD, effect, new FilterPermanentThisOrAnother(filter, onlyControlled), optional, setTargetPointer);
         setTriggerPhrase("Whenever " + this.filter.getMessage() + " enters the battlefield" + (onlyControlled ? " under your control, " : ", "));
     }
 

--- a/Mage/src/main/java/mage/abilities/common/EntersBattlefieldThisOrAnotherTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/EntersBattlefieldThisOrAnotherTriggeredAbility.java
@@ -26,7 +26,7 @@ public class EntersBattlefieldThisOrAnotherTriggeredAbility extends EntersBattle
     public EntersBattlefieldThisOrAnotherTriggeredAbility(Zone zone, Effect effect, FilterPermanent filter, boolean optional, SetTargetPointer setTargetPointer, boolean onlyControlled) {
         super(zone, effect,
                 new FilterPermanentThisOrAnother(filter, onlyControlled),
-                optional, setTargetPointer, null, onlyControlled);
+                optional, setTargetPointer, null);
     }
 
     private EntersBattlefieldThisOrAnotherTriggeredAbility(final EntersBattlefieldThisOrAnotherTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandChosenPermanentEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnToHandChosenPermanentEffect.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.effects.common;
 
 import mage.abilities.Ability;
@@ -60,10 +59,10 @@ public class ReturnToHandChosenPermanentEffect extends OneShotEffect {
 
     protected String getText() {
         StringBuilder sb = new StringBuilder("that player returns ");
-        if (!filter.getMessage().startsWith("another")) {
-            sb.append(CardUtil.numberToText(number, "a"));
+        if (!filter.getMessage().startsWith("another") && !filter.getMessage().startsWith("a ")) {
+            sb.append(CardUtil.numberToText(number, "a")).append(' ');
         }
-        sb.append(' ').append(filter.getMessage());
+        sb.append(filter.getMessage());
         sb.append(" they control");
         if (number > 1) {
             sb.append(" to their owner's hand");

--- a/Mage/src/main/java/mage/abilities/keyword/SoulbondAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SoulbondAbility.java
@@ -175,7 +175,7 @@ class SoulbondEntersOtherAbility extends EntersBattlefieldAllTriggeredAbility {
     }
 
     public SoulbondEntersOtherAbility() {
-        super(Zone.BATTLEFIELD, new SoulboundEntersOtherEffect(), soulbondFilter, true, SetTargetPointer.PERMANENT, "");
+        super(Zone.BATTLEFIELD, new SoulboundEntersOtherEffect(), soulbondFilter, true, SetTargetPointer.PERMANENT);
         setRuleVisible(false);
     }
 

--- a/Mage/src/main/java/mage/game/command/emblems/KioraMasterOfTheDepthsEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/KioraMasterOfTheDepthsEmblem.java
@@ -6,7 +6,7 @@ import mage.abilities.effects.OneShotEffect;
 import mage.constants.Outcome;
 import mage.constants.SetTargetPointer;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.command.Emblem;
 import mage.game.permanent.Permanent;
@@ -17,14 +17,11 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class KioraMasterOfTheDepthsEmblem extends Emblem {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Creatures");
-
     public KioraMasterOfTheDepthsEmblem() {
         super("Emblem Kiora");
 
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.COMMAND,
-                new KioraFightEffect(), filter, true, SetTargetPointer.PERMANENT,
-                "Whenever a creature enters the battlefield under your control, you may have it fight target creature.");
+                new KioraFightEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null);
         ability.addTarget(new TargetCreaturePermanent());
         this.getAbilities().add(ability);
     }
@@ -43,6 +40,7 @@ class KioraFightEffect extends OneShotEffect {
 
     KioraFightEffect() {
         super(Outcome.Damage);
+        staticText = "you may have it fight target creature";
     }
 
     KioraFightEffect(final KioraFightEffect effect) {

--- a/Mage/src/main/java/mage/game/command/emblems/KioraMasterOfTheDepthsEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/KioraMasterOfTheDepthsEmblem.java
@@ -21,7 +21,7 @@ public final class KioraMasterOfTheDepthsEmblem extends Emblem {
         super("Emblem Kiora");
 
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.COMMAND,
-                new KioraFightEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT, null);
+                new KioraFightEffect(), StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT);
         ability.addTarget(new TargetCreaturePermanent());
         this.getAbilities().add(ability);
     }

--- a/Mage/src/main/java/mage/game/command/emblems/NissaVitalForceEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/NissaVitalForceEmblem.java
@@ -1,10 +1,10 @@
 package mage.game.command.emblems;
 
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
+import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.StaticFilters;
 import mage.game.command.Emblem;
 
 /**
@@ -15,8 +15,8 @@ public final class NissaVitalForceEmblem extends Emblem {
 
     public NissaVitalForceEmblem() {
         super("Emblem Nissa");
-        Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.COMMAND, new DrawCardSourceControllerEffect(1), new FilterControlledLandPermanent("a land"),
-                true, null);
+        Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.COMMAND,
+                new DrawCardSourceControllerEffect(1), StaticFilters.FILTER_LAND_A, true, null);
         getAbilities().add(ability);
     }
 

--- a/Mage/src/main/java/mage/game/command/emblems/NissaVitalForceEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/NissaVitalForceEmblem.java
@@ -16,7 +16,7 @@ public final class NissaVitalForceEmblem extends Emblem {
     public NissaVitalForceEmblem() {
         super("Emblem Nissa");
         Ability ability = new EntersBattlefieldControlledTriggeredAbility(Zone.COMMAND,
-                new DrawCardSourceControllerEffect(1), StaticFilters.FILTER_LAND_A, true, null);
+                new DrawCardSourceControllerEffect(1), StaticFilters.FILTER_LAND_A, true);
         getAbilities().add(ability);
     }
 

--- a/Mage/src/main/java/mage/game/command/emblems/NissaVitalForceEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/NissaVitalForceEmblem.java
@@ -16,7 +16,7 @@ public final class NissaVitalForceEmblem extends Emblem {
     public NissaVitalForceEmblem() {
         super("Emblem Nissa");
         Ability ability = new EntersBattlefieldAllTriggeredAbility(Zone.COMMAND, new DrawCardSourceControllerEffect(1), new FilterControlledLandPermanent("a land"),
-                true, null, true);
+                true, null);
         getAbilities().add(ability);
     }
 


### PR DESCRIPTION
This PR removes hardcoded rule strings, simplifies the constructors, and improves the capabilities of automatic text generation in general.
* EntersBattlefieldAllTriggeredAbility
* EntersBattlefieldControlledTriggeredAbility
* EntersBattlefieldOpponentTriggeredAbility
* EntersBattlefieldThisOrAnotherTriggeredAbility
* EntersBattlefieldCastTriggeredAbility