### PR TITLE
Checks the ID of the card instead of the nonland object

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GuffRewritesHistory.java
+++ b/Mage.Sets/src/mage/cards/g/GuffRewritesHistory.java
@@ -161,7 +161,7 @@ class GuffRewritesHistoryEffect extends OneShotEffect {
             cards.retainZone(Zone.EXILED, game);
             // reveal all the exiled cards, as they are reshuffled instantly and do not stay in exile.
             controller.revealCards(source, " — " + controller.getName(), cards, game);
-            if (nonland != null && cards.contains(nonland)) {
+            if (nonland != null && cards.contains(nonland.getId())) {
                 nonlands.put(playerId, nonland);
                 cards.remove(nonland);
             }


### PR DESCRIPTION
Fix for https://github.com/magefree/mage/issues/11206 following xenohedron's suggestion