### PR TITLE
[VIS] Implement Heat Wave

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HeatWave.java
+++ b/Mage.Sets/src/mage/cards/h/HeatWave.java
@@ -97,12 +97,12 @@ class HeatWaveEffect2 extends ReplacementEffectImpl {
         }
 
         Permanent blocker = game.getPermanent(event.getSourceId());
-        if (blocker.getColor(game).isBlue()) {
+        if (blocker == null || blocker.getColor(game).isBlue()) {
             return false;
         }
 
         Permanent attacker = game.getPermanent(event.getTargetId());
-        if (!attacker.isControlledBy(source.getControllerId())) {
+        if (attacker == null || !attacker.isControlledBy(source.getControllerId())) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/h/HeatWave.java
+++ b/Mage.Sets/src/mage/cards/h/HeatWave.java
@@ -1,0 +1,131 @@
+package mage.cards.h;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.ReplacementEffect;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.RestrictionEffect;
+import mage.abilities.keyword.CumulativeUpkeepAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+import java.util.UUID;
+
+/**
+ * @author Cguy7777
+ */
+public final class HeatWave extends CardImpl {
+
+    public HeatWave(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{R}");
+
+        // Cumulative upkeep {R}
+        this.addAbility(new CumulativeUpkeepAbility(new ManaCostsImpl<>("{R}")));
+
+        // Blue creatures can't block creatures you control.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new HeatWaveEffect1()));
+
+        // Nonblue creatures can't block creatures you control unless their controller pays 1 life for each blocking creature they control.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new HeatWaveEffect2()));
+
+    }
+
+    private HeatWave(final HeatWave card) {
+        super(card);
+    }
+
+    @Override
+    public HeatWave copy() {
+        return new HeatWave(this);
+    }
+}
+
+class HeatWaveEffect1 extends RestrictionEffect {
+
+    HeatWaveEffect1() {
+        super(Duration.WhileOnBattlefield);
+        staticText = "Blue creatures can't block creatures you control";
+    }
+
+    private HeatWaveEffect1(final HeatWaveEffect1 effect) {
+        super(effect);
+    }
+
+    @Override
+    public ContinuousEffect copy() {
+        return new HeatWaveEffect1(this);
+    }
+
+    @Override
+    public boolean applies(Permanent permanent, Ability source, Game game) {
+        return true;
+    }
+
+    @Override
+    public boolean canBlock(Permanent attacker, Permanent blocker, Ability source, Game game, boolean canUseChooseDialogs) {
+        return attacker == null || !attacker.isControlledBy(source.getControllerId()) || !blocker.getColor(game).isBlue();
+    }
+}
+
+class HeatWaveEffect2 extends ReplacementEffectImpl {
+
+    HeatWaveEffect2() {
+        super(Duration.WhileOnBattlefield, Outcome.Detriment);
+        staticText = "Nonblue creatures can't block creatures you control unless their controller pays 1 life for each blocking creature they control";
+    }
+
+    private HeatWaveEffect2(final HeatWaveEffect2 effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Player player = game.getPlayer(event.getPlayerId());
+        if (player == null) {
+            return false;
+        }
+
+        Permanent blocker = game.getPermanent(event.getSourceId());
+        if (blocker.getColor(game).isBlue()) {
+            return false;
+        }
+
+        Permanent attacker = game.getPermanent(event.getTargetId());
+        if (!attacker.isControlledBy(source.getControllerId())) {
+            return false;
+        }
+
+        PayLifeCost cost = new PayLifeCost(1);
+        if (cost.canPay(source, source, player.getId(), game)
+                && player.chooseUse(Outcome.Benefit, "Pay 1 life to declare blocker?", source, game)) {
+            return !cost.pay(source, game, source, player.getId(), true, cost);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DECLARE_BLOCKER;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return true;
+    }
+
+    @Override
+    public ReplacementEffect copy() {
+        return new HeatWaveEffect2(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Visions.java
+++ b/Mage.Sets/src/mage/sets/Visions.java
@@ -80,6 +80,7 @@ public final class Visions extends ExpansionSet {
         cards.add(new SetCardInfo("Griffin Canyon", 163, Rarity.RARE, mage.cards.g.GriffinCanyon.class));
         cards.add(new SetCardInfo("Guiding Spirit", 131, Rarity.RARE, mage.cards.g.GuidingSpirit.class));
         cards.add(new SetCardInfo("Hearth Charm", 82, Rarity.COMMON, mage.cards.h.HearthCharm.class));
+        cards.add(new SetCardInfo("Heat Wave", 83, Rarity.UNCOMMON, mage.cards.h.HeatWave.class));
         cards.add(new SetCardInfo("Helm of Awakening", 145, Rarity.UNCOMMON, mage.cards.h.HelmOfAwakening.class));
         cards.add(new SetCardInfo("Honorable Passage", 7, Rarity.UNCOMMON, mage.cards.h.HonorablePassage.class));
         cards.add(new SetCardInfo("Hope Charm", 8, Rarity.COMMON, mage.cards.h.HopeCharm.class));


### PR DESCRIPTION
In both of the effects I wrote for this, I have `applies()` simply `return true`. That's in line with similar cards that I looked at while working on this, but I just want to make sure that this is fine?

Fun fact: Once this is in, XMage will support every cumulative upkeep card that's in-scope! The only missing cards will be Balduvian Shaman (text-changing effect) and Toy Boat (impossible silver-border).