### PR TITLE
MageObjectReference usage

### DIFF
--- a/Mage/src/main/java/mage/MageObjectReference.java
+++ b/Mage/src/main/java/mage/MageObjectReference.java
@@ -172,11 +172,7 @@ public class MageObjectReference implements Comparable<MageObjectReference>, Ser
     }
 
     public Permanent getPermanentOrLKIBattlefield(Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(sourceId);
-        if (permanent != null && permanent.getZoneChangeCounter(game) == zoneChangeCounter) {
-            return permanent;
-        }
-        return null;
+        return game.getPermanentOrLKIBattlefield(this);
     }
 
     public Card getCard(Game game) {

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -112,8 +112,25 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
      */
     Permanent getPermanent(UUID permanentId);
 
+    /**
+     * Given the UUID of a permanent, this method returns the permanent. If the current game state does not contain
+     * a permanent with the given UUID, this method checks the last known information on the battlefield to look for it.
+     * <br>
+     * Warning: if the permanent has left the battlefield and then returned, this information might be wrong.
+     * Prefer usage of a MageObjectReference instead of only the UUID.
+     *
+     * @param permanentId - The UUID of the permanent
+     * @return permanent or permanent's LKI
+     */
     Permanent getPermanentOrLKIBattlefield(UUID permanentId);
 
+    /**
+     * Given a MageObjectReference to a permanent, this method returns the permanent. If the current game state does not
+     * contain that permanent, this method checks the last known information on the battlefield.
+     *
+     * @param permanentRef - A MOR to the permanent
+     * @return permanent or permanent's LKI
+     */
     Permanent getPermanentOrLKIBattlefield(MageObjectReference permanentRef);
 
     Permanent getPermanentEntering(UUID permanentId);

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -114,6 +114,8 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
 
     Permanent getPermanentOrLKIBattlefield(UUID permanentId);
 
+    Permanent getPermanentOrLKIBattlefield(MageObjectReference permanentRef);
+
     Permanent getPermanentEntering(UUID permanentId);
 
     Map<UUID, Permanent> getPermanentsEntering();

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -716,6 +716,15 @@ public abstract class GameImpl implements Game {
         }
         return permanent;
     }
+    @Override
+    public Permanent getPermanentOrLKIBattlefield(MageObjectReference permanentRef) {
+        UUID id = permanentRef.getSourceId();
+        Permanent permanent = state.getPermanent(id);
+        if (permanent == null || state.getZoneChangeCounter(id) != permanentRef.getZoneChangeCounter()) {
+            permanent = (Permanent) this.getLastKnownInformation(id, Zone.BATTLEFIELD, permanentRef.getZoneChangeCounter());
+        }
+        return permanent;
+    }
 
     @Override
     public Permanent getPermanentEntering(UUID permanentId) {

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -716,6 +716,7 @@ public abstract class GameImpl implements Game {
         }
         return permanent;
     }
+
     @Override
     public Permanent getPermanentOrLKIBattlefield(MageObjectReference permanentRef) {
         UUID id = permanentRef.getSourceId();

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -1375,7 +1375,7 @@ public class GameState implements Serializable, Copyable<GameState> {
     public void cleanupPermanentCostsTags(Game game){
         getPermanentCostsTags().entrySet().removeIf(entry ->
                 !(entry.getKey().getZoneChangeCounter() == game.getState().getZoneChangeCounter(entry.getKey().getSourceId())-1)
-        );
+        ); // The stored MOR is the stack-moment MOR so need to subtract one from the permanent's ZCC for the check
     }
 
     public void addWatcher(Watcher watcher) {

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -1374,7 +1374,7 @@ public class GameState implements Serializable, Copyable<GameState> {
      */
     public void cleanupPermanentCostsTags(Game game){
         getPermanentCostsTags().entrySet().removeIf(entry ->
-                !(entry.getKey().zoneCounterIsCurrent(game))
+                !(entry.getKey().getZoneChangeCounter() == game.getState().getZoneChangeCounter(entry.getKey().getSourceId())-1)
         );
     }
 


### PR DESCRIPTION
First of all, permanent cost tags were being incorrectly cleared due to checking if the stack moment zcc was equal to the battlefield zcc. This has been fixed.

Secondly, `getPermanentOrLKIBattlefield` is incorrect: since its only input is the UUID, if that card left the battlefield and then returned, it will find the new permanent instead of correctly returning the LKI. I can think of no circumstance in which the current behavior is desired.

Since this function is used hundreds of times across the code base I'm not going to attempt to fix all usage of it here, just provide an alternative option and fix the helper function on `MageObjectReference` itself. Maybe I should add a deprecated tag as well?