### PR TITLE
Cheats: added default special menus (add cards to hand, add lands to battlefield)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ Mage.Verify/*.zip
 Mage.Verify/*.json
 Mage.Verify/db
 
+# Mage.Reports
+Mage.Reports/target
+
 # Logs rotation
 *.log.*
 

--- a/Mage.Client/src/main/java/mage/client/dialog/PickMultiNumberDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/PickMultiNumberDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.2" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JInternalFrameFormInfo">
+<Form version="1.8" maxVersion="1.9" type="org.netbeans.modules.form.forminfo.JInternalFrameFormInfo">
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="2"/>
   </SyntheticProperties>
@@ -14,71 +14,17 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-42,0,0,1,-89"/>
   </AuxValues>
 
-  <Layout>
-    <DimensionLayout dim="0">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <EmptySpace min="12" pref="12" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="header" alignment="1" max="32767" attributes="0"/>
-                          <Component id="counterText" max="32767" attributes="0"/>
-                      </Group>
-                  </Group>
-                  <Group type="102" attributes="0">
-                      <EmptySpace min="-2" pref="184" max="-2" attributes="0"/>
-                      <Component id="chooseButton" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="172" max="32767" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="jScrollPane1" max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-              <EmptySpace max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-    <DimensionLayout dim="1">
-      <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="1" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="header" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="counterText" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="jScrollPane1" pref="276" max="32767" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="chooseButton" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-          </Group>
-      </Group>
-    </DimensionLayout>
-  </Layout>
+  <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
   <SubComponents>
-    <Component class="javax.swing.JButton" name="chooseButton">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="Choose"/>
-        <Property name="enabled" type="boolean" value="false"/>
-      </Properties>
-      <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="chooseButtonActionPerformed"/>
-      </Events>
-    </Component>
-    <Component class="javax.swing.JLabel" name="header">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="Header"/>
-      </Properties>
-    </Component>
-    <Component class="javax.swing.JLabel" name="counterText">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="Counter"/>
-      </Properties>
-    </Component>
     <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+          <BorderConstraints direction="Center"/>
+        </Constraint>
+      </Constraints>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
       <SubComponents>
@@ -87,16 +33,103 @@
           <Layout>
             <DimensionLayout dim="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <EmptySpace min="0" pref="413" max="32767" attributes="0"/>
+                  <EmptySpace min="0" pref="598" max="32767" attributes="0"/>
               </Group>
             </DimensionLayout>
             <DimensionLayout dim="1">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <EmptySpace min="0" pref="273" max="32767" attributes="0"/>
+                  <EmptySpace min="0" pref="828" max="32767" attributes="0"/>
               </Group>
             </DimensionLayout>
           </Layout>
         </Container>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="panelCommands">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+          <BorderConstraints direction="South"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout>
+        <DimensionLayout dim="0">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <EmptySpace pref="257" max="32767" attributes="0"/>
+                  <Component id="btnOk" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Component id="btnCancel" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+        <DimensionLayout dim="1">
+          <Group type="103" groupAlignment="0" attributes="0">
+              <Group type="102" alignment="0" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="3" attributes="0">
+                      <Component id="btnOk" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="btnCancel" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+              </Group>
+          </Group>
+        </DimensionLayout>
+      </Layout>
+      <SubComponents>
+        <Component class="javax.swing.JButton" name="btnOk">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Choose"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnOkActionPerformed"/>
+          </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_AddingCodePost" type="java.lang.String" value="getRootPane().setDefaultButton(btnOk);"/>
+          </AuxValues>
+        </Component>
+        <Component class="javax.swing.JButton" name="btnCancel">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Cancel"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnCancelActionPerformed"/>
+          </Events>
+        </Component>
+      </SubComponents>
+    </Container>
+    <Container class="javax.swing.JPanel" name="panelHeader">
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+          <BorderConstraints direction="North"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JLabel" name="header">
+          <Properties>
+            <Property name="horizontalAlignment" type="int" value="0"/>
+            <Property name="text" type="java.lang.String" value="Header 12312321312312"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="North"/>
+            </Constraint>
+          </Constraints>
+        </Component>
+        <Component class="javax.swing.JLabel" name="counterText">
+          <Properties>
+            <Property name="horizontalAlignment" type="int" value="0"/>
+            <Property name="text" type="java.lang.String" value="Counter 213123 213 213123213 123 123213123123123"/>
+          </Properties>
+          <Constraints>
+            <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
+              <BorderConstraints direction="South"/>
+            </Constraint>
+          </Constraints>
+        </Component>
       </SubComponents>
     </Container>
   </SubComponents>

--- a/Mage.Client/src/main/java/mage/client/dialog/PickMultiNumberDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PickMultiNumberDialog.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
  */
 public class PickMultiNumberDialog extends MageDialog {
 
+    private boolean cancel;
+    
     private List<JLabel> labelList = null;
     private List<JSpinner> spinnerList = null;
 
@@ -28,9 +30,11 @@ public class PickMultiNumberDialog extends MageDialog {
     }
 
     public void showDialog(List<MultiAmountMessage> messages, int min, int max, Map<String, Serializable> options) {
-        this.header.setText((String) options.get("header"));
-        this.header.setHorizontalAlignment(SwingConstants.CENTER);
+        this.header.setText("<html>" + ManaSymbols.replaceSymbolsWithHTML((String) options.get("header"), ManaSymbols.Type.DIALOG));
         this.setTitle((String) options.get("title"));
+
+        boolean canCancel = options.get("canCancel") != null && (boolean) options.get("canCancel");
+        btnCancel.setVisible(canCancel);
 
         if (labelList != null) {
             for (JLabel label : labelList) {
@@ -79,7 +83,7 @@ public class PickMultiNumberDialog extends MageDialog {
                 }
             } else {
                 // text mode
-                label.setText("<html>" + input);
+                label.setText("<html>" + ManaSymbols.replaceSymbolsWithHTML(input, ManaSymbols.Type.DIALOG));
             }
 
             labelC.weightx = 0.5;
@@ -89,7 +93,7 @@ public class PickMultiNumberDialog extends MageDialog {
             labelList.add(label);
 
             JSpinner spinner = new JSpinner();
-            spinner.setModel(new SpinnerNumberModel(messages.get(i).min, messages.get(i).min, messages.get(i).max, 1));
+            spinner.setModel(new SpinnerNumberModel(messages.get(i).defaultValue, messages.get(i).min, messages.get(i).max, 1));
             spinnerC.weightx = 0.5;
             spinnerC.gridx = 1;
             spinnerC.gridy = i;
@@ -101,7 +105,6 @@ public class PickMultiNumberDialog extends MageDialog {
             spinnerList.add(spinner);
         }
         this.counterText.setText("0 out of 0");
-        this.counterText.setHorizontalAlignment(SwingConstants.CENTER);
 
         updateControls(min, max, messages);
 
@@ -124,7 +127,7 @@ public class PickMultiNumberDialog extends MageDialog {
         counterText.setText(totalChosenAmount + " out of " + max);
 
         chooseEnabled &= totalChosenAmount >= min && totalChosenAmount <= max;
-        chooseButton.setEnabled(chooseEnabled);
+        btnOk.setEnabled(chooseEnabled);
     }
 
     public String getMultiAmount() {
@@ -133,6 +136,10 @@ public class PickMultiNumberDialog extends MageDialog {
                 .map(spinner -> ((Number) spinner.getValue()).intValue())
                 .map(String::valueOf)
                 .collect(Collectors.joining(" "));
+    }
+    
+    public boolean isCancel() {
+        return cancel;
     }
 
     /**
@@ -144,82 +151,103 @@ public class PickMultiNumberDialog extends MageDialog {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
-        chooseButton = new javax.swing.JButton();
-        header = new javax.swing.JLabel();
-        counterText = new javax.swing.JLabel();
         jScrollPane1 = new javax.swing.JScrollPane();
         jPanel1 = new javax.swing.JPanel();
+        panelCommands = new javax.swing.JPanel();
+        btnOk = new javax.swing.JButton();
+        btnCancel = new javax.swing.JButton();
+        panelHeader = new javax.swing.JPanel();
+        header = new javax.swing.JLabel();
+        counterText = new javax.swing.JLabel();
 
-        chooseButton.setText("Choose");
-        chooseButton.setEnabled(false);
-        chooseButton.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                chooseButtonActionPerformed(evt);
-            }
-        });
-
-        header.setText("Header");
-
-        counterText.setText("Counter");
+        getContentPane().setLayout(new java.awt.BorderLayout());
 
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 413, Short.MAX_VALUE)
+            .addGap(0, 598, Short.MAX_VALUE)
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGap(0, 273, Short.MAX_VALUE)
+            .addGap(0, 828, Short.MAX_VALUE)
         );
 
         jScrollPane1.setViewportView(jPanel1);
 
-        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-        getContentPane().setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(12, 12, 12)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(header, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(counterText, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(184, 184, 184)
-                        .addComponent(chooseButton)
-                        .addGap(0, 172, Short.MAX_VALUE))
-                    .addGroup(layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addComponent(jScrollPane1)))
+        getContentPane().add(jScrollPane1, java.awt.BorderLayout.CENTER);
+
+        btnOk.setText("Choose");
+        btnOk.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnOkActionPerformed(evt);
+            }
+        });
+
+        btnCancel.setText("Cancel");
+        btnCancel.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnCancelActionPerformed(evt);
+            }
+        });
+
+        javax.swing.GroupLayout panelCommandsLayout = new javax.swing.GroupLayout(panelCommands);
+        panelCommands.setLayout(panelCommandsLayout);
+        panelCommandsLayout.setHorizontalGroup(
+            panelCommandsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(panelCommandsLayout.createSequentialGroup()
+                .addContainerGap(257, Short.MAX_VALUE)
+                .addComponent(btnOk)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(btnCancel)
                 .addContainerGap())
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+        panelCommandsLayout.setVerticalGroup(
+            panelCommandsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(panelCommandsLayout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(header)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(counterText)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 276, Short.MAX_VALUE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(chooseButton)
+                .addGroup(panelCommandsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(btnOk)
+                    .addComponent(btnCancel))
                 .addContainerGap())
         );
+
+        getRootPane().setDefaultButton(btnOk);
+
+        getContentPane().add(panelCommands, java.awt.BorderLayout.SOUTH);
+
+        panelHeader.setLayout(new java.awt.BorderLayout());
+
+        header.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
+        header.setText("Header 12312321312312");
+        panelHeader.add(header, java.awt.BorderLayout.NORTH);
+
+        counterText.setHorizontalAlignment(javax.swing.SwingConstants.CENTER);
+        counterText.setText("Counter 213123 213 213123213 123 123213123123123");
+        panelHeader.add(counterText, java.awt.BorderLayout.SOUTH);
+
+        getContentPane().add(panelHeader, java.awt.BorderLayout.NORTH);
     }// </editor-fold>//GEN-END:initComponents
 
-    private void chooseButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_chooseButtonActionPerformed
+    private void btnOkActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnOkActionPerformed
+        this.cancel = false;
         this.hideDialog();
-    }//GEN-LAST:event_chooseButtonActionPerformed
+    }//GEN-LAST:event_btnOkActionPerformed
+
+    private void btnCancelActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnCancelActionPerformed
+        this.cancel = true;
+        this.hideDialog();
+    }//GEN-LAST:event_btnCancelActionPerformed
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.JButton chooseButton;
+    private javax.swing.JButton btnCancel;
+    private javax.swing.JButton btnOk;
     private javax.swing.JLabel counterText;
     private javax.swing.JLabel header;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JPanel panelCommands;
+    private javax.swing.JPanel panelHeader;
     // End of variables declaration//GEN-END:variables
 }

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -1785,7 +1785,11 @@ public final class GamePanel extends javax.swing.JPanel {
         DialogManager.getManager(gameId).fadeOut();
 
         pickMultiNumber.showDialog(messages, min, max, lastGameData.options);
-        SessionHandler.sendPlayerString(gameId, pickMultiNumber.getMultiAmount());
+        if (pickMultiNumber.isCancel()) {
+            SessionHandler.sendPlayerBoolean(gameId, false);
+        } else {
+            SessionHandler.sendPlayerString(gameId, pickMultiNumber.getMultiAmount());
+        }
     }
 
     public void getChoice(int messageId, GameView gameView, Map<String, Serializable> options, Choice choice, UUID objectId) {

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2154,6 +2154,9 @@ public class HumanPlayer extends PlayerImpl {
                 Map<String, Serializable> options = new HashMap<>(2);
                 options.put("title", type.getTitle());
                 options.put("header", type.getHeader());
+                if (type.isCanCancel()) {
+                    options.put("canCancel", true);
+                }
                 game.fireGetMultiAmountEvent(playerId, messages, min, max, options);
             }
             waitForResponse(game);
@@ -2169,11 +2172,17 @@ public class HumanPlayer extends PlayerImpl {
                     logger.error(String.format("GUI return wrong MultiAmountType values: %d %d %d - %s", needCount, min, max, response.getString()));
                     game.informPlayer(this, "Error, you must enter correct values.");
                 }
+            } else if (type.isCanCancel() && response.getBoolean() != null) {
+                answer = null;
+                break;
             }
         }
 
         if (answer != null) {
             return answer;
+        } else if (type.isCanCancel()) {
+            // cancel
+            return null;
         } else {
             // something wrong, e.g. player disconnected
             return defaultList;

--- a/Mage.Server/release/config/init.example.txt
+++ b/Mage.Server/release/config/init.example.txt
@@ -1,0 +1,47 @@
+// Allows run cheat commands. How to use:
+// * open launcher and add to server's command line: -Dxmage.testMode=true
+// * rename that file to init.txt and put to server's config folder
+// * activate smiley button on your player's panel
+
+[init]
+battlefield:Human:Forest:5
+battlefield:Human:Plains:5
+battlefield:Human:Mountain:5
+battlefield:Human:Swamp:5
+battlefield:Human:Island:5
+hand:Human:Lightning Bolt:2
+library:Human:Doom Blade:2
+
+// special command, see SystemUtil for more special commands list
+[@activate opponent ability]
+
+[current test]
+graveyard:Human:Bloodghast:1
+graveyard:Computer:Bloodghast:1
+hand:Human:Bloodghast:1
+hand:Computer:Bloodghast:1
+
+[diff set codes example]
+battlefield:Human:XLN-Island:1
+battlefield:Human:UST-Island:1
+battlefield:Human:HOU-Island:1
+
+// @ref command example (all refs will be replaced by commands from ref's group)
+[another test]
+@init
+hand:Human:Lightning Bolt:2
+
+[2x bears to me]
+battlefield:Human:Kitesail Corsair:2
+
+[2x bears to comp]
+battlefield:Computer:Kitesail Corsair:2
+//battlefield:Computer:Grizzly Bears:1
+
+// create any useful commands
+[clone]
+hand:Human:Clone:3
+[force attack]
+hand:Human:Pit Fight:3
+[exile]
+hand:Human:Angelic Edict:3

--- a/Mage.Sets/src/mage/cards/b/BosiumStrip.java
+++ b/Mage.Sets/src/mage/cards/b/BosiumStrip.java
@@ -119,7 +119,7 @@ class BosiumStripReplacementEffect extends ReplacementEffectImpl {
         }
 
         ((ZoneChangeEvent) event).setToZone(Zone.EXILED);
-        return true;
+        return false;
     }
 
     @Override

--- a/Mage/src/main/java/mage/cards/decks/importer/CardLookup.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/CardLookup.java
@@ -20,6 +20,10 @@ public class CardLookup {
     }
 
     public Optional<CardInfo> lookupCardInfo(String name, String set) {
+        if (set == null) {
+            return lookupCardInfo(name);
+        }
+
         Optional<CardInfo> result = lookupCardInfo(new CardCriteria().name(name).setCodes(set))
                 .stream()
                 .findAny();

--- a/Mage/src/main/java/mage/constants/MultiAmountType.java
+++ b/Mage/src/main/java/mage/constants/MultiAmountType.java
@@ -13,14 +13,21 @@ public enum MultiAmountType {
     MANA("Add mana", "Distribute mana among colors"),
     DAMAGE("Assign damage", "Assign damage among targets"),
     P1P1("Add +1/+1 counters", "Distribute +1/+1 counters among creatures"),
-    COUNTERS("Choose counters", "Move counters");
+    COUNTERS("Choose counters", "Move counters"),
+    CHEAT_LANDS("Choose lands", "Add lands to your battlefield", true);
 
     private final String title;
     private final String header;
+    private final boolean canCancel; // choice dialog will return null instead default values
 
     MultiAmountType(String title, String header) {
+        this(title, header, false);
+    }
+
+    MultiAmountType(String title, String header, boolean canCancel) {
         this.title = title;
         this.header = header;
+        this.canCancel = canCancel;
     }
 
     public String getTitle() {
@@ -31,9 +38,13 @@ public enum MultiAmountType {
         return header;
     }
 
+    public boolean isCanCancel() {
+        return canCancel;
+    }
+
     public static List<Integer> prepareDefaltValues(List<MultiAmountMessage> constraints, int min, int max) {
         // default values must be assigned from first to last by minimum values
-        List<Integer> res = constraints.stream().map(m -> m.min > Integer.MIN_VALUE ? m.min : (0 < max ? 0 : max))
+        List<Integer> res = constraints.stream().map(m -> m.defaultValue > Integer.MIN_VALUE ? m.defaultValue : Math.min(0, max))
                 .collect(Collectors.toList());
         if (res.isEmpty()) {
             return res;

--- a/Mage/src/main/java/mage/util/MultiAmountMessage.java
+++ b/Mage/src/main/java/mage/util/MultiAmountMessage.java
@@ -8,10 +8,16 @@ public class MultiAmountMessage implements Serializable {
     public String message;
     public int min;
     public int max;
+    public int defaultValue;
 
     public MultiAmountMessage(String message, int min, int max) {
+        this(message, min, max, min);
+    }
+
+    public MultiAmountMessage(String message, int min, int max, int defaultValue) {
         this.message = message;
         this.min = min;
         this.max = max;
+        this.defaultValue = defaultValue;
     }
 }


### PR DESCRIPTION
Default menu will be visible at the top of cheat menu. It's very useful if you want to fast test some cards without `init.txt` edit (or if you miss some commands in it);

Menu example:
![shot_231102_122158](https://github.com/magefree/mage/assets/8344157/07422d64-994f-4c53-805b-b9f4e5384db2)

Add lands example:
![shot_231102_122214](https://github.com/magefree/mage/assets/8344157/7940cd83-fea6-40ee-9197-7ce9d92cbfac)