### PR TITLE
Benevolent Blessing Protection Fixes and Tests

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BenevolentBlessing.java
+++ b/Mage.Sets/src/mage/cards/b/BenevolentBlessing.java
@@ -43,7 +43,7 @@ public final class BenevolentBlessing extends CardImpl {
 
         // Enchanted creature has protection from the chosen color. This effect doesn't remove Auras and Equipment you control that are already attached to it.
         this.addAbility(new SimpleStaticAbility(
-                new ProtectionChosenColorAttachedEffect(false)
+                new ProtectionChosenColorAttachedEffect(true)
                         .setNotRemoveControlled(true)
                         .setText("Enchanted creature has protection from the chosen color. This effect doesn't " +
                                 "remove Auras and Equipment you control that are already attached to it.")

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/cmr/BenevolentBlessingTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/cmr/BenevolentBlessingTest.java
@@ -1,0 +1,91 @@
+package org.mage.test.cards.single.cmr;
+
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.LifelinkAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommanderDuelBase;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Shashakar
+ */
+
+public class BenevolentBlessingTest extends CardTestPlayerBase {
+
+    // Flash
+    // Enchant creature
+    // As Benevolent Blessing enters the battlefield, choose a color.
+    // Enchanted creature has protection from the chosen color. This effect doesn't remove Auras and Equipment you control that are already attached to it.
+
+    @Test
+    public void testPlayable() {
+        String protectionColor = "White";
+
+        SetupBaseState();
+
+        setChoice(playerA, protectionColor);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Benevolent Blessing", "Serra Angel");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Serra Angel", 1);
+        assertPermanentCount(playerA, "Benevolent Blessing", 1);
+    }
+
+    @Test
+    public void test_DoesNotRemoveAurasOfProtectionColor() {
+        String protectionColor = "White";
+
+        SetupBaseState();
+        addCard(Zone.HAND, playerA, "Pacifism", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Pacifism", "Serra Angel");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        setChoice(playerA, protectionColor);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Benevolent Blessing", "Serra Angel");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Serra Angel", 1);
+        assertPermanentCount(playerA, "Benevolent Blessing", 1);
+        assertAttachedTo(playerA, "Pacifism", "Serra Angel", true);
+    }
+
+    @Test
+    public void test_DoesNotRemoveEquipmentOfProtectionColor() {
+        String protectionColor = "White";
+
+        SetupBaseState();
+        addCard(Zone.BATTLEFIELD, playerA, "Ancestral Katana", 1);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip", "Serra Angel");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        setStrictChooseMode(true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Benevolent Blessing", "Serra Angel");
+        setChoice(playerA, protectionColor);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Serra Angel", 1);
+        //assertPermanentCount(playerA, "Benevolent Blessing", 1);
+
+        assertAttachedTo(playerA, "Ancestral Katana", "Serra Angel", true);
+    }
+
+    private void SetupBaseState()
+    {
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 10);
+        addCard(Zone.BATTLEFIELD, playerA, "Serra Angel", 1);
+        addCard(Zone.HAND, playerA, "Benevolent Blessing", 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/ProtectionAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ProtectionAbility.java
@@ -75,7 +75,7 @@ public class ProtectionAbility extends StaticAbility {
 
     @Override
     public String getRule() {
-        return "protection from " + filter.getMessage() + (removeAuras ? "" : ". This effect doesn't remove Auras.");
+        return "protection from " + filter.getMessage() + (removeAuras ? "" : ". This effect doesn't remove Auras" + (removeEquipment ? "" : ". This effect doesn't remove Equipment"));
     }
 
     public boolean canTarget(MageObject source, Game game) {

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -1279,6 +1279,14 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     public boolean hasProtectionFrom(MageObject source, Game game) {
         for (ProtectionAbility ability : this.getAbilities(game).getProtectionAbilities()) {
             if (!ability.canTarget(source, game)) {
+                //Support cards like "Benevolent Blessing"
+                if (source.hasSubtype(SubType.EQUIPMENT, game) && !ability.removesEquipment() && this.attachments.contains(source.getId())) {
+                    return false;
+                }
+                if (source.hasSubtype(SubType.AURA, game) && !ability.removesAuras() && this.attachments.contains(source.getId()))
+                {
+                    return false;
+                }
                 return true;
             }
         }


### PR DESCRIPTION
- Benevolent Blessing no longer removes itself if white is chosen
- Benevolent Blessing no longer removes attached auras of the chosen color
- Benevolent Blessing no longer removes attached equipment of the chosen color
- Added tests to verify Benevolent Blessing's effects