### PR TITLE
Improved network stability and other related fixes

### DIFF
--- a/Mage.Client/src/main/java/mage/client/SessionHandler.java
+++ b/Mage.Client/src/main/java/mage/client/SessionHandler.java
@@ -225,8 +225,8 @@ public final class SessionHandler {
         return session.isTestMode();
     }
 
-    public static void cheat(UUID gameId, UUID playerId, DeckCardLists deckCardLists) {
-        session.cheat(gameId, playerId, deckCardLists);
+    public static void cheatShow(UUID gameId, UUID playerId) {
+        session.cheatShow(gameId, playerId);
     }
 
     public static String getSessionId() {

--- a/Mage.Client/src/main/java/mage/client/game/PlayAreaPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayAreaPanel.java
@@ -588,7 +588,7 @@ public class PlayAreaPanel extends javax.swing.JPanel {
     }
 
     private void btnCheatActionPerformed(java.awt.event.ActionEvent evt) {
-        SessionHandler.cheat(gameId, playerId, DeckImporter.importDeckFromFile("cheat.dck", false));
+        SessionHandler.cheatShow(gameId, playerId);
     }
 
     public boolean isSmallMode() {

--- a/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
@@ -970,8 +970,7 @@ public class PlayerPanelExt extends javax.swing.JPanel {
     }
 
     private void btnCheatActionPerformed(java.awt.event.ActionEvent evt) {
-        DckDeckImporter deckImporter = new DckDeckImporter();
-        SessionHandler.cheat(gameId, playerId, deckImporter.importDeck("cheat.dck", false));
+        SessionHandler.cheatShow(gameId, playerId);
     }
 
     private void btnToolHintsHelperActionPerformed(java.awt.event.ActionEvent evt) {

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/CardImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/CardImageSource.java
@@ -64,8 +64,4 @@ public interface CardImageSource {
     default boolean isTokenImageProvided(String setCode, String cardName, Integer tokenNumber) {
         return false;
     }
-
-    default int getDownloadTimeoutMs() {
-        return 0;
-    }
 }

--- a/Mage.Common/src/main/java/mage/interfaces/MageServer.java
+++ b/Mage.Common/src/main/java/mage/interfaces/MageServer.java
@@ -155,9 +155,7 @@ public interface MageServer {
 
     void replaySkipForward(UUID gameId, String sessionId, int moves) throws MageException;
 
-    void cheatMultiple(UUID gameId, String sessionId, UUID playerId, DeckCardLists deckList) throws MageException;
-
-    boolean cheatOne(UUID gameId, String sessionId, UUID playerId, String cardName) throws MageException;
+    void cheatShow(UUID gameId, String sessionId, UUID playerId) throws MageException;
 
     List<UserView> adminGetUsers(String sessionId) throws MageException;
 

--- a/Mage.Common/src/main/java/mage/remote/SessionImpl.java
+++ b/Mage.Common/src/main/java/mage/remote/SessionImpl.java
@@ -1499,10 +1499,10 @@ public class SessionImpl implements Session {
     }
 
     @Override
-    public boolean cheat(UUID gameId, UUID playerId, DeckCardLists deckList) {
+    public boolean cheatShow(UUID gameId, UUID playerId) {
         try {
             if (isConnected()) {
-                server.cheatMultiple(gameId, sessionId, playerId, deckList);
+                server.cheatShow(gameId, sessionId, playerId);
                 return true;
             }
         } catch (MageException ex) {

--- a/Mage.Common/src/main/java/mage/remote/interfaces/Testable.java
+++ b/Mage.Common/src/main/java/mage/remote/interfaces/Testable.java
@@ -12,5 +12,5 @@ public interface Testable {
 
     boolean isTestMode();
 
-    boolean cheat(UUID gameId, UUID playerId, DeckCardLists deckList);
+    boolean cheatShow(UUID gameId, UUID playerId);
 }

--- a/Mage.Server/src/main/java/mage/server/ChatManagerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/ChatManagerImpl.java
@@ -7,7 +7,7 @@ import mage.server.exceptions.UserNotFoundException;
 import mage.server.game.GameController;
 import mage.server.managers.ChatManager;
 import mage.server.managers.ManagerFactory;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.view.ChatMessage.MessageColor;
 import mage.view.ChatMessage.MessageType;
 import mage.view.ChatMessage.SoundToPlay;

--- a/Mage.Server/src/main/java/mage/server/MageServerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/MageServerImpl.java
@@ -30,7 +30,7 @@ import mage.server.managers.ManagerFactory;
 import mage.server.services.impl.FeedbackServiceImpl;
 import mage.server.tournament.TournamentFactory;
 import mage.server.util.ServerMessagesUtil;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.utils.*;
 import mage.view.*;
 import mage.view.ChatMessage.MessageColor;
@@ -974,32 +974,13 @@ public class MageServerImpl implements MageServer {
     }
 
     @Override
-    public void cheatMultiple(final UUID gameId, final String sessionId, final UUID playerId, final DeckCardLists deckList) throws MageException {
-        execute("cheat", sessionId, () -> {
+    public void cheatShow(final UUID gameId, final String sessionId, final UUID playerId) throws MageException {
+        execute("cheatShow", sessionId, () -> {
             if (testMode) {
                 managerFactory.sessionManager().getSession(sessionId).ifPresent(session -> {
                     UUID userId = session.getUserId();
-                    managerFactory.gameManager().cheat(gameId, userId, playerId, deckList);
+                    managerFactory.gameManager().cheatShow(gameId, userId, playerId);
                 });
-            }
-        });
-    }
-
-    @Override
-    public boolean cheatOne(final UUID gameId, final String sessionId, final UUID playerId, final String cardName) throws MageException {
-        return executeWithResult("cheatOne", sessionId, new ActionWithBooleanResult() {
-            @Override
-            public Boolean execute() {
-                if (testMode) {
-                    Optional<Session> session = managerFactory.sessionManager().getSession(sessionId);
-                    if (!session.isPresent()) {
-                        logger.error("Session not found : " + sessionId);
-                    } else {
-                        UUID userId = session.get().getUserId();
-                        return managerFactory.gameManager().cheat(gameId, userId, playerId, cardName);
-                    }
-                }
-                return false;
             }
         });
     }

--- a/Mage.Server/src/main/java/mage/server/Main.java
+++ b/Mage.Server/src/main/java/mage/server/Main.java
@@ -22,6 +22,7 @@ import mage.server.util.*;
 import mage.server.util.config.GamePlugin;
 import mage.server.util.config.Plugin;
 import mage.utils.MageVersion;
+import mage.utils.SystemUtil;
 import org.apache.log4j.Logger;
 import org.jboss.remoting.*;
 import org.jboss.remoting.callback.InvokerCallbackHandler;

--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -9,7 +9,7 @@ import mage.players.net.UserGroup;
 import mage.server.game.GamesRoom;
 import mage.server.managers.ConfigSettings;
 import mage.server.managers.ManagerFactory;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.util.RandomUtil;
 import org.apache.log4j.Logger;
 import org.jboss.remoting.callback.AsynchInvokerCallbackHandler;

--- a/Mage.Server/src/main/java/mage/server/User.java
+++ b/Mage.Server/src/main/java/mage/server/User.java
@@ -19,7 +19,7 @@ import mage.server.record.UserStatsRepository;
 import mage.server.tournament.TournamentController;
 import mage.server.tournament.TournamentSession;
 import mage.server.util.ServerMessagesUtil;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.view.TableClientMessage;
 import org.apache.log4j.Logger;
 

--- a/Mage.Server/src/main/java/mage/server/game/GameManagerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/game/GameManagerImpl.java
@@ -146,20 +146,11 @@ public class GameManagerImpl implements GameManager {
     }
 
     @Override
-    public void cheat(UUID gameId, UUID userId, UUID playerId, DeckCardLists deckList) {
+    public void cheatShow(UUID gameId, UUID userId, UUID playerId) {
         GameController gameController = getGameControllerSafe(gameId);
         if (gameController != null) {
-            gameController.cheat(userId, playerId, deckList);
+            gameController.cheatShow(playerId);
         }
-    }
-
-    @Override
-    public boolean cheat(UUID gameId, UUID userId, UUID playerId, String cardName) {
-        GameController gameController = getGameControllerSafe(gameId);
-        if (gameController != null) {
-            return gameController.cheat(userId, playerId, cardName);
-        }
-        return false;
     }
 
     @Override

--- a/Mage.Server/src/main/java/mage/server/managers/GameManager.java
+++ b/Mage.Server/src/main/java/mage/server/managers/GameManager.java
@@ -38,9 +38,7 @@ public interface GameManager {
 
     void stopWatching(UUID gameId, UUID userId);
 
-    void cheat(UUID gameId, UUID userId, UUID playerId, DeckCardLists deckList);
-
-    boolean cheat(UUID gameId, UUID userId, UUID playerId, String cardName);
+    void cheatShow(UUID gameId, UUID userId, UUID playerId);
 
     void removeGame(UUID gameId);
 

--- a/Mage.Server/src/main/java/mage/server/util/ThreadExecutorImpl.java
+++ b/Mage.Server/src/main/java/mage/server/util/ThreadExecutorImpl.java
@@ -2,15 +2,19 @@ package mage.server.util;
 
 import mage.server.managers.ConfigSettings;
 import mage.server.managers.ThreadExecutor;
+import org.apache.log4j.Logger;
 
 import java.util.concurrent.*;
 
 /**
- * @author BetaSteward_at_googlemail.com
+ * @author BetaSteward_at_googlemail.com, JayDi85
  */
 public class ThreadExecutorImpl implements ThreadExecutor {
-    private final ExecutorService callExecutor;
-    private final ExecutorService gameExecutor;
+
+    private static final Logger logger = Logger.getLogger(ThreadExecutorImpl.class);
+
+    private final ExecutorService callExecutor; // shareable threads to run single task (example: save new game settings from a user, send chat message, etc)
+    private final ExecutorService gameExecutor; // game threads to run long tasks, one per game (example: run game and wait user's feedback)
     private final ScheduledExecutorService timeoutExecutor;
     private final ScheduledExecutorService timeoutIdleExecutor;
 
@@ -26,8 +30,10 @@ public class ThreadExecutorImpl implements ThreadExecutor {
      */
 
     public ThreadExecutorImpl(ConfigSettings config) {
-        callExecutor = Executors.newCachedThreadPool();
-        gameExecutor = Executors.newFixedThreadPool(config.getMaxGameThreads());
+        //callExecutor = Executors.newCachedThreadPool();
+        callExecutor = new CachedThreadPoolWithException();
+        //gameExecutor = Executors.newFixedThreadPool(config.getMaxGameThreads());
+        gameExecutor = new FixedThreadPoolWithException(config.getMaxGameThreads());
         timeoutExecutor = Executors.newScheduledThreadPool(4);
         timeoutIdleExecutor = Executors.newScheduledThreadPool(4);
 
@@ -45,6 +51,42 @@ public class ThreadExecutorImpl implements ThreadExecutor {
         ((ThreadPoolExecutor) timeoutIdleExecutor).setThreadFactory(new XMageThreadFactory("TIMEOUT_IDLE"));
     }
 
+    static class CachedThreadPoolWithException extends ThreadPoolExecutor {
+
+        CachedThreadPoolWithException() {
+            // use same params as Executors.newCachedThreadPool()
+            super(0, Integer.MAX_VALUE,60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());
+        }
+
+        @Override
+        protected void afterExecute(Runnable r, Throwable t) {
+            super.afterExecute(r, t);
+
+            // catch errors in CALL threads (from client commands)
+            if (t != null) {
+                logger.error("Catch unhandled error in CALL thread: " + t.getMessage(), t);
+            }
+        }
+    }
+
+    static class FixedThreadPoolWithException extends ThreadPoolExecutor {
+
+        FixedThreadPoolWithException(int nThreads) {
+            // use same params as Executors.newFixedThreadPool()
+            super(nThreads, nThreads,0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>());
+        }
+
+        @Override
+        protected void afterExecute(Runnable r, Throwable t) {
+            super.afterExecute(r, t);
+
+            // catch errors in GAME threads (from game processing)
+            if (t != null) {
+                // it's impossible to brake game thread in normal use case, so each bad use case must be researched
+                logger.error("Catch unhandled error in GAME thread: " + t.getMessage(), t);
+            }
+        }
+    }
 
     @Override
     public int getActiveThreads(ExecutorService executerService) {
@@ -90,5 +132,4 @@ class XMageThreadFactory implements ThreadFactory {
         thread.setName(prefix + ' ' + thread.getThreadGroup().getName() + '-' + thread.getId());
         return thread;
     }
-
 }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2932,6 +2932,11 @@ public class TestPlayer implements Player {
     }
 
     @Override
+    public void signalPlayerCheat() {
+        computerPlayer.signalPlayerCheat();
+    }
+
+    @Override
     public void abortReset() {
         computerPlayer.abortReset();
     }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/MageTestPlayerBase.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/MageTestPlayerBase.java
@@ -35,7 +35,7 @@ import mage.server.managers.ConfigSettings;
 import mage.server.util.ConfigFactory;
 import mage.server.util.ConfigWrapper;
 import mage.server.util.PluginClassLoader;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.server.util.config.GamePlugin;
 import mage.server.util.config.Plugin;
 import mage.target.TargetPermanent;

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -28,7 +28,7 @@ import mage.player.ai.ComputerPlayerMCTS;
 import mage.players.ManaPool;
 import mage.players.Player;
 import mage.server.game.GameSessionPlayer;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.util.CardUtil;
 import mage.view.GameView;
 import org.junit.Assert;

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/cheats/LoadCheatsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/cheats/LoadCheatsTest.java
@@ -1,7 +1,7 @@
 package org.mage.test.serverside.cheats;
 
 import mage.constants.*;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -56,7 +56,7 @@ public class LoadCheatsTest extends CardTestPlayerBase {
         execute();
 
         setChoice(playerA, "5"); // choose [group 3]: 5 = 2 default menus + 3 group
-        SystemUtil.addCardsForTesting(currentGame, commandsFile, playerA);
+        SystemUtil.executeCheatCommands(currentGame, commandsFile, playerA);
 
         assertHandCount(playerA, "Razorclaw Bear", 1);
         assertPermanentCount(playerA, "Mountain", 3);

--- a/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
+++ b/Mage.Tests/src/test/java/org/mage/test/stub/PlayerStub.java
@@ -725,6 +725,11 @@ public class PlayerStub implements Player {
     }
 
     @Override
+    public void signalPlayerCheat() {
+
+    }
+
+    @Override
     public void abortReset() {
 
     }

--- a/Mage.Tests/src/test/java/org/mage/test/testapi/AddCardApiTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/testapi/AddCardApiTest.java
@@ -2,7 +2,7 @@ package org.mage.test.testapi;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -35,7 +35,7 @@ import mage.game.draft.DraftCube;
 import mage.game.permanent.token.Token;
 import mage.game.permanent.token.TokenImpl;
 import mage.game.permanent.token.custom.CreatureToken;
-import mage.server.util.SystemUtil;
+import mage.utils.SystemUtil;
 import mage.sets.TherosBeyondDeath;
 import mage.target.targetpointer.TargetPointer;
 import mage.util.CardUtil;

--- a/Mage/src/main/java/mage/cards/decks/DeckCardLists.java
+++ b/Mage/src/main/java/mage/cards/decks/DeckCardLists.java
@@ -1,24 +1,44 @@
-
 package mage.cards.decks;
+
+import mage.util.CardUtil;
+import mage.util.Copyable;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
- * @author BetaSteward_at_googlemail.com
+ * @author BetaSteward_at_googlemail.com, JayDi85
  */
-public class DeckCardLists implements Serializable {
+public class DeckCardLists implements Serializable, Copyable<DeckCardLists> {
 
-    private String name;
-    private String author;
+    private String name = null;
+    private String author = null;
     private List<DeckCardInfo> cards = new ArrayList<>();
     private List<DeckCardInfo> sideboard = new ArrayList<>();
 
     // Layout (if supported)
     private DeckCardLayout cardLayout = null;
     private DeckCardLayout sideboardLayout = null;
+
+    public DeckCardLists() {
+    }
+
+    protected DeckCardLists(final DeckCardLists deck) {
+        this.name = deck.name;
+        this.author = deck.author;
+        this.cards = CardUtil.deepCopyObject(deck.cards);
+        this.sideboard = CardUtil.deepCopyObject(deck.sideboard);
+        this.cardLayout = CardUtil.deepCopyObject(deck.cardLayout);
+        this.sideboardLayout = CardUtil.deepCopyObject(deck.sideboardLayout);
+    }
+
+    @Override
+    public DeckCardLists copy() {
+        return new DeckCardLists(this);
+    }
 
     /**
      * @return The layout of the cards

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -534,7 +534,6 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
 
     // game cheats (for tests only)
     void cheat(UUID ownerId, Map<Zone, String> commands);
-
     void cheat(UUID ownerId, List<Card> library, List<Card> hand, List<PermanentCard> battlefield, List<Card> graveyard, List<Card> command);
 
     // controlling the behaviour of replacement effects while permanents entering the battlefield

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -794,7 +794,7 @@ public abstract class GameImpl implements Game {
                 if (!concedingPlayers.contains(playerId)) {
                     logger.debug("Game over for player Id: " + playerId + " gameId " + getId());
                     concedingPlayers.add(playerId);
-                    player.signalPlayerConcede();
+                    player.signalPlayerConcede(); // will be executed on next priority
                 }
             } else {
                 // no asynchronous action so check directly
@@ -3799,8 +3799,9 @@ public abstract class GameImpl implements Game {
                 for (Player playerObject : getPlayers().values()) {
                     if (playerObject.isHuman() && playerObject.canRespond()) {
                         playerObject.resetStoredBookmark(this);
-                        playerObject.abort();
                         playerObject.resetPlayerPassedActions();
+                        playerObject.abort();
+
                     }
                 }
                 fireUpdatePlayersEvent();

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -77,7 +77,7 @@ public class GameState implements Serializable, Copyable<GameState> {
     private Turn turn;
     private TurnMods turnMods; // one time turn modifications (turn, phase or step)
     private UUID activePlayerId; // playerId which turn it is
-    private UUID priorityPlayerId; // player that has currently priority
+    private UUID priorityPlayerId; // player that has currently priority (setup before any choose)
     private UUID playerByOrderId; // player that has currently priority
     private UUID monarchId; // player that is the monarch
     private UUID initiativeId; // player that has the initiative

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -550,6 +550,8 @@ public interface Player extends MageItem, Copyable<Player> {
 
     void signalPlayerConcede();
 
+    void signalPlayerCheat();
+
     void skip();
 
     // priority, undo, ...

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -5088,7 +5088,10 @@ public abstract class PlayerImpl implements Player, Serializable {
 
     @Override
     public void signalPlayerConcede() {
+    }
 
+    @Override
+    public void signalPlayerCheat() {
     }
 
     @Override

--- a/Mage/src/main/java/mage/util/DebugUtil.java
+++ b/Mage/src/main/java/mage/util/DebugUtil.java
@@ -1,5 +1,7 @@
 package mage.util;
 
+import java.lang.reflect.Method;
+
 /**
  * Devs only: enable or disable debug features
  * <p>
@@ -28,4 +30,47 @@ public class DebugUtil {
     public static boolean GUI_GAME_DRAW_BATTLEFIELD_BORDER = false;
     public static boolean GUI_GAME_DRAW_HAND_AND_STACK_BORDER = false;
     public static boolean GUI_GAME_DIALOGS_DRAW_CARDS_AREA_BORDER = false;
+
+    public static String getMethodNameWithSource(final int depth) {
+        return TraceHelper.getMethodNameWithSource(depth);
+    }
+
+}
+
+/**
+ * Debug: allows to find a caller's method name
+ * <a href="https://stackoverflow.com/a/11726687/1276632">Original code</a>
+ */
+class TraceHelper {
+
+    private static Method m;
+
+    static {
+        try {
+            m = Throwable.class.getDeclaredMethod("getStackTraceElement", int.class);
+            m.setAccessible(true);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String getMethodName(final int depth) {
+        try {
+            StackTraceElement element = (StackTraceElement) m.invoke(new Throwable(), depth + 1);
+            return element.getMethodName();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static String getMethodNameWithSource(final int depth) {
+        try {
+            StackTraceElement element = (StackTraceElement) m.invoke(new Throwable(), depth + 1);
+            return String.format("%s - %s:%d", element.getMethodName(), element.getFileName(), element.getLineNumber());
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
Most important change:
* only latest user response will be used now, all other will be ignored. Example: user clicks on cards, avatars and buttons in game with slow/bad connection;
  * old version: keeps all clicks for 30 seconds and use it on game unfreeze (user was able to catch random choices or miss dialogs);
  * new version: all outdated clicks will be ignored;

Full changes:
* server: fixed that a critical errors ignored in user commands threads (now it will be added to the logs);
* network: fixed frozen user responses in some use cases;
* network: fixed accidental and incorrect user responses (only latest response will be used now);
* network: improved freeze logs, added problem method name and code's line number;
* cheats: removed outdated deck and card load logic (only init.txt commands supports now);
* cheats: fixed wrong priority after add card dialog (closes #11437);
* cheats: improved stability and random errors on cheat executes (related to #11437);
* docs: added details on network and thread logic, human feedback life cycle, etc (see HumanPlayer, ThreadExecutorImpl);