### PR TITLE
Cost tag tracking part 1: subability copy bug

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AgathasSoulCauldron.java
+++ b/Mage.Sets/src/mage/cards/a/AgathasSoulCauldron.java
@@ -139,7 +139,7 @@ class AgathasSoulCauldronAbilityEffect extends ContinuousEffectImpl {
         }
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
             for (Ability ability : abilities) {
-                permanent.addAbility(ability, source.getSourceId(), game, false);
+                permanent.addAbility(ability, source.getSourceId(), game, true);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/a/AgathasSoulCauldron.java
+++ b/Mage.Sets/src/mage/cards/a/AgathasSoulCauldron.java
@@ -139,7 +139,7 @@ class AgathasSoulCauldronAbilityEffect extends ContinuousEffectImpl {
         }
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
             for (Ability ability : abilities) {
-                permanent.addAbility(ability, source.getSourceId(), game);
+                permanent.addAbility(ability, source.getSourceId(), game, false);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/d/DarkImpostor.java
+++ b/Mage.Sets/src/mage/cards/d/DarkImpostor.java
@@ -110,7 +110,7 @@ class DarkImpostorContinuousEffect extends ContinuousEffectImpl {
         for (Card card : exileZone.getCards(StaticFilters.FILTER_CARD_CREATURE, game)) {
             for (Ability ability : card.getAbilities(game)) {
                 if (ability instanceof ActivatedAbility) {
-                    permanent.addAbility(ability, source.getSourceId(), game);
+                    permanent.addAbility(ability, source.getSourceId(), game, false);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/d/DarkImpostor.java
+++ b/Mage.Sets/src/mage/cards/d/DarkImpostor.java
@@ -110,7 +110,7 @@ class DarkImpostorContinuousEffect extends ContinuousEffectImpl {
         for (Card card : exileZone.getCards(StaticFilters.FILTER_CARD_CREATURE, game)) {
             for (Ability ability : card.getAbilities(game)) {
                 if (ability instanceof ActivatedAbility) {
-                    permanent.addAbility(ability, source.getSourceId(), game, false);
+                    permanent.addAbility(ability, source.getSourceId(), game, true);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/d/DranaAndLinvala.java
+++ b/Mage.Sets/src/mage/cards/d/DranaAndLinvala.java
@@ -123,7 +123,7 @@ class DranaAndLinvalaGainAbilitiesEffect extends ContinuousEffectImpl {
                 .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
                         || ability.getAbilityType() == AbilityType.MANA)
                 .collect(Collectors.toList())) {
-            Ability addedAbility = perm.addAbility(ability, source.getSourceId(), game);
+            Ability addedAbility = perm.addAbility(ability, source.getSourceId(), game, false);
             if (addedAbility != null) {
                 addedAbility.getEffects().setValue("dranaLinvalaFlag", true);
             }

--- a/Mage.Sets/src/mage/cards/d/DranaAndLinvala.java
+++ b/Mage.Sets/src/mage/cards/d/DranaAndLinvala.java
@@ -123,7 +123,7 @@ class DranaAndLinvalaGainAbilitiesEffect extends ContinuousEffectImpl {
                 .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
                         || ability.getAbilityType() == AbilityType.MANA)
                 .collect(Collectors.toList())) {
-            Ability addedAbility = perm.addAbility(ability, source.getSourceId(), game, false);
+            Ability addedAbility = perm.addAbility(ability, source.getSourceId(), game, true);
             if (addedAbility != null) {
                 addedAbility.getEffects().setValue("dranaLinvalaFlag", true);
             }

--- a/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
@@ -79,7 +79,7 @@ class ExperimentKrajEffect extends ContinuousEffectImpl {
             for (Permanent creature :game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)){
                 for (Ability ability: creature.getAbilities()) {
                     if (ability instanceof ActivatedAbility) {
-                        perm.addAbility(ability, source.getSourceId(), game, false);
+                        perm.addAbility(ability, source.getSourceId(), game, true);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
@@ -79,7 +79,7 @@ class ExperimentKrajEffect extends ContinuousEffectImpl {
             for (Permanent creature :game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)){
                 for (Ability ability: creature.getAbilities()) {
                     if (ability instanceof ActivatedAbility) {
-                        perm.addAbility(ability, source.getSourceId(), game);
+                        perm.addAbility(ability, source.getSourceId(), game, false);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/h/HavengulLich.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulLich.java
@@ -25,7 +25,6 @@ import mage.filter.FilterCard;
 import mage.filter.common.FilterCreatureCard;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCardInGraveyard;
 
@@ -188,7 +187,7 @@ class HavengulLichEffect extends ContinuousEffectImpl {
         Card card = game.getCard(cardId);
         if (permanent != null && card != null) {
             for (ActivatedAbility ability : card.getAbilities(game).getActivatedAbilities(Zone.BATTLEFIELD)) {
-                permanent.addAbility(ability, source.getSourceId(), game, false);
+                permanent.addAbility(ability, source.getSourceId(), game, true);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/h/HavengulLich.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulLich.java
@@ -188,7 +188,7 @@ class HavengulLichEffect extends ContinuousEffectImpl {
         Card card = game.getCard(cardId);
         if (permanent != null && card != null) {
             for (ActivatedAbility ability : card.getAbilities(game).getActivatedAbilities(Zone.BATTLEFIELD)) {
-                permanent.addAbility(ability, source.getSourceId(), game);
+                permanent.addAbility(ability, source.getSourceId(), game, false);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/k/KasminaEnigmaSage.java
+++ b/Mage.Sets/src/mage/cards/k/KasminaEnigmaSage.java
@@ -93,7 +93,7 @@ class KasminaEnigmaSageGainAbilitiesEffect extends ContinuousEffectImpl {
                 continue;
             }
             for (Ability ability : loyaltyAbilities) {
-                permanent.addAbility(ability, source.getSourceId(), game, false);
+                permanent.addAbility(ability, source.getSourceId(), game, true);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/k/KasminaEnigmaSage.java
+++ b/Mage.Sets/src/mage/cards/k/KasminaEnigmaSage.java
@@ -93,7 +93,7 @@ class KasminaEnigmaSageGainAbilitiesEffect extends ContinuousEffectImpl {
                 continue;
             }
             for (Ability ability : loyaltyAbilities) {
-                permanent.addAbility(ability, source.getSourceId(), game);
+                permanent.addAbility(ability, source.getSourceId(), game, false);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
+++ b/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
@@ -141,7 +141,7 @@ class MairsilThePretenderGainAbilitiesEffect extends ContinuousEffectImpl {
                     if (ability instanceof ActivatedAbility) {
                         ActivatedAbility copyAbility = (ActivatedAbility) ability.copy();
                         copyAbility.setMaxActivationsPerTurn(1);
-                        perm.addAbility(copyAbility, source.getSourceId(), game, false);
+                        perm.addAbility(copyAbility, source.getSourceId(), game, true);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
+++ b/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
@@ -141,7 +141,7 @@ class MairsilThePretenderGainAbilitiesEffect extends ContinuousEffectImpl {
                     if (ability instanceof ActivatedAbility) {
                         ActivatedAbility copyAbility = (ActivatedAbility) ability.copy();
                         copyAbility.setMaxActivationsPerTurn(1);
-                        perm.addAbility(copyAbility, source.getSourceId(), game);
+                        perm.addAbility(copyAbility, source.getSourceId(), game, false);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
+++ b/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
@@ -90,7 +90,7 @@ class ManascapeRefractorGainAbilitiesEffect extends ContinuousEffectImpl {
                     || perm.getAbilities(game)
                     .stream()
                     .noneMatch(ability.getClass()::isInstance)) {
-                perm.addAbility(ability, source.getSourceId(), game, false);
+                perm.addAbility(ability, source.getSourceId(), game, true);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
+++ b/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
@@ -90,7 +90,7 @@ class ManascapeRefractorGainAbilitiesEffect extends ContinuousEffectImpl {
                     || perm.getAbilities(game)
                     .stream()
                     .noneMatch(ability.getClass()::isInstance)) {
-                perm.addAbility(ability, source.getSourceId(), game);
+                perm.addAbility(ability, source.getSourceId(), game, false);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
+++ b/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
@@ -140,7 +140,7 @@ class MetamorphicAlterationEffect extends ContinuousEffectImpl {
         permanent.getColor(game).setColor(copied.getColor(game));
         permanent.removeAllAbilities(source.getSourceId(), game);
         for (Ability ability : copied.getAbilities()) {
-            permanent.addAbility(ability, source.getSourceId(), game);
+            permanent.addAbility(ability, source.getSourceId(), game, false);
         }
         permanent.getPower().setModifiedBaseValue(copied.getPower().getBaseValue());
         permanent.getToughness().setModifiedBaseValue(copied.getToughness().getBaseValue());

--- a/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
+++ b/Mage.Sets/src/mage/cards/m/MetamorphicAlteration.java
@@ -140,7 +140,7 @@ class MetamorphicAlterationEffect extends ContinuousEffectImpl {
         permanent.getColor(game).setColor(copied.getColor(game));
         permanent.removeAllAbilities(source.getSourceId(), game);
         for (Ability ability : copied.getAbilities()) {
-            permanent.addAbility(ability, source.getSourceId(), game, false);
+            permanent.addAbility(ability, source.getSourceId(), game, true);
         }
         permanent.getPower().setModifiedBaseValue(copied.getPower().getBaseValue());
         permanent.getToughness().setModifiedBaseValue(copied.getToughness().getBaseValue());

--- a/Mage.Sets/src/mage/cards/m/MirranSafehouse.java
+++ b/Mage.Sets/src/mage/cards/m/MirranSafehouse.java
@@ -73,7 +73,7 @@ class MirranSafehouseEffect extends ContinuousEffectImpl {
                 .filter(ActivatedAbility.class::isInstance)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
-            permanent.addAbility(ability, source.getSourceId(), game);
+            permanent.addAbility(ability, source.getSourceId(), game, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MirranSafehouse.java
+++ b/Mage.Sets/src/mage/cards/m/MirranSafehouse.java
@@ -73,7 +73,7 @@ class MirranSafehouseEffect extends ContinuousEffectImpl {
                 .filter(ActivatedAbility.class::isInstance)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
-            permanent.addAbility(ability, source.getSourceId(), game, false);
+            permanent.addAbility(ability, source.getSourceId(), game, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MyrWelder.java
+++ b/Mage.Sets/src/mage/cards/m/MyrWelder.java
@@ -101,7 +101,7 @@ class MyrWelderContinuousEffect extends ContinuousEffectImpl {
                 if (card != null) {
                     for (Ability ability : card.getAbilities(game)) {
                         if (ability instanceof ActivatedAbility) {
-                            perm.addAbility(ability, source.getId(), game);
+                            perm.addAbility(ability, source.getId(), game, false);
                         }
                     }
                 }

--- a/Mage.Sets/src/mage/cards/m/MyrWelder.java
+++ b/Mage.Sets/src/mage/cards/m/MyrWelder.java
@@ -101,7 +101,7 @@ class MyrWelderContinuousEffect extends ContinuousEffectImpl {
                 if (card != null) {
                     for (Ability ability : card.getAbilities(game)) {
                         if (ability instanceof ActivatedAbility) {
-                            perm.addAbility(ability, source.getId(), game, false);
+                            perm.addAbility(ability, source.getId(), game, true);
                         }
                     }
                 }

--- a/Mage.Sets/src/mage/cards/n/NecroticOoze.java
+++ b/Mage.Sets/src/mage/cards/n/NecroticOoze.java
@@ -79,7 +79,7 @@ class NecroticOozeEffect extends ContinuousEffectImpl {
                 .filter(ActivatedAbility.class::isInstance)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
-            permanent.addAbility(ability, source.getSourceId(), game, false);
+            permanent.addAbility(ability, source.getSourceId(), game, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NecroticOoze.java
+++ b/Mage.Sets/src/mage/cards/n/NecroticOoze.java
@@ -79,7 +79,7 @@ class NecroticOozeEffect extends ContinuousEffectImpl {
                 .filter(ActivatedAbility.class::isInstance)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
-            permanent.addAbility(ability, source.getSourceId(), game);
+            permanent.addAbility(ability, source.getSourceId(), game, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
@@ -91,7 +91,7 @@ class NicolBolasDragonGodGainAbilitiesEffect extends ContinuousEffectImpl {
         )) {
             for (Ability ability : permanent.getAbilities()) {
                 if (ability instanceof LoyaltyAbility) {
-                    perm.addAbility(ability, source.getSourceId(), game, false);
+                    perm.addAbility(ability, source.getSourceId(), game, true);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
@@ -91,7 +91,7 @@ class NicolBolasDragonGodGainAbilitiesEffect extends ContinuousEffectImpl {
         )) {
             for (Ability ability : permanent.getAbilities()) {
                 if (ability instanceof LoyaltyAbility) {
-                    perm.addAbility(ability, source.getSourceId(), game);
+                    perm.addAbility(ability, source.getSourceId(), game, false);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PatchworkCrawler.java
+++ b/Mage.Sets/src/mage/cards/p/PatchworkCrawler.java
@@ -77,7 +77,7 @@ class PatchworkCrawlerEffect extends ContinuousEffectImpl {
         for (Card card : exileZone.getCards(StaticFilters.FILTER_CARD_CREATURE, game)) {
             for (Ability ability : card.getAbilities(game)) {
                 if (ability instanceof ActivatedAbility) {
-                    permanent.addAbility(ability, source.getSourceId(), game, false);
+                    permanent.addAbility(ability, source.getSourceId(), game, true);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PatchworkCrawler.java
+++ b/Mage.Sets/src/mage/cards/p/PatchworkCrawler.java
@@ -77,7 +77,7 @@ class PatchworkCrawlerEffect extends ContinuousEffectImpl {
         for (Card card : exileZone.getCards(StaticFilters.FILTER_CARD_CREATURE, game)) {
             for (Ability ability : card.getAbilities(game)) {
                 if (ability instanceof ActivatedAbility) {
-                    permanent.addAbility(ability, source.getSourceId(), game);
+                    permanent.addAbility(ability, source.getSourceId(), game, false);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/q/QuicksilverElemental.java
+++ b/Mage.Sets/src/mage/cards/q/QuicksilverElemental.java
@@ -77,6 +77,7 @@ class QuicksilverElementalEffect extends OneShotEffect {
             for (ActivatedAbility ability : creature.getAbilities().getActivatedAbilities(Zone.BATTLEFIELD)) {
                 Ability newAbility = ability.copy();
                 newAbility.newOriginalId();
+                newAbility.getSubAbilities().clear(); //Should not copy subabilities
                 game.addEffect(new GainAbilitySourceEffect(newAbility, Duration.EndOfTurn), source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/r/RobaranMercenaries.java
+++ b/Mage.Sets/src/mage/cards/r/RobaranMercenaries.java
@@ -87,7 +87,7 @@ class RobaranMercenariesEffect extends ContinuousEffectImpl {
                     || perm.getAbilities(game)
                     .stream()
                     .noneMatch(ability.getClass()::isInstance)) {
-                perm.addAbility(ability, source.getSourceId(), game);
+                perm.addAbility(ability, source.getSourceId(), game, false);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/r/RobaranMercenaries.java
+++ b/Mage.Sets/src/mage/cards/r/RobaranMercenaries.java
@@ -87,7 +87,7 @@ class RobaranMercenariesEffect extends ContinuousEffectImpl {
                     || perm.getAbilities(game)
                     .stream()
                     .noneMatch(ability.getClass()::isInstance)) {
-                perm.addAbility(ability, source.getSourceId(), game, false);
+                perm.addAbility(ability, source.getSourceId(), game, true);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/s/SchemingFence.java
+++ b/Mage.Sets/src/mage/cards/s/SchemingFence.java
@@ -184,7 +184,7 @@ class SchemingFenceGainEffect extends ContinuousEffectImpl {
             if (!(ability instanceof LoyaltyAbility)) {
                 Ability copied = ability.copy();
                 ability.getEffects().setValue("schemingFence", source.getSourceId());
-                permanent.addAbility(copied, source.getSourceId(), game);
+                permanent.addAbility(copied, source.getSourceId(), game, false);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/s/SchemingFence.java
+++ b/Mage.Sets/src/mage/cards/s/SchemingFence.java
@@ -184,7 +184,7 @@ class SchemingFenceGainEffect extends ContinuousEffectImpl {
             if (!(ability instanceof LoyaltyAbility)) {
                 Ability copied = ability.copy();
                 ability.getEffects().setValue("schemingFence", source.getSourceId());
-                permanent.addAbility(copied, source.getSourceId(), game, false);
+                permanent.addAbility(copied, source.getSourceId(), game, true);
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
+++ b/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
@@ -145,7 +145,7 @@ class SharkeyTyrantOfTheShireContinousEffect extends ContinuousEffectImpl {
                 .filter(Objects::nonNull)
                 .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED) // Mana abilities are separated in their own AbilityType.Mana
                 .collect(Collectors.toList())) {
-            perm.addAbility(ability, source.getSourceId(), game);
+            perm.addAbility(ability, source.getSourceId(), game, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
+++ b/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
@@ -145,7 +145,7 @@ class SharkeyTyrantOfTheShireContinousEffect extends ContinuousEffectImpl {
                 .filter(Objects::nonNull)
                 .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED) // Mana abilities are separated in their own AbilityType.Mana
                 .collect(Collectors.toList())) {
-            perm.addAbility(ability, source.getSourceId(), game, false);
+            perm.addAbility(ability, source.getSourceId(), game, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
+++ b/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
@@ -191,7 +191,7 @@ class TheBookOfVileDarknessEffect extends OneShotEffect {
                     Ability copyAbility = ability.copy();
                     copyAbility.newId();
                     copyAbility.setControllerId(source.getControllerId());
-                    token.addAbility(copyAbility, false);
+                    token.addAbility(copyAbility, true);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
+++ b/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
@@ -191,7 +191,7 @@ class TheBookOfVileDarknessEffect extends OneShotEffect {
                     Ability copyAbility = ability.copy();
                     copyAbility.newId();
                     copyAbility.setControllerId(source.getControllerId());
-                    token.addAbility(copyAbility);
+                    token.addAbility(copyAbility, false);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/t/TrazynTheInfinite.java
+++ b/Mage.Sets/src/mage/cards/t/TrazynTheInfinite.java
@@ -77,7 +77,7 @@ class TrazynTheInfiniteEffect extends ContinuousEffectImpl {
                 .filter(ActivatedAbility.class::isInstance)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
-            permanent.addAbility(ability, source.getSourceId(), game, false);
+            permanent.addAbility(ability, source.getSourceId(), game, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TrazynTheInfinite.java
+++ b/Mage.Sets/src/mage/cards/t/TrazynTheInfinite.java
@@ -77,7 +77,7 @@ class TrazynTheInfiniteEffect extends ContinuousEffectImpl {
                 .filter(ActivatedAbility.class::isInstance)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
-            permanent.addAbility(ability, source.getSourceId(), game);
+            permanent.addAbility(ability, source.getSourceId(), game, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/v/VolrathsShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsShapeshifter.java
@@ -97,7 +97,7 @@ class VolrathsShapeshifterEffect extends ContinuousEffectImpl {
 
         for (Ability ability : card.getAbilities(game)) {
             if (!permanent.getAbilities().contains(ability)) {
-                permanent.addAbility(ability, source.getSourceId(), game, false);
+                permanent.addAbility(ability, source.getSourceId(), game, true);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/v/VolrathsShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsShapeshifter.java
@@ -97,7 +97,7 @@ class VolrathsShapeshifterEffect extends ContinuousEffectImpl {
 
         for (Ability ability : card.getAbilities(game)) {
             if (!permanent.getAbilities().contains(ability)) {
-                permanent.addAbility(ability, source.getSourceId(), game);
+                permanent.addAbility(ability, source.getSourceId(), game, false);
             }
         }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
@@ -198,9 +198,7 @@ public class SquadTest extends CardTestPlayerBase {
     }
 
     // The squad status is a copiable value of the spell, and should be carried over on copy.
-    @Ignore
     @Test
-    //TODO: Enable after fixing subability copying twice bug
     public void test_CopyingSpellMustKeepSquadStatus() {
 
         addCard(Zone.HAND, playerA, flagellant, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/CopyPermanentSpellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/CopyPermanentSpellTest.java
@@ -80,7 +80,6 @@ public class CopyPermanentSpellTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Dead Weight", 2);
     }
 
-    @Ignore // currently fails
     @Test
     public void testKickerTrigger() {
         makeTester();
@@ -98,7 +97,6 @@ public class CopyPermanentSpellTest extends CardTestPlayerBase {
         assertPowerToughness(playerA, "Grizzly Bears", 4, 2);
     }
 
-    @Ignore // currently fails
     @Test
     public void testKickerReplacement() {
         makeTester();

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -332,6 +332,8 @@ public interface Ability extends Controllable, Serializable {
 
     /**
      * Gets the list of sub-abilities associated with this ability.
+     * When copying, subabilities are copied separately and thus the list is desynced.
+     * Do not interact with the subabilities list during a game!
      *
      * @return
      */

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
@@ -119,11 +119,11 @@ public class CopyEffect extends ContinuousEffectImpl {
         permanent.removeAllAbilities(source.getSourceId(), game);
         if (copyFromObject instanceof Permanent) {
             for (Ability ability : ((Permanent) copyFromObject).getAbilities(game)) {
-                permanent.addAbility(ability, getSourceId(), game);
+                permanent.addAbility(ability, getSourceId(), game, false);
             }
         } else {
             for (Ability ability : copyFromObject.getAbilities()) {
-                permanent.addAbility(ability, getSourceId(), game);
+                permanent.addAbility(ability, getSourceId(), game, false);
             }
         }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyEffect.java
@@ -119,11 +119,11 @@ public class CopyEffect extends ContinuousEffectImpl {
         permanent.removeAllAbilities(source.getSourceId(), game);
         if (copyFromObject instanceof Permanent) {
             for (Ability ability : ((Permanent) copyFromObject).getAbilities(game)) {
-                permanent.addAbility(ability, getSourceId(), game, false);
+                permanent.addAbility(ability, getSourceId(), game, true);
             }
         } else {
             for (Ability ability : copyFromObject.getAbilities()) {
-                permanent.addAbility(ability, getSourceId(), game, false);
+                permanent.addAbility(ability, getSourceId(), game, true);
             }
         }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyTokenEffect.java
@@ -39,7 +39,7 @@ public class CopyTokenEffect extends ContinuousEffectImpl {
         }
         permanent.getAbilities().clear();
         for (Ability ability : token.getAbilities()) {
-            permanent.addAbility(ability, source.getSourceId(), game, false);
+            permanent.addAbility(ability, source.getSourceId(), game, true);
         }
         permanent.getPower().setModifiedBaseValue(token.getPower().getModifiedBaseValue());
         permanent.getToughness().setModifiedBaseValue(token.getToughness().getModifiedBaseValue());

--- a/Mage/src/main/java/mage/abilities/effects/common/CopyTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CopyTokenEffect.java
@@ -39,7 +39,7 @@ public class CopyTokenEffect extends ContinuousEffectImpl {
         }
         permanent.getAbilities().clear();
         for (Ability ability : token.getAbilities()) {
-            permanent.addAbility(ability, source.getSourceId(), game);
+            permanent.addAbility(ability, source.getSourceId(), game, false);
         }
         permanent.getPower().setModifiedBaseValue(token.getPower().getModifiedBaseValue());
         permanent.getToughness().setModifiedBaseValue(token.getToughness().getModifiedBaseValue());

--- a/Mage/src/main/java/mage/abilities/effects/common/GainActivatedAbilitiesOfTopCardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/GainActivatedAbilitiesOfTopCardEffect.java
@@ -43,7 +43,7 @@ public class GainActivatedAbilitiesOfTopCardEffect extends ContinuousEffectImpl 
                 if (permanent != null) {
                     for (Ability ability : card.getAbilities(game)) {
                         if (ability instanceof ActivatedAbility) {
-                            permanent.addAbility(ability, source.getSourceId(), game);
+                            permanent.addAbility(ability, source.getSourceId(), game, false);
                         }
                     }
                     return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/GainActivatedAbilitiesOfTopCardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/GainActivatedAbilitiesOfTopCardEffect.java
@@ -43,7 +43,7 @@ public class GainActivatedAbilitiesOfTopCardEffect extends ContinuousEffectImpl 
                 if (permanent != null) {
                     for (Ability ability : card.getAbilities(game)) {
                         if (ability instanceof ActivatedAbility) {
-                            permanent.addAbility(ability, source.getSourceId(), game, false);
+                            permanent.addAbility(ability, source.getSourceId(), game, true);
                         }
                     }
                     return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAllEffect.java
@@ -128,7 +128,7 @@ public class BecomesCreatureAllEffect extends ContinuousEffectImpl {
                 case AbilityAddingRemovingEffects_6:
                     if (!token.getAbilities().isEmpty()) {
                         for (Ability ability : token.getAbilities()) {
-                            permanent.addAbility(ability, source.getSourceId(), game, false);
+                            permanent.addAbility(ability, source.getSourceId(), game, true);
                         }
                     }
                     break;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAllEffect.java
@@ -128,7 +128,7 @@ public class BecomesCreatureAllEffect extends ContinuousEffectImpl {
                 case AbilityAddingRemovingEffects_6:
                     if (!token.getAbilities().isEmpty()) {
                         for (Ability ability : token.getAbilities()) {
-                            permanent.addAbility(ability, source.getSourceId(), game);
+                            permanent.addAbility(ability, source.getSourceId(), game, false);
                         }
                     }
                     break;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAttachedEffect.java
@@ -112,7 +112,7 @@ public class BecomesCreatureAttachedEffect extends ContinuousEffectImpl {
                         break;
                 }
                 for (Ability ability : token.getAbilities()) {
-                    permanent.addAbility(ability, source.getSourceId(), game);
+                    permanent.addAbility(ability, source.getSourceId(), game, false);
                 }
                 break;
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAttachedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureAttachedEffect.java
@@ -112,7 +112,7 @@ public class BecomesCreatureAttachedEffect extends ContinuousEffectImpl {
                         break;
                 }
                 for (Ability ability : token.getAbilities()) {
-                    permanent.addAbility(ability, source.getSourceId(), game, false);
+                    permanent.addAbility(ability, source.getSourceId(), game, true);
                 }
                 break;
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -141,7 +141,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl {
                     permanent.removeAllAbilities(source.getSourceId(), game);
                 }
                 for (Ability ability : token.getAbilities()) {
-                    permanent.addAbility(ability, source.getSourceId(), game, false);
+                    permanent.addAbility(ability, source.getSourceId(), game, true);
                 }
                 break;
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureSourceEffect.java
@@ -141,7 +141,7 @@ public class BecomesCreatureSourceEffect extends ContinuousEffectImpl {
                     permanent.removeAllAbilities(source.getSourceId(), game);
                 }
                 for (Ability ability : token.getAbilities()) {
-                    permanent.addAbility(ability, source.getSourceId(), game);
+                    permanent.addAbility(ability, source.getSourceId(), game, false);
                 }
                 break;
 

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
@@ -133,7 +133,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
                     if (sublayer == SubLayer.NA) {
                         if (!token.getAbilities().isEmpty()) {
                             for (Ability ability : token.getAbilities()) {
-                                permanent.addAbility(ability, source.getSourceId(), game, false);
+                                permanent.addAbility(ability, source.getSourceId(), game, true);
                             }
                         }
                     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesCreatureTargetEffect.java
@@ -133,7 +133,7 @@ public class BecomesCreatureTargetEffect extends ContinuousEffectImpl {
                     if (sublayer == SubLayer.NA) {
                         if (!token.getAbilities().isEmpty()) {
                             for (Ability ability : token.getAbilities()) {
-                                permanent.addAbility(ability, source.getSourceId(), game);
+                                permanent.addAbility(ability, source.getSourceId(), game, false);
                             }
                         }
                     }

--- a/Mage/src/main/java/mage/abilities/keyword/CrewAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CrewAbility.java
@@ -51,6 +51,8 @@ public class CrewAbility extends SimpleActivatedAbility {
         this.addIcon(new CardIconImpl(CardIconType.ABILITY_CREW, "Crew " + value));
         this.value = value;
         if (altCost != null) {
+            //TODO: the entire alternative cost should be included in the subability, not just the hint text
+            // Heart of Kiran's alternative crew cost is a static ability, not part of the activated ability directly
             this.addSubAbility(new SimpleStaticAbility(Zone.ALL, new InfoEffect(
                     "you may " + CardUtil.addCostVerb(altCost.getText())
                             + " rather than pay {this}'s crew cost"

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -67,7 +67,7 @@ public class TransformAbility extends SimpleStaticAbility {
         for (Ability ability : sourceCard.getAbilities()) {
             // source == null -- call from init card (e.g. own abilities)
             // source != null -- from apply effect
-            permanent.addAbility(ability, source == null ? permanent.getId() : source.getSourceId(), game, false);
+            permanent.addAbility(ability, source == null ? permanent.getId() : source.getSourceId(), game, true);
         }
         permanent.getPower().setModifiedBaseValue(sourceCard.getPower().getValue());
         permanent.getToughness().setModifiedBaseValue(sourceCard.getToughness().getValue());

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -67,7 +67,7 @@ public class TransformAbility extends SimpleStaticAbility {
         for (Ability ability : sourceCard.getAbilities()) {
             // source == null -- call from init card (e.g. own abilities)
             // source != null -- from apply effect
-            permanent.addAbility(ability, source == null ? permanent.getId() : source.getSourceId(), game);
+            permanent.addAbility(ability, source == null ? permanent.getId() : source.getSourceId(), game, false);
         }
         permanent.getPower().setModifiedBaseValue(sourceCard.getPower().getValue());
         permanent.getToughness().setModifiedBaseValue(sourceCard.getToughness().getValue());

--- a/Mage/src/main/java/mage/game/permanent/Permanent.java
+++ b/Mage/src/main/java/mage/game/permanent/Permanent.java
@@ -218,6 +218,7 @@ public interface Permanent extends Card, Controllable {
      * @return can be null for exists abilities
      */
     Ability addAbility(Ability ability, UUID sourceId, Game game);
+    Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities);
 
     void removeAllAbilities(UUID sourceId, Game game);
 

--- a/Mage/src/main/java/mage/game/permanent/Permanent.java
+++ b/Mage/src/main/java/mage/game/permanent/Permanent.java
@@ -218,7 +218,7 @@ public interface Permanent extends Card, Controllable {
      * @return can be null for exists abilities
      */
     Ability addAbility(Ability ability, UUID sourceId, Game game);
-    Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities);
+    Ability addAbility(Ability ability, UUID sourceId, Game game, boolean fromExistingObject);
 
     void removeAllAbilities(UUID sourceId, Game game);
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -388,6 +388,14 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         return super.getAbilities(game);
     }
 
+    /**
+     * Add an ability to the permanent. When copying from an existing source
+     * you should use the withSubabilities variant of this function to prevent double-copying subabilities
+     * @param ability The ability to be added
+     * @param sourceId   id of the source doing the added (for the effect created to add it)
+     * @param game
+     * @return The newly added ability copy
+     */
     @Override
     public Ability addAbility(Ability ability, UUID sourceId, Game game) {
         return addAbility(ability, sourceId, game, true);

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -390,6 +390,10 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
 
     @Override
     public Ability addAbility(Ability ability, UUID sourceId, Game game) {
+        return addAbility(ability, sourceId, game, true);
+    }
+    @Override
+    public Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities) {
         // singleton abilities -- only one instance
         // other abilities -- any amount of instances
         if (!abilities.containsKey(ability.getId())) {
@@ -404,7 +408,9 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 game.getState().addAbility(copyAbility, sourceId, this);
             }
             abilities.add(copyAbility);
-            abilities.addAll(ability.getSubAbilities());
+            if (withSubabilities) {
+                abilities.addAll(copyAbility.getSubAbilities());
+            }
             return copyAbility;
         }
         return null;

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -392,6 +392,15 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     public Ability addAbility(Ability ability, UUID sourceId, Game game) {
         return addAbility(ability, sourceId, game, true);
     }
+
+    /**
+     * @param ability The ability to be added
+     * @param sourceId   id of the source doing the added (for the effect created to add it)
+     * @param game
+     * @param withSubabilities if copying abilities from an existing source then must ignore sub-abilities because they're already on the source object
+     *                         Otherwise sub-abilities will be added twice to the resulting object
+     * @return The newly added ability copy
+     */
     @Override
     public Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities) {
         // singleton abilities -- only one instance

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -390,7 +390,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
 
     /**
      * Add an ability to the permanent. When copying from an existing source
-     * you should use the withSubabilities variant of this function to prevent double-copying subabilities
+     * you should use the fromExistingObject variant of this function to prevent double-copying subabilities
      * @param ability The ability to be added
      * @param sourceId   id of the source doing the added (for the effect created to add it)
      * @param game
@@ -398,19 +398,19 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
      */
     @Override
     public Ability addAbility(Ability ability, UUID sourceId, Game game) {
-        return addAbility(ability, sourceId, game, true);
+        return addAbility(ability, sourceId, game, false);
     }
 
     /**
      * @param ability The ability to be added
      * @param sourceId   id of the source doing the added (for the effect created to add it)
      * @param game
-     * @param withSubabilities if copying abilities from an existing source then must ignore sub-abilities because they're already on the source object
+     * @param fromExistingObject if copying abilities from an existing source then must ignore sub-abilities because they're already on the source object
      *                         Otherwise sub-abilities will be added twice to the resulting object
      * @return The newly added ability copy
      */
     @Override
-    public Ability addAbility(Ability ability, UUID sourceId, Game game, boolean withSubabilities) {
+    public Ability addAbility(Ability ability, UUID sourceId, Game game, boolean fromExistingObject) {
         // singleton abilities -- only one instance
         // other abilities -- any amount of instances
         if (!abilities.containsKey(ability.getId())) {
@@ -425,7 +425,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 game.getState().addAbility(copyAbility, sourceId, this);
             }
             abilities.add(copyAbility);
-            if (withSubabilities) {
+            if (!fromExistingObject) {
                 abilities.addAll(copyAbility.getSubAbilities());
             }
             return copyAbility;

--- a/Mage/src/main/java/mage/game/permanent/PermanentToken.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentToken.java
@@ -90,7 +90,7 @@ public class PermanentToken extends PermanentImpl {
             // so sourceId must be null (keep triggered abilities forever?)
             for (Ability ability : token.getAbilities()) {
                 //Don't add subabilities since the original token already has them in its abilities list
-                this.addAbility(ability, null, game, false);
+                this.addAbility(ability, null, game, true);
             }
         }
         this.abilities.setControllerId(this.controllerId);

--- a/Mage/src/main/java/mage/game/permanent/PermanentToken.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentToken.java
@@ -89,7 +89,8 @@ public class PermanentToken extends PermanentImpl {
             // first time -> create ContinuousEffects only once
             // so sourceId must be null (keep triggered abilities forever?)
             for (Ability ability : token.getAbilities()) {
-                this.addAbility(ability, null, game);
+                //Don't add subabilities since the original token already has them in its abilities list
+                this.addAbility(ability, null, game, false);
             }
         }
         this.abilities.setControllerId(this.controllerId);

--- a/Mage/src/main/java/mage/game/permanent/token/Token.java
+++ b/Mage/src/main/java/mage/game/permanent/token/Token.java
@@ -22,7 +22,7 @@ public interface Token extends MageObject {
     List<UUID> getLastAddedTokenIds();
 
     void addAbility(Ability ability);
-    void addAbility(Ability ability, boolean withSubabilities);
+    void addAbility(Ability ability, boolean fromExistingObject);
 
     void removeAbility(Ability abilityToRemove);
 

--- a/Mage/src/main/java/mage/game/permanent/token/Token.java
+++ b/Mage/src/main/java/mage/game/permanent/token/Token.java
@@ -22,6 +22,7 @@ public interface Token extends MageObject {
     List<UUID> getLastAddedTokenIds();
 
     void addAbility(Ability ability);
+    void addAbility(Ability ability, boolean withSubabilities);
 
     void removeAbility(Ability abilityToRemove);
 

--- a/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
@@ -77,6 +77,11 @@ public abstract class TokenImpl extends MageObjectImpl implements Token {
         return new ArrayList<>(lastAddedTokenIds);
     }
 
+    /**
+     * Add an ability to the token. When copying from an existing source
+     * you should use the withSubabilities variant of this function to prevent double-copying subabilities
+     * @param ability The ability to be added
+     */
     @Override
     public void addAbility(Ability ability) {
         addAbility(ability, true);

--- a/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
@@ -81,6 +81,12 @@ public abstract class TokenImpl extends MageObjectImpl implements Token {
     public void addAbility(Ability ability) {
         addAbility(ability, true);
     }
+
+    /**
+     * @param ability The ability to be added
+     * @param withSubabilities if copying abilities from an existing source then must ignore sub-abilities because they're already on the source object
+     *                         Otherwise sub-abilities will be added twice to the resulting object
+     */
     @Override
     public void addAbility(Ability ability, boolean withSubabilities) {
         ability.setSourceId(this.getId());

--- a/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
@@ -79,13 +79,20 @@ public abstract class TokenImpl extends MageObjectImpl implements Token {
 
     @Override
     public void addAbility(Ability ability) {
+        addAbility(ability, true);
+    }
+    @Override
+    public void addAbility(Ability ability, boolean withSubabilities) {
         ability.setSourceId(this.getId());
         abilities.add(ability);
-        abilities.addAll(ability.getSubAbilities());
+        if (withSubabilities) {
+            abilities.addAll(ability.getSubAbilities());
+        }
 
         // TODO: remove all override and backFace changes (bug example: active transform ability in back face)
         if (backFace != null) {
             backFace.addAbility(ability);
+            // Maybe supposed to add subabilities here too?
         }
     }
 

--- a/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/token/TokenImpl.java
@@ -79,24 +79,24 @@ public abstract class TokenImpl extends MageObjectImpl implements Token {
 
     /**
      * Add an ability to the token. When copying from an existing source
-     * you should use the withSubabilities variant of this function to prevent double-copying subabilities
+     * you should use the fromExistingObject variant of this function to prevent double-copying subabilities
      * @param ability The ability to be added
      */
     @Override
     public void addAbility(Ability ability) {
-        addAbility(ability, true);
+        addAbility(ability, false);
     }
 
     /**
      * @param ability The ability to be added
-     * @param withSubabilities if copying abilities from an existing source then must ignore sub-abilities because they're already on the source object
+     * @param fromExistingObject if copying abilities from an existing source then must ignore sub-abilities because they're already on the source object
      *                         Otherwise sub-abilities will be added twice to the resulting object
      */
     @Override
-    public void addAbility(Ability ability, boolean withSubabilities) {
+    public void addAbility(Ability ability, boolean fromExistingObject) {
         ability.setSourceId(this.getId());
         abilities.add(ability);
-        if (withSubabilities) {
+        if (!fromExistingObject) {
             abilities.addAll(ability.getSubAbilities());
         }
 

--- a/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
+++ b/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
@@ -140,8 +140,8 @@ public class CopyTokenFunction {
             // otherwise there are problems to check for created continuous effects to check if
             // the source (the Token) has still this ability
             ability.newOriginalId();
-
-            target.addAbility(ability);
+            //Don't re-add subabilities since they've already in sourceObj's abilities list
+            target.addAbility(ability, false);
         }
 
         target.setPower(sourceObj.getPower().getBaseValue());
@@ -152,7 +152,6 @@ public class CopyTokenFunction {
 
     private Token from(Card source, Game game, Spell spell) {
         apply(source, game);
-
         // token's ZCC must be synced with original card to keep abilities settings
         // Example: kicker ability and kicked status
         if (spell != null) {

--- a/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
+++ b/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
@@ -141,7 +141,7 @@ public class CopyTokenFunction {
             // the source (the Token) has still this ability
             ability.newOriginalId();
             //Don't re-add subabilities since they've already in sourceObj's abilities list
-            target.addAbility(ability, false);
+            target.addAbility(ability, true);
         }
 
         target.setPower(sourceObj.getPower().getBaseValue());


### PR DESCRIPTION
@xenohedron Here's the first PR as we discussed in #10546
This one was quick since I already did most of the work separating it out for #10679.
I did not include the additional tests that one added, I'll add those tests in when the abilities get converted to using cost tags.

Also, I realized that there were additional cards that shouldn't be adding subabilities when copying other cards' abilities and have fixed them.