### PR TITLE
Fix Uba Mask

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UbaMask.java
+++ b/Mage.Sets/src/mage/cards/u/UbaMask.java
@@ -66,7 +66,16 @@ class UbaMaskReplacementEffect extends ReplacementEffectImpl {
         if (player != null && sourceObject != null) {
             Card card = player.getLibrary().getFromTop(game);
             if (card != null) {
-                if (player.moveCardsToExile(card, source, game, true, source.getSourceId(), sourceObject.getIdName())) {
+                UUID exileId = CardUtil.getExileZoneId(
+                        player.getId().toString()
+                                + "-" + game.getState().getTurnNum()
+                                + "-" + sourceObject.getIdName(), game
+                );
+                String exileName = sourceObject.getIdName() + " play on turn " + game.getState().getTurnNum()
+                        + " for " + player.getName();
+                game.getExile().createZone(exileId, exileName).setCleanupOnEndTurn(true);
+
+                if (player.moveCardsToExile(card, source, game, true, exileId, exileName)) {
                     UbaMaskExiledCardsWatcher watcher = game.getState().getWatcher(UbaMaskExiledCardsWatcher.class);
                     if (watcher != null) {
                         watcher.addExiledCard(event.getPlayerId(), card, game);
@@ -91,7 +100,7 @@ class UbaMaskReplacementEffect extends ReplacementEffectImpl {
 class UbaMaskPlayEffect extends AsThoughEffectImpl {
 
     public UbaMaskPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "Each player may play lands and cast spells from among cards they exiled with {this} this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/u/UbaMask.java
+++ b/Mage.Sets/src/mage/cards/u/UbaMask.java
@@ -10,6 +10,7 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.game.ExileZone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
@@ -69,7 +70,8 @@ class UbaMaskReplacementEffect extends ReplacementEffectImpl {
                 UUID exileId = CardUtil.getExileZoneId(
                         player.getId().toString()
                                 + "-" + game.getState().getTurnNum()
-                                + "-" + sourceObject.getIdName(), game
+                                + "-" + sourceObject.getIdName()
+                                + "-" + sourceObject.getZoneChangeCounter(game), game
                 );
                 String exileName = sourceObject.getIdName() + " play on turn " + game.getState().getTurnNum()
                         + " for " + player.getName();
@@ -128,8 +130,17 @@ class UbaMaskPlayEffect extends AsThoughEffectImpl {
             UbaMaskExiledCardsWatcher watcher = game.getState().getWatcher(UbaMaskExiledCardsWatcher.class);
             if (watcher != null) {
                 List<MageObjectReference> exiledThisTurn = watcher.getUbaMaskExiledCardsThisTurn(affectedControllerId);
+                UUID exileId = CardUtil.getExileZoneId(
+                            affectedControllerId
+                                + "-" + game.getState().getTurnNum()
+                                + "-" + source.getSourceObject(game).getIdName()
+                                + "-" + source.getSourceObject(game).getZoneChangeCounter(game), game
+                );
+                ExileZone exileZone = game.getExile().getExileZone(exileId);
                 return exiledThisTurn != null
-                        && exiledThisTurn.contains(new MageObjectReference(card, game));
+                        && exiledThisTurn.contains(new MageObjectReference(card, game))
+                        && exileZone != null
+                        && exileZone.contains(objectId);
             }
         }
         return false;


### PR DESCRIPTION
~~Related to #11512. Does not fix the gameplay issue of zone changes not being accounted for, just causes Uba Mask's exile zone to be cleared at end of each turn. Based on the implementation of Rashmi and Ragavan.~~

Fixes #11512