### PR TITLE
[LTC] 16x Card implementations

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AndurilNarsilReforged.java
+++ b/Mage.Sets/src/mage/cards/a/AndurilNarsilReforged.java
@@ -1,0 +1,55 @@
+package mage.cards.a;
+
+import mage.abilities.common.AttacksAttachedTriggeredAbility;
+import mage.abilities.condition.common.CitysBlessingCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.common.counter.AddCountersAllEffect;
+import mage.abilities.hint.common.CitysBlessingHint;
+import mage.abilities.keyword.AscendAbility;
+import mage.abilities.keyword.EquipAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class AndurilNarsilReforged extends CardImpl {
+
+    public AndurilNarsilReforged(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.EQUIPMENT);
+
+        // Ascend
+        this.addAbility(new AscendAbility());
+
+        // Whenever equipped creature attacks, put a +1/+1 counter on each creature you control. If you have the city's blessing, put two +1/+1 counters on each creature you control instead.
+        this.addAbility(new AttacksAttachedTriggeredAbility(
+                new ConditionalOneShotEffect(new AddCountersAllEffect(CounterType.P1P1.createInstance(2), StaticFilters.FILTER_CONTROLLED_CREATURE),
+                        new AddCountersAllEffect(CounterType.P1P1.createInstance(), StaticFilters.FILTER_CONTROLLED_CREATURE), CitysBlessingCondition.instance,
+                        "put a +1/+1 counter on each creature you control. If you have the city's blessing, put two +1/+1 counters on each creature you control instead"),
+                AttachmentType.EQUIPMENT, false)
+                .addHint(CitysBlessingHint.instance));
+        // Equip {3}
+        this.addAbility(new EquipAbility(3, false));
+    }
+
+    private AndurilNarsilReforged(final AndurilNarsilReforged card) {
+        super(card);
+    }
+
+    @Override
+    public AndurilNarsilReforged copy() {
+        return new AndurilNarsilReforged(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/a/AragornHornburgHero.java
+++ b/Mage.Sets/src/mage/cards/a/AragornHornburgHero.java
@@ -55,7 +55,7 @@ public final class AragornHornburgHero extends CardImpl {
         // Whenever a renowned creature you control deals combat damage to a player, double the number of +1/+1 counters on it.
         this.addAbility(new DealsDamageToAPlayerAllTriggeredAbility(
                 new AragornDoubleCountersTargetEffect(), filter,
-                false, SetTargetPointer.NONE, true
+                false, SetTargetPointer.PERMANENT, true
         ));
 
     }

--- a/Mage.Sets/src/mage/cards/a/AragornHornburgHero.java
+++ b/Mage.Sets/src/mage/cards/a/AragornHornburgHero.java
@@ -1,0 +1,96 @@
+package mage.cards.a;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DealsDamageToAPlayerAllTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.FirstStrikeAbility;
+import mage.abilities.keyword.RenownAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.permanent.RenownedPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class AragornHornburgHero extends CardImpl {
+
+    private static final FilterPermanent filter
+            = new FilterControlledCreaturePermanent("a renowned creature you control");
+
+    static {
+        filter.add(RenownedPredicate.instance);
+    }
+    public AragornHornburgHero(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{R}{G}{W}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SOLDIER);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Attacking creatures you control have first strike and renown 1.
+        Ability ability = new SimpleStaticAbility(new GainAbilityControlledEffect(
+                FirstStrikeAbility.getInstance(), Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_ATTACKING_CREATURES
+        ));
+        ability.addEffect(new GainAbilityControlledEffect(
+                new RenownAbility(1), Duration.WhileOnBattlefield,
+                StaticFilters.FILTER_ATTACKING_CREATURES
+        ).setText("and renown 1"));
+        this.addAbility(ability);
+        // Whenever a renowned creature you control deals combat damage to a player, double the number of +1/+1 counters on it.
+        this.addAbility(new DealsDamageToAPlayerAllTriggeredAbility(
+                new AragornDoubleCountersTargetEffect(), filter,
+                false, SetTargetPointer.NONE, true
+        ));
+
+    }
+
+    private AragornHornburgHero(final AragornHornburgHero card) {
+        super(card);
+    }
+
+    @Override
+    public AragornHornburgHero copy() {
+        return new AragornHornburgHero(this);
+    }
+}
+//Copied from Elvish Vatkeeper
+class AragornDoubleCountersTargetEffect extends OneShotEffect {
+
+    AragornDoubleCountersTargetEffect() {
+        super(Outcome.Benefit);
+        staticText = "double the number of +1/+1 counters on it";
+    }
+
+    private AragornDoubleCountersTargetEffect(final AragornDoubleCountersTargetEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public AragornDoubleCountersTargetEffect copy() {
+        return new AragornDoubleCountersTargetEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
+        return permanent != null && permanent.addCounters(CounterType.P1P1.createInstance(
+                permanent.getCounters(game).getCount(CounterType.P1P1)
+        ), source.getControllerId(), source, game);
+    }
+}

--- a/Mage.Sets/src/mage/cards/c/CracklingDoom.java
+++ b/Mage.Sets/src/mage/cards/c/CracklingDoom.java
@@ -7,12 +7,10 @@ import mage.abilities.effects.common.DamagePlayersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.ComparisonType;
 import mage.constants.Outcome;
 import mage.constants.TargetController;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.PowerPredicate;
+import mage.filter.predicate.permanent.GreatestPowerControlledPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -50,6 +48,10 @@ public final class CracklingDoom extends CardImpl {
 
 class CracklingDoomEffect extends OneShotEffect {
 
+    static FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature with the greatest power among creatures you control");
+    static {
+        filter.add(GreatestPowerControlledPredicate.instance);
+    }
     public CracklingDoomEffect() {
         super(Outcome.Sacrifice);
         this.staticText = "Each opponent sacrifices a creature with the greatest power among creatures that player controls";
@@ -73,31 +75,12 @@ class CracklingDoomEffect extends OneShotEffect {
                 if (controller.hasOpponent(playerId, game)) {
                     Player opponent = game.getPlayer(playerId);
                     if (opponent != null) {
-                        int greatestPower = Integer.MIN_VALUE;
-                        int numberOfCreatures = 0;
-                        Permanent permanentToSacrifice = null;
-                        for (Permanent permanent : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, playerId, game)) {
-                            if (permanent.getPower().getValue() > greatestPower) {
-                                greatestPower = permanent.getPower().getValue();
-                                numberOfCreatures = 1;
-                                permanentToSacrifice = permanent;
-                            } else if (permanent.getPower().getValue() == greatestPower) {
-                                numberOfCreatures++;
-                            }
-                        }
-                        if (numberOfCreatures == 1) {
-                            if (permanentToSacrifice != null) {
-                                toSacrifice.add(permanentToSacrifice);
-                            }
-                        } else if (greatestPower != Integer.MIN_VALUE) {
-                            FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature to sacrifice with power equal to " + greatestPower);
-                            filter.add(new PowerPredicate(ComparisonType.EQUAL_TO, greatestPower));
-                            Target target = new TargetControlledCreaturePermanent(filter);
-                            if (opponent.choose(outcome, target, source, game)) {
-                                Permanent permanent = game.getPermanent(target.getFirstTarget());
-                                if (permanent != null) {
-                                    toSacrifice.add(permanent);
-                                }
+                        Target target = new TargetControlledCreaturePermanent(filter);
+                        target.withNotTarget(true);
+                        if (opponent.choose(outcome, target, source, game)) {
+                            Permanent permanent = game.getPermanent(target.getFirstTarget());
+                            if (permanent != null) {
+                                toSacrifice.add(permanent);
                             }
                         }
                     }

--- a/Mage.Sets/src/mage/cards/f/FellBeastsShriek.java
+++ b/Mage.Sets/src/mage/cards/f/FellBeastsShriek.java
@@ -1,0 +1,93 @@
+package mage.cards.f;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.TapAllEffect;
+import mage.abilities.effects.common.combat.GoadAllEffect;
+import mage.abilities.keyword.SpliceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.PermanentInListPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.common.TargetControlledCreaturePermanent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class FellBeastsShriek extends CardImpl {
+
+    public FellBeastsShriek(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{U}{R}");
+
+        // Each opponent chooses a creature they control. Tap and goad the chosen creatures.
+        this.getSpellAbility().addEffect(new FellBeastsShriekEffect());
+        // Splice onto instant or sorcery {2}{U}{R}
+        this.addAbility(new SpliceAbility(SpliceAbility.INSTANT_OR_SORCERY, "{2}{U}{R}"));
+    }
+
+    private FellBeastsShriek(final FellBeastsShriek card) {
+        super(card);
+    }
+
+    @Override
+    public FellBeastsShriek copy() {
+        return new FellBeastsShriek(this);
+    }
+}
+
+class FellBeastsShriekEffect extends OneShotEffect {
+
+    public FellBeastsShriekEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Each opponent chooses a creature they control. Tap and goad the chosen creatures.";
+    }
+
+    private FellBeastsShriekEffect(final FellBeastsShriekEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public FellBeastsShriekEffect copy() {
+        return new FellBeastsShriekEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            List<Permanent> creaturesChosen = new ArrayList<>();
+
+            // For each opponent, get the creature to tap+goad
+            for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+                if (controller.hasOpponent(playerId, game)) {
+                    Player opponent = game.getPlayer(playerId);
+                    if (opponent != null) {
+                        TargetControlledCreaturePermanent target = new TargetControlledCreaturePermanent();
+                        target.withNotTarget(true);
+                        if (opponent.choose(Outcome.Detriment, target, source, game)) {
+                            creaturesChosen.add(game.getPermanent(target.getTargets().get(0)));
+                        }
+                    }
+                }
+            }
+
+            FilterPermanent filter = new FilterCreaturePermanent();
+            filter.add(new PermanentInListPredicate(creaturesChosen));
+            new TapAllEffect(filter).apply(game, source);
+            new GoadAllEffect(filter).apply(game, source);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FellBeastsShriek.java
+++ b/Mage.Sets/src/mage/cards/f/FellBeastsShriek.java
@@ -1,6 +1,7 @@
 package mage.cards.f;
 
 import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.TapAllEffect;
 import mage.abilities.effects.common.combat.GoadAllEffect;
@@ -85,7 +86,8 @@ class FellBeastsShriekEffect extends OneShotEffect {
             FilterPermanent filter = new FilterCreaturePermanent();
             filter.add(new PermanentInListPredicate(creaturesChosen));
             new TapAllEffect(filter).apply(game, source);
-            new GoadAllEffect(filter).apply(game, source);
+            ContinuousEffect goadEffect = new GoadAllEffect(filter);
+            game.addEffect(goadEffect, source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
+++ b/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
@@ -60,7 +60,7 @@ class GaladrielsDismissalPhaseOutTargetPlayerEffect extends OneShotEffect {
 
     public GaladrielsDismissalPhaseOutTargetPlayerEffect() {
         super(Outcome.Benefit);
-        this.staticText = "each creature target player controls phases out. <i>(Treat phased-out creatures and anything attached to them as though they don’t exist until their controller’s next turn.)</i>";
+        this.staticText = "each creature target player controls phases out. <i>(Treat phased-out creatures and anything attached to them as though they don't exist until their controller's next turn.)</i>";
     }
 
     private GaladrielsDismissalPhaseOutTargetPlayerEffect(final GaladrielsDismissalPhaseOutTargetPlayerEffect effect) {

--- a/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
+++ b/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
@@ -93,9 +93,9 @@ enum GaladrielsDismissalAdjuster implements TargetAdjuster {
     public void adjustTargets(Ability ability, Game game) {
         ability.getTargets().clear();
         if (KickedCondition.ONCE.apply(game, ability)) {
-            ability.addTarget(new TargetCreaturePermanent());
-        } else {
             ability.addTarget(new TargetPlayer());
+        } else {
+            ability.addTarget(new TargetCreaturePermanent());
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
+++ b/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
@@ -1,0 +1,101 @@
+package mage.cards.g;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.common.KickedCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.PhaseOutAllEffect;
+import mage.abilities.effects.common.PhaseOutTargetEffect;
+import mage.abilities.keyword.KickerAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.TargetAdjuster;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class GaladrielsDismissal extends CardImpl {
+
+    public GaladrielsDismissal(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{W}");
+
+        // Kicker {2}{W}
+        this.addAbility(new KickerAbility("{2}{W}"));
+
+        // Target creature phases out. If this spell was kicked, each creature target player controls phases out instead.
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new GaladrielsDismissalPhaseOutTargetPlayerEffect(),
+                new PhaseOutTargetEffect(),
+                KickedCondition.ONCE, "Target creature phases out. If this spell was kicked, each creature target player controls phases out instead. "+
+                "<i>(Treat phased-out creatures and anything attached to them as though they don't exist until their controller's next turn.)</i>"
+        ));
+        this.getSpellAbility().setTargetAdjuster(GaladrielsDismissalAdjuster.instance);
+
+    }
+
+    private GaladrielsDismissal(final GaladrielsDismissal card) {
+        super(card);
+    }
+
+    @Override
+    public GaladrielsDismissal copy() {
+        return new GaladrielsDismissal(this);
+    }
+}
+
+class GaladrielsDismissalPhaseOutTargetPlayerEffect extends OneShotEffect {
+
+    public GaladrielsDismissalPhaseOutTargetPlayerEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "each creature target player controls phases out. <i>(Treat phased-out creatures and anything attached to them as though they don’t exist until their controller’s next turn.)</i>";
+    }
+
+    private GaladrielsDismissalPhaseOutTargetPlayerEffect(final GaladrielsDismissalPhaseOutTargetPlayerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public GaladrielsDismissalPhaseOutTargetPlayerEffect copy() {
+        return new GaladrielsDismissalPhaseOutTargetPlayerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getFirstTarget());
+        if (player != null) {
+            List<UUID> permIds = new ArrayList<>();
+            for (Permanent permanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_CONTROLLED_PERMANENT, player.getId(), game)) {
+                permIds.add(permanent.getId());
+            }
+            return new PhaseOutAllEffect(permIds).apply(game, source);
+        }
+        return false;
+    }
+}
+
+enum GaladrielsDismissalAdjuster implements TargetAdjuster {
+    instance;
+
+    @Override
+    public void adjustTargets(Ability ability, Game game) {
+        ability.getTargets().clear();
+        if (KickedCondition.ONCE.apply(game, ability)) {
+            ability.addTarget(new TargetCreaturePermanent());
+        } else {
+            ability.addTarget(new TargetPlayer());
+        }
+    }
+}

--- a/Mage.Sets/src/mage/cards/g/GimlisRecklessMight.java
+++ b/Mage.Sets/src/mage/cards/g/GimlisRecklessMight.java
@@ -1,0 +1,56 @@
+package mage.cards.g;
+
+import mage.abilities.TriggeredAbility;
+import mage.abilities.common.AttacksWithCreaturesTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.FormidableCondition;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.effects.common.FightTargetsEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterAttackingCreature;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.target.TargetPermanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class GimlisRecklessMight extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterAttackingCreature("attacking creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+    }
+
+    public GimlisRecklessMight(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{R}");
+
+        // Creatures you control have haste.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(
+                HasteAbility.getInstance(), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURES)));
+        // Formidable -- Whenever you attack, if creatures you control have total power 8 or greater, target attacking creature you control fights up to one target creature you don't control.
+        TriggeredAbility ability = new AttacksWithCreaturesTriggeredAbility(new FightTargetsEffect(),1);
+        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL));
+        ability.setAbilityWord(AbilityWord.FORMIDABLE);
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, FormidableCondition.instance,
+                "<i>Formidable</i> &mdash; Whenever you attack, if creatures you control have total power 8 or greater, target attacking creature you control fights up to one target creature you don't control."));
+    }
+
+    private GimlisRecklessMight(final GimlisRecklessMight card) {
+        super(card);
+    }
+
+    @Override
+    public GimlisRecklessMight copy() {
+        return new GimlisRecklessMight(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/i/IsengardUnleashed.java
+++ b/Mage.Sets/src/mage/cards/i/IsengardUnleashed.java
@@ -1,0 +1,99 @@
+package mage.cards.i;
+
+import mage.abilities.Ability;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.continuous.DamageCantBePreventedEffect;
+import mage.abilities.keyword.FlashbackAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class IsengardUnleashed extends CardImpl {
+
+    public IsengardUnleashed(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}{R}{R}");
+
+        // Damage can't be prevented this turn. If a source you control would deal damage this turn to an opponent or a permanent an opponent controls, it deals triple that damage instead.
+        this.getSpellAbility().addEffect(new DamageCantBePreventedEffect(Duration.EndOfTurn, "Damage can't be prevented this turn"));
+        this.getSpellAbility().addEffect(new IsengardUnleashedTripleDamageEffect());
+        // Flashback {4}{R}{R}{R}
+        this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{4}{R}{R}{R}")));
+
+    }
+
+    private IsengardUnleashed(final IsengardUnleashed card) {
+        super(card);
+    }
+
+    @Override
+    public IsengardUnleashed copy() {
+        return new IsengardUnleashed(this);
+    }
+}
+class IsengardUnleashedTripleDamageEffect extends ReplacementEffectImpl {
+
+    public IsengardUnleashedTripleDamageEffect() {
+        super(Duration.EndOfTurn, Outcome.Damage);
+        staticText = "If a source you control would deal damage this turn to an opponent or a permanent an opponent controls, it deals triple that damage instead.";
+    }
+
+    private IsengardUnleashedTripleDamageEffect(final IsengardUnleashedTripleDamageEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public IsengardUnleashedTripleDamageEffect copy() {
+        return new IsengardUnleashedTripleDamageEffect(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGE_PLAYER
+                || event.getType() == GameEvent.EventType.DAMAGE_PERMANENT;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (!game.getControllerId(event.getSourceId()).equals(source.getControllerId())) {
+            return false;
+        }
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+
+        if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER) {
+            return game.isOpponent(controller, event.getTargetId());
+        }
+        if (event.getType() == GameEvent.EventType.DAMAGE_PERMANENT) {
+            Permanent permanent = game.getPermanent(event.getTargetId());
+            return permanent != null && game.isOpponent(controller, permanent.getControllerId());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 3));
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MinasMorgulDarkFortress.java
+++ b/Mage.Sets/src/mage/cards/m/MinasMorgulDarkFortress.java
@@ -1,0 +1,84 @@
+package mage.cards.m;
+
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTappedAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.continuous.AddCardSubTypeTargetEffect;
+import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.abilities.mana.BlackManaAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class MinasMorgulDarkFortress extends CardImpl {
+
+    public MinasMorgulDarkFortress(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
+
+        this.supertype.add(SuperType.LEGENDARY);
+
+        // Minas Morgul, Dark Fortress enters the battlefield tapped.
+        this.addAbility(new EntersBattlefieldTappedAbility());
+
+        // {T}: Add {B}.
+        this.addAbility(new BlackManaAbility());
+
+        // {3}{B}, {T}: Put a shadow counter on target creature. For as long as that creature has a shadow counter on it, it's a Wraith in addition to its other types.
+        Ability ability = new SimpleActivatedAbility(new AddCountersTargetEffect(CounterType.SHADOW.createInstance()),new ManaCostsImpl<>("{3}{B}"));
+        ability.addCost(new TapSourceCost());
+        ability.addEffect(new MinasMorgulEffect());
+        ability.addTarget(new TargetCreaturePermanent());
+        this.addAbility(ability);
+    }
+
+    private MinasMorgulDarkFortress(final MinasMorgulDarkFortress card) {
+        super(card);
+    }
+
+    @Override
+    public MinasMorgulDarkFortress copy() {
+        return new MinasMorgulDarkFortress(this);
+    }
+}
+//Based on Aquitects Will
+class MinasMorgulEffect extends AddCardSubTypeTargetEffect {
+
+    MinasMorgulEffect() {
+        super(SubType.WRAITH, Duration.Custom);
+        staticText = "For as long as that creature has a shadow counter on it, it's a Wraith in addition to its other types";
+    }
+
+    private MinasMorgulEffect(final MinasMorgulEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MinasMorgulEffect copy() {
+        return new MinasMorgulEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent creature = game.getPermanent(this.targetPointer.getFirst(game, source));
+        if (creature == null || creature.getCounters(game).getCount(CounterType.SHADOW) < 1) {
+            discard();
+            return false;
+        }
+        return super.apply(game, source);
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MistsOfLorien.java
+++ b/Mage.Sets/src/mage/cards/m/MistsOfLorien.java
@@ -1,0 +1,84 @@
+package mage.cards.m;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.ReplicateAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
+import mage.constants.CardType;
+import mage.constants.ComparisonType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterNonlandPermanent;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.common.TargetNonlandPermanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class MistsOfLorien extends CardImpl {
+
+    public MistsOfLorien(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{U}");
+
+        // Replicate {U}
+        this.addAbility(new ReplicateAbility("{U}"));
+
+        // Return target nonland permanent and each other nonland permanent with the same mana value as that permanent to their owners' hands.
+        this.getSpellAbility().addTarget(new TargetNonlandPermanent());
+        this.getSpellAbility().addEffect(new MistsOfLorienEffect());
+
+    }
+
+    private MistsOfLorien(final MistsOfLorien card) {
+        super(card);
+    }
+
+    @Override
+    public MistsOfLorien copy() {
+        return new MistsOfLorien(this);
+    }
+}
+
+class MistsOfLorienEffect extends OneShotEffect {
+
+    public MistsOfLorienEffect() {
+        super(Outcome.ReturnToHand);
+        this.staticText = "Return target nonland permanent and each other nonland permanent with the same mana value as that permanent to their owners' hands.";
+    }
+
+    private MistsOfLorienEffect(final MistsOfLorienEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MistsOfLorienEffect copy() {
+        return new MistsOfLorienEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Permanent permanent = game.getPermanent(source.getFirstTarget());
+        if (controller != null && permanent != null) {
+            FilterPermanent filter = new FilterNonlandPermanent();
+            filter.add(new ManaValuePredicate(ComparisonType.EQUAL_TO, permanent.getManaValue()));
+            Cards cardsToHand = new CardsImpl();
+            for (Permanent perm : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
+                cardsToHand.add(perm);
+            }
+            controller.moveCards(cardsToHand, Zone.HAND, source, game);
+            return true;
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MordorOnTheMarch.java
+++ b/Mage.Sets/src/mage/cards/m/MordorOnTheMarch.java
@@ -1,0 +1,108 @@
+package mage.cards.m;
+
+import mage.abilities.Ability;
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.StormAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetCardInYourGraveyard;
+import mage.target.targetpointer.FixedTarget;
+import mage.target.targetpointer.FixedTargets;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class MordorOnTheMarch extends CardImpl {
+
+    public MordorOnTheMarch(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}{R}");
+
+        // Exile a creature card from your graveyard. Create a token that's a copy of it. It gains haste until end of turn. Exile it at the beginning of the next end step.
+        this.getSpellAbility().addEffect(new MordorOnTheMarchEffect());
+
+        // Storm
+        this.addAbility(new StormAbility());
+
+    }
+
+    private MordorOnTheMarch(final MordorOnTheMarch card) {
+        super(card);
+    }
+
+    @Override
+    public MordorOnTheMarch copy() {
+        return new MordorOnTheMarch(this);
+    }
+}
+
+class MordorOnTheMarchEffect extends OneShotEffect {
+
+    public MordorOnTheMarchEffect() {
+        super(Outcome.PutCreatureInPlay);
+        this.staticText = "exile a creature card from your graveyard. Create a token that's a copy of it. It gains haste until end of turn. Exile it at the beginning of the next end step";
+    }
+
+    private MordorOnTheMarchEffect(final MordorOnTheMarchEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MordorOnTheMarchEffect copy() {
+        return new MordorOnTheMarchEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+        TargetCard target = new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD);
+        target.withNotTarget(true);
+        if (!target.canChoose(source.getControllerId(), source, game)) {
+            return true;
+        }
+        controller.choose(outcome, target, source, game);
+        Card card = game.getCard(target.getFirstTarget());
+        if (card != null) {
+            CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(source.getControllerId(), null, false);
+            effect.setTargetPointer(new FixedTarget(card.getId(), card.getZoneChangeCounter(game) + 1));
+            controller.moveCards(card, Zone.EXILED, source, game);
+            effect.apply(game, source);
+            effect.getAddedPermanents().stream().forEach(permanent -> {
+                ContinuousEffect continuousEffect = new GainAbilityTargetEffect(
+                        HasteAbility.getInstance(), Duration.UntilYourNextTurn
+                );
+                continuousEffect.setTargetPointer(new FixedTarget(permanent, game));
+                game.addEffect(continuousEffect, source);
+            });
+            ExileTargetEffect exileEffect = new ExileTargetEffect();
+            exileEffect.setTargetPointer(new FixedTargets(effect.getAddedPermanents(), game));
+            DelayedTriggeredAbility delayedAbility = new AtTheBeginOfNextEndStepDelayedTriggeredAbility(exileEffect);
+            game.addDelayedTriggeredAbility(delayedAbility, source);
+            return true;
+        }
+
+        return false;
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/n/NazgulBattleMace.java
+++ b/Mage.Sets/src/mage/cards/n/NazgulBattleMace.java
@@ -1,0 +1,60 @@
+package mage.cards.n;
+
+import mage.abilities.Ability;
+import mage.abilities.common.OpponentSacrificesNonTokenPermanentTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.effects.common.DoUnlessTargetPlayerOrTargetsControllerPaysEffect;
+import mage.abilities.effects.common.ReturnToBattlefieldUnderYourControlTargetEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.keyword.AnnihilatorAbility;
+import mage.abilities.keyword.DeathtouchAbility;
+import mage.abilities.keyword.EquipAbility;
+import mage.abilities.keyword.MenaceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.Zone;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class NazgulBattleMace extends CardImpl {
+
+    public NazgulBattleMace(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{5}");
+
+        this.subtype.add(SubType.EQUIPMENT);
+        //String abilityText =  "Whenever an opponent sacrifices a nontoken permanent, put that card onto the battlefield under your control unless that player pays 3 life";
+        // Equipped creature has menace, deathtouch, annihilator 1, and
+        // "Whenever an opponent sacrifices a nontoken permanent, put that card onto the battlefield under your control unless that player pays 3 life."
+        Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAttachedEffect(new MenaceAbility(false), AttachmentType.EQUIPMENT));
+        ability.addEffect(new GainAbilityAttachedEffect(DeathtouchAbility.getInstance(), AttachmentType.EQUIPMENT).setText(", deathtouch"));
+        ability.addEffect(new GainAbilityAttachedEffect(new AnnihilatorAbility(1), AttachmentType.EQUIPMENT).setText(", annihilator 1"));
+        Ability sacTriggerAbility = new OpponentSacrificesNonTokenPermanentTriggeredAbility(
+                new DoUnlessTargetPlayerOrTargetsControllerPaysEffect(
+                        new ReturnToBattlefieldUnderYourControlTargetEffect(),
+                        new PayLifeCost(3)
+                ).setText("put that card onto the battlefield under your control unless that player pays 3 life"));
+        ability.addEffect(new GainAbilityAttachedEffect(sacTriggerAbility, AttachmentType.EQUIPMENT)
+                .setText(", and \""+sacTriggerAbility.getRule()+"\"")
+        );
+        this.addAbility(ability);
+        // Equip {3}
+        this.addAbility(new EquipAbility(3, false));
+    }
+
+    private NazgulBattleMace(final NazgulBattleMace card) {
+        super(card);
+    }
+
+    @Override
+    public NazgulBattleMace copy() {
+        return new NazgulBattleMace(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OlorinsSearingLight.java
+++ b/Mage.Sets/src/mage/cards/o/OlorinsSearingLight.java
@@ -1,0 +1,99 @@
+package mage.cards.o;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.common.SpellMasteryCondition;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.permanent.GreatestPowerControlledPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.common.TargetControlledCreaturePermanent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class OlorinsSearingLight extends CardImpl {
+
+    public OlorinsSearingLight(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{R}{W}");
+
+        // Each opponent exiles a creature with the greatest power among creatures that player controls.
+        // Spell mastery -- If there are two or more instant and/or sorcery cards in your graveyard, Olorin's Searing Light deals damage to each opponent equal to the power of the creature they exiled.
+        this.getSpellAbility().addEffect(new OlorinsSearingLightEffect());
+    }
+
+    private OlorinsSearingLight(final OlorinsSearingLight card) {
+        super(card);
+    }
+
+    @Override
+    public OlorinsSearingLight copy() {
+        return new OlorinsSearingLight(this);
+    }
+}
+//See Crackling Doom
+class OlorinsSearingLightEffect extends OneShotEffect {
+
+    static FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature with the greatest power among creatures you control");
+    static {
+        filter.add(GreatestPowerControlledPredicate.instance);
+    }
+    public OlorinsSearingLightEffect() {
+        super(Outcome.Sacrifice);
+        this.staticText = "Each opponent exiles a creature with the greatest power among creatures that player controls.<br>"
+                +"<i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, Olórin’s Searing Light deals damage to each opponent equal to the power of the creature they exiled.";
+    }
+
+    private OlorinsSearingLightEffect(final OlorinsSearingLightEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public OlorinsSearingLightEffect copy() {
+        return new OlorinsSearingLightEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            List<Permanent> toExile = new ArrayList<>();
+            for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+                if (controller.hasOpponent(playerId, game)) {
+                    Player opponent = game.getPlayer(playerId);
+                    if (opponent != null) {
+                        Target target = new TargetControlledCreaturePermanent(filter);
+                        target.withNotTarget(true);
+                        if (opponent.choose(outcome, target, source, game)) {
+                            Permanent permanentChosen = game.getPermanent(target.getFirstTarget());
+                            if (permanentChosen != null) {
+                                toExile.add(permanentChosen);
+                            }
+                        }
+                    }
+                }
+            }
+            for (Permanent permanent : toExile) {
+                Player opponent = game.getPlayer(permanent.getControllerId());
+                if (SpellMasteryCondition.instance.apply(game, source)){
+                    opponent.damage(permanent.getPower().getValue(),source, game);
+                }
+                opponent.moveCards(permanent, Zone.EXILED, source, game);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OlorinsSearingLight.java
+++ b/Mage.Sets/src/mage/cards/o/OlorinsSearingLight.java
@@ -53,7 +53,7 @@ class OlorinsSearingLightEffect extends OneShotEffect {
     public OlorinsSearingLightEffect() {
         super(Outcome.Sacrifice);
         this.staticText = "Each opponent exiles a creature with the greatest power among creatures that player controls.<br>"
-                +"<i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, Olórin’s Searing Light deals damage to each opponent equal to the power of the creature they exiled.";
+                +"<i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, {this} deals damage to each opponent equal to the power of the creature they exiled.";
     }
 
     private OlorinsSearingLightEffect(final OlorinsSearingLightEffect effect) {

--- a/Mage.Sets/src/mage/cards/r/RallyTheGaladhrim.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheGaladhrim.java
@@ -1,0 +1,37 @@
+package mage.cards.r;
+
+import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
+import mage.abilities.keyword.ConspireAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.target.common.TargetControlledCreaturePermanent;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class RallyTheGaladhrim extends CardImpl {
+
+    public RallyTheGaladhrim(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}{U}");
+
+        // Create a token that's a copy of target creature you control.
+        this.getSpellAbility().addEffect(new CreateTokenCopyTargetEffect());
+        this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
+        // Conspire
+        this.addAbility(new ConspireAbility(ConspireAbility.ConspireTargets.ONE));
+
+    }
+
+    private RallyTheGaladhrim(final RallyTheGaladhrim card) {
+        super(card);
+    }
+
+    @Override
+    public RallyTheGaladhrim copy() {
+        return new RallyTheGaladhrim(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RammasEchorAncientShield.java
+++ b/Mage.Sets/src/mage/cards/r/RammasEchorAncientShield.java
@@ -1,0 +1,56 @@
+package mage.cards.r;
+
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfCombatTriggeredAbility;
+import mage.abilities.common.CastSecondSpellTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.DefenderAbility;
+import mage.abilities.keyword.ExaltedAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SuperType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.mageobject.AbilityPredicate;
+import mage.game.permanent.token.TeyoToken;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class RammasEchorAncientShield extends CardImpl {
+
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creatures you control with defender");
+
+    static {
+        filter.add(new AbilityPredicate(DefenderAbility.class));
+    }
+    public RammasEchorAncientShield(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}{W}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+
+        // Whenever you cast your second spell each turn, draw a card, then create a 0/3 white Wall creature token with defender.
+        Ability ability = new CastSecondSpellTriggeredAbility(new DrawCardSourceControllerEffect(1));
+        ability.addEffect(new CreateTokenEffect(new TeyoToken()).concatBy(", then"));
+        this.addAbility(ability);
+
+        // At the beginning of combat on your turn, creatures you control with defender gain exalted until end of turn.
+        this.addAbility(new BeginningOfCombatTriggeredAbility(new GainAbilityControlledEffect(new ExaltedAbility(), Duration.EndOfTurn, filter), TargetController.YOU, false));
+    }
+
+    private RammasEchorAncientShield(final RammasEchorAncientShield card) {
+        super(card);
+    }
+
+    @Override
+    public RammasEchorAncientShield copy() {
+        return new RammasEchorAncientShield(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RohirrimChargers.java
+++ b/Mage.Sets/src/mage/cards/r/RohirrimChargers.java
@@ -1,0 +1,103 @@
+package mage.cards.r;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.ExertCreatureControllerTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.ExertAbility;
+import mage.cards.*;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Library;
+import mage.players.Player;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class RohirrimChargers extends CardImpl {
+
+    public RohirrimChargers(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}{W}");
+
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.KNIGHT);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // You may exert Rohirrim Chargers as it attacks.
+        this.addAbility(new ExertAbility(null, false));
+        // Whenever you exert a creature, reveal cards from the top of your library until you reveal an Equipment card. Put that card onto the battlefield attached to that creature, then put the rest on the bottom of your library in a random order.
+        this.addAbility(new ExertCreatureControllerTriggeredAbility(new RohirrimChargersEffect(), true));
+    }
+
+    private RohirrimChargers(final RohirrimChargers card) {
+        super(card);
+    }
+
+    @Override
+    public RohirrimChargers copy() {
+        return new RohirrimChargers(this);
+    }
+}
+
+class RohirrimChargersEffect extends OneShotEffect {
+
+    RohirrimChargersEffect() {
+        super(Outcome.Benefit);
+        staticText = "reveal cards from the top of your library until you reveal an Equipment card. "+
+                "Put that card onto the battlefield attached to that creature, then put the rest on the bottom of your library in a random order.";
+    }
+
+    private RohirrimChargersEffect(final RohirrimChargersEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RohirrimChargersEffect copy() {
+        return new RohirrimChargersEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        Library library = player.getLibrary();
+        if (!library.hasCards()) {
+            return true;
+        }
+        Cards cards = new CardsImpl();
+        Card toBattlefield = null;
+        for (Card card : library.getCards(game)) {
+            cards.add(card);
+            if (card.hasSubtype(SubType.EQUIPMENT, game)) {
+                toBattlefield = card;
+                break;
+            }
+        }
+        if (toBattlefield != null) {
+            Permanent attachTarget = game.getPermanent(getTargetPointer().getFirst(game, source));
+            if (attachTarget != null) {
+                game.getState().setValue("attachTo:" + toBattlefield.getId(), attachTarget);
+            }
+            player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
+            if (attachTarget != null) {
+                attachTarget.addAttachment(toBattlefield.getId(), source, game);
+            }
+        }
+        player.revealCards(source, cards, game);
+        cards.remove(toBattlefield);
+        if (!cards.isEmpty()) {
+            player.putCardsOnBottomOfLibrary(cards, game, source, false);
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SorcerousSquall.java
+++ b/Mage.Sets/src/mage/cards/s/SorcerousSquall.java
@@ -1,0 +1,87 @@
+package mage.cards.s;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.MayCastTargetThenExileEffect;
+import mage.abilities.effects.common.MillCardsTargetEffect;
+import mage.abilities.effects.common.replacement.ThatSpellGraveyardExileReplacementEffect;
+import mage.abilities.keyword.DelveAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.FilterCard;
+import mage.filter.common.FilterInstantOrSorceryCard;
+import mage.filter.predicate.card.OwnerIdPredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.common.TargetCardInGraveyard;
+import mage.target.common.TargetOpponent;
+import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class SorcerousSquall extends CardImpl {
+
+    public SorcerousSquall(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{6}{U}{U}{U}");
+
+        // Delve
+        this.addAbility(new DelveAbility());
+
+        // Target opponent mills nine cards, then you may cast an instant or sorcery spell from that player's graveyard without paying its mana cost. If that spell would be put into a graveyard, exile it instead.
+        this.getSpellAbility().addEffect(new MillCardsTargetEffect(9));
+        this.getSpellAbility().addEffect(new SorcerousSquallEffect().concatBy(", then"));
+        this.getSpellAbility().addTarget(new TargetOpponent());
+
+    }
+
+    private SorcerousSquall(final SorcerousSquall card) {
+        super(card);
+    }
+
+    @Override
+    public SorcerousSquall copy() {
+        return new SorcerousSquall(this);
+    }
+}
+
+
+class SorcerousSquallEffect extends OneShotEffect {
+
+    SorcerousSquallEffect() {
+        super(Outcome.Detriment);
+        setText("you may cast an instant or sorcery spell from that player's graveyard without paying its mana cost. "+ ThatSpellGraveyardExileReplacementEffect.RULE_A);
+    }
+
+    private SorcerousSquallEffect(final SorcerousSquallEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SorcerousSquallEffect copy() {
+        return new SorcerousSquallEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getFirstTarget());
+        if (player == null) {
+            return false;
+        }
+        FilterCard filter = new FilterInstantOrSorceryCard("instant or sorcery card from that player’s graveyard");
+        filter.add(new OwnerIdPredicate(source.getFirstTarget()));
+        Target target = new TargetCardInGraveyard(1, 1, filter, true);
+        player.choose(outcome, target, source, game);
+        Effect effect = new MayCastTargetThenExileEffect(true);
+        effect.setTargetPointer(new FixedTarget(target.getFirstTarget(), game));
+        effect.apply(game, source);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SorcerousSquall.java
+++ b/Mage.Sets/src/mage/cards/s/SorcerousSquall.java
@@ -75,7 +75,7 @@ class SorcerousSquallEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        FilterCard filter = new FilterInstantOrSorceryCard("instant or sorcery card from that player’s graveyard");
+        FilterCard filter = new FilterInstantOrSorceryCard("instant or sorcery card from that player's graveyard");
         filter.add(new OwnerIdPredicate(source.getFirstTarget()));
         Target target = new TargetCardInGraveyard(1, 1, filter, true);
         player.choose(outcome, target, source, game);

--- a/Mage.Sets/src/mage/cards/w/WitchKingSkyScourge.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingSkyScourge.java
@@ -1,0 +1,117 @@
+package mage.cards.w;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksWithCreaturesTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.ExileTopXMayPlayUntilEndOfTurnEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.UndyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.constants.TargetController;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterAttackingCreature;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class WitchKingSkyScourge extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterAttackingCreature("Wraiths");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.WRAITH.getPredicate());
+    }
+    public WitchKingSkyScourge(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{B}{R}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.WRAITH);
+        this.subtype.add(SubType.NOBLE);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Whenever you attack with one or more Wraiths, exile the top X cards of your library, where X is their total power. You may play those cards this turn.
+        this.addAbility(new AttacksWithCreaturesTriggeredAbility(
+                new ExileTopXMayPlayUntilEndOfTurnEffect(new TotalPermanentsPowerValue(filter))
+                        .setText("exile the top X cards of your library, where X is their total power. You may play those cards this turn.")
+                ,1,filter));
+
+        // Undying
+        this.addAbility(new UndyingAbility());
+
+    }
+
+    private WitchKingSkyScourge(final WitchKingSkyScourge card) {
+        super(card);
+    }
+
+    @Override
+    public WitchKingSkyScourge copy() {
+        return new WitchKingSkyScourge(this);
+    }
+}
+
+class TotalPermanentsPowerValue implements DynamicValue {
+
+    private final FilterPermanent filter;
+
+    public TotalPermanentsPowerValue(FilterPermanent filter) {
+        this.filter = filter.copy();
+    }
+
+    private TotalPermanentsPowerValue(final TotalPermanentsPowerValue value) {
+        this.filter = value.filter.copy();
+    }
+
+    @Override
+    public TotalPermanentsPowerValue copy() {
+        return new TotalPermanentsPowerValue(this);
+    }
+
+    @Override
+    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+        int totalPower = 0;
+        List<Permanent> permanents = game.getBattlefield().getActivePermanents(
+                filter,
+                sourceAbility.getControllerId(),
+                sourceAbility,
+                game);
+        for (Permanent permanent : permanents) {
+            totalPower += permanent.getPower().getValue();
+        }
+        return totalPower;
+    }
+
+    @Override
+    public String getMessage() {
+        return "their total power";
+    }
+
+    @Override
+    public String toString() {
+        return "X";
+    }
+
+    public Hint getHint() {
+        return new ValueHint("Total power of " + filter.getMessage(), this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WitchKingSkyScourge.java
+++ b/Mage.Sets/src/mage/cards/w/WitchKingSkyScourge.java
@@ -12,17 +12,14 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.UndyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.constants.TargetController;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
+import mage.constants.*;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterAttackingCreature;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -31,7 +28,7 @@ import java.util.UUID;
  */
 public final class WitchKingSkyScourge extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterAttackingCreature("Wraiths");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Wraiths");
 
     static {
         filter.add(TargetController.YOU.getControllerPredicate());
@@ -50,10 +47,10 @@ public final class WitchKingSkyScourge extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever you attack with one or more Wraiths, exile the top X cards of your library, where X is their total power. You may play those cards this turn.
-        this.addAbility(new AttacksWithCreaturesTriggeredAbility(
+        this.addAbility(new AttacksWithCreaturesTriggeredAbility(Zone.BATTLEFIELD,
                 new ExileTopXMayPlayUntilEndOfTurnEffect(new TotalPermanentsPowerValue(filter))
                         .setText("exile the top X cards of your library, where X is their total power. You may play those cards this turn.")
-                ,1,filter));
+                ,1,filter, true));
 
         // Undying
         this.addAbility(new UndyingAbility());
@@ -90,12 +87,12 @@ class TotalPermanentsPowerValue implements DynamicValue {
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
         int totalPower = 0;
-        List<Permanent> permanents = game.getBattlefield().getActivePermanents(
-                filter,
-                sourceAbility.getControllerId(),
-                sourceAbility,
-                game);
-        for (Permanent permanent : permanents) {
+        Cards cards = new CardsImpl(effect.getTargetPointer().getTargets(game, sourceAbility));
+        for (UUID targetId : cards) {
+            Permanent permanent = game.getPermanent(targetId);
+            if (permanent == null) {
+                continue;
+            }
             totalPower += permanent.getPower().getValue();
         }
         return totalPower;

--- a/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
+++ b/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
@@ -282,6 +282,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Smoldering Marsh", 332, Rarity.RARE, mage.cards.s.SmolderingMarsh.class));
         cards.add(new SetCardInfo("Sol Ring", 284, Rarity.UNCOMMON, mage.cards.s.SolRing.class));
         cards.add(new SetCardInfo("Song of Earendil", 69, Rarity.RARE, mage.cards.s.SongOfEarendil.class));
+        cards.add(new SetCardInfo("Sorcerous Squall", 504, Rarity.RARE, mage.cards.s.SorcerousSquall.class));
         cards.add(new SetCardInfo("Soul's Attendant", 520, Rarity.UNCOMMON, mage.cards.s.SoulsAttendant.class));
         cards.add(new SetCardInfo("Stonehewer Giant", 521, Rarity.RARE, mage.cards.s.StonehewerGiant.class));
         cards.add(new SetCardInfo("Subjugate the Hobbits", 24, Rarity.RARE, mage.cards.s.SubjugateTheHobbits.class));

--- a/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
+++ b/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
@@ -220,6 +220,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Oath of Eorl", 64, Rarity.RARE, mage.cards.o.OathOfEorl.class));
         cards.add(new SetCardInfo("Oboro, Palace in the Clouds", 371, Rarity.MYTHIC, mage.cards.o.OboroPalaceInTheClouds.class));
         cards.add(new SetCardInfo("Of Herbs and Stewed Rabbit", 17, Rarity.RARE, mage.cards.o.OfHerbsAndStewedRabbit.class));
+        cards.add(new SetCardInfo("Olorin's Searing Light", 503, Rarity.RARE, mage.cards.o.OlorinsSearingLight.class));
         cards.add(new SetCardInfo("Opt", 194, Rarity.COMMON, mage.cards.o.Opt.class));
         cards.add(new SetCardInfo("Orchard Strider", 253, Rarity.COMMON, mage.cards.o.OrchardStrider.class));
         cards.add(new SetCardInfo("Orcish Siegemaster", 33, Rarity.RARE, mage.cards.o.OrcishSiegemaster.class));

--- a/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
+++ b/Mage.Sets/src/mage/sets/TalesOfMiddleEarthCommander.java
@@ -19,8 +19,10 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Abyssal Persecutor", 525, Rarity.MYTHIC, mage.cards.a.AbyssalPersecutor.class));
         cards.add(new SetCardInfo("Access Tunnel", 294, Rarity.UNCOMMON, mage.cards.a.AccessTunnel.class));
         cards.add(new SetCardInfo("Ancient Tomb", 357, Rarity.MYTHIC, mage.cards.a.AncientTomb.class));
+        cards.add(new SetCardInfo("Anduril, Narsil Reforged", 491, Rarity.RARE, mage.cards.a.AndurilNarsilReforged.class));
         cards.add(new SetCardInfo("Anger", 210, Rarity.UNCOMMON, mage.cards.a.Anger.class));
         cards.add(new SetCardInfo("Anguished Unmaking", 265, Rarity.RARE, mage.cards.a.AnguishedUnmaking.class));
+        cards.add(new SetCardInfo("Aragorn, Hornburg Hero", 492, Rarity.MYTHIC, mage.cards.a.AragornHornburgHero.class));
         cards.add(new SetCardInfo("Aragorn, King of Gondor", 5, Rarity.MYTHIC, mage.cards.a.AragornKingOfGondor.class));
         cards.add(new SetCardInfo("Arbor Elf", 232, Rarity.COMMON, mage.cards.a.ArborElf.class));
         cards.add(new SetCardInfo("Arboreal Alliance", 497, Rarity.RARE, mage.cards.a.ArborealAlliance.class));
@@ -112,6 +114,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Feasting Hobbit", 37, Rarity.RARE, mage.cards.f.FeastingHobbit.class));
         cards.add(new SetCardInfo("Feed the Swarm", 200, Rarity.COMMON, mage.cards.f.FeedTheSwarm.class));
         cards.add(new SetCardInfo("Fell Beast of Mordor", 513, Rarity.RARE, mage.cards.f.FellBeastOfMordor.class));
+        cards.add(new SetCardInfo("Fell Beast's Shriek", 508, Rarity.RARE, mage.cards.f.FellBeastsShriek.class));
         cards.add(new SetCardInfo("Fell the Mighty", 167, Rarity.RARE, mage.cards.f.FellTheMighty.class));
         cards.add(new SetCardInfo("Field of Ruin", 308, Rarity.UNCOMMON, mage.cards.f.FieldOfRuin.class));
         cards.add(new SetCardInfo("Field-Tested Frying Pan", 11, Rarity.RARE, mage.cards.f.FieldTestedFryingPan.class));
@@ -130,6 +133,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Furycalm Snarl", 313, Rarity.RARE, mage.cards.f.FurycalmSnarl.class));
         cards.add(new SetCardInfo("Galadhrim Ambush", 38, Rarity.RARE, mage.cards.g.GaladhrimAmbush.class));
         cards.add(new SetCardInfo("Galadhrim Brigade", 502, Rarity.RARE, mage.cards.g.GaladhrimBrigade.class));
+        cards.add(new SetCardInfo("Galadriel's Dismissal", 500, Rarity.RARE, mage.cards.g.GaladrielsDismissal.class));
         cards.add(new SetCardInfo("Galadriel, Elven-Queen", 3, Rarity.MYTHIC, mage.cards.g.GaladrielElvenQueen.class));
         cards.add(new SetCardInfo("Galadriel, Light of Valinor", 498, Rarity.MYTHIC, mage.cards.g.GaladrielLightOfValinor.class));
         cards.add(new SetCardInfo("Gandalf, Westward Voyager", 6, Rarity.MYTHIC, mage.cards.g.GandalfWestwardVoyager.class));
@@ -139,6 +143,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Gilded Goose", 246, Rarity.RARE, mage.cards.g.GildedGoose.class));
         cards.add(new SetCardInfo("Gilraen, Dunedain Protector", 13, Rarity.RARE, mage.cards.g.GilraenDunedainProtector.class));
         cards.add(new SetCardInfo("Gimli of the Glittering Caves", 32, Rarity.RARE, mage.cards.g.GimliOfTheGlitteringCaves.class));
+        cards.add(new SetCardInfo("Gimli's Reckless Might", 494, Rarity.RARE, mage.cards.g.GimlisRecklessMight.class));
         cards.add(new SetCardInfo("Glacial Fortress", 315, Rarity.RARE, mage.cards.g.GlacialFortress.class));
         cards.add(new SetCardInfo("Go for the Throat", 201, Rarity.UNCOMMON, mage.cards.g.GoForTheThroat.class));
         cards.add(new SetCardInfo("Goblin Cratermaker", 218, Rarity.UNCOMMON, mage.cards.g.GoblinCratermaker.class));
@@ -168,6 +173,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Increasing Devotion", 171, Rarity.RARE, mage.cards.i.IncreasingDevotion.class));
         cards.add(new SetCardInfo("Inferno Titan", 223, Rarity.MYTHIC, mage.cards.i.InfernoTitan.class));
         cards.add(new SetCardInfo("Inscription of Abundance", 251, Rarity.RARE, mage.cards.i.InscriptionOfAbundance.class));
+        cards.add(new SetCardInfo("Isengard Unleashed", 495, Rarity.RARE, mage.cards.i.IsengardUnleashed.class));
         cards.add(new SetCardInfo("Ishkanah, Grafwidow", 516, Rarity.MYTHIC, mage.cards.i.IshkanahGrafwidow.class));
         cards.add(new SetCardInfo("Isolated Chapel", 318, Rarity.RARE, mage.cards.i.IsolatedChapel.class));
         cards.add(new SetCardInfo("Karakas", 367, Rarity.MYTHIC, mage.cards.k.Karakas.class));
@@ -192,11 +198,14 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Merciless Executioner", 204, Rarity.UNCOMMON, mage.cards.m.MercilessExecutioner.class));
         cards.add(new SetCardInfo("Merry, Warden of Isengard", 61, Rarity.RARE, mage.cards.m.MerryWardenOfIsengard.class));
         cards.add(new SetCardInfo("Minamo, School at Water's Edge", 369, Rarity.MYTHIC, mage.cards.m.MinamoSchoolAtWatersEdge.class));
+        cards.add(new SetCardInfo("Minas Morgul, Dark Fortress", 514, Rarity.RARE, mage.cards.m.MinasMorgulDarkFortress.class));
         cards.add(new SetCardInfo("Mind Stone", 282, Rarity.UNCOMMON, mage.cards.m.MindStone.class));
         cards.add(new SetCardInfo("Mirkwood Elk", 41, Rarity.RARE, mage.cards.m.MirkwoodElk.class));
         cards.add(new SetCardInfo("Mirkwood Trapper", 62, Rarity.RARE, mage.cards.m.MirkwoodTrapper.class));
+        cards.add(new SetCardInfo("Mists of Lorien", 501, Rarity.RARE, mage.cards.m.MistsOfLorien.class));
         cards.add(new SetCardInfo("Model of Unity", 78, Rarity.RARE, mage.cards.m.ModelOfUnity.class));
         cards.add(new SetCardInfo("Monstrosity of the Lake", 22, Rarity.RARE, mage.cards.m.MonstrosityOfTheLake.class));
+        cards.add(new SetCardInfo("Mordor on the March", 512, Rarity.RARE, mage.cards.m.MordorOnTheMarch.class));
         cards.add(new SetCardInfo("Moria Scavenger", 63, Rarity.RARE, mage.cards.m.MoriaScavenger.class));
         cards.add(new SetCardInfo("Mortify", 269, Rarity.UNCOMMON, mage.cards.m.Mortify.class));
         cards.add(new SetCardInfo("Motivated Pony", 42, Rarity.RARE, mage.cards.m.MotivatedPony.class));
@@ -204,6 +213,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Murmuring Bosk", 320, Rarity.RARE, mage.cards.m.MurmuringBosk.class));
         cards.add(new SetCardInfo("Myriad Landscape", 534, Rarity.UNCOMMON, mage.cards.m.MyriadLandscape.class));
         cards.add(new SetCardInfo("Mystic Confluence", 193, Rarity.RARE, mage.cards.m.MysticConfluence.class));
+        cards.add(new SetCardInfo("Nazgul Battle-Mace", 510, Rarity.RARE, mage.cards.n.NazgulBattleMace.class));
         cards.add(new SetCardInfo("Necroblossom Snarl", 321, Rarity.RARE, mage.cards.n.NecroblossomSnarl.class));
         cards.add(new SetCardInfo("Night's Whisper", 205, Rarity.COMMON, mage.cards.n.NightsWhisper.class));
         cards.add(new SetCardInfo("Notion Thief", 270, Rarity.RARE, mage.cards.n.NotionThief.class));
@@ -230,6 +240,8 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Prosperous Innkeeper", 256, Rarity.UNCOMMON, mage.cards.p.ProsperousInnkeeper.class));
         cards.add(new SetCardInfo("Radagast, Wizard of Wilds", 66, Rarity.RARE, mage.cards.r.RadagastWizardOfWilds.class));
         cards.add(new SetCardInfo("Raise the Palisade", 23, Rarity.RARE, mage.cards.r.RaiseThePalisade.class));
+        cards.add(new SetCardInfo("Rally the Galadhrim", 499, Rarity.RARE, mage.cards.r.RallyTheGaladhrim.class));
+        cards.add(new SetCardInfo("Rammas Echor, Ancient Shield", 505, Rarity.RARE, mage.cards.r.RammasEchorAncientShield.class));
         cards.add(new SetCardInfo("Rampaging War Mammoth", 34, Rarity.RARE, mage.cards.r.RampagingWarMammoth.class));
         cards.add(new SetCardInfo("Rampant Growth", 257, Rarity.COMMON, mage.cards.r.RampantGrowth.class));
         cards.add(new SetCardInfo("Rapacious Guest", 28, Rarity.RARE, mage.cards.r.RapaciousGuest.class));
@@ -244,6 +256,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Rings of Brighthearth", 352, Rarity.MYTHIC, mage.cards.r.RingsOfBrighthearth.class));
         cards.add(new SetCardInfo("River Kelpie", 524, Rarity.RARE, mage.cards.r.RiverKelpie.class));
         cards.add(new SetCardInfo("Rogue's Passage", 326, Rarity.UNCOMMON, mage.cards.r.RoguesPassage.class));
+        cards.add(new SetCardInfo("Rohirrim Chargers", 496, Rarity.RARE, mage.cards.r.RohirrimChargers.class));
         cards.add(new SetCardInfo("Sail into the West", 68, Rarity.RARE, mage.cards.s.SailIntoTheWest.class));
         cards.add(new SetCardInfo("Sam, Loyal Attendant", 7, Rarity.MYTHIC, mage.cards.s.SamLoyalAttendant.class));
         cards.add(new SetCardInfo("Sandsteppe Citadel", 327, Rarity.UNCOMMON, mage.cards.s.SandsteppeCitadel.class));
@@ -329,6 +342,7 @@ public final class TalesOfMiddleEarthCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Wind-Scarred Crag", 344, Rarity.COMMON, mage.cards.w.WindScarredCrag.class));
         cards.add(new SetCardInfo("Windbrisk Heights", 345, Rarity.RARE, mage.cards.w.WindbriskHeights.class));
         cards.add(new SetCardInfo("Windswift Slice", 45, Rarity.RARE, mage.cards.w.WindswiftSlice.class));
+        cards.add(new SetCardInfo("Witch-king, Sky Scourge", 511, Rarity.MYTHIC, mage.cards.w.WitchKingSkyScourge.class));
         cards.add(new SetCardInfo("Wood Elves", 263, Rarity.COMMON, mage.cards.w.WoodElves.class));
         cards.add(new SetCardInfo("Woodfall Primus", 264, Rarity.RARE, mage.cards.w.WoodfallPrimus.class));
         cards.add(new SetCardInfo("Woodland Cemetery", 346, Rarity.RARE, mage.cards.w.WoodlandCemetery.class));

--- a/Mage/src/main/java/mage/abilities/common/ExertCreatureControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/ExertCreatureControllerTriggeredAbility.java
@@ -40,7 +40,7 @@ public class ExertCreatureControllerTriggeredAbility extends TriggeredAbilityImp
         boolean exertedIsCreature = (exerted != null) && exerted.isCreature(game);
         if (weAreExerting && exertedIsCreature) {
             if (setTargetPointer) {
-                getAllEffects().setTargetPointer(new FixedTarget(event.getPlayerId()));
+                getAllEffects().setTargetPointer(new FixedTarget(event.getTargetId()));
             }
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/common/ExertCreatureControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/ExertCreatureControllerTriggeredAbility.java
@@ -6,19 +6,26 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.target.targetpointer.FixedTarget;
 
 /**
  * @author stravant
  */
 public class ExertCreatureControllerTriggeredAbility extends TriggeredAbilityImpl {
 
+    protected final boolean setTargetPointer;
     public ExertCreatureControllerTriggeredAbility(Effect effect) {
+        this(effect, false);
+    }
+    public ExertCreatureControllerTriggeredAbility(Effect effect, boolean setTargetPointer) {
         super(Zone.BATTLEFIELD, effect);
+        this.setTargetPointer = setTargetPointer;
         setTriggerPhrase("Whenever you exert a creature, ");
     }
 
     protected ExertCreatureControllerTriggeredAbility(final ExertCreatureControllerTriggeredAbility ability) {
         super(ability);
+        this.setTargetPointer = ability.setTargetPointer;
     }
 
     @Override
@@ -31,7 +38,13 @@ public class ExertCreatureControllerTriggeredAbility extends TriggeredAbilityImp
         boolean weAreExerting = isControlledBy(event.getPlayerId());
         Permanent exerted = game.getPermanent(event.getTargetId());
         boolean exertedIsCreature = (exerted != null) && exerted.isCreature(game);
-        return weAreExerting && exertedIsCreature;
+        if (weAreExerting && exertedIsCreature) {
+            if (setTargetPointer) {
+                getAllEffects().setTargetPointer(new FixedTarget(event.getPlayerId()));
+            }
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/Mage/src/main/java/mage/counters/CounterType.java
+++ b/Mage/src/main/java/mage/counters/CounterType.java
@@ -176,6 +176,7 @@ public enum CounterType {
     QUEST("quest"),
     SILVER("silver"),
     SCREAM("scream"),
+    SHADOW("shadow"),
     SHELL("shell"),
     SHIELD("shield"),
     SHRED("shred"),
@@ -311,6 +312,8 @@ public enum CounterType {
                 return new AbilityCounter(new MenaceAbility(), amount);
             case REACH:
                 return new AbilityCounter(ReachAbility.getInstance(), amount);
+            case SHADOW:
+                return new AbilityCounter(ShadowAbility.getInstance(), amount);
             case TRAMPLE:
                 return new AbilityCounter(TrampleAbility.getInstance(), amount);
             case VIGILANCE:

--- a/Mage/src/main/java/mage/filter/predicate/permanent/RenownedPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/RenownedPredicate.java
@@ -1,0 +1,23 @@
+
+package mage.filter.predicate.permanent;
+
+import mage.filter.predicate.Predicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ * @author notgreat
+ */
+public enum RenownedPredicate implements Predicate<Permanent> {
+    instance;
+
+    @Override
+    public boolean apply(Permanent input, Game game) {
+        return input.isRenowned();
+    }
+
+    @Override
+    public String toString() {
+        return "Renowned";
+    }
+}


### PR DESCRIPTION
As I mentioned in the tracking thread, this PR adds the following cards from LTC:

Anduril, Narsil Reforged
Aragorn, Hornburg Hero
Fell Beast's Shriek
Galadriel's Dismissal
Gimli's Reckless Might
Isengard Unleashed
Minas Morgul, Dark Fortress
Mists of Lorien
Mordor on the March
Nazgul Battle-Mace
Rally the Galadhrim
Rammas Echor, Ancient Shield
Rohirrim Chargers
Witch-king, Sky Scourge

I also implemented two more:
Olorin's Searing Light
Sorcerous Squall

in addition to simplifying Crackling Doom's implementation.

I didn't manually test all the cards that might have problems yet, so keeping this as draft until I finish up the testing.