### PR TITLE
Refactor: replacement effects don't use apply method

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbandonedSarcophagus.java
+++ b/Mage.Sets/src/mage/cards/a/AbandonedSarcophagus.java
@@ -75,11 +75,6 @@ class AbandonedSarcophagusReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller == null) {

--- a/Mage.Sets/src/mage/cards/a/Abundance.java
+++ b/Mage.Sets/src/mage/cards/a/Abundance.java
@@ -57,11 +57,6 @@ class AbundanceReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(event.getPlayerId());
         MageObject sourceObject = game.getObject(source);

--- a/Mage.Sets/src/mage/cards/a/AcolytesReward.java
+++ b/Mage.Sets/src/mage/cards/a/AcolytesReward.java
@@ -70,11 +70,6 @@ class AcolytesRewardEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         boolean result = false;
         int toPrevent = amount;

--- a/Mage.Sets/src/mage/cards/a/AegisOfHonor.java
+++ b/Mage.Sets/src/mage/cards/a/AegisOfHonor.java
@@ -63,11 +63,6 @@ class AegisOfHonorEffect extends RedirectionEffect {
 
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.DAMAGE_PLAYER;
     }    

--- a/Mage.Sets/src/mage/cards/a/AlhammarretsArchive.java
+++ b/Mage.Sets/src/mage/cards/a/AlhammarretsArchive.java
@@ -90,11 +90,6 @@ class AlhammarretsArchiveReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/a/AlmsCollector.java
+++ b/Mage.Sets/src/mage/cards/a/AlmsCollector.java
@@ -65,11 +65,6 @@ class AlmsCollectorReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         Player opponent = game.getPlayer(event.getPlayerId());

--- a/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
+++ b/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
@@ -82,11 +82,6 @@ class AnafenzaTheForemostEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/a/AnthemOfRakdos.java
+++ b/Mage.Sets/src/mage/cards/a/AnthemOfRakdos.java
@@ -79,11 +79,6 @@ class AnthemOfRakdosHellbentEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/a/ArchmageAscension.java
+++ b/Mage.Sets/src/mage/cards/a/ArchmageAscension.java
@@ -81,11 +81,6 @@ class ArchmageAscensionReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player == null) {

--- a/Mage.Sets/src/mage/cards/a/ArchonOfCoronation.java
+++ b/Mage.Sets/src/mage/cards/a/ArchonOfCoronation.java
@@ -80,11 +80,6 @@ class ArchonOfCoronationEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(0);
         return false;

--- a/Mage.Sets/src/mage/cards/a/ArlinnThePacksHope.java
+++ b/Mage.Sets/src/mage/cards/a/ArlinnThePacksHope.java
@@ -82,11 +82,6 @@ class ArlinnThePacksHopeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage.Sets/src/mage/cards/a/AvacynGuardianAngel.java
+++ b/Mage.Sets/src/mage/cards/a/AvacynGuardianAngel.java
@@ -110,11 +110,6 @@ class AvacynGuardianAngelPreventToCreaturePreventionEffect extends PreventionEff
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (!super.applies(event, source, game)
                 || event.getType() != GameEvent.EventType.DAMAGE_PERMANENT
@@ -173,11 +168,6 @@ class AvacynGuardianAngelPreventToPlayerPreventionEffect extends PreventionEffec
     private AvacynGuardianAngelPreventToPlayerPreventionEffect(AvacynGuardianAngelPreventToPlayerPreventionEffect effect) {
         super(effect);
         this.color = effect.color;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BarbarianClass.java
+++ b/Mage.Sets/src/mage/cards/b/BarbarianClass.java
@@ -106,11 +106,6 @@ class BarbarianClassEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public BarbarianClassEffect copy() {
         return new BarbarianClassEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/b/BenevolentUnicorn.java
+++ b/Mage.Sets/src/mage/cards/b/BenevolentUnicorn.java
@@ -64,11 +64,6 @@ class BenevolentUnicornEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(event.getAmount() - 1);
         return false;

--- a/Mage.Sets/src/mage/cards/b/BewitchingLeechcraft.java
+++ b/Mage.Sets/src/mage/cards/b/BewitchingLeechcraft.java
@@ -94,11 +94,6 @@ class BewitchingLeechcraftReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return game.getTurnStepType() == PhaseStep.UNTAP
             && event.getTargetId().equals(source.getSourceId());

--- a/Mage.Sets/src/mage/cards/b/Biophagus.java
+++ b/Mage.Sets/src/mage/cards/b/Biophagus.java
@@ -103,11 +103,6 @@ class BiophagusEntersBattlefieldEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage.Sets/src/mage/cards/b/BitterFeud.java
+++ b/Mage.Sets/src/mage/cards/b/BitterFeud.java
@@ -181,11 +181,6 @@ class BitterFeudEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/b/BloodOfTheMartyr.java
+++ b/Mage.Sets/src/mage/cards/b/BloodOfTheMartyr.java
@@ -60,11 +60,6 @@ class BloodOfTheMartyrEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         DamageEvent damageEvent = (DamageEvent) event;

--- a/Mage.Sets/src/mage/cards/b/BloodScrivener.java
+++ b/Mage.Sets/src/mage/cards/b/BloodScrivener.java
@@ -62,11 +62,6 @@ class BloodScrivenerReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/b/BloodletterOfAclazotz.java
+++ b/Mage.Sets/src/mage/cards/b/BloodletterOfAclazotz.java
@@ -64,11 +64,6 @@ class BloodletterOfAclazotzEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;
@@ -85,4 +80,3 @@ class BloodletterOfAclazotzEffect extends ReplacementEffectImpl {
                 && game.getOpponents(source.getControllerId()).contains(event.getPlayerId());
     }
 }
-

--- a/Mage.Sets/src/mage/cards/b/BoonReflection.java
+++ b/Mage.Sets/src/mage/cards/b/BoonReflection.java
@@ -54,11 +54,6 @@ class BoonReflectionEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/b/BorealOutrider.java
+++ b/Mage.Sets/src/mage/cards/b/BorealOutrider.java
@@ -87,11 +87,6 @@ class BorealOutriderEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/b/BraceForImpact.java
+++ b/Mage.Sets/src/mage/cards/b/BraceForImpact.java
@@ -65,11 +65,6 @@ class BraceForImpactPreventDamageTargetEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
         if (game.replaceEvent(preventEvent)) {

--- a/Mage.Sets/src/mage/cards/b/BranchingEvolution.java
+++ b/Mage.Sets/src/mage/cards/b/BranchingEvolution.java
@@ -75,11 +75,6 @@ class BranchingEvolutionEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public BranchingEvolutionEffect copy() {
         return new BranchingEvolutionEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/b/BreathstealersCrypt.java
+++ b/Mage.Sets/src/mage/cards/b/BreathstealersCrypt.java
@@ -54,11 +54,6 @@ class BreathstealersCryptEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player == null) {

--- a/Mage.Sets/src/mage/cards/b/BruvacTheGrandiloquent.java
+++ b/Mage.Sets/src/mage/cards/b/BruvacTheGrandiloquent.java
@@ -58,11 +58,6 @@ class BruvacTheGrandiloquentReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.MILL_CARDS;
     }

--- a/Mage.Sets/src/mage/cards/c/CallousGiant.java
+++ b/Mage.Sets/src/mage/cards/c/CallousGiant.java
@@ -59,11 +59,6 @@ class CallousGiantEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if(event.getAmount() <= 3)
         {

--- a/Mage.Sets/src/mage/cards/c/CandlesGlow.java
+++ b/Mage.Sets/src/mage/cards/c/CandlesGlow.java
@@ -65,11 +65,6 @@ class CandlesGlowPreventDamageTargetEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
         if (!game.replaceEvent(preventEvent)) {

--- a/Mage.Sets/src/mage/cards/c/ChainsOfMephistopheles.java
+++ b/Mage.Sets/src/mage/cards/c/ChainsOfMephistopheles.java
@@ -56,11 +56,6 @@ class ChainsOfMephistophelesReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/c/ChannelHarm.java
+++ b/Mage.Sets/src/mage/cards/c/ChannelHarm.java
@@ -59,11 +59,6 @@ class ChannelHarmEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player sourceController = game.getPlayer(source.getControllerId());
         PreventionEffectData preventionData = preventDamageAction(event, source, game);

--- a/Mage.Sets/src/mage/cards/c/ChaosMoon.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosMoon.java
@@ -150,11 +150,6 @@ class ChaosMoonEvenReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/c/ChargingTuskodon.java
+++ b/Mage.Sets/src/mage/cards/c/ChargingTuskodon.java
@@ -76,11 +76,6 @@ class ChargingTuskodonEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/c/ChoArrimAlchemist.java
+++ b/Mage.Sets/src/mage/cards/c/ChoArrimAlchemist.java
@@ -73,11 +73,6 @@ class ChoArrimAlchemistEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         this.target.choose(Outcome.PreventDamage, source.getControllerId(), source.getSourceId(), source, game);
     }

--- a/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
@@ -125,11 +125,6 @@ class ChorusOfTheConclaveReplacementEffect2 extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
     }

--- a/Mage.Sets/src/mage/cards/c/ClamIAm.java
+++ b/Mage.Sets/src/mage/cards/c/ClamIAm.java
@@ -64,11 +64,6 @@ class ClamIAmEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public ClamIAmEffect copy() {
         return new ClamIAmEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/CloakOfConfusion.java
+++ b/Mage.Sets/src/mage/cards/c/CloakOfConfusion.java
@@ -107,11 +107,6 @@ class CloakOfConfusionEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CombineGuildmage.java
+++ b/Mage.Sets/src/mage/cards/c/CombineGuildmage.java
@@ -92,11 +92,6 @@ class CombineGuildmageReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage.Sets/src/mage/cards/c/Comeuppance.java
+++ b/Mage.Sets/src/mage/cards/c/Comeuppance.java
@@ -60,11 +60,6 @@ class ComeuppanceEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         PreventionEffectData preventionData = preventDamageAction(event, source, game);
         if (preventionData.getPreventedDamage() > 0) {

--- a/Mage.Sets/src/mage/cards/c/ContainmentPriest.java
+++ b/Mage.Sets/src/mage/cards/c/ContainmentPriest.java
@@ -65,11 +65,6 @@ class ContainmentPriestReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/c/Contamination.java
+++ b/Mage.Sets/src/mage/cards/c/Contamination.java
@@ -64,11 +64,6 @@ class ContaminationReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/c/CorpsejackMenace.java
+++ b/Mage.Sets/src/mage/cards/c/CorpsejackMenace.java
@@ -87,11 +87,6 @@ class CorpsejackMenaceReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CorpsejackMenaceReplacementEffect copy() {
         return new CorpsejackMenaceReplacementEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/CosmicIntervention.java
+++ b/Mage.Sets/src/mage/cards/c/CosmicIntervention.java
@@ -66,11 +66,6 @@ class CosmicInterventionReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/c/CracklingEmergence.java
+++ b/Mage.Sets/src/mage/cards/c/CracklingEmergence.java
@@ -102,11 +102,6 @@ class CracklingEmergenceEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CracklingEmergenceEffect copy() {
         return new CracklingEmergenceEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/c/CraftyCutpurse.java
+++ b/Mage.Sets/src/mage/cards/c/CraftyCutpurse.java
@@ -66,11 +66,6 @@ class CraftyCutpurseReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.ZONE_CHANGE || event.getType() == GameEvent.EventType.CREATE_TOKEN;
     }

--- a/Mage.Sets/src/mage/cards/c/CrumblingSanctuary.java
+++ b/Mage.Sets/src/mage/cards/c/CrumblingSanctuary.java
@@ -55,11 +55,6 @@ class CrumblingSanctuaryEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         int amount = event.getAmount();
         Player player = game.getPlayer(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/c/CurseOfBloodletting.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfBloodletting.java
@@ -79,11 +79,6 @@ class CurseOfBloodlettingEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/d/DampingSphere.java
+++ b/Mage.Sets/src/mage/cards/d/DampingSphere.java
@@ -64,11 +64,6 @@ class DampingSphereReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/d/DarkIntimations.java
+++ b/Mage.Sets/src/mage/cards/d/DarkIntimations.java
@@ -196,11 +196,6 @@ class DarkIntimationsReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/d/DauntingDefender.java
+++ b/Mage.Sets/src/mage/cards/d/DauntingDefender.java
@@ -57,11 +57,6 @@ class DauntingDefenderEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PERMANENT) {
             Permanent permanent = game.getPermanent(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/d/DebtOfLoyalty.java
+++ b/Mage.Sets/src/mage/cards/d/DebtOfLoyalty.java
@@ -1,4 +1,3 @@
-
 package mage.cards.d;
 
 import java.util.UUID;
@@ -10,6 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.game.Game;
+import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -35,32 +35,33 @@ public final class DebtOfLoyalty extends CardImpl {
     public DebtOfLoyalty copy() {
         return new DebtOfLoyalty(this);
     }
-    
-    static class DebtOfLoyaltyEffect extends RegenerateTargetEffect {
-        public DebtOfLoyaltyEffect ( ) {
-            super();
-            this.staticText = "Regenerate target creature. You gain control of that creature if it regenerates this way.";
-        }
 
-        private DebtOfLoyaltyEffect(final DebtOfLoyaltyEffect effect) {
-            super(effect);
+}
+
+class DebtOfLoyaltyEffect extends RegenerateTargetEffect {
+    DebtOfLoyaltyEffect() {
+        super();
+        this.staticText = "Regenerate target creature. You gain control of that creature if it regenerates this way.";
+    }
+
+    private DebtOfLoyaltyEffect(final DebtOfLoyaltyEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DebtOfLoyaltyEffect copy() {
+        return new DebtOfLoyaltyEffect(this);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
+        if (super.replaceEvent(event, source, game) && permanent != null) {
+            GainControlTargetEffect effect = new GainControlTargetEffect(Duration.EndOfGame);
+            effect.setTargetPointer(targetPointer);
+            game.addEffect(effect, source);
+            return true;
         }
-        
-        @Override
-        public DebtOfLoyaltyEffect copy() {
-            return new DebtOfLoyaltyEffect(this);
-        }
-        
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
-            if (super.apply(game, source) && permanent != null) {
-                GainControlTargetEffect effect = new GainControlTargetEffect(Duration.EndOfGame);
-                effect.setTargetPointer(targetPointer);
-                game.addEffect(effect, source);
-                return true;
-            }
-            return false;
-        }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DeepWater.java
+++ b/Mage.Sets/src/mage/cards/d/DeepWater.java
@@ -57,11 +57,6 @@ class DeepWaterReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/d/DictateOfTheTwinGods.java
+++ b/Mage.Sets/src/mage/cards/d/DictateOfTheTwinGods.java
@@ -78,11 +78,6 @@ class DictateOfTheTwinGodsEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         DamageEvent damageEvent = (DamageEvent) event;
         if (damageEvent.getType() == GameEvent.EventType.DAMAGE_PLAYER) {

--- a/Mage.Sets/src/mage/cards/d/DivineDeflection.java
+++ b/Mage.Sets/src/mage/cards/d/DivineDeflection.java
@@ -56,11 +56,6 @@ class DivineDeflectionPreventDamageTargetEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         /*
         If damage is dealt to multiple permanents you control, or is dealt to you and at least

--- a/Mage.Sets/src/mage/cards/d/DivinePresence.java
+++ b/Mage.Sets/src/mage/cards/d/DivinePresence.java
@@ -65,11 +65,6 @@ class DivinePresenceEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return event.getAmount() > 3;
     }

--- a/Mage.Sets/src/mage/cards/d/DjeruWithEyesOpen.java
+++ b/Mage.Sets/src/mage/cards/d/DjeruWithEyesOpen.java
@@ -78,11 +78,6 @@ class DjeruWithEyesOpenPreventEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PERMANENT) {
             Permanent permanent = game.getPermanent(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/d/DoublingSeason.java
+++ b/Mage.Sets/src/mage/cards/d/DoublingSeason.java
@@ -119,11 +119,6 @@ class DoublingSeasonCounterEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public DoublingSeasonCounterEffect copy() {
         return new DoublingSeasonCounterEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/d/DranaTheLastBloodchief.java
+++ b/Mage.Sets/src/mage/cards/d/DranaTheLastBloodchief.java
@@ -167,11 +167,6 @@ class DranaTheLastBloodchiefCounterEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null && mor.refersTo(creature, game)) {

--- a/Mage.Sets/src/mage/cards/d/DryadMilitant.java
+++ b/Mage.Sets/src/mage/cards/d/DryadMilitant.java
@@ -63,11 +63,6 @@ class DryadMilitantReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ((ZoneChangeEvent) event).setToZone(Zone.EXILED);
         return false;

--- a/Mage.Sets/src/mage/cards/e/EerieInterference.java
+++ b/Mage.Sets/src/mage/cards/e/EerieInterference.java
@@ -51,11 +51,6 @@ class EerieInterferenceEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (!super.applies(event, source, game)) {
             return false;

--- a/Mage.Sets/src/mage/cards/e/ElfhameSanctuary.java
+++ b/Mage.Sets/src/mage/cards/e/ElfhameSanctuary.java
@@ -62,11 +62,6 @@ class SkipDrawStepThisTurn extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EmbermawHellion.java
+++ b/Mage.Sets/src/mage/cards/e/EmbermawHellion.java
@@ -88,11 +88,6 @@ class EmbermawHellionEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
         return false;

--- a/Mage.Sets/src/mage/cards/e/EnduringRenewal.java
+++ b/Mage.Sets/src/mage/cards/e/EnduringRenewal.java
@@ -64,11 +64,6 @@ class EnduringRenewalReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller == null) {

--- a/Mage.Sets/src/mage/cards/e/EnergyField.java
+++ b/Mage.Sets/src/mage/cards/e/EnergyField.java
@@ -71,11 +71,6 @@ class EnergyFieldEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER) {
             if (event.getTargetId().equals(source.getControllerId()) && !Objects.equals(game.getControllerId(event.getSourceId()), source.getControllerId())) {

--- a/Mage.Sets/src/mage/cards/e/EqualTreatment.java
+++ b/Mage.Sets/src/mage/cards/e/EqualTreatment.java
@@ -67,11 +67,6 @@ class EqualTreatmentEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         DamageEvent damageEvent = (DamageEvent) event;
         damageEvent.setAmount(2);

--- a/Mage.Sets/src/mage/cards/e/EruthTormentedProphet.java
+++ b/Mage.Sets/src/mage/cards/e/EruthTormentedProphet.java
@@ -62,11 +62,6 @@ class EruthTormentedProphetEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player == null) {

--- a/Mage.Sets/src/mage/cards/e/EverlastingTorment.java
+++ b/Mage.Sets/src/mage/cards/e/EverlastingTorment.java
@@ -63,11 +63,6 @@ class DamageDealtAsIfSourceHadWitherEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ((DamageEvent) event).setAsThoughWither(true);
         return false;

--- a/Mage.Sets/src/mage/cards/e/ExquisiteArchangel.java
+++ b/Mage.Sets/src/mage/cards/e/ExquisiteArchangel.java
@@ -68,11 +68,6 @@ class ExquisiteArchangelEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());

--- a/Mage.Sets/src/mage/cards/e/EyeForAnEye.java
+++ b/Mage.Sets/src/mage/cards/e/EyeForAnEye.java
@@ -69,11 +69,6 @@ class EyeForAnEyeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         DamageEvent damageEvent = (DamageEvent) event;

--- a/Mage.Sets/src/mage/cards/f/FarrelsMantle.java
+++ b/Mage.Sets/src/mage/cards/f/FarrelsMantle.java
@@ -161,11 +161,6 @@ class FarrelsMantleDamageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/f/Fasting.java
+++ b/Mage.Sets/src/mage/cards/f/Fasting.java
@@ -72,11 +72,6 @@ class FastingReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/f/Fatespinner.java
+++ b/Mage.Sets/src/mage/cards/f/Fatespinner.java
@@ -109,11 +109,6 @@ class FatespinnerSkipEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         EventType type = event.getType();
         return ((phase.equals("Draw step") && type == EventType.DRAW_STEP)

--- a/Mage.Sets/src/mage/cards/f/FiendishDuo.java
+++ b/Mage.Sets/src/mage/cards/f/FiendishDuo.java
@@ -76,11 +76,6 @@ class FiendishDuoEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/f/FireServant.java
+++ b/Mage.Sets/src/mage/cards/f/FireServant.java
@@ -79,11 +79,6 @@ class FireServantEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/f/FlamesOfTheBloodHand.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfTheBloodHand.java
@@ -67,11 +67,6 @@ class FlamesOfTheBloodHandReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/f/ForbiddenCrypt.java
+++ b/Mage.Sets/src/mage/cards/f/ForbiddenCrypt.java
@@ -115,11 +115,6 @@ class ForbiddenCryptPutIntoYourGraveyardReplacementEffect extends ReplacementEff
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ((ZoneChangeEvent) event).setToZone(Zone.EXILED);
         return false;

--- a/Mage.Sets/src/mage/cards/f/ForethoughtAmulet.java
+++ b/Mage.Sets/src/mage/cards/f/ForethoughtAmulet.java
@@ -67,11 +67,6 @@ class ForethoughtAmuletEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getAmount() >= 3) {
             MageObject object = game.getObject(event.getSourceId());

--- a/Mage.Sets/src/mage/cards/f/FreyalisesWinds.java
+++ b/Mage.Sets/src/mage/cards/f/FreyalisesWinds.java
@@ -62,11 +62,6 @@ class FreyalisesWindsReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanentUntapping = game.getPermanent(event.getTargetId());
         if (permanentUntapping != null) {

--- a/Mage.Sets/src/mage/cards/g/GatherSpecimens.java
+++ b/Mage.Sets/src/mage/cards/g/GatherSpecimens.java
@@ -57,11 +57,6 @@ class GatherSpecimensReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.ZONE_CHANGE || event.getType() == GameEvent.EventType.CREATE_TOKEN;
     }

--- a/Mage.Sets/src/mage/cards/g/GhostsOfTheInnocent.java
+++ b/Mage.Sets/src/mage/cards/g/GhostsOfTheInnocent.java
@@ -71,11 +71,6 @@ class GhostsOfTheInnocentPreventDamageEffect extends ReplacementEffectImpl imple
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         int amount = (int) Math.ceil(event.getAmount() / 2.0);
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), amount, ((DamageEvent) event).isCombatDamage());

--- a/Mage.Sets/src/mage/cards/g/GideonsIntervention.java
+++ b/Mage.Sets/src/mage/cards/g/GideonsIntervention.java
@@ -120,11 +120,6 @@ class GideonsInterventionPreventAllDamageEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
         if (!game.replaceEvent(preventEvent)) {

--- a/Mage.Sets/src/mage/cards/g/GideonsSacrifice.java
+++ b/Mage.Sets/src/mage/cards/g/GideonsSacrifice.java
@@ -167,11 +167,6 @@ class GideonsSacrificeEffectReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public GideonsSacrificeEffectReplacementEffect copy() {
         return new GideonsSacrificeEffectReplacementEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/g/GiselaBladeOfGoldnight.java
+++ b/Mage.Sets/src/mage/cards/g/GiselaBladeOfGoldnight.java
@@ -91,11 +91,6 @@ class GiselaBladeOfGoldnightDoubleDamageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/g/Glarecaster.java
+++ b/Mage.Sets/src/mage/cards/g/Glarecaster.java
@@ -102,10 +102,4 @@ class GlarecasterEffect extends RedirectionEffect {
         return false;
     }
 
-    @Override
-    public boolean apply(Game game, Ability source
-    ) {
-        return true;
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
@@ -120,11 +120,6 @@ class GlimpseTheCosmosReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/g/GoblinBowlingTeam.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinBowlingTeam.java
@@ -80,11 +80,6 @@ class GoblinBowlingTeamEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/g/GoblinGoliath.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinGoliath.java
@@ -93,11 +93,6 @@ class GoblinGoliathDamageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/g/GoldnightCastigator.java
+++ b/Mage.Sets/src/mage/cards/g/GoldnightCastigator.java
@@ -83,11 +83,6 @@ class GoldnightCastigatorDoubleDamageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         switch (event.getType()) {
             case DAMAGE_PLAYER:

--- a/Mage.Sets/src/mage/cards/g/GratuitousViolence.java
+++ b/Mage.Sets/src/mage/cards/g/GratuitousViolence.java
@@ -75,11 +75,6 @@ class GratuitousViolenceReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
+++ b/Mage.Sets/src/mage/cards/g/GraveBetrayal.java
@@ -149,11 +149,6 @@ class GraveBetrayalReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/g/GuildmagesForum.java
+++ b/Mage.Sets/src/mage/cards/g/GuildmagesForum.java
@@ -107,11 +107,6 @@ class GuildmagesForumEntersBattlefieldEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage.Sets/src/mage/cards/g/Guile.java
+++ b/Mage.Sets/src/mage/cards/g/Guile.java
@@ -71,11 +71,6 @@ class GuileReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Spell spell = game.getStack().getSpell(event.getTargetId());
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/h/HallOfGemstone.java
+++ b/Mage.Sets/src/mage/cards/h/HallOfGemstone.java
@@ -60,11 +60,6 @@ class HallOfGemstoneEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
         Player player = game.getPlayer(getTargetPointer().getFirst(game, source));

--- a/Mage.Sets/src/mage/cards/h/HarmoniousEmergence.java
+++ b/Mage.Sets/src/mage/cards/h/HarmoniousEmergence.java
@@ -104,11 +104,6 @@ class HarmoniousEmergenceEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public HarmoniousEmergenceEffect copy() {
         return new HarmoniousEmergenceEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/h/HarshJudgment.java
+++ b/Mage.Sets/src/mage/cards/h/HarshJudgment.java
@@ -95,9 +95,4 @@ class HarshJudgmentEffect extends RedirectionEffect {
     public HarshJudgmentEffect copy() {
         return new HarshJudgmentEffect(this);
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
 }

--- a/Mage.Sets/src/mage/cards/h/HarvestMage.java
+++ b/Mage.Sets/src/mage/cards/h/HarvestMage.java
@@ -69,11 +69,6 @@ class HarvestMageReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/h/HeartOfLight.java
+++ b/Mage.Sets/src/mage/cards/h/HeartOfLight.java
@@ -67,11 +67,6 @@ class HeartOfLightEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
         if (!game.replaceEvent(preventEvent)) {

--- a/Mage.Sets/src/mage/cards/h/HedronFieldPurists.java
+++ b/Mage.Sets/src/mage/cards/h/HedronFieldPurists.java
@@ -77,11 +77,6 @@ class HedronFieldPuristsEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER
                 && event.getTargetId().equals(source.getControllerId())) {

--- a/Mage.Sets/src/mage/cards/h/Hullbreacher.java
+++ b/Mage.Sets/src/mage/cards/h/Hullbreacher.java
@@ -65,11 +65,6 @@ class HullbreacherReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         new TreasureToken().putOntoBattlefield(1, game, source, source.getControllerId());
         return true;

--- a/Mage.Sets/src/mage/cards/i/ImmortalCoil.java
+++ b/Mage.Sets/src/mage/cards/i/ImmortalCoil.java
@@ -101,11 +101,6 @@ class ImmortalCoilPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if (game.replaceEvent(new PreventDamageEvent(
                 event.getTargetId(), source.getSourceId(), source, source.getControllerId(),

--- a/Mage.Sets/src/mage/cards/i/InfernalDarkness.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalDarkness.java
@@ -65,11 +65,6 @@ class InfernalDarknessReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/i/InquisitorsFlail.java
+++ b/Mage.Sets/src/mage/cards/i/InquisitorsFlail.java
@@ -85,11 +85,6 @@ class InquisitorsFlailEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/i/InsultInjury.java
+++ b/Mage.Sets/src/mage/cards/i/InsultInjury.java
@@ -82,11 +82,6 @@ class InsultDoubleDamageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/i/InterventionPact.java
+++ b/Mage.Sets/src/mage/cards/i/InterventionPact.java
@@ -99,11 +99,6 @@ class InterventionPactPreventDamageEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         PreventionEffectData preventEffectData = preventDamageAction(event, source, game);
         if (preventEffectData.getPreventedDamage() > 0) {

--- a/Mage.Sets/src/mage/cards/i/IsengardUnleashed.java
+++ b/Mage.Sets/src/mage/cards/i/IsengardUnleashed.java
@@ -87,11 +87,6 @@ class IsengardUnleashedTripleDamageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 3));
         return false;

--- a/Mage.Sets/src/mage/cards/i/IslandSanctuary.java
+++ b/Mage.Sets/src/mage/cards/i/IslandSanctuary.java
@@ -85,11 +85,6 @@ class IslandSanctuaryEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public IslandSanctuaryEffect copy() {
         return new IslandSanctuaryEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/j/JaceWielderOfMysteries.java
+++ b/Mage.Sets/src/mage/cards/j/JaceWielderOfMysteries.java
@@ -69,11 +69,6 @@ class JaceWielderOfMysteriesContinuousEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/j/JadeOrbOfDragonkind.java
+++ b/Mage.Sets/src/mage/cards/j/JadeOrbOfDragonkind.java
@@ -119,11 +119,6 @@ class JadeOrbAdditionalCounterEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage.Sets/src/mage/cards/j/JayaVeneratedFiremage.java
+++ b/Mage.Sets/src/mage/cards/j/JayaVeneratedFiremage.java
@@ -88,11 +88,6 @@ class JayaVeneratedFiremageEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
         return false;

--- a/Mage.Sets/src/mage/cards/j/JeskaThriceReborn.java
+++ b/Mage.Sets/src/mage/cards/j/JeskaThriceReborn.java
@@ -144,11 +144,6 @@ class JeskaThriceRebornEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 3));
         return false;

--- a/Mage.Sets/src/mage/cards/k/KalitasTraitorOfGhet.java
+++ b/Mage.Sets/src/mage/cards/k/KalitasTraitorOfGhet.java
@@ -88,11 +88,6 @@ class KalitasTraitorOfGhetEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/k/KillSuitCultist.java
+++ b/Mage.Sets/src/mage/cards/k/KillSuitCultist.java
@@ -81,11 +81,6 @@ class KillSuitCultistEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
         if(permanent != null) {

--- a/Mage.Sets/src/mage/cards/k/KioraTheCrashingWave.java
+++ b/Mage.Sets/src/mage/cards/k/KioraTheCrashingWave.java
@@ -85,11 +85,6 @@ class KioraPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
         for (UUID targetId : this.getTargetPointer().getTargets(game, source)) {

--- a/Mage.Sets/src/mage/cards/k/KrarksOtherThumb.java
+++ b/Mage.Sets/src/mage/cards/k/KrarksOtherThumb.java
@@ -69,11 +69,6 @@ class KrarksOtherThumbEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public KrarksOtherThumbEffect copy() {
         return new KrarksOtherThumbEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/k/KrarksThumb.java
+++ b/Mage.Sets/src/mage/cards/k/KrarksThumb.java
@@ -71,9 +71,4 @@ class KrarksThumbEffect extends ReplacementEffectImpl {
     public boolean applies(GameEvent event, Ability source, Game game) {
         return source.isControlledBy(event.getPlayerId());
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
 }

--- a/Mage.Sets/src/mage/cards/l/LaboratoryManiac.java
+++ b/Mage.Sets/src/mage/cards/l/LaboratoryManiac.java
@@ -64,11 +64,6 @@ class LaboratoryManiacEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
+++ b/Mage.Sets/src/mage/cards/l/LaezelVlaakithsChampion.java
@@ -87,11 +87,6 @@ class LaezelVlaakithsChampionEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public LaezelVlaakithsChampionEffect copy() {
         return new LaezelVlaakithsChampionEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/l/LashknifeBarrier.java
+++ b/Mage.Sets/src/mage/cards/l/LashknifeBarrier.java
@@ -59,11 +59,6 @@ class LashknifeBarrierEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(event.getAmount() - 1);
         return false;

--- a/Mage.Sets/src/mage/cards/l/Lichenthrope.java
+++ b/Mage.Sets/src/mage/cards/l/Lichenthrope.java
@@ -85,11 +85,6 @@ class LichenthropeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public LichenthropeEffect copy() {
         return new LichenthropeEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/l/LichsMirror.java
+++ b/Mage.Sets/src/mage/cards/l/LichsMirror.java
@@ -57,11 +57,6 @@ class LichsMirrorEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/l/LongListOfTheEnts.java
+++ b/Mage.Sets/src/mage/cards/l/LongListOfTheEnts.java
@@ -194,11 +194,6 @@ class LongListOfTheEntsCounterEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/l/Luminesce.java
+++ b/Mage.Sets/src/mage/cards/l/Luminesce.java
@@ -48,11 +48,6 @@ class LuminescePreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (super.applies(event, source, game)) {
             if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER

--- a/Mage.Sets/src/mage/cards/m/MagebaneArmor.java
+++ b/Mage.Sets/src/mage/cards/m/MagebaneArmor.java
@@ -87,11 +87,6 @@ class MagebaneArmorPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent equipment = game.getPermanent(source.getSourceId());
         if (equipment != null && equipment.getAttachedTo() != null) {

--- a/Mage.Sets/src/mage/cards/m/ManaReflection.java
+++ b/Mage.Sets/src/mage/cards/m/ManaReflection.java
@@ -51,11 +51,6 @@ class ManaReflectionReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Mana mana = ((ManaEvent) event).getMana();
         if (mana.getBlack() > 0) {

--- a/Mage.Sets/src/mage/cards/m/MetallicMimic.java
+++ b/Mage.Sets/src/mage/cards/m/MetallicMimic.java
@@ -87,11 +87,6 @@ class MetallicMimicReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/m/MirrorStrike.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorStrike.java
@@ -71,11 +71,6 @@ class MirrorStrikeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         DamageEvent damageEvent = (DamageEvent) event;

--- a/Mage.Sets/src/mage/cards/m/MirroredLotus.java
+++ b/Mage.Sets/src/mage/cards/m/MirroredLotus.java
@@ -86,11 +86,6 @@ class MirroredLotusReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return event.getTargetId().equals(source.getSourceId());
     }

--- a/Mage.Sets/src/mage/cards/m/MirrorwoodTreefolk.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorwoodTreefolk.java
@@ -87,9 +87,4 @@ class MirrorwoodTreefolkEffect extends RedirectionEffect {
         return false;
     }
 
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/m/Mistcaller.java
+++ b/Mage.Sets/src/mage/cards/m/Mistcaller.java
@@ -65,11 +65,6 @@ class ContainmentPriestReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/m/MowuLoyalCompanion.java
+++ b/Mage.Sets/src/mage/cards/m/MowuLoyalCompanion.java
@@ -87,11 +87,6 @@ class MowuLoyalCompanionEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public MowuLoyalCompanionEffect copy() {
         return new MowuLoyalCompanionEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/m/MoxDiamond.java
+++ b/Mage.Sets/src/mage/cards/m/MoxDiamond.java
@@ -63,11 +63,6 @@ class MoxDiamondReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/m/MysteriousPathlighter.java
+++ b/Mage.Sets/src/mage/cards/m/MysteriousPathlighter.java
@@ -77,11 +77,6 @@ class MysteriousPathlighterEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage.Sets/src/mage/cards/n/NakedSingularity.java
+++ b/Mage.Sets/src/mage/cards/n/NakedSingularity.java
@@ -65,11 +65,6 @@ class NakedSingularityEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         TappedForManaEvent manaEvent = (TappedForManaEvent) event;
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/n/NecromancersMagemark.java
+++ b/Mage.Sets/src/mage/cards/n/NecromancersMagemark.java
@@ -85,11 +85,6 @@ class NecromancersMagemarkEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/n/NecromanticSummons.java
+++ b/Mage.Sets/src/mage/cards/n/NecromanticSummons.java
@@ -74,11 +74,6 @@ class NecromanticSummoningReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/n/Neoform.java
+++ b/Mage.Sets/src/mage/cards/n/Neoform.java
@@ -129,11 +129,6 @@ class NeoformReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/n/NotionThief.java
+++ b/Mage.Sets/src/mage/cards/n/NotionThief.java
@@ -68,11 +68,6 @@ class NotionThiefReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/n/NyxbloomAncient.java
+++ b/Mage.Sets/src/mage/cards/n/NyxbloomAncient.java
@@ -57,11 +57,6 @@ class NyxbloomAncientReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Mana mana = ((ManaEvent) event).getMana();
         if (mana.getBlack() > 0) {

--- a/Mage.Sets/src/mage/cards/o/OathOfGideon.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfGideon.java
@@ -69,11 +69,6 @@ class OathOfGideonReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/o/ObstinateFamiliar.java
+++ b/Mage.Sets/src/mage/cards/o/ObstinateFamiliar.java
@@ -62,11 +62,6 @@ class ObstinateFamiliarReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player you = game.getPlayer(source.getControllerId());
         if (you != null && you.chooseUse(Outcome.AIDontUseIt, "Skip this draw?", source, game)){

--- a/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
+++ b/Mage.Sets/src/mage/cards/o/OonasBlackguard.java
@@ -83,11 +83,6 @@ class OonasBlackguardReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/o/OrmosArchiveKeeper.java
+++ b/Mage.Sets/src/mage/cards/o/OrmosArchiveKeeper.java
@@ -82,11 +82,6 @@ class OrmosArchiveKeeperEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null) {

--- a/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
+++ b/Mage.Sets/src/mage/cards/o/OutOfTheTombs.java
@@ -65,11 +65,6 @@ class OutOfTheTombsReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player == null) {

--- a/Mage.Sets/src/mage/cards/o/Overblaze.java
+++ b/Mage.Sets/src/mage/cards/o/Overblaze.java
@@ -70,11 +70,6 @@ class OverblazeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/p/PaleMoon.java
+++ b/Mage.Sets/src/mage/cards/p/PaleMoon.java
@@ -55,11 +55,6 @@ class PaleMoonReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/p/PalisadeGiant.java
+++ b/Mage.Sets/src/mage/cards/p/PalisadeGiant.java
@@ -130,11 +130,6 @@ class PalisadeGiantReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PalisadeGiantReplacementEffect copy() {
         return new PalisadeGiantReplacementEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/Pariah.java
+++ b/Mage.Sets/src/mage/cards/p/Pariah.java
@@ -49,49 +49,45 @@ public final class Pariah extends CardImpl {
     public Pariah copy() {
         return new Pariah(this);
     }
+    
+}
 
-    static class PariahEffect extends ReplacementEffectImpl {
-        PariahEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.RedirectDamage);
-            staticText = "All damage that would be dealt to you is dealt to enchanted creature instead";
-        }
+class PariahEffect extends ReplacementEffectImpl { // TODO: extend redirection effect instead?
+    PariahEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.RedirectDamage);
+        staticText = "All damage that would be dealt to you is dealt to enchanted creature instead";
+    }
 
-        private PariahEffect(final PariahEffect effect) {
-            super(effect);
-        }
+    private PariahEffect(final PariahEffect effect) {
+        super(effect);
+    }
 
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
-            Permanent equipment = game.getPermanent(source.getSourceId());
-            if (equipment != null) {
-                Permanent permanent = game.getPermanent(equipment.getAttachedTo());
-                if (permanent != null) {
-                    permanent.damage(damageEvent.getAmount(), event.getSourceId(), source, game, damageEvent.isCombatDamage(), damageEvent.isPreventable());
-                    return true;
-                }
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
+        Permanent equipment = game.getPermanent(source.getSourceId());
+        if (equipment != null) {
+            Permanent permanent = game.getPermanent(equipment.getAttachedTo());
+            if (permanent != null) {
+                permanent.damage(damageEvent.getAmount(), event.getSourceId(), source, game, damageEvent.isCombatDamage(), damageEvent.isPreventable());
+                return true;
             }
-            return true;
         }
+        return true;
+    }
 
-        @Override
-        public boolean checksEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.DAMAGE_PLAYER;
-        }
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGE_PLAYER;
+    }
 
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            return event.getPlayerId().equals(source.getControllerId());
-        }
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return event.getPlayerId().equals(source.getControllerId());
+    }
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
-        public PariahEffect copy() {
-            return new PariahEffect(this);
-        }
+    @Override
+    public PariahEffect copy() {
+        return new PariahEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PariahsShield.java
+++ b/Mage.Sets/src/mage/cards/p/PariahsShield.java
@@ -31,7 +31,7 @@ public final class PariahsShield extends CardImpl {
         this.subtype.add(SubType.EQUIPMENT);
 
         // All damage that would be dealt to you is dealt to equipped creature instead.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PariahEffect()));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PariahsShieldEffect()));
         
         // Equip {3}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(3), new TargetControlledCreaturePermanent(), false));
@@ -46,48 +46,43 @@ public final class PariahsShield extends CardImpl {
         return new PariahsShield(this);
     }
 
-    class PariahEffect extends ReplacementEffectImpl {
-        PariahEffect() {
-            super(Duration.WhileOnBattlefield, Outcome.RedirectDamage);
-            staticText = "All damage that would be dealt to you is dealt to equipped creature instead";
-        }
+}
+class PariahsShieldEffect extends ReplacementEffectImpl { // TODO: extend redirection effect instead? Redundant with PariahEffect?
+    PariahsShieldEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.RedirectDamage);
+        staticText = "All damage that would be dealt to you is dealt to equipped creature instead";
+    }
 
-        private PariahEffect(final PariahEffect effect) {
-            super(effect);
-        }
+    private PariahsShieldEffect(final PariahsShieldEffect effect) {
+        super(effect);
+    }
 
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            Permanent equipment = game.getPermanent(source.getSourceId());
-            if (equipment != null) {
-                Permanent permanent = game.getPermanent(equipment.getAttachedTo());
-                if (permanent != null) {
-                    DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
-                    permanent.damage(damageEvent.getAmount(), event.getSourceId(), source, game, damageEvent.isCombatDamage(), damageEvent.isPreventable());
-                    return true;
-                }
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent equipment = game.getPermanent(source.getSourceId());
+        if (equipment != null) {
+            Permanent permanent = game.getPermanent(equipment.getAttachedTo());
+            if (permanent != null) {
+                DamagePlayerEvent damageEvent = (DamagePlayerEvent) event;
+                permanent.damage(damageEvent.getAmount(), event.getSourceId(), source, game, damageEvent.isCombatDamage(), damageEvent.isPreventable());
+                return true;
             }
-            return false;
         }
+        return false;
+    }
 
-        @Override
-        public boolean checksEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.DAMAGE_PLAYER;
-        }
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGE_PLAYER;
+    }
 
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            return event.getPlayerId().equals(source.getControllerId());
-        }
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return event.getPlayerId().equals(source.getControllerId());
+    }
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
-        public PariahEffect copy() {
-            return new PariahEffect(this);
-        }
+    @Override
+    public PariahsShieldEffect copy() {
+        return new PariahsShieldEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PersonalSanctuary.java
+++ b/Mage.Sets/src/mage/cards/p/PersonalSanctuary.java
@@ -63,11 +63,6 @@ class PersonalSanctuaryEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER) {
             if (event.getTargetId().equals(source.getControllerId()) && game.isActivePlayer(source.getControllerId()))

--- a/Mage.Sets/src/mage/cards/p/PhialOfGaladriel.java
+++ b/Mage.Sets/src/mage/cards/p/PhialOfGaladriel.java
@@ -105,11 +105,6 @@ class PhialOfGaladrielDrawEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/p/PhyrexianHydra.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianHydra.java
@@ -66,11 +66,6 @@ class PhyrexianHydraEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         boolean retValue = false;
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());

--- a/Mage.Sets/src/mage/cards/p/Phytohydra.java
+++ b/Mage.Sets/src/mage/cards/p/Phytohydra.java
@@ -74,11 +74,6 @@ class PhytohydraEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PhytohydraEffect copy() {
         return new PhytohydraEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/PilgrimOfJustice.java
+++ b/Mage.Sets/src/mage/cards/p/PilgrimOfJustice.java
@@ -81,11 +81,6 @@ class PilgrimOfJusticeEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         this.target.choose(Outcome.PreventDamage, source.getControllerId(), source.getSourceId(), source, game);
     }

--- a/Mage.Sets/src/mage/cards/p/PilgrimOfVirtue.java
+++ b/Mage.Sets/src/mage/cards/p/PilgrimOfVirtue.java
@@ -81,11 +81,6 @@ class PilgrimOfVirtueEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         this.target.choose(Outcome.PreventDamage, source.getControllerId(), source.getSourceId(), source, game);
     }

--- a/Mage.Sets/src/mage/cards/p/PixieGuide.java
+++ b/Mage.Sets/src/mage/cards/p/PixieGuide.java
@@ -74,11 +74,6 @@ class PixieGuideEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public PixieGuideEffect copy() {
         return new PixieGuideEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/Plagiarize.java
+++ b/Mage.Sets/src/mage/cards/p/Plagiarize.java
@@ -54,12 +54,7 @@ class PlagiarizeEffect extends ReplacementEffectImpl {
     public PlagiarizeEffect copy() {
         return new PlagiarizeEffect(this);
     }
-    
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-    
+        
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/p/PrimalClay.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalClay.java
@@ -77,11 +77,6 @@ public final class PrimalClay extends CardImpl {
         }
 
         @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
-
-        @Override
         public boolean replaceEvent(GameEvent event, Ability source, Game game) {
             Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
             if (permanent == null) {

--- a/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalPlasma.java
@@ -78,11 +78,6 @@ public final class PrimalPlasma extends CardImpl {
         }
 
         @Override
-        public boolean apply(Game game, Ability source) {
-            return false;
-        }
-
-        @Override
         public boolean replaceEvent(GameEvent event, Ability source, Game game) {
             Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
             Player controller = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/p/PrimalVigor.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalVigor.java
@@ -112,11 +112,6 @@ class PrimalVigorCounterEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public PrimalVigorCounterEffect copy() {
         return new PrimalVigorCounterEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/p/PrimalVigor.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalVigor.java
@@ -70,11 +70,6 @@ class PrimalVigorTokenEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if (event instanceof CreateTokenEvent) {
             ((CreateTokenEvent) event).multiplyTokens(2);

--- a/Mage.Sets/src/mage/cards/p/PrimevalSpawn.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalSpawn.java
@@ -77,11 +77,6 @@ class PrimevalSpawnReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller == null) {

--- a/Mage.Sets/src/mage/cards/p/PrismaticStrands.java
+++ b/Mage.Sets/src/mage/cards/p/PrismaticStrands.java
@@ -107,11 +107,6 @@ class PrismaticStrandsPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (super.applies(event, source, game)) {
             if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER

--- a/Mage.Sets/src/mage/cards/p/PulseOfLlanowar.java
+++ b/Mage.Sets/src/mage/cards/p/PulseOfLlanowar.java
@@ -57,11 +57,6 @@ class PulseOfLlanowarReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/p/PursuitOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/p/PursuitOfKnowledge.java
@@ -77,11 +77,6 @@ class PursuitOfKnowledgeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(event.getPlayerId());
         if(controller != null) {
@@ -93,4 +88,3 @@ class PursuitOfKnowledgeEffect extends ReplacementEffectImpl {
         return false;
     }
 }
-

--- a/Mage.Sets/src/mage/cards/p/PyromancersSwath.java
+++ b/Mage.Sets/src/mage/cards/p/PyromancersSwath.java
@@ -74,11 +74,6 @@ class PyromancersSwathReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/r/RadiantScrollwielder.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantScrollwielder.java
@@ -131,11 +131,6 @@ class RadiantScrollwielderReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ((ZoneChangeEvent) event).setToZone(Zone.EXILED);
         return false;

--- a/Mage.Sets/src/mage/cards/r/RankleAndTorbran.java
+++ b/Mage.Sets/src/mage/cards/r/RankleAndTorbran.java
@@ -102,11 +102,6 @@ class RankleAndTorbranEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 2));
         return false;

--- a/Mage.Sets/src/mage/cards/r/RavenousSlime.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousSlime.java
@@ -66,11 +66,6 @@ class RavenousSlimeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         Permanent sourceCreature = game.getPermanent(source.getSourceId());

--- a/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
+++ b/Mage.Sets/src/mage/cards/r/RaziaBorosArchangel.java
@@ -95,11 +95,6 @@ class RaziaBorosArchangelEffect extends RedirectionEffect {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
         redirectToObject = new MageObjectReference(source.getTargets().get(1).getFirstTarget(), game);

--- a/Mage.Sets/src/mage/cards/r/RealityTwist.java
+++ b/Mage.Sets/src/mage/cards/r/RealityTwist.java
@@ -65,11 +65,6 @@ class RealityTwistEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         TappedForManaEvent manaEvent = (TappedForManaEvent) event;
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/r/RefractionTrap.java
+++ b/Mage.Sets/src/mage/cards/r/RefractionTrap.java
@@ -111,11 +111,6 @@ class RefractionTrapPreventDamageEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         PreventionEffectData preventionData = preventDamageAction(event, source, game);
         this.used = true;

--- a/Mage.Sets/src/mage/cards/r/ReidaneGodOfTheWorthy.java
+++ b/Mage.Sets/src/mage/cards/r/ReidaneGodOfTheWorthy.java
@@ -135,11 +135,6 @@ class ValkmiraProtectorsShieldPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         switch (event.getType()) {
             case DAMAGE_PLAYER:

--- a/Mage.Sets/src/mage/cards/r/Reverberation.java
+++ b/Mage.Sets/src/mage/cards/r/Reverberation.java
@@ -69,11 +69,6 @@ class ReverberationEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         DamageEvent damageEvent = (DamageEvent) event;

--- a/Mage.Sets/src/mage/cards/r/ReverseDamage.java
+++ b/Mage.Sets/src/mage/cards/r/ReverseDamage.java
@@ -60,11 +60,6 @@ class ReverseDamageEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         this.target.choose(Outcome.PreventDamage, source.getControllerId(), source.getSourceId(), source, game);
     }

--- a/Mage.Sets/src/mage/cards/r/RhoxFaithmender.java
+++ b/Mage.Sets/src/mage/cards/r/RhoxFaithmender.java
@@ -67,11 +67,6 @@ class RhoxFaithmenderEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowMultiply(event.getAmount(), 2));
         return false;
@@ -87,4 +82,3 @@ class RhoxFaithmenderEffect extends ReplacementEffectImpl {
         return event.getPlayerId().equals(source.getControllerId()) && (source.getControllerId() != null);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/r/RitualOfSubdual.java
+++ b/Mage.Sets/src/mage/cards/r/RitualOfSubdual.java
@@ -61,11 +61,6 @@ class RitualOfSubdualReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ManaEvent manaEvent = (ManaEvent) event;
         Mana mana = manaEvent.getMana();

--- a/Mage.Sets/src/mage/cards/r/RockHydra.java
+++ b/Mage.Sets/src/mage/cards/r/RockHydra.java
@@ -1,4 +1,3 @@
-
 package mage.cards.r;
 
 import java.util.UUID;
@@ -57,48 +56,44 @@ public final class RockHydra extends CardImpl {
     public RockHydra copy() {
         return new RockHydra(this);
     }
-    
-    static class RockHydraEffect extends PreventionEffectImpl {
 
-        public RockHydraEffect() {
-            super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
-            staticText = "For each 1 damage that would be dealt to {this}, if it has a +1/+1 counter on it, remove a +1/+1 counter from it and prevent that 1 damage.";
-        }
+}
 
-        private RockHydraEffect(final RockHydraEffect effect) {
-            super(effect);
-        }
+class RockHydraEffect extends PreventionEffectImpl {
 
-        @Override
-        public RockHydraEffect copy() {
-            return new RockHydraEffect(this);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
-        public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-            int damage = event.getAmount();
-            preventDamageAction(event, source, game);
-            Permanent permanent = game.getPermanent(source.getSourceId());
-            if (permanent != null) {
-                permanent.removeCounters(CounterType.P1P1.createInstance(damage), source, game); //MTG ruling Rock Hydra loses counters even if the damage isn't prevented
-            }
-            return false;
-        }
-
-        @Override
-        public boolean applies(GameEvent event, Ability source, Game game) {
-            if (super.applies(event, source, game)) {
-                if (event.getTargetId().equals(source.getSourceId())) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
+    RockHydraEffect() {
+        super(Duration.WhileOnBattlefield, Integer.MAX_VALUE, false, false);
+        staticText = "For each 1 damage that would be dealt to {this}, if it has a +1/+1 counter on it, remove a +1/+1 counter from it and prevent that 1 damage.";
     }
+
+    private RockHydraEffect(final RockHydraEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RockHydraEffect copy() {
+        return new RockHydraEffect(this);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        int damage = event.getAmount();
+        preventDamageAction(event, source, game);
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        if (permanent != null) {
+            permanent.removeCounters(CounterType.P1P1.createInstance(damage), source, game); //MTG ruling Rock Hydra loses counters even if the damage isn't prevented
+        }
+        return false;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (super.applies(event, source, game)) {
+            if (event.getTargetId().equals(source.getSourceId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/Mage.Sets/src/mage/cards/s/SageOfFables.java
+++ b/Mage.Sets/src/mage/cards/s/SageOfFables.java
@@ -78,11 +78,6 @@ class SageOfFablesReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/s/SagesOfTheAnima.java
+++ b/Mage.Sets/src/mage/cards/s/SagesOfTheAnima.java
@@ -68,11 +68,6 @@ class SagesOfTheAnimaReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/s/SamitePilgrim.java
+++ b/Mage.Sets/src/mage/cards/s/SamitePilgrim.java
@@ -69,11 +69,6 @@ class SamitePilgrimPreventDamageToTargetEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return !this.used && super.applies(event, source, game) && event.getTargetId().equals(source.getFirstTarget());
     }

--- a/Mage.Sets/src/mage/cards/s/SavingGrace.java
+++ b/Mage.Sets/src/mage/cards/s/SavingGrace.java
@@ -137,11 +137,6 @@ class SavingGraceReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SavingGraceReplacementEffect copy() {
         return new SavingGraceReplacementEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/ScionOfHalaster.java
+++ b/Mage.Sets/src/mage/cards/s/ScionOfHalaster.java
@@ -61,11 +61,6 @@ class ScionOfHalasterReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         new LookLibraryAndPickControllerEffect(2, 1, PutCards.GRAVEYARD, PutCards.TOP_ANY).apply(game, source);
         Player you = game.getPlayer(event.getPlayerId());

--- a/Mage.Sets/src/mage/cards/s/SekkiSeasonsGuide.java
+++ b/Mage.Sets/src/mage/cards/s/SekkiSeasonsGuide.java
@@ -83,11 +83,6 @@ class SekkiSeasonsGuideEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         int damage = event.getAmount();
         preventDamageAction(event, source, game);

--- a/Mage.Sets/src/mage/cards/s/ShamanEnKor.java
+++ b/Mage.Sets/src/mage/cards/s/ShamanEnKor.java
@@ -114,11 +114,6 @@ class ShamanEnKorRedirectFromTargetEffect extends RedirectionEffect {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ShamanEnKorRedirectFromTargetEffect copy() {
         return new ShamanEnKorRedirectFromTargetEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/ShieldOfTheAvatar.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldOfTheAvatar.java
@@ -64,11 +64,6 @@ class ShieldOfTheAvatarPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         boolean result = false;
         Permanent equipment = game.getPermanent(source.getSourceId());

--- a/Mage.Sets/src/mage/cards/s/ShiningShoal.java
+++ b/Mage.Sets/src/mage/cards/s/ShiningShoal.java
@@ -90,11 +90,6 @@ class ShiningShoalRedirectDamageTargetEffect extends RedirectDamageFromSourceToT
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (!this.used && event.getFlag()) {
 

--- a/Mage.Sets/src/mage/cards/s/SithMagic.java
+++ b/Mage.Sets/src/mage/cards/s/SithMagic.java
@@ -144,9 +144,4 @@ class SithMagicReplacementEffect extends ReplacementEffectImpl {
         }
         return false;
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
 }

--- a/Mage.Sets/src/mage/cards/s/SivvisValor.java
+++ b/Mage.Sets/src/mage/cards/s/SivvisValor.java
@@ -84,11 +84,6 @@ class SivvisValorEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         DamageEvent damageEvent = (DamageEvent) event;

--- a/Mage.Sets/src/mage/cards/s/SnickeringSquirrel.java
+++ b/Mage.Sets/src/mage/cards/s/SnickeringSquirrel.java
@@ -85,11 +85,6 @@ class SnickeringSquirrelEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public SnickeringSquirrelEffect copy() {
         return new SnickeringSquirrelEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SolphimMayhemDominus.java
+++ b/Mage.Sets/src/mage/cards/s/SolphimMayhemDominus.java
@@ -87,11 +87,6 @@ class SolphimMayhemDominusEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), event.getAmount()));
         return false;

--- a/Mage.Sets/src/mage/cards/s/SoltariGuerrillas.java
+++ b/Mage.Sets/src/mage/cards/s/SoltariGuerrillas.java
@@ -97,11 +97,6 @@ class SoltariGuerrillasReplacementEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SoltariGuerrillasReplacementEffect copy() {
         return new SoltariGuerrillasReplacementEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
+++ b/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
@@ -87,11 +87,6 @@ class SoulfireGrandMasterCastFromHandReplacementEffect extends ReplacementEffect
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        throw new UnsupportedOperationException("Not supported.");
-    }
-
-    @Override
     public SoulfireGrandMasterCastFromHandReplacementEffect copy() {
         return new SoulfireGrandMasterCastFromHandReplacementEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SquirrelPoweredScheme.java
+++ b/Mage.Sets/src/mage/cards/s/SquirrelPoweredScheme.java
@@ -63,11 +63,6 @@ class SquirrelPoweredSchemeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public SquirrelPoweredSchemeEffect copy() {
         return new SquirrelPoweredSchemeEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/StonewiseFortifier.java
+++ b/Mage.Sets/src/mage/cards/s/StonewiseFortifier.java
@@ -67,11 +67,6 @@ class StonewiseFortifierPreventAllDamageToEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), event.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
         if (!game.replaceEvent(preventEvent)) {

--- a/Mage.Sets/src/mage/cards/s/StormHerald.java
+++ b/Mage.Sets/src/mage/cards/s/StormHerald.java
@@ -176,11 +176,6 @@ class StormHeraldReplacementEffect extends ReplacementEffectImpl {
                 && ((ZoneChangeEvent) event).getToZone() != Zone.EXILED
                 && getTargetPointer().getTargets(game, source).contains(event.getTargetId());
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
 }
 
 class StormHeraldAttachablePredicate implements mage.filter.predicate.Predicate<Card> {

--- a/Mage.Sets/src/mage/cards/s/StormwildCapridor.java
+++ b/Mage.Sets/src/mage/cards/s/StormwildCapridor.java
@@ -68,11 +68,6 @@ class StormwildCapridorEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         PreventionEffectData preventionEffectData = preventDamageAction(event, source, game);
         if (preventionEffectData.getPreventedDamage() > 0) {

--- a/Mage.Sets/src/mage/cards/s/Storyweave.java
+++ b/Mage.Sets/src/mage/cards/s/Storyweave.java
@@ -106,11 +106,6 @@ class StoryweaveReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/s/Stranglehold.java
+++ b/Mage.Sets/src/mage/cards/s/Stranglehold.java
@@ -98,11 +98,6 @@ class StrangleholdSkipExtraTurnsEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         MageObject sourceObject = game.getObject(source);

--- a/Mage.Sets/src/mage/cards/s/StunningReversal.java
+++ b/Mage.Sets/src/mage/cards/s/StunningReversal.java
@@ -57,11 +57,6 @@ class StunningReversalEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         if (player != null) {

--- a/Mage.Sets/src/mage/cards/s/SulfuricVapors.java
+++ b/Mage.Sets/src/mage/cards/s/SulfuricVapors.java
@@ -70,11 +70,6 @@ class SulfuricVaporsEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
         return false;

--- a/Mage.Sets/src/mage/cards/s/SulfuricVortex.java
+++ b/Mage.Sets/src/mage/cards/s/SulfuricVortex.java
@@ -72,11 +72,6 @@ class SulfuricVortexReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/SustainingSpirit.java
+++ b/Mage.Sets/src/mage/cards/s/SustainingSpirit.java
@@ -88,11 +88,6 @@ class SustainingSpiritReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return false;
     }

--- a/Mage.Sets/src/mage/cards/s/SwansOfBrynArgoll.java
+++ b/Mage.Sets/src/mage/cards/s/SwansOfBrynArgoll.java
@@ -124,11 +124,6 @@ class SwansOfBrynArgollEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SwansOfBrynArgollEffect copy() {
         return new SwansOfBrynArgollEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/s/SzadekLordOfSecrets.java
+++ b/Mage.Sets/src/mage/cards/s/SzadekLordOfSecrets.java
@@ -95,11 +95,6 @@ class SzadekLordOfSecretsEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public SzadekLordOfSecretsEffect copy() {
         return new SzadekLordOfSecretsEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/t/TeferisAgelessInsight.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisAgelessInsight.java
@@ -53,11 +53,6 @@ class TeferisAgelessInsightEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/t/Temper.java
+++ b/Mage.Sets/src/mage/cards/t/Temper.java
@@ -68,11 +68,6 @@ class TemperPreventDamageTargetEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if (!initialized) {
             amount = dVal.calculate(game, source, this);

--- a/Mage.Sets/src/mage/cards/t/TempleAltisaur.java
+++ b/Mage.Sets/src/mage/cards/t/TempleAltisaur.java
@@ -66,11 +66,6 @@ class TempleAltisaurPreventEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PERMANENT) {
             Permanent permanent = game.getPermanent(event.getTargetId());

--- a/Mage.Sets/src/mage/cards/t/TestOfFaith.java
+++ b/Mage.Sets/src/mage/cards/t/TestOfFaith.java
@@ -60,11 +60,6 @@ class TestOfFaithPreventDamageTargetEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
         if (!game.replaceEvent(preventEvent)) {

--- a/Mage.Sets/src/mage/cards/t/TheBigIdea.java
+++ b/Mage.Sets/src/mage/cards/t/TheBigIdea.java
@@ -78,11 +78,6 @@ class TheBigIdeaReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ((RollDieEvent) event).incBigIdeaRollsAmount();
         discard();

--- a/Mage.Sets/src/mage/cards/t/TheFirstTyrannicWar.java
+++ b/Mage.Sets/src/mage/cards/t/TheFirstTyrannicWar.java
@@ -119,11 +119,6 @@ class TheFirstTyrannicWarReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/t/TheGreatWork.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatWork.java
@@ -152,11 +152,6 @@ class TheGreatWorkReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller == null) {

--- a/Mage.Sets/src/mage/cards/t/ThoughtReflection.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtReflection.java
@@ -58,11 +58,6 @@ class ThoughtReflectionReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.DRAW_CARD;
     }

--- a/Mage.Sets/src/mage/cards/t/TomorrowAzamisFamiliar.java
+++ b/Mage.Sets/src/mage/cards/t/TomorrowAzamisFamiliar.java
@@ -57,11 +57,6 @@ class TomorrowAzamisFamiliarReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         new LookLibraryAndPickControllerEffect(3, 1, PutCards.HAND, PutCards.BOTTOM_ANY).apply(game, source);
         return true;

--- a/Mage.Sets/src/mage/cards/t/TorWaukiTheYounger.java
+++ b/Mage.Sets/src/mage/cards/t/TorWaukiTheYounger.java
@@ -88,11 +88,6 @@ class TorWaukiTheYoungerEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
         return false;

--- a/Mage.Sets/src/mage/cards/t/TreacherousLink.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousLink.java
@@ -74,11 +74,6 @@ class TreacherousLinkEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         DamageEvent damageEvent = (DamageEvent) event;
         Permanent enchantedCreature = game.getPermanentOrLKIBattlefield(damageEvent.getTargetId());

--- a/Mage.Sets/src/mage/cards/u/UginsNexus.java
+++ b/Mage.Sets/src/mage/cards/u/UginsNexus.java
@@ -99,11 +99,6 @@ class UginsNexusExileEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((ZoneChangeEvent)event).getTarget();
         if (permanent != null) {

--- a/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
+++ b/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
@@ -80,11 +80,6 @@ class UnboundFlourishingDoubleXEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public UnboundFlourishingDoubleXEffect copy() {
         return new UnboundFlourishingDoubleXEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/u/UndeadAlchemist.java
+++ b/Mage.Sets/src/mage/cards/u/UndeadAlchemist.java
@@ -134,11 +134,6 @@ class UndeadAlchemistEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public UndeadAlchemistEffect copy() {
         return new UndeadAlchemistEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/u/UnderrealmLich.java
+++ b/Mage.Sets/src/mage/cards/u/UnderrealmLich.java
@@ -79,11 +79,6 @@ class UnderrealmLichReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         new LookLibraryAndPickControllerEffect(3, 1, PutCards.HAND, PutCards.GRAVEYARD).apply(game, source);
         return true;

--- a/Mage.Sets/src/mage/cards/u/UnpredictableCyclone.java
+++ b/Mage.Sets/src/mage/cards/u/UnpredictableCyclone.java
@@ -63,11 +63,6 @@ class UnpredictableCycloneReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(event.getPlayerId());
         StackObject stackObject = game.getStack().getStackObject(event.getSourceId());

--- a/Mage.Sets/src/mage/cards/u/UrabraskHereticPraetor.java
+++ b/Mage.Sets/src/mage/cards/u/UrabraskHereticPraetor.java
@@ -69,11 +69,6 @@ class UrabraskHereticPraetorEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.DRAW_CARD;
     }

--- a/Mage.Sets/src/mage/cards/v/VigorMortis.java
+++ b/Mage.Sets/src/mage/cards/v/VigorMortis.java
@@ -73,11 +73,6 @@ class VigorMortisReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         if (creature != null) {

--- a/Mage.Sets/src/mage/cards/v/VirtueOfStrength.java
+++ b/Mage.Sets/src/mage/cards/v/VirtueOfStrength.java
@@ -72,11 +72,6 @@ class VirtueOfStrengthReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Mana mana = ((ManaEvent) event).getMana();
         if (mana.getBlack() > 0) {

--- a/Mage.Sets/src/mage/cards/v/VoidMaw.java
+++ b/Mage.Sets/src/mage/cards/v/VoidMaw.java
@@ -74,11 +74,6 @@ class VoidMawEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = source.getSourceObject(game);

--- a/Mage.Sets/src/mage/cards/v/VorinclexMonstrousRaider.java
+++ b/Mage.Sets/src/mage/cards/v/VorinclexMonstrousRaider.java
@@ -104,11 +104,6 @@ class VorinclexMonstrousRaiderEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public VorinclexMonstrousRaiderEffect copy() {
         return new VorinclexMonstrousRaiderEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/w/WardOfPiety.java
+++ b/Mage.Sets/src/mage/cards/w/WardOfPiety.java
@@ -76,11 +76,6 @@ class WardOfPietyPreventDamageTargetEffect extends RedirectionEffect {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
         redirectToObject = new MageObjectReference(source.getTargets().get(0).getFirstTarget(), game);

--- a/Mage.Sets/src/mage/cards/w/WindingConstrictor.java
+++ b/Mage.Sets/src/mage/cards/w/WindingConstrictor.java
@@ -79,11 +79,6 @@ class WindingConstrictorPlayerEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public WindingConstrictorPlayerEffect copy() {
         return new WindingConstrictorPlayerEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/w/WordsOfWar.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWar.java
@@ -60,11 +60,6 @@ class WordsOfWarEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage.Sets/src/mage/cards/w/WordsOfWorship.java
+++ b/Mage.Sets/src/mage/cards/w/WordsOfWorship.java
@@ -55,12 +55,7 @@ class WordsOfWorshipEffect extends ReplacementEffectImpl {
     public WordsOfWorshipEffect copy() {
         return new WordsOfWorshipEffect(this);
     }
-    
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-    
+        
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/w/Worship.java
+++ b/Mage.Sets/src/mage/cards/w/Worship.java
@@ -71,11 +71,6 @@ class WorshipReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return false;
     }

--- a/Mage.Sets/src/mage/cards/w/WyllBladeOfFrontiers.java
+++ b/Mage.Sets/src/mage/cards/w/WyllBladeOfFrontiers.java
@@ -85,11 +85,6 @@ class WyllBladeOfFrontiersEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public WyllBladeOfFrontiersEffect copy() {
         return new WyllBladeOfFrontiersEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/z/ZabazTheGlimmerwasp.java
+++ b/Mage.Sets/src/mage/cards/z/ZabazTheGlimmerwasp.java
@@ -106,11 +106,6 @@ class ZabazTheGlimmerwaspEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ZabazTheGlimmerwaspEffect copy() {
         return new ZabazTheGlimmerwaspEffect(this);
     }

--- a/Mage.Sets/src/mage/cards/z/ZameckGuildmage.java
+++ b/Mage.Sets/src/mage/cards/z/ZameckGuildmage.java
@@ -73,11 +73,6 @@ class ZameckGuildmageEntersBattlefieldEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent target = ((EntersTheBattlefieldEvent) event).getTarget();
         if (target != null) {

--- a/Mage/src/main/java/mage/abilities/common/CantHaveMoreThanAmountCountersSourceAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/CantHaveMoreThanAmountCountersSourceAbility.java
@@ -93,11 +93,6 @@ class CantHaveMoreThanAmountCountersSourceEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public CantHaveMoreThanAmountCountersSourceEffect copy() {
         return new CantHaveMoreThanAmountCountersSourceEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromAnywhereSourceAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromAnywhereSourceAbility.java
@@ -109,11 +109,6 @@ class PutIntoGraveFromAnywhereEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if (optional) {
             Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalPreventionEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalPreventionEffect.java
@@ -98,11 +98,6 @@ public class ConditionalPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return effect.checksEventType(event, game)
                 || (otherwiseEffect != null && otherwiseEffect.checksEventType(event, game));

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalReplacementEffect.java
@@ -88,11 +88,6 @@ public class ConditionalReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return effect.checksEventType(event, game)
                 || (otherwiseEffect != null && otherwiseEffect.checksEventType(event, game));

--- a/Mage/src/main/java/mage/abilities/effects/AsTurnedFaceUpEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AsTurnedFaceUpEffect.java
@@ -44,11 +44,6 @@ public class AsTurnedFaceUpEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         if (optional) {
             Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
@@ -49,11 +49,6 @@ public class AuraReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Zone fromZone = ((ZoneChangeEvent) event).getFromZone();
         Card card = game.getCard(event.getTargetId());

--- a/Mage/src/main/java/mage/abilities/effects/PhantomPreventionEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/PhantomPreventionEffect.java
@@ -35,11 +35,6 @@ public class PhantomPreventionEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         preventDamageAction(event, source, game);
 

--- a/Mage/src/main/java/mage/abilities/effects/PreventDamageAndRemoveCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/PreventDamageAndRemoveCountersEffect.java
@@ -37,11 +37,6 @@ public class PreventDamageAndRemoveCountersEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         int damage = event.getAmount();
         preventDamageAction(event, source, game);

--- a/Mage/src/main/java/mage/abilities/effects/PreventionEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/PreventionEffectImpl.java
@@ -20,15 +20,15 @@ public abstract class PreventionEffectImpl extends ReplacementEffectImpl impleme
     protected final boolean onlyCombat;
     protected boolean consumable;
 
-    public PreventionEffectImpl(Duration duration) {
+    protected PreventionEffectImpl(Duration duration) {
         this(duration, Integer.MAX_VALUE, false);
     }
 
-    public PreventionEffectImpl(Duration duration, int amountToPrevent, boolean onlyCombat) {
+    protected PreventionEffectImpl(Duration duration, int amountToPrevent, boolean onlyCombat) {
         this(duration, amountToPrevent, onlyCombat, true);
     }
 
-    public PreventionEffectImpl(Duration duration, int amountToPrevent, boolean onlyCombat, boolean consumable) {
+    protected PreventionEffectImpl(Duration duration, int amountToPrevent, boolean onlyCombat, boolean consumable) {
         this(duration, amountToPrevent, onlyCombat, consumable, null);
     }
 
@@ -40,7 +40,7 @@ public abstract class PreventionEffectImpl extends ReplacementEffectImpl impleme
      * @param amountToPreventDynamic if set, on init amountToPrevent is set to
      *                               calculated value of amountToPreventDynamic
      */
-    public PreventionEffectImpl(Duration duration, int amountToPrevent, boolean onlyCombat, boolean consumable, DynamicValue amountToPreventDynamic) {
+    protected PreventionEffectImpl(Duration duration, int amountToPrevent, boolean onlyCombat, boolean consumable, DynamicValue amountToPreventDynamic) {
         super(duration, Outcome.PreventDamage);
         this.effectType = EffectType.PREVENTION;
         this.amountToPrevent = amountToPrevent;
@@ -63,12 +63,6 @@ public abstract class PreventionEffectImpl extends ReplacementEffectImpl impleme
         if (amountToPreventDynamic != null) {
             amountToPrevent = amountToPreventDynamic.calculate(game, source, this);
         }
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        // not used for prevention effect
-        return true;
     }
 
     protected PreventionEffectData preventDamageAction(GameEvent event, Ability source, Game game) {

--- a/Mage/src/main/java/mage/abilities/effects/ReplacementEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ReplacementEffectImpl.java
@@ -49,9 +49,8 @@ public abstract class ReplacementEffectImpl extends ContinuousEffectImpl impleme
         return selfScope;
     }
 
-    // TODO: Change to final; refactor Regenerate effect to use replaceEvent rather than calling an overridden apply method
     @Override
-    public boolean apply(Game game, Ability source) {
+    public final boolean apply(Game game, Ability source) {
         throw new UnsupportedOperationException("Wrong code usage: apply() not used for replacement effect.");
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/ReplacementEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ReplacementEffectImpl.java
@@ -1,4 +1,3 @@
-
 package mage.abilities.effects;
 
 import mage.abilities.Ability;
@@ -24,7 +23,7 @@ public abstract class ReplacementEffectImpl extends ContinuousEffectImpl impleme
     // continuous effects from any other source that would affect it.
     protected boolean selfScope;
 
-    public ReplacementEffectImpl(Duration duration, Outcome outcome) {
+    protected ReplacementEffectImpl(Duration duration, Outcome outcome) {
         this(duration, outcome, true);
     }
 
@@ -34,7 +33,7 @@ public abstract class ReplacementEffectImpl extends ContinuousEffectImpl impleme
      * @param selfScope - is only relevant while permanents entering the
      *                  battlefield events
      */
-    public ReplacementEffectImpl(Duration duration, Outcome outcome, boolean selfScope) {
+    protected ReplacementEffectImpl(Duration duration, Outcome outcome, boolean selfScope) {
         super(duration, outcome);
         this.effectType = EffectType.REPLACEMENT;
         this.selfScope = selfScope;
@@ -50,9 +49,10 @@ public abstract class ReplacementEffectImpl extends ContinuousEffectImpl impleme
         return selfScope;
     }
 
+    // TODO: Change to final; refactor Regenerate effect to use replaceEvent rather than calling an overridden apply method
     @Override
     public boolean apply(Game game, Ability source) {
-        throw new UnsupportedOperationException("Not used for replacemnt effect.");
+        throw new UnsupportedOperationException("Wrong code usage: apply() not used for replacement effect.");
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/DevourEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DevourEffect.java
@@ -75,11 +75,6 @@ public class DevourEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/effects/common/EnterBattlefieldPayCostOrPutGraveyardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/EnterBattlefieldPayCostOrPutGraveyardEffect.java
@@ -40,11 +40,6 @@ public class EnterBattlefieldPayCostOrPutGraveyardEffect extends ReplacementEffe
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player player = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source);

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventAllDamageToAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventAllDamageToAllEffect.java
@@ -79,11 +79,6 @@ public class PreventAllDamageToAllEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (super.applies(event, source, game)) {
             MageItem object;

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventAllDamageToPlayersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventAllDamageToPlayersEffect.java
@@ -28,11 +28,6 @@ public class PreventAllDamageToPlayersEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (super.applies(event, source, game) && event.getType() == GameEvent.EventType.DAMAGE_PLAYER) {
             Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventDamageToSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventDamageToSourceEffect.java
@@ -38,11 +38,6 @@ public class PreventDamageToSourceEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return super.applies(event, source, game) && event.getTargetId().equals(source.getSourceId());
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventDamageToTargetMultiAmountEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventDamageToTargetMultiAmountEffect.java
@@ -73,11 +73,6 @@ public class PreventDamageToTargetMultiAmountEffect extends PreventionEffectImpl
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         int targetAmount = targetAmountMap.get(event.getTargetId());
         GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());

--- a/Mage/src/main/java/mage/abilities/effects/common/RegenerateSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RegenerateSourceEffect.java
@@ -32,19 +32,6 @@ public class RegenerateSourceEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        //20110204 - 701.11
-        Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent != null
-                && permanent.regenerate(source, game)) {
-            this.used = true;
-            discard();
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
 
@@ -58,7 +45,14 @@ public class RegenerateSourceEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        return apply(game, source);
+        //20110204 - 701.11
+        Permanent permanent = game.getPermanent(source.getSourceId());
+        if (permanent != null && permanent.regenerate(source, game)) {
+            this.used = true;
+            discard();
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/RegenerateSourceWithReflexiveEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RegenerateSourceWithReflexiveEffect.java
@@ -3,6 +3,7 @@ package mage.abilities.effects.common;
 import mage.abilities.Ability;
 import mage.abilities.common.delayed.ReflexiveTriggeredAbility;
 import mage.game.Game;
+import mage.game.events.GameEvent;
 import mage.target.targetpointer.FixedTarget;
 
 /**
@@ -34,8 +35,8 @@ public class RegenerateSourceWithReflexiveEffect extends RegenerateSourceEffect 
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        if (super.apply(game, source)) {
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        if (super.replaceEvent(event, source, game)) {
             if (this.setReflexiveTarget) {
                 reflexive.getEffects().setTargetPointer(
                         new FixedTarget(targetPointer.getFirst(game, source), game)

--- a/Mage/src/main/java/mage/abilities/effects/common/RegenerateTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RegenerateTargetEffect.java
@@ -24,17 +24,6 @@ public class RegenerateTargetEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        //20110204 - 701.11
-        Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
-        if (permanent != null && permanent.regenerate(source, game)) {
-            this.used = true;
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
         RegenerateSourceEffect.initRegenerationShieldInfo(game, source, targetPointer.getFirst(game, source));
@@ -47,7 +36,13 @@ public class RegenerateTargetEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        return apply(game, source);
+        //20110204 - 701.11
+        Permanent permanent = game.getPermanent(targetPointer.getFirst(game, source));
+        if (permanent != null && permanent.regenerate(source, game)) {
+            this.used = true;
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/SkipCombatStepEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/SkipCombatStepEffect.java
@@ -28,11 +28,6 @@ public class SkipCombatStepEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/SkipDrawStepEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/SkipDrawStepEffect.java
@@ -58,11 +58,6 @@ public class SkipDrawStepEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/SkipNextDrawStepTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/SkipNextDrawStepTargetEffect.java
@@ -28,11 +28,6 @@ public class SkipNextDrawStepTargetEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/AssignNoCombatDamageSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/AssignNoCombatDamageSourceEffect.java
@@ -33,11 +33,6 @@ public class AssignNoCombatDamageSourceEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/AssignNoCombatDamageTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/AssignNoCombatDamageTargetEffect.java
@@ -33,11 +33,6 @@ public class AssignNoCombatDamageTargetEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderManaReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderManaReplacementEffect.java
@@ -49,11 +49,6 @@ public class CommanderManaReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Mana mana = ((ManaEvent) event).getMana();
         if (mana.getBlack() > 0 && !commanderMana.isBlack()) {

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
@@ -86,11 +86,6 @@ public class CommanderReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public void init(Ability source, Game game) {
         super.init(source, game);
         if (commanderId == null) {

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/DealtDamageToCreatureBySourceDies.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/DealtDamageToCreatureBySourceDies.java
@@ -36,11 +36,6 @@ public class DealtDamageToCreatureBySourceDies extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ((ZoneChangeEvent) event).setToZone(Zone.EXILED);
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/DiesReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/DiesReplacementEffect.java
@@ -37,11 +37,6 @@ public class DiesReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent permanent = ((ZoneChangeEvent) event).getTarget();
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/GainPlusOneLifeReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/GainPlusOneLifeReplacementEffect.java
@@ -28,11 +28,6 @@ public class GainPlusOneLifeReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/ModifyCountersAddedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/ModifyCountersAddedEffect.java
@@ -58,11 +58,6 @@ public class ModifyCountersAddedEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public ModifyCountersAddedEffect copy() {
         return new ModifyCountersAddedEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/effects/keyword/FinalityCounterEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/FinalityCounterEffect.java
@@ -49,9 +49,4 @@ public class FinalityCounterEffect extends ReplacementEffectImpl {
         Permanent permanent = game.getPermanent(event.getTargetId());
         return permanent != null && permanent.getCounters(game).getCount(CounterType.FINALITY) > 0;
     }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/BuybackAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BuybackAbility.java
@@ -205,11 +205,6 @@ class BuybackEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Card card = game.getCard(source.getSourceId());
         if (card != null && source instanceof BuybackAbility) {

--- a/Mage/src/main/java/mage/abilities/keyword/DredgeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/DredgeAbility.java
@@ -58,11 +58,6 @@ class DredgeEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Card sourceCard = game.getCard(source.getSourceId());
         if (sourceCard == null) {

--- a/Mage/src/main/java/mage/abilities/keyword/EnlistAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/EnlistAbility.java
@@ -78,11 +78,6 @@ class EnlistEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = game.getPermanent(event.getSourceId());
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/keyword/ExertAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ExertAbility.java
@@ -99,11 +99,6 @@ class ExertReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = game.getPermanent(event.getSourceId());
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/keyword/FlashbackAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/FlashbackAbility.java
@@ -201,11 +201,6 @@ class FlashbackReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage/src/main/java/mage/abilities/keyword/JumpStartAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/JumpStartAbility.java
@@ -103,11 +103,6 @@ class JumpStartReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage/src/main/java/mage/abilities/keyword/MadnessAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/MadnessAbility.java
@@ -120,11 +120,6 @@ class MadnessReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller == null) {

--- a/Mage/src/main/java/mage/abilities/keyword/RiotAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RiotAbility.java
@@ -61,11 +61,6 @@ class RiotReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/abilities/keyword/TotemArmorAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TotemArmorAbility.java
@@ -76,11 +76,6 @@ class TotemArmorEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public TotemArmorEffect copy() {
         return new TotemArmorEffect(this);
     }

--- a/Mage/src/main/java/mage/abilities/keyword/UnleashAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/UnleashAbility.java
@@ -64,11 +64,6 @@ class UnleashReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
         Player controller = game.getPlayer(source.getControllerId());

--- a/Mage/src/main/java/mage/game/command/emblems/AjaniSteadfastEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/AjaniSteadfastEmblem.java
@@ -53,11 +53,6 @@ class AjaniSteadfastPreventEffect extends PreventionEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (event.getType() == GameEvent.EventType.DAMAGE_PLAYER
                 && event.getTargetId().equals(source.getControllerId())) {

--- a/Mage/src/main/java/mage/game/command/emblems/JayaBallardEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/JayaBallardEmblem.java
@@ -96,11 +96,6 @@ class JayaBallardReplacementEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {

--- a/Mage/src/main/java/mage/game/command/emblems/SerraTheBenevolentEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/SerraTheBenevolentEmblem.java
@@ -71,11 +71,6 @@ class SerraTheBenevolentEmblemEffect extends ReplacementEffectImpl {
     }
 
     @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
-    @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return false;
     }


### PR DESCRIPTION
For whatever reason, a huge number of replacement effects were overriding this method in `ReplacementEffectImpl`:

https://github.com/magefree/mage/blob/f75b1c9f0aa8f17c6df4e2570c39739a9a2691b7/Mage/src/main/java/mage/abilities/effects/ReplacementEffectImpl.java#L53-L56

The vast majority were overriding just to return `true` or `false`, so most of this PR is removing that boilerplate.

However, `RegenerateSourceEffect`, `RegenerateTargetEffect`, and a subclass of each were re-implementing the `apply()` method to be called from `replaceEvent()`, obscuring the intent of the code structure. I simply moved the code back to `replaceEvent()` where it belongs. Test coverage provided by `SoldeviSentryTest` and `DebtOfLoyaltyTest`.

This allowed for the removal of all overrides so the method that throws the unsupported operation exception can now be marked as final.