### PR TITLE
Counter text improvements (plus a Magus Lucea Kane gamplay fix)

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MagusLuceaKane.java
+++ b/Mage.Sets/src/mage/cards/m/MagusLuceaKane.java
@@ -104,11 +104,9 @@ class MagusLuceaKaneTriggeredAbility extends DelayedTriggeredAbility {
         // spell
         if (event.getType() == GameEvent.EventType.SPELL_CAST) {
             Spell spell = game.getStack().getSpell(event.getTargetId());
-            if (spell != null && spell.isInstantOrSorcery(game)) {
-                if (spell.getSpellAbility().getManaCostsToPay().containsX()) {
-                    this.getEffects().setValue("stackObject", (StackObject) spell);
-                    return true;
-                }
+            if (spell != null && spell.getSpellAbility().getManaCostsToPay().containsX()) {
+                this.getEffects().setValue("stackObject", (StackObject) spell);
+                return true;
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/p/PhantomNomad.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomNomad.java
@@ -30,7 +30,7 @@ public final class PhantomNomad extends CardImpl {
 
         // Phantom Nomad enters the battlefield with two +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)),
-                "two +1/+1 counters on it"));
+                "with two +1/+1 counters on it"));
 
         // If damage would be dealt to Phantom Nomad, prevent that damage. Remove a +1/+1 counter from Phantom Nomad.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));

--- a/Mage.Sets/src/mage/cards/t/ThaliasLieutenant.java
+++ b/Mage.Sets/src/mage/cards/t/ThaliasLieutenant.java
@@ -20,7 +20,7 @@ import java.util.UUID;
  */
 public final class ThaliasLieutenant extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("another Human");
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("other Human you control");
 
     static {
         filter.add(AnotherPredicate.instance);
@@ -35,7 +35,7 @@ public final class ThaliasLieutenant extends CardImpl {
         this.toughness = new MageInt(1);
 
         // When Thalia's Lieutenant enters the battlefield, put +1/+1 counter on each other Human you control.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter).setText("put +1/+1 counter on each other Human you control"), false));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter), false));
 
         // Whenever another Human enters the battlefield under you control, put a +1/+1 counter on Thalia's Lieutenant.
         this.addAbility(new EntersBattlefieldControlledTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), filter));

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
@@ -16,19 +16,16 @@ import mage.util.CardUtil;
  */
 public class PutCountersSourceCost extends CostImpl {
 
-    private final String name;
     private final Counter counter;
 
     public PutCountersSourceCost(Counter counter) {
         this.counter = counter.copy();
-        this.name = counter.getName();
         this.text = "Put " + counter.getDescription() + " on {this}";
     }
 
     public PutCountersSourceCost(PutCountersSourceCost cost) {
         super(cost);
         this.counter = cost.counter;
-        this.name = cost.name;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
@@ -16,22 +16,18 @@ import mage.util.CardUtil;
  */
 public class PutCountersSourceCost extends CostImpl {
 
-    private final int amount;
     private final String name;
     private final Counter counter;
 
     public PutCountersSourceCost(Counter counter) {
         this.counter = counter.copy();
-        this.amount = counter.getCount();
         this.name = counter.getName();
-        this.text = "Put " + CardUtil.numberToText(amount, "a") +
-                " " + name + " counter" + (amount != 1 ? "s" : "") + " on {this}";
+        this.text = "Put " + counter.getDescription() + " on {this}";
     }
 
     public PutCountersSourceCost(PutCountersSourceCost cost) {
         super(cost);
         this.counter = cost.counter;
-        this.amount = cost.amount;
         this.name = cost.name;
     }
 

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCountersSourceCost.java
@@ -24,10 +24,8 @@ public class PutCountersSourceCost extends CostImpl {
         this.counter = counter.copy();
         this.amount = counter.getCount();
         this.name = counter.getName();
-        this.text = new StringBuilder("Put ").append((amount == 1 ? "a" : CardUtil.numberToText(amount)))
-                .append(' ').append(name).append(" counter").append((amount != 1 ? "s" : ""))
-                .append(" on {this}").toString();
-
+        this.text = "Put " + CardUtil.numberToText(amount, "a") +
+                " " + name + " counter" + (amount != 1 ? "s" : "") + " on {this}";
     }
 
     public PutCountersSourceCost(PutCountersSourceCost cost) {

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddPoisonCounterTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddPoisonCounterTargetEffect.java
@@ -53,6 +53,6 @@ public class AddPoisonCounterTargetEffect extends OneShotEffect {
         }
         return getTargetPointer().describeTargets(mode.getTargets(), "it") +
                 (getTargetPointer().isPlural(mode.getTargets()) ? " get " : " gets ") +
-                CardUtil.numberToText(amount, "a") + " poison counter" + (amount > 1 ? "s" : "");
+                CardUtil.getSimpleCountersText(amount, "a",  "poison");
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/GetEnergyCountersControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/GetEnergyCountersControllerEffect.java
@@ -57,9 +57,7 @@ public class GetEnergyCountersControllerEffect extends OneShotEffect {
             sb.append("{E}");
         }
         sb.append(" <i>(");
-        sb.append(CardUtil.numberToText(val, "an"));
-        sb.append(" energy counter");
-        sb.append(val > 1 ? "s" : "");
+        sb.append(CardUtil.getSimpleCountersText(val, "an",  "energy"));
         sb.append(")</i>");
         if ((value instanceof StaticValue)) {
             sb.append('.');

--- a/Mage/src/main/java/mage/abilities/effects/keyword/IncubateEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/IncubateEffect.java
@@ -23,7 +23,7 @@ public class IncubateEffect extends OneShotEffect {
         super(Outcome.Detriment);
         this.amount = amount;
         staticText = "incubate " + amount + ". <i>(Create an Incubator artifact token with " +
-                CardUtil.numberToText(amount, "a") + " +1/+1 counter" + (amount > 1 ? "s" : "") +
+                CardUtil.getOneOneCountersText(amount) +
                 " on it and \"{2}: Transform this artifact.\" It transforms into a 0/0 Phyrexian artifact creature.)</i>";
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/AwakenAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/AwakenAbility.java
@@ -52,8 +52,8 @@ public class AwakenAbility extends SpellAbility {
         this.awakenValue = awakenValue;
         rule = "Awaken " + awakenValue + "&mdash;" + awakenCosts
                 + " <i>(If you cast this spell for " + awakenCosts + ", also put "
-                + CardUtil.numberToText(awakenValue, "a")
-                + " +1/+1 counters on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)</i>";
+                + CardUtil.getOneOneCountersText(awakenValue)
+                + " on target land you control and it becomes a 0/0 Elemental creature with haste. It's still a land.)</i>";
     }
 
     protected AwakenAbility(final AwakenAbility ability) {
@@ -81,7 +81,7 @@ public class AwakenAbility extends SpellAbility {
 
         private AwakenEffect() {
             super(Outcome.BoostCreature);
-            this.staticText = "put " + CardUtil.numberToText(awakenValue, "a") + " +1/+1 counters on target land you control";
+            this.staticText = "put " + CardUtil.getOneOneCountersText(awakenValue) +" on target land you control";
         }
 
         protected AwakenEffect(final AwakenEffect effect) {

--- a/Mage/src/main/java/mage/abilities/keyword/BackupAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BackupAbility.java
@@ -71,9 +71,10 @@ public class BackupAbility extends EntersBattlefieldTriggeredAbility {
 
     @Override
     public String getRule() {
-        return "Backup " + amount + " <i>(When this creature enters the battlefield, " +
-                "put a +1/+1 counter on target creature. If that's another creature, " +
-                "it gains the following abilit" + (abilitiesToAdd.size() > 1 ? "ies" : "y") + " until end of turn.)</i>";
+        return "Backup " + amount + " <i>(When this creature enters the battlefield," +
+                " put" +CardUtil.numberToText(amount, "a")+" 1/+1 counter"+ (amount==1 ? "" : "s")
+                +" on target creature. If that's another creature, it gains the following"
+                +" abilit" + (abilitiesToAdd.size() > 1 ? "ies" : "y") + " until end of turn.)</i>";
     }
 
     public void addAbility(Ability ability) {

--- a/Mage/src/main/java/mage/abilities/keyword/BackupAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BackupAbility.java
@@ -72,7 +72,7 @@ public class BackupAbility extends EntersBattlefieldTriggeredAbility {
     @Override
     public String getRule() {
         return "Backup " + amount + " <i>(When this creature enters the battlefield," +
-                " put" +CardUtil.numberToText(amount, "a")+" 1/+1 counter"+ (amount==1 ? "" : "s")
+                " put " + CardUtil.getOneOneCountersText(amount)
                 +" on target creature. If that's another creature, it gains the following"
                 +" abilit" + (abilitiesToAdd.size() > 1 ? "ies" : "y") + " until end of turn.)</i>";
     }

--- a/Mage/src/main/java/mage/abilities/keyword/BloodthirstAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/BloodthirstAbility.java
@@ -39,15 +39,9 @@ public class BloodthirstAbility extends EntersBattlefieldAbility {
 
     @Override
     public String getRule() {
-        StringBuilder sb = new StringBuilder("Bloodthirst ").append(amount)
-                .append(" <i>(If an opponent was dealt damage this turn, this creature enters the battlefield with ");
-        if (amount == 1) {
-            sb.append("a +1/+1 counter");
-        } else {
-            sb.append(CardUtil.numberToText(amount)).append(" +1/+1 counters");
-        }
-        sb.append(" on it.)</i>");
-        return sb.toString();
+        return "Bloodthirst " + amount +
+                " <i>(If an opponent was dealt damage this turn, this creature enters the battlefield with " +
+                CardUtil.getOneOneCountersText(amount) + " on it.)</i>";
     }
 }
 

--- a/Mage/src/main/java/mage/abilities/keyword/FabricateAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/FabricateAbility.java
@@ -38,7 +38,7 @@ public class FabricateAbility extends EntersBattlefieldTriggeredAbility {
     @Override
     public String getRule() {
         return "Fabricate " + value + " <i>(When this creature enters the battlefield, put "
-                + CardUtil.numberToText(value, "a") + " +1/+1 counter" + (value > 1 ? "s" : "")
+                + CardUtil.getOneOneCountersText(value)
                 + " on it or create " + CardUtil.numberToText(value, "a")
                 + " 1/1 colorless Servo artifact creature token" + (value > 1 ? "s" : "") + ".)</i>";
     }
@@ -72,7 +72,7 @@ class FabricateEffect extends OneShotEffect {
                     Outcome.BoostCreature,
                     "Fabricate " + value,
                     null,
-                    "Put " + CardUtil.numberToText(value, "a") + " +1/+1 counter" + (value > 1 ? "s" : ""),
+                    "Put " + CardUtil.getOneOneCountersText(value),
                     "Create " + CardUtil.numberToText(value, "a") + " 1/1 token" + (value > 1 ? "s" : ""),
                     source,
                     game)) {

--- a/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
@@ -87,10 +87,9 @@ public class GraftAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        return "Graft" + ' ' + amount
-                + " <i>(This " + cardtype + " enters the battlefield with " + CardUtil.getOneOneCountersText(amount)
-                +" on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this "
-                + cardtype + " onto it.)</i>";
+        return "Graft" + ' ' + amount + " <i>(This " + cardtype + " enters the battlefield with "
+                + CardUtil.getOneOneCountersText(amount) + " on it. Whenever " + (cardtype.contains("creature") ? "another" : "a")
+                + " creature enters the battlefield, you may move a +1/+1 counter from this " + cardtype + " onto it.)</i>";
     }
 
 }
@@ -101,7 +100,7 @@ class GraftStaticAbility extends StaticAbility {
 
     public GraftStaticAbility(int amount) {
         super(Zone.ALL, new EntersBattlefieldEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(amount))));
-        ruleText = new StringBuilder("This enters the battlefield with ").append(amount).append(" +1/+1 counter on it.").toString();
+        ruleText = "This enters the battlefield with " + CardUtil.getOneOneCountersText(amount) + " on it.";
         this.setRuleVisible(false);
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
@@ -87,12 +87,10 @@ public class GraftAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        StringBuilder sb = new StringBuilder("Graft");
-        sb.append(' ').append(amount).append(" <i>(This ").append(cardtype).append(" enters the battlefield with ")
-                .append(amount == 1 ? "a" : CardUtil.numberToText(amount))
-                .append(" +1/+1 counter on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this ")
-                .append(cardtype).append(" onto it.)</i>");
-        return sb.toString();
+        return "Graft" + ' ' + amount
+                + " <i>(This " + cardtype + " enters the battlefield with " + CardUtil.getOneOneCountersText(amount)
+                +" on it. Whenever a creature enters the battlefield, you may move a +1/+1 counter from this "
+                + cardtype + " onto it.)</i>";
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/keyword/ModularAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ModularAbility.java
@@ -89,16 +89,14 @@ public class ModularAbility extends DiesSourceTriggeredAbility {
 
     @Override
     public String getRule() {
-        StringBuilder sb = new StringBuilder("Modular");
         if (sunburst) {
-            sb.append("&mdash;Sunburst <i>(This enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it. When it dies, you may put its +1/+1 counters on target artifact creature.)</i>");
+            return "Modular&mdash;Sunburst <i>(This enters the battlefield with a +1/+1 counter on it for each"
+            + " color of mana spent to cast it. When it dies, you may put its +1/+1 counters on target artifact creature.)</i>";
         } else {
-            sb.append(' ').append(amount).append(" <i>(This creature enters the battlefield with ")
-                    .append(CardUtil.numberToText(amount, "a"))
-                    .append(" +1/+1 counter").append(amount != 1 ? "s" : "")
-                    .append(" on it. When it dies, you may put its +1/+1 counters on target artifact creature.)</i>");
+            return "Modular " + amount + " <i>(This creature enters the battlefield with " +
+                    CardUtil.getOneOneCountersText(amount) +
+                    " on it. When it dies, you may put its +1/+1 counters on target artifact creature.)</i>";
         }
-        return sb.toString();
     }
 
     @Override
@@ -113,7 +111,7 @@ class ModularStaticAbility extends StaticAbility {
 
     ModularStaticAbility(int amount) {
         super(Zone.ALL, new EntersBattlefieldEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(amount))));
-        ruleText = "This enters the battlefield with " + CardUtil.numberToText(amount, "a") + " +1/+1 counter" + (amount != 1 ? "s" : "") + " on it.";
+        ruleText = "This enters the battlefield with " + CardUtil.getOneOneCountersText(amount) + " on it.";
         this.setRuleVisible(false);
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/ReinforceAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ReinforceAbility.java
@@ -42,16 +42,9 @@ public class ReinforceAbility extends SimpleActivatedAbility {
 
     @Override
     public String getRule() {
-        StringBuilder sb = new StringBuilder("Reinforce ");
-        sb.append(count.toString()).append("&mdash;");
-        sb.append(cost.getText());
-        sb.append(" <i>(").append(cost.getText()).append(", Discard this card: Put ");
-        if (count.toString().equals("1")) {
-            sb.append("a +1/+1 counter");
-        } else {
-            sb.append(CardUtil.numberToText(count.toString())).append(" +1/+1 counters");
-        }
-        sb.append(" on target creature.)</i>");
-        return sb.toString();
+        String countStr = count.toString();
+        return "Reinforce " + countStr + "&mdash;" + cost.getText() + " <i>(" + cost.getText() + ", Discard this card: Put "
+                + CardUtil.numberToText(countStr, "a") + " +1/+1 counter" + (countStr.equals("1")?"":"s")
+                + " on target creature.)</i>";
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/ToxicAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ToxicAbility.java
@@ -28,7 +28,7 @@ public class ToxicAbility extends StaticAbility {
     @Override
     public String getRule() {
         return "toxic " + amount + " <i>(Players dealt combat damage by this creature also get " +
-                CardUtil.numberToText(amount, "a") + " poison counter" + (amount > 1 ? "s" : "") + ".)</i>";
+                CardUtil.getSimpleCountersText(amount, "a", "poison") + ".)</i>";
     }
 
     @Override

--- a/Mage/src/main/java/mage/counters/Counter.java
+++ b/Mage/src/main/java/mage/counters/Counter.java
@@ -100,7 +100,7 @@ public class Counter implements Serializable, Copyable<Counter> {
      * @return a full description of this {@link Counter}
      */
     public String getDescription() {
-        return CardUtil.numberToText(Math.max(count, 1), CounterType.findArticle(name)) + ' ' + name + (count > 1 ? " counters" : " counter");
+        return CardUtil.getSimpleCountersText(Math.max(count, 1), CounterType.findArticle(name), name);
     }
 
     /**

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -904,6 +904,14 @@ public final class CardUtil {
         return Outcome.BoostCreature;
     }
 
+    public static String getSimpleCountersText(int amount, String forOne, String counterType) {
+        return numberToText(amount, forOne)+" "+counterType+" counter"+ (amount==1 ? "" : "s");
+    }
+
+    public static String getOneOneCountersText(int amount) {
+        return getSimpleCountersText(amount, "a", "+1/+1");
+    }
+
     public static String getAddRemoveCountersText(DynamicValue amount, Counter counter, String description, boolean add) {
         StringBuilder sb = new StringBuilder(add ? "put " : "remove ");
         boolean xValue = amount.toString().equals("X");


### PR DESCRIPTION
An instant or sorcery check was incorrectly added to Magus Lucea Kane while fixing #11440, this removes that. If we don't want to merge these text changes immediately I'll put that into a separate PR.

Backup incorrectly said "a +1/+1 counter" for higher numbers, fixed.

Adds some simple helper functions to `CardUtil` to make generating counter text simpler when you don't have easy access to the Counters object. We may want to consider splitting the text helpers into a separate file? (`ReinforceAbility` can't use this new function because it uses a string to handle the Reinforce X cards)

`PutCountersSourceCost` never actually uses two of its private variables, removed.

In Java, string building with the addition operator generates the same bytecode as using a string builder class unless appending in a loop, so simplifies some code involving that.