### PR TITLE
add tests for Scry & Surveil

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BargainTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BargainTest.java
@@ -46,15 +46,15 @@ public class BargainTest extends CardTestPlayerBase {
      * Hamlet Glutton
      * {5}{G}{G}
      * Creature — Giant
-     *
+     * <p>
      * Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)
-     *
+     * <p>
      * This spell costs {2} less to cast if it’s bargained.
-     *
+     * <p>
      * Trample
-     *
+     * <p>
      * When Hamlet Glutton enters the battlefield, you gain 3 life.
-     *
+     * <p>
      * 6/6
      */
     private static final String glutton = "Hamlet Glutton";
@@ -223,6 +223,7 @@ public class BargainTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, lightningBolt, 1);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
         addCard(Zone.BATTLEFIELD, playerA, glider); // Could be bargain.
+        addCard(Zone.LIBRARY, playerA, "Plains"); // see the card on scry
 
         addCard(Zone.BATTLEFIELD, playerB, stoneGolem);
 
@@ -232,6 +233,7 @@ public class BargainTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, torchTheTower, stoneGolem);
         setChoice(playerA, true); // Do bargain.
         setChoice(playerA, glider); // Bargain the glider away.
+        addTarget(playerA, "Plains"); // scry the Plains away
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BestowTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BestowTest.java
@@ -9,6 +9,7 @@ import mage.constants.Zone;
 import mage.game.permanent.Permanent;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -49,6 +50,7 @@ public class BestowTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Hopeful Eidolon using bestow", "Silent Artisan");
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Gods Willing", "Silent Artisan");
         setChoice(playerA, "White");
+        addTarget(playerA, TestPlayer.TARGET_SKIP); // scrying 1 to the top
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -530,6 +532,7 @@ public class BestowTest extends CardTestPlayerBase {
         assertType("Nylea's Emissary", CardType.CREATURE, false);
         assertType("Nylea's Emissary", CardType.ENCHANTMENT, SubType.AURA);
     }
+
     @Test
     public void testCastBestowFlash() {
         addCard(Zone.HAND, playerA, "Nylea's Emissary"); // +3/+3, only an aura if cast with bestow

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ForetellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ForetellTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- *
  * @author jeffwadsworth
  */
 public class ForetellTest extends CardTestPlayerBase {
@@ -48,10 +47,19 @@ public class ForetellTest extends CardTestPlayerBase {
     public void testForetoldCastOtherTurnAsForetold() {
         // verify that foretold card can be cast on a turn other than the one it was foretold
         setStrictChooseMode(true);
+
         addCard(Zone.BATTLEFIELD, playerA, "Island", 4);  // Foretell cost 2 mana and {1}{U} for foretell cast from exile
         addCard(Zone.HAND, playerA, "Behold the Multiverse");  // (Instant) Scry 2 and draw 2 cards
+
+        // Setting up for the scry 2
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Altar of Dementia");
+        addCard(Zone.LIBRARY, playerA, "Millstone");
+
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fore");
         activateAbility(2, PhaseStep.PRECOMBAT_MAIN, playerA, "Foretell {1}{U}");
+        addTarget(playerA, "Millstone"); // scrying to the bottom.
+
         setStopAt(2, PhaseStep.END_TURN);
         execute();
 
@@ -59,7 +67,7 @@ public class ForetellTest extends CardTestPlayerBase {
         assertGraveyardCount(playerA, "Behold the Multiverse", 1);  // now in graveyard
         assertHandCount(playerA, 2); // 2 cards drawn
     }
-    
+
     @Test
     public void testDreamDevourerTrigger() {
         // Issue #8876
@@ -68,7 +76,7 @@ public class ForetellTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5); // 3 mana for suspend and 2 for foretell
         addCard(Zone.HAND, playerA, "Sol Talisman", 1);  // Suspend card
         addCard(Zone.HAND, playerA, "Lightning Bolt", 1); // card to foretell
-        
+
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Susp"); // suspend the Sol Talisman
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fore"); // foretell the Lightning Bolt
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/library/ScryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/library/ScryTest.java
@@ -1,0 +1,169 @@
+package org.mage.test.cards.abilities.oneshot.library;
+
+import mage.cards.Card;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.player.TestPlayer;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+import java.util.List;
+
+/**
+ * @author Susucr
+ */
+public class ScryTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.p.Preordain} <br>
+     * Preordain {U} <br>
+     * Sorcery <br>
+     * Scry 2, then draw a card. (To scry 2, look at the top two cards of your library, then put any number of them on the bottom and the rest on top in any order.)
+     */
+    private static String preordain = "Preordain";
+
+    private static String cardD = "Devilthorn Fox";
+    private static String cardC = "Canopy Gorger";
+    private static String cardB = "Barbtooth Wurm";
+    private static String cardA = "Alaborn Trooper";
+
+    private void initLibrary() {
+        // make a library of 4 cards, bottom : D C B A : top
+        skipInitShuffling();
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, cardD);
+        addCard(Zone.LIBRARY, playerA, cardC);
+        addCard(Zone.LIBRARY, playerA, cardB);
+        addCard(Zone.LIBRARY, playerA, cardA);
+    }
+
+    /**
+     * assert that the library is exactly the cards provided in argument
+     */
+    private void assertLibrary(TestPlayer player, String... cards) {
+        List<Card> library = player.getLibrary().getCards(currentGame);
+        Assert.assertEquals("Library of " + player.getName() + " is not of the expected size", cards.length, library.size());
+        for (int i = 0; i < cards.length; i++) {
+            Assert.assertEquals("Library of " + player.getName() + " has different card #" + i, cards[i], library.get(i).getName());
+        }
+    }
+
+    @Test
+    public void Scry2_BottomBottom() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, preordain);
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, preordain);
+        addTarget(playerA, cardA + "^" + cardB); // scrying both bottom
+        setChoice(playerA, cardB); // cardB before cardA
+        // + draw C
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardC, 1);
+        assertLibrary(playerA, cardD, cardB, cardA);
+    }
+
+    @Test
+    public void Scry2_BottomBottom_otherorder() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, preordain);
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, preordain);
+        addTarget(playerA, cardA + "^" + cardB); // scrying both bottom
+        setChoice(playerA, cardA); // cardA before cardB
+        // + draw C
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardC, 1);
+        assertLibrary(playerA, cardD, cardA, cardB);
+    }
+
+    @Test
+    public void Scry2_BottomTop() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, preordain);
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, preordain);
+        addTarget(playerA, cardA); // scrying A bottom
+        // + draw B
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardB, 1);
+        assertLibrary(playerA, cardC, cardD, cardA);
+    }
+
+    @Test
+    public void Scry2_TopBottom() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, preordain);
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, preordain);
+        addTarget(playerA, cardB); // scrying B bottom
+        // + draw A
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardA, 1);
+        assertLibrary(playerA, cardC, cardD, cardB);
+    }
+
+    @Test
+    public void Scry2_TopTop() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, preordain);
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, preordain);
+        addTarget(playerA, TestPlayer.TARGET_SKIP); // scrying both on top
+        setChoice(playerA, cardB); // cardB below cardA
+        // + draw A
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardA, 1);
+        assertLibrary(playerA, cardB, cardC, cardD);
+    }
+
+    @Test
+    public void Scry2_TopTop_otherorder() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, preordain);
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, preordain);
+        addTarget(playerA, TestPlayer.TARGET_SKIP); // scrying both on top
+        setChoice(playerA, cardA); // cardA below cardB
+        // + draw B
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardB, 1);
+        assertLibrary(playerA, cardA, cardC, cardD);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/library/SurveilTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/library/SurveilTest.java
@@ -1,0 +1,153 @@
+package org.mage.test.cards.abilities.oneshot.library;
+
+import mage.cards.Card;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.player.TestPlayer;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+import java.util.List;
+
+/**
+ * @author Susucr
+ */
+public class SurveilTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.c.Curate} <br>
+     * Curate {U} <br>
+     * Instant <br>
+     * Surveil 2. (Look at the top two cards of your library, then put any number of them into your graveyard and the rest on top of your library in any order.) <br>
+     * Draw a card.
+     */
+    private static String curate = "Curate";
+
+    private static String cardD = "Devilthorn Fox";
+    private static String cardC = "Canopy Gorger";
+    private static String cardB = "Barbtooth Wurm";
+    private static String cardA = "Alaborn Trooper";
+
+    private void initLibrary() {
+        // make a library of 4 cards, bottom : D C B A : top
+        skipInitShuffling();
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, cardD);
+        addCard(Zone.LIBRARY, playerA, cardC);
+        addCard(Zone.LIBRARY, playerA, cardB);
+        addCard(Zone.LIBRARY, playerA, cardA);
+    }
+
+    /**
+     * assert that the library is exactly the cards provided in argument
+     */
+    private void assertLibrary(TestPlayer player, String... cards) {
+        List<Card> library = player.getLibrary().getCards(currentGame);
+        Assert.assertEquals("Library of " + player.getName() + " is not of the expected size", cards.length, library.size());
+        for (int i = 0; i < cards.length; i++) {
+            Assert.assertEquals("Library of " + player.getName() + " has different card #" + i, cards[i], library.get(i).getName());
+        }
+    }
+
+    @Test
+    public void Surveil2_YardYard() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, curate);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, curate);
+        addTarget(playerA, cardA + "^" + cardB); // surveil both in graveyard
+        // + draw C
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, cardA, 1);
+        assertGraveyardCount(playerA, cardB, 1);
+        assertHandCount(playerA, cardC, 1);
+        assertLibrary(playerA, cardD);
+    }
+
+    @Test
+    public void Surveil2_YardTop() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, curate);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, curate);
+        addTarget(playerA, cardA); // surveil A in graveyard
+        // + draw B
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, cardA, 1);
+        assertHandCount(playerA, cardB, 1);
+        assertLibrary(playerA, cardC, cardD);
+    }
+
+    @Test
+    public void Surveil2_TopYard() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, curate);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, curate);
+        addTarget(playerA, cardB); // surveil B in graveyard
+        // + draw A
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardA, 1);
+        assertGraveyardCount(playerA, cardB, 1);
+        assertLibrary(playerA, cardC, cardD);
+    }
+
+    @Test
+    public void Surveil2_TopTop() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, curate);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, curate);
+        addTarget(playerA, TestPlayer.TARGET_SKIP); // surveil both on top
+        setChoice(playerA, cardB); // cardB below cardA
+        // + draw A
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardA, 1);
+        assertLibrary(playerA, cardB, cardC, cardD);
+    }
+
+    @Test
+    public void Surveil2_TopTop_otherorder() {
+        setStrictChooseMode(true);
+        initLibrary();
+
+        addCard(Zone.HAND, playerA, curate);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, curate);
+        addTarget(playerA, TestPlayer.TARGET_SKIP); // surveil both on top
+        setChoice(playerA, cardA); // cardA below cardB
+        // + draw B
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, cardB, 1);
+        assertLibrary(playerA, cardA, cardC, cardD);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/modification/CostReduceWithConditionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/modification/CostReduceWithConditionTest.java
@@ -15,11 +15,18 @@ public class CostReduceWithConditionTest extends CardTestPlayerBaseWithAIHelps {
         // {3}{B}
         // This spell costs {2} less to cast if it targets a legendary creature.
         // Destroy target creature.
+        // Surveil 2.
         addCard(Zone.HAND, playerA, "Price of Fame", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
         addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears", 1);
 
+        // Init library for scry 2
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Plains");
+        addCard(Zone.LIBRARY, playerA, "Forest");
+
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Price of Fame", "Balduvian Bears");
+        addTarget(playerA, "Plains"); // surveilling plains to the graveyard.
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -35,11 +42,18 @@ public class CostReduceWithConditionTest extends CardTestPlayerBaseWithAIHelps {
         // {3}{B}
         // This spell costs {2} less to cast if it targets a legendary creature.
         // Destroy target creature.
+        // Surveil 2.
         addCard(Zone.HAND, playerA, "Price of Fame", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4 - 2);
         addCard(Zone.BATTLEFIELD, playerB, "Anje Falkenrath", 1);
 
+        // Init library for scry 2
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Plains");
+        addCard(Zone.LIBRARY, playerA, "Forest");
+
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Price of Fame", "Anje Falkenrath");
+        addTarget(playerA, "Plains"); // surveilling plains to the graveyard.
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -55,6 +69,7 @@ public class CostReduceWithConditionTest extends CardTestPlayerBaseWithAIHelps {
         // {3}{B}
         // This spell costs {2} less to cast if it targets a legendary creature.
         // Destroy target creature.
+        // Surveil 2.
         addCard(Zone.HAND, playerA, "Price of Fame", 1);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4 - 2);
         addCard(Zone.BATTLEFIELD, playerB, "Anje Falkenrath", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/RosheenMeandererManaXTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/RosheenMeandererManaXTest.java
@@ -155,6 +155,11 @@ public class RosheenMeandererManaXTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Lightning Bolt");
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
 
+        // init the top of library for the scry 2
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerB, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerB, "Abandon Hope");
+
         // cast bolt
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
         // counter with condescend
@@ -166,6 +171,7 @@ public class RosheenMeandererManaXTest extends CardTestPlayerBase {
         checkManaPool("mana", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "C", 4);
         // pay to prevent
         setChoice(playerA, true); // pay 2 to prevent counter
+        addTarget(playerB, "Abandon Hope"); // scry 2: choosing to bottom Abandon Hope.
 
         checkLife("after", 1, PhaseStep.POSTCOMBAT_MAIN, playerB, 20 - 3);
         checkHandCardCount("after", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", 0);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/conditional/ConditionalManaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/conditional/ConditionalManaTest.java
@@ -11,7 +11,6 @@ import mage.counters.CounterType;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
-
 import static org.mage.test.utils.ManaOptionsTestUtils.assertManaOptions;
 
 /**
@@ -370,6 +369,12 @@ public class ConditionalManaTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
 
         addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears", 2);
+
+        // Init library to mill a third bear
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Grizzly Bears");
+
+        addTarget(playerA, "Grizzly Bears"); // upkeep surveil: put the Bears in the graveyard.
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m21/SeeTheTruthTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m21/SeeTheTruthTest.java
@@ -5,6 +5,9 @@ import mage.constants.Zone;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
+/**
+ * @author Susucr
+ */
 public class SeeTheTruthTest extends CardTestPlayerBase {
 
     // See the Truth {1}{U}
@@ -27,6 +30,7 @@ public class SeeTheTruthTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, seeTheTruth);
         addTarget(playerA, "Bear Cub");         // card chosen to be put in hand
+        setChoice(playerA, "Alpine Grizzly");   // ordering the 2 other cards
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
@@ -94,7 +98,9 @@ public class SeeTheTruthTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, seeTheTruth);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Twincast", seeTheTruth);
         addTarget(playerA, "Bear Cub");         // card chosen to be put in hand   -- for the copy.
+        setChoice(playerA, "Alpine Grizzly");   // ordering the 2 other cards
         addTarget(playerA, "Enormous Baloth");  // card chosen to be put in hand   -- for the initial cast.
+        setChoice(playerA, "Durkwood Boars");   // ordering the 2 other cards
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/neo/StoryweaveTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/neo/StoryweaveTest.java
@@ -47,8 +47,14 @@ public class StoryweaveTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, intervention);
         addCard(Zone.HAND, playerA, fang);
 
+        // For scry, putting 2 cards on top.
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerA, "Elite Vanguard");
+
         addEffectToGame();
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, intervention, true);
+        addTarget(playerA, "Elite Vanguard"); // scry Vanguard on bottom
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, fang);
 
         setStrictChooseMode(true);
@@ -71,9 +77,15 @@ public class StoryweaveTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, intervention);
         addCard(Zone.HAND, playerA, fang);
 
+        // For scry, putting 2 cards on top.
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerA, "Elite Vanguard");
+
         addEffectToGame();
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, fang);
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, intervention);
+        addTarget(playerA, "Elite Vanguard"); // scry Vanguard on bottom
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/pcy/MunghaWurmTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/pcy/MunghaWurmTest.java
@@ -24,6 +24,7 @@ public class MunghaWurmTest extends CardTestPlayerBase {
     private static final String meadow = "Alpine Meadow";
     private static final String treeline = "Arctic Treeline";
     private static final String guildgate = "Azorius Guildgate";
+    private static final String guildgate2 = "Golgari Guildgate";
 
     // destroy the wurm
     private static final String doomBlade = "Doom Blade";
@@ -34,16 +35,22 @@ public class MunghaWurmTest extends CardTestPlayerBase {
 
         addCard(Zone.BATTLEFIELD, playerA, wurm);
         addCard(Zone.BATTLEFIELD, playerA, meadow, 10);
-        //addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        addCard(Zone.BATTLEFIELD, playerA, guildgate2, 1);
         addCard(Zone.BATTLEFIELD, playerB, treeline, 10);
 
-        //setChoice(playerA, guildgate);
+        addTarget(playerA, guildgate); // untapping the first guildgate t1
+
+        // t2, no effect since wurm is only messing with its controller untap
+
+        addTarget(playerA, guildgate2); // untapping the second guildgate t3
+
         setStopAt(3, PhaseStep.UPKEEP);
         execute();
 
-        assertTappedCount(meadow, true, 10 - 1);
-        assertTappedCount(meadow, false, 1);
-        //assertTappedCount(guildgate, false, 1);
+        assertTappedCount(meadow, true, 10); // all meadows still tapped
+        assertTappedCount(guildgate, false, 1);
+        assertTappedCount(guildgate2, false, 1);
         assertTappedCount(treeline, false, 10);
     }
 
@@ -54,19 +61,20 @@ public class MunghaWurmTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, doomBlade);
         addCard(Zone.BATTLEFIELD, playerA, wurm);
         addCard(Zone.BATTLEFIELD, playerA, meadow, 10);
-        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
-        //addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 1);
+        addCard(Zone.BATTLEFIELD, playerA, guildgate, 1);
         addCard(Zone.BATTLEFIELD, playerB, treeline, 10);
+
+        addTarget(playerA, guildgate); // untapping the guildgate t1
 
         // Killing the wurm, get rid of the untap replacement effect.
         castSpell(2, PhaseStep.END_TURN, playerA, doomBlade, wurm);
 
-        //setChoice(playerA, guildgate);
         setStopAt(3, PhaseStep.UPKEEP);
         execute();
 
         assertTappedCount(meadow, false, 10);
-        //assertTappedCount(guildgate, false, 1);
+        assertTappedCount(guildgate, false, 1);
         assertTappedCount(treeline, false, 10);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer.java
@@ -1,12 +1,14 @@
 package org.mage.test.player;
 
 import mage.abilities.Ability;
+import mage.cards.Cards;
 import mage.choices.Choice;
 import mage.constants.Outcome;
 import mage.constants.RangeOfInfluence;
 import mage.game.Game;
 import mage.player.ai.ComputerPlayer;
 import mage.target.Target;
+import mage.target.TargetCard;
 
 /**
  * @author JayDi85
@@ -56,6 +58,33 @@ public class TestComputerPlayer extends ComputerPlayer {
             return super.choose(outcome, choice, game);
         } else {
             return testPlayerLink.choose(outcome, choice, game);
+        }
+    }
+
+    @Override
+    public boolean choose(Outcome outcome, Cards cards, TargetCard target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.choose(outcome, cards, target, source, game);
+        } else {
+            return testPlayerLink.choose(outcome, cards, target, source, game);
+        }
+    }
+
+    @Override
+    public boolean chooseTarget(Outcome outcome, Target target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.chooseTarget(outcome, target, source, game);
+        } else {
+            return testPlayerLink.chooseTarget(outcome, target, source, game);
+        }
+    }
+
+    @Override
+    public boolean chooseTarget(Outcome outcome, Cards cards, TargetCard target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.chooseTarget(outcome, cards, target, source, game);
+        } else {
+            return testPlayerLink.chooseTarget(outcome, cards, target, source, game);
         }
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer7.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayer7.java
@@ -1,12 +1,14 @@
 package org.mage.test.player;
 
 import mage.abilities.Ability;
+import mage.cards.Cards;
 import mage.choices.Choice;
 import mage.constants.Outcome;
 import mage.constants.RangeOfInfluence;
 import mage.game.Game;
 import mage.player.ai.ComputerPlayer7;
 import mage.target.Target;
+import mage.target.TargetCard;
 
 /**
  * Copied-pasted methods from TestComputerPlayer, see docs in there
@@ -41,6 +43,33 @@ public class TestComputerPlayer7 extends ComputerPlayer7 {
             return super.choose(outcome, choice, game);
         } else {
             return testPlayerLink.choose(outcome, choice, game);
+        }
+    }
+
+    @Override
+    public boolean choose(Outcome outcome, Cards cards, TargetCard target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.choose(outcome, cards, target, source, game);
+        } else {
+            return testPlayerLink.choose(outcome, cards, target, source, game);
+        }
+    }
+
+    @Override
+    public boolean chooseTarget(Outcome outcome, Target target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.chooseTarget(outcome, target, source, game);
+        } else {
+            return testPlayerLink.chooseTarget(outcome, target, source, game);
+        }
+    }
+
+    @Override
+    public boolean chooseTarget(Outcome outcome, Cards cards, TargetCard target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.chooseTarget(outcome, cards, target, source, game);
+        } else {
+            return testPlayerLink.chooseTarget(outcome, cards, target, source, game);
         }
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayerMonteCarlo.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestComputerPlayerMonteCarlo.java
@@ -1,12 +1,14 @@
 package org.mage.test.player;
 
 import mage.abilities.Ability;
+import mage.cards.Cards;
 import mage.choices.Choice;
 import mage.constants.Outcome;
 import mage.constants.RangeOfInfluence;
 import mage.game.Game;
 import mage.player.ai.ComputerPlayerMCTS;
 import mage.target.Target;
+import mage.target.TargetCard;
 
 /**
  * Copied-pasted methods from TestComputerPlayer, see docs in there
@@ -41,6 +43,33 @@ public class TestComputerPlayerMonteCarlo extends ComputerPlayerMCTS {
             return super.choose(outcome, choice, game);
         } else {
             return testPlayerLink.choose(outcome, choice, game);
+        }
+    }
+
+    @Override
+    public boolean choose(Outcome outcome, Cards cards, TargetCard target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.choose(outcome, cards, target, source, game);
+        } else {
+            return testPlayerLink.choose(outcome, cards, target, source, game);
+        }
+    }
+
+    @Override
+    public boolean chooseTarget(Outcome outcome, Target target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.chooseTarget(outcome, target, source, game);
+        } else {
+            return testPlayerLink.chooseTarget(outcome, target, source, game);
+        }
+    }
+
+    @Override
+    public boolean chooseTarget(Outcome outcome, Cards cards, TargetCard target, Ability source, Game game) {
+        if (testPlayerLink.canChooseByComputer()) {
+            return super.chooseTarget(outcome, cards, target, source, game);
+        } else {
+            return testPlayerLink.chooseTarget(outcome, cards, target, source, game);
         }
     }
 


### PR DESCRIPTION
tests using StrictChooseMode are now more strict, with 3 more overriden methods.

A few existing tests needed a little work as they were calling those methods under StrictChooseMode and ComputerPlayer made AI choices instead of the test specifying the choices.

closes #10887