### PR TITLE
Fix conditional mana

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AutomatedArtificer.java
+++ b/Mage.Sets/src/mage/cards/a/AutomatedArtificer.java
@@ -5,6 +5,7 @@ import mage.MageInt;
 import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.mana.ConditionalColorlessManaAbility;
@@ -75,7 +76,7 @@ class AutomatedArtificerManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source == null) {
+        if (source == null || source.isActivated()) {
             return false;
         }
         switch (source.getAbilityType()) {
@@ -83,15 +84,10 @@ class AutomatedArtificerManaCondition extends ManaCondition {
             case ACTIVATED:
                 return true;
             case SPELL:
-                MageObject object = source.getSourceObject(game);
-                if (!(object instanceof StackObject) && !game.inCheckPlayableState()) {
-                    return false;
+                if (source instanceof SpellAbility) {
+                    MageObject object = game.getObject(source);
+                    return object != null && object.isArtifact(game);
                 }
-                if (object instanceof Commander) {
-                    Card card = ((Commander) object).getSourceObject();
-                    return card != null && card.isArtifact(game);
-                }
-                return object.isArtifact(game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/a/AutomatedArtificer.java
+++ b/Mage.Sets/src/mage/cards/a/AutomatedArtificer.java
@@ -11,14 +11,11 @@ import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.mana.ConditionalColorlessManaAbility;
 import mage.abilities.mana.builder.ConditionalManaBuilder;
 import mage.abilities.mana.conditional.ManaCondition;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.game.Game;
-import mage.game.command.Commander;
-import mage.game.stack.StackObject;
 
 import java.util.UUID;
 

--- a/Mage.Sets/src/mage/cards/c/CrypticTrilobite.java
+++ b/Mage.Sets/src/mage/cards/c/CrypticTrilobite.java
@@ -94,7 +94,7 @@ class CrypticTrilobiteManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source != null) {
+        if (source != null && !source.isActivated()) {
             // ex: SimpleManaAbility is an ACTIVATED ability, but it is categorized as a MANA ability
             return source.getAbilityType() == AbilityType.MANA
                     || source.getAbilityType() == AbilityType.ACTIVATED;

--- a/Mage.Sets/src/mage/cards/c/CultivatorDrone.java
+++ b/Mage.Sets/src/mage/cards/c/CultivatorDrone.java
@@ -79,13 +79,13 @@ class CultivatorDroneManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costToPay) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             if (object != null && object.getColor(game).isColorless()) {
                 return true;
             }
         }
-        if (source instanceof ActivatedAbility) {
+        if (source instanceof ActivatedAbility && !source.isActivated()) {
             Permanent object = game.getPermanentOrLKIBattlefield(source.getSourceId());
             if (object != null && object.getColor(game).isColorless()) {
                 return true;

--- a/Mage.Sets/src/mage/cards/d/DelightedHalfling.java
+++ b/Mage.Sets/src/mage/cards/d/DelightedHalfling.java
@@ -85,7 +85,7 @@ class DelightedHalflingManaCondition extends ManaCondition {
     @Override
     public boolean apply(Game game, Ability source) {
         // check: ... to cast a spell
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             // check: ... that is legendary
             if (object != null && object.isLegendary(game)) {

--- a/Mage.Sets/src/mage/cards/g/GreatHallOfTheCitadel.java
+++ b/Mage.Sets/src/mage/cards/g/GreatHallOfTheCitadel.java
@@ -75,7 +75,7 @@ class GreatHallOfTheCitadelManaCondition extends ManaCondition implements Condit
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.isLegendary(game);
         }

--- a/Mage.Sets/src/mage/cards/k/KarfellHarbinger.java
+++ b/Mage.Sets/src/mage/cards/k/KarfellHarbinger.java
@@ -74,7 +74,7 @@ class KarfellHarbingerManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.isInstantOrSorcery(game);
         }

--- a/Mage.Sets/src/mage/cards/k/KlauthUnrivaledAncient.java
+++ b/Mage.Sets/src/mage/cards/k/KlauthUnrivaledAncient.java
@@ -122,7 +122,7 @@ class KlauthUnrivaledAncientManaCondition extends ManaCondition implements Condi
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return source instanceof SpellAbility;
+        return source instanceof SpellAbility && !source.isActivated();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/MeetingOfTheFive.java
+++ b/Mage.Sets/src/mage/cards/m/MeetingOfTheFive.java
@@ -130,7 +130,7 @@ class MeetingOfTheFiveManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (!(source instanceof SpellAbility)) {
+        if (!(source instanceof SpellAbility) || source.isActivated()) {
             return false;
         }
         MageObject object = game.getObject(source);

--- a/Mage.Sets/src/mage/cards/n/NarsetOfTheAncientWay.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetOfTheAncientWay.java
@@ -97,7 +97,7 @@ class NarsetOfTheAncientWayManaCondition extends ManaCondition implements Condit
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (!(source instanceof SpellAbility)) {
+        if (!(source instanceof SpellAbility) || source.isActivated()) {
             return false;
         }
         MageObject object = game.getObject(source);

--- a/Mage.Sets/src/mage/cards/n/NikoDefiesDestiny.java
+++ b/Mage.Sets/src/mage/cards/n/NikoDefiesDestiny.java
@@ -166,7 +166,7 @@ class NikoDefiesDestinyManaCondition extends ManaCondition implements Condition 
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.getAbilities().containsClass(ForetellAbility.class);
         }

--- a/Mage.Sets/src/mage/cards/o/OmenHawker.java
+++ b/Mage.Sets/src/mage/cards/o/OmenHawker.java
@@ -73,7 +73,7 @@ class OmenHawkerManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source != null) {
+        if (source != null && !source.isActivated()) {
             return source.getAbilityType() == AbilityType.MANA
                     || source.getAbilityType() == AbilityType.ACTIVATED;
         }

--- a/Mage.Sets/src/mage/cards/o/OpenTheOmenpaths.java
+++ b/Mage.Sets/src/mage/cards/o/OpenTheOmenpaths.java
@@ -84,7 +84,7 @@ class OpenTheOmenpathsCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (!(source instanceof SpellAbility)) {
+        if (!(source instanceof SpellAbility) || source.isActivated()) {
             return false;
         }
         MageObject object = game.getObject(source);

--- a/Mage.Sets/src/mage/cards/p/PlazaOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/p/PlazaOfHeroes.java
@@ -107,7 +107,7 @@ class PlazaOfHeroesManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             if (object != null && object.isLegendary(game)) {
                 return true;

--- a/Mage.Sets/src/mage/cards/s/SoldeviMachinist.java
+++ b/Mage.Sets/src/mage/cards/s/SoldeviMachinist.java
@@ -80,7 +80,7 @@ class ArtifactAbilityManaCondition extends ManaCondition implements Condition {
                 return false;
         }
         MageObject object = game.getObject(source);
-        return object != null && object.isArtifact(game);
+        return object != null && object.isArtifact(game) && !source.isActivated();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SorcererClass.java
+++ b/Mage.Sets/src/mage/cards/s/SorcererClass.java
@@ -115,7 +115,7 @@ class SorcererClassManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.isInstantOrSorcery(game);
         }

--- a/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
+++ b/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
@@ -132,7 +132,7 @@ class TazriStalwartSurvivorManaEffect extends ManaEffect {
                     return false;
             }
             MageObject object = game.getObject(source);
-            return object != null && object.isCreature(game);
+            return object != null && object.isCreature(game) && !source.isActivated();
         }
 
         @Override

--- a/Mage.Sets/src/mage/cards/t/TheEnigmaJewel.java
+++ b/Mage.Sets/src/mage/cards/t/TheEnigmaJewel.java
@@ -108,7 +108,7 @@ class TheEnigmaJewelManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source != null) {
+        if (source != null && !source.isActivated()) {
             return source.getAbilityType() == AbilityType.MANA
                     || source.getAbilityType() == AbilityType.ACTIVATED;
         }

--- a/Mage.Sets/src/mage/cards/t/ThranTurbine.java
+++ b/Mage.Sets/src/mage/cards/t/ThranTurbine.java
@@ -3,6 +3,7 @@ package mage.cards.t;
 import mage.ConditionalMana;
 import mage.Mana;
 import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
@@ -101,6 +102,6 @@ class ThranTurbineManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costToPay) {
-        return !(source instanceof Spell);
+        return !(source instanceof SpellAbility && !source.isActivated());
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TitansNest.java
+++ b/Mage.Sets/src/mage/cards/t/TitansNest.java
@@ -94,7 +94,7 @@ class TitansNestManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costToPay) {
-        if (!(source instanceof SpellAbility)) {
+        if (!(source instanceof SpellAbility) || source.isActivated()) {
             return false;
         }
         MageObject object = game.getObject(source);

--- a/Mage.Sets/src/mage/cards/u/UnblinkingObserver.java
+++ b/Mage.Sets/src/mage/cards/u/UnblinkingObserver.java
@@ -75,10 +75,10 @@ class UnblinkingObserverManaCondition extends ManaCondition implements Condition
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof DisturbAbility) {
+        if (source instanceof DisturbAbility && !source.isActivated()) {
             return true;
         }
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.isInstantOrSorcery(game);
         }

--- a/Mage.Sets/src/mage/cards/u/UntaidakeTheCloudKeeper.java
+++ b/Mage.Sets/src/mage/cards/u/UntaidakeTheCloudKeeper.java
@@ -76,7 +76,7 @@ class LegendaryCastManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             if (object != null && object.isLegendary(game)) {
                 return true;

--- a/Mage.Sets/src/mage/cards/v/VoldarenEstate.java
+++ b/Mage.Sets/src/mage/cards/v/VoldarenEstate.java
@@ -107,7 +107,7 @@ class VoldarenEstateManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.hasSubtype(SubType.VAMPIRE, game);
         }

--- a/Mage.Sets/src/mage/cards/v/VolsheTideturner.java
+++ b/Mage.Sets/src/mage/cards/v/VolsheTideturner.java
@@ -75,11 +75,11 @@ class VolsheTideturnerCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
+        if (!(source instanceof SpellAbility) && !source.isActivated()) {
+            return false;
+        }
         if (KickedCondition.ONCE.apply(game, source)) {
             return true;
-        }
-        if (!(source instanceof SpellAbility)) {
-            return false;
         }
         MageObject object = game.getObject(source);
         return object != null && object.isInstantOrSorcery(game);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/conditional/ConditionalManaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/conditional/ConditionalManaTest.java
@@ -390,6 +390,45 @@ public class ConditionalManaTest extends CardTestPlayerBase {
     }
 
     @Test
+    public void testConditionalManaSoftCounter() {
+        addCard(Zone.HAND, playerA, "Fallaji Excavation", 1);
+        addCard(Zone.HAND, playerA, "Gigantosaurus", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+        addCard(Zone.HAND, playerB, "Mana Leak");
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fallaji Excavation");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Gigantosaurus");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerB, "Mana Leak", "Gigantosaurus");
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertPermanentCount(playerA, "Gigantosaurus", 1);
+        assertTappedCount("Powerstone Token", true, 3);
+    }
+    @Test
+    public void testConditionalManaCantSoftCounter() {
+        addCard(Zone.BATTLEFIELD, playerA, "Jaya Ballard");
+        addCard(Zone.HAND, playerA, "Gigantosaurus", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+        addCard(Zone.HAND, playerB, "Mana Leak");
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+1: Add");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gigantosaurus");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Mana Leak", "Gigantosaurus");
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertPermanentCount(playerA, "Gigantosaurus", 0);
+    }
+
+    @Test
     public void testConditionalManaDeduplication() {
         ManaOptions manaOptions = new ManaOptions();
 

--- a/Mage/src/main/java/mage/abilities/mana/builder/common/InstantOrSorcerySpellManaBuilder.java
+++ b/Mage/src/main/java/mage/abilities/mana/builder/common/InstantOrSorcerySpellManaBuilder.java
@@ -42,7 +42,7 @@ class InstantOrSorceryCastManaCondition extends ManaCondition implements Conditi
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             return object != null && object.isInstantOrSorcery(game);
         }

--- a/Mage/src/main/java/mage/abilities/mana/builder/common/SimpleActivatedAbilityManaBuilder.java
+++ b/Mage/src/main/java/mage/abilities/mana/builder/common/SimpleActivatedAbilityManaBuilder.java
@@ -43,7 +43,7 @@ class SimpleActivatedAbilityManaCondition extends ManaCondition implements Condi
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return source instanceof SimpleActivatedAbility;
+        return source instanceof SimpleActivatedAbility && !source.isActivated();
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/mana/builder/common/SimpleActivatedAbilityManaBuilder.java
+++ b/Mage/src/main/java/mage/abilities/mana/builder/common/SimpleActivatedAbilityManaBuilder.java
@@ -26,7 +26,7 @@ public class SimpleActivatedAbilityManaBuilder extends ConditionalManaBuilder {
 
     @Override
     public String getRule() {
-        return "Spend this mana only to activate simple abilities";
+        return "Spend this mana only to activate or pay for simple abilities";
     }
 }
 
@@ -34,7 +34,7 @@ class SimpleActivatedAbilityConditionalMana extends ConditionalMana {
 
     public SimpleActivatedAbilityConditionalMana(Mana mana) {
         super(mana);
-        staticText = "Spend this mana only to activate simple abilities";
+        staticText = "Spend this mana only to activate or pay for simple abilities";
         addCondition(new SimpleActivatedAbilityManaCondition());
     }
 }
@@ -43,7 +43,7 @@ class SimpleActivatedAbilityManaCondition extends ManaCondition implements Condi
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return source instanceof SimpleActivatedAbility && !source.isActivated();
+        return source instanceof SimpleActivatedAbility;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/mana/conditional/ConditionalSpellManaBuilder.java
+++ b/Mage/src/main/java/mage/abilities/mana/conditional/ConditionalSpellManaBuilder.java
@@ -74,7 +74,7 @@ class SpellCastManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
             if ((object instanceof StackObject)) {
                 return filter.match((StackObject) object, source.getControllerId(), source, game);

--- a/Mage/src/main/java/mage/abilities/mana/conditional/CreatureCastManaCondition.java
+++ b/Mage/src/main/java/mage/abilities/mana/conditional/CreatureCastManaCondition.java
@@ -16,11 +16,9 @@ public class CreatureCastManaCondition extends ManaCondition implements Conditio
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
-            if (object != null && object.isCreature(game)) {
-                return true;
-            }
+            return object != null && object.isCreature(game);
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/mana/conditional/PlaneswalkerCastManaCondition.java
+++ b/Mage/src/main/java/mage/abilities/mana/conditional/PlaneswalkerCastManaCondition.java
@@ -17,11 +17,9 @@ public class PlaneswalkerCastManaCondition extends ManaCondition implements Cond
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source instanceof SpellAbility) {
+        if (source instanceof SpellAbility && !source.isActivated()) {
             MageObject object = game.getObject(source);
-            if (object != null && object.isPlaneswalker(game)) {
-                return true;
-            }
+            return object != null && object.isPlaneswalker(game);
         }
         return false;
     }

--- a/Mage/src/main/java/mage/game/permanent/token/PowerstoneToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/PowerstoneToken.java
@@ -73,14 +73,11 @@ class PowerstoneTokenManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (!(source instanceof SpellAbility)) {
+        if (!(source instanceof SpellAbility) || source.isActivated()) {
             return true;
         }
         MageObject object = game.getObject(source);
-        if (object != null && object.isArtifact(game)) {
-            return true;
-        }
-        return false;
+        return object != null && object.isArtifact(game);
     }
 
     @Override


### PR DESCRIPTION
As a direct example, Powerstone Tokens can't be used to pay for Mana Leak's counterspell effect.

Mana Leak's `SpellAbility` is the source of the `CounterUnlessPaysEffect`'s cost. Thus when checking to see if the Powerstone is being used to cast a non-artifact spell, the condition returns false since Mana Leak is a non-artifact spell, even though the mana is not being used to *cast* the spell.

In `ManaPoolTest` some `SimpleActivatedAbilityConditionalMana` is used to pay for a "counter unless pay" effect, so I suppose it is meant to be used for non-activations of those abilities. Since this ability is only used in tests and not any cards, I kept the original behavior rather than try to adjust the test.