### PR TITLE
Small rework for autochoosing color of mana to add

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -24,7 +24,6 @@ import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
 import mage.choices.Choice;
-import mage.choices.ChoiceColor;
 import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.FilterCard;
@@ -1956,7 +1955,7 @@ public class ComputerPlayer extends PlayerImpl implements Player {
         }
 
         // choose the correct color to pay a spell
-        if (outcome == Outcome.PutManaInPool && choice instanceof ChoiceColor && currentUnpaidMana != null) {
+        if (outcome == Outcome.PutManaInPool && choice.isManaColorChoice() && currentUnpaidMana != null) {
             if (currentUnpaidMana.containsColor(ColoredManaSymbol.W) && choice.getChoices().contains("White")) {
                 choice.setChoice("White");
                 return true;

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -16,7 +16,6 @@ import mage.abilities.mana.ManaAbility;
 import mage.cards.*;
 import mage.cards.decks.Deck;
 import mage.choices.Choice;
-import mage.choices.ChoiceColor;
 import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.filter.StaticFilters;
@@ -583,7 +582,7 @@ public class HumanPlayer extends PlayerImpl {
         }
 
         // Try to autopay for mana
-        if (Outcome.PutManaInPool == outcome && choice instanceof ChoiceColor && currentlyUnpaidMana != null) {
+        if (Outcome.PutManaInPool == outcome && choice.isManaColorChoice() && currentlyUnpaidMana != null) {
             // Check check if the spell being paid for cares about the color of mana being paid
             // See: https://github.com/magefree/mage/issues/9070
             boolean caresAboutManaColor = false;

--- a/Mage.Sets/src/mage/cards/k/KatildaDawnhartPrime.java
+++ b/Mage.Sets/src/mage/cards/k/KatildaDawnhartPrime.java
@@ -150,7 +150,7 @@ class KatildaDawnhartPrimeManaEffect extends ManaEffect {
         if (controller == null || permanent == null) {
             return new Mana();
         }
-        Choice choice = new ChoiceImpl();
+        Choice choice = new ChoiceImpl().setManaColorChoice(true);
         choice.setMessage("Pick a mana color");
         ObjectColor color = permanent.getColor(game);
         if (color.isWhite()) {

--- a/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
+++ b/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
@@ -195,7 +195,7 @@ class TazriStalwartSurvivorManaEffect extends ManaEffect {
         if (controller == null || permanent == null) {
             return new Mana();
         }
-        Choice choice = new ChoiceImpl();
+        Choice choice = new ChoiceImpl().setManaColorChoice(true);
         choice.setMessage("Pick a mana color");
         ObjectColor color = permanent.getColor(game);
         if (color.isWhite()) {

--- a/Mage/src/main/java/mage/abilities/mana/CommanderColorIdentityManaAbility.java
+++ b/Mage/src/main/java/mage/abilities/mana/CommanderColorIdentityManaAbility.java
@@ -106,7 +106,7 @@ class CommanderIdentityManaEffect extends ManaEffect {
         }
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            Choice choice = new ChoiceImpl();
+            Choice choice = new ChoiceImpl().setManaColorChoice(true);
             choice.setMessage("Pick a mana color");
             for (UUID commanderId : game.getCommandersIds(controller, CommanderCardType.COMMANDER_OR_OATHBREAKER, false)) {
                 Card commander = game.getCard(commanderId);

--- a/Mage/src/main/java/mage/choices/Choice.java
+++ b/Mage/src/main/java/mage/choices/Choice.java
@@ -41,6 +41,10 @@ public interface Choice extends Serializable, Copyable<Choice> {
 
     ChoiceHintType getHintType();
 
+    boolean isManaColorChoice();
+
+    Choice setManaColorChoice(boolean manaColorChoice);
+
     // string choice
     void setChoices(Set<String> choices);
 

--- a/Mage/src/main/java/mage/choices/ChoiceColor.java
+++ b/Mage/src/main/java/mage/choices/ChoiceColor.java
@@ -47,6 +47,7 @@ public class ChoiceColor extends ChoiceImpl {
 
         this.setMessage(chooseMessage);
         this.setSubMessage(chooseSubMessage);
+        this.manaColorChoice = true;
     }
 
     protected ChoiceColor(final ChoiceColor choice) {

--- a/Mage/src/main/java/mage/choices/ChoiceImpl.java
+++ b/Mage/src/main/java/mage/choices/ChoiceImpl.java
@@ -34,6 +34,8 @@ public class ChoiceImpl implements Choice {
     protected String specialText = "";
     protected String specialHint = "";
 
+    protected boolean manaColorChoice = false; // set true to allow automatic choosing with Outcome.PutManaInPool
+
     public ChoiceImpl() {
         this(false);
     }
@@ -65,6 +67,7 @@ public class ChoiceImpl implements Choice {
         this.specialCanBeEmpty = choice.specialCanBeEmpty;
         this.specialText = choice.specialText;
         this.specialHint = choice.specialHint;
+        this.manaColorChoice = choice.manaColorChoice;
     }
 
     @Override
@@ -326,6 +329,17 @@ public class ChoiceImpl implements Choice {
     @Override
     public ChoiceHintType getHintType() {
         return this.hintType;
+    }
+
+    @Override
+    public boolean isManaColorChoice() {
+        return manaColorChoice;
+    }
+
+    @Override
+    public ChoiceImpl setManaColorChoice(boolean manaColorChoice) {
+        this.manaColorChoice = manaColorChoice;
+        return this;
     }
 
     private void protectFromEmptyChoices() {


### PR DESCRIPTION
This should fix #11494. I prefer a style with explicit parameters rather than instanceof checks, even though it requires more getters and setters.

There's probably room to refactor the technique of creating a choice for adding mana of a color corresponding to some object or set of objects, but I consider that a separate scope.