### PR TITLE
Fix MDFCs being able to be turned face down

### DIFF
--- a/Mage.Sets/src/mage/cards/i/IllithidHarvester.java
+++ b/Mage.Sets/src/mage/cards/i/IllithidHarvester.java
@@ -8,8 +8,7 @@ import mage.abilities.effects.common.DontUntapInControllersNextUntapStepTargetEf
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.abilities.effects.common.continuous.BecomesFaceDownCreatureAllEffect;
 import mage.abilities.effects.common.continuous.BecomesSubtypeAllEffect;
-import mage.cards.AdventureCard;
-import mage.cards.CardSetInfo;
+import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
@@ -106,7 +105,7 @@ class IllithidHarvesterEffect extends OneShotEffect {
         Predicate<Permanent> pred = new PermanentIdPredicate(UUID.randomUUID());
         for (Target target : source.getTargets()) {
             for (UUID targetId : target.getTargets()) {
-                if (!game.getPermanent(targetId).isTransformable()) {
+                if (!game.getPermanent(targetId).isTransformable() && !(game.getCard(targetId) instanceof ModalDoubleFacedCardHalf)) {
                     pred = Predicates.or(pred, new PermanentIdPredicate(targetId));
                 }
             }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/facedown/TurnFaceDownTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/facedown/TurnFaceDownTest.java
@@ -1,0 +1,79 @@
+package org.mage.test.cards.facedown;
+
+import mage.constants.EmptyNames;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author PurpleCrowbar
+ */
+public class TurnFaceDownTest extends CardTestPlayerBase {
+
+    // MDFCs cannot be turned face down when on the battlefield
+    @Test
+    public void testTurnMDFCFaceDown() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.HAND, playerA, "Ixidron", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Tergrid, God of Fright", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ixidron");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerB, EmptyNames.FACE_DOWN_CREATURE.toString(), 0);
+    }
+
+    // TDFCs cannot be turned face down when on the battlefield
+    @Test
+    public void testTurnTDFCFaceDown() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.HAND, playerA, "Ixidron", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Delver of Secrets", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ixidron");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerB, EmptyNames.FACE_DOWN_CREATURE.toString(), 0);
+    }
+
+    // TODO: Currently no implemented cards can turn token creatures face down. This test is to be uncommented after the implementation of [WHO] Cyber Conversion
+    // Tokens can be turned face down
+    /*
+    @Test
+    public void testTurnTokenFaceDown() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, "Cyber Conversion", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 1);
+        addCard(Zone.HAND, playerB, "Sprout", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Sprout", playerB);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cyber Conversion", "Saproling Token");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerB, EmptyNames.FACE_DOWN_CREATURE.toString(), 1);
+    }
+     */
+
+    // Nontoken, non-DFC creatures should be able to be turned face down
+    @Test
+    public void testTurnNonTokenFaceDown() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.HAND, playerA, "Ixidron", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Runeclaw Bear", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ixidron");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerB, EmptyNames.FACE_DOWN_CREATURE.toString(), 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesFaceDownCreatureAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/BecomesFaceDownCreatureAllEffect.java
@@ -7,6 +7,7 @@ import mage.abilities.common.TurnFaceUpAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.keyword.MorphAbility;
 import mage.cards.Card;
+import mage.cards.ModalDoubleFacedCardHalf;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.game.Game;
@@ -46,11 +47,11 @@ public class BecomesFaceDownCreatureAllEffect extends ContinuousEffectImpl {
     public void init(Ability source, Game game) {
         super.init(source, game);
         for (Permanent perm : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
-            if (!perm.isFaceDown(game) && !perm.isTransformable()) {
+            Card card = game.getCard(perm.getId());
+            if (!perm.isFaceDown(game) && !perm.isTransformable() && !(card instanceof ModalDoubleFacedCardHalf)) {
                 affectedObjectList.add(new MageObjectReference(perm, game));
                 perm.setFaceDown(true, game);
                 // check for Morph
-                Card card = game.getCard(perm.getId());
                 if (card != null) {
                     for (Ability ability : card.getAbilities(game)) {
                         if (ability instanceof MorphAbility) {


### PR DESCRIPTION
Previously, MDFCs could (wrongly) be turned face-down via effects of cards like [[Ixidron]]. This would not apply to TDFCs which had a check in place to prevent this. This PR adds an equivalent check for MDFCs.