### PR TITLE
Bugfix Urza's Avenger, Jodah's Avenger, Multiform Wonder

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MultiformWonder.java
+++ b/Mage.Sets/src/mage/cards/m/MultiformWonder.java
@@ -1,18 +1,14 @@
 
 package mage.cards.m;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.PayEnergyCost;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.effects.common.counter.GetEnergyCountersControllerEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -24,8 +20,11 @@ import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.players.Player;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  *
@@ -115,22 +114,14 @@ class MultiformWonderEffect extends OneShotEffect {
     }
 }
 
-class MultiformWonder2Effect extends ContinuousEffectImpl {
-
-    private int power;
-    private int toughness;
-
+class MultiformWonder2Effect extends OneShotEffect {
     public MultiformWonder2Effect() {
-        super(Duration.EndOfTurn, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, Outcome.BoostCreature);
-        this.power = 2;
-        this.toughness = -2;
+        super(Outcome.BoostCreature);
         this.staticText = "{this} gets +2/-2 or -2/+2 until end of turn";
     }
 
     private MultiformWonder2Effect(final MultiformWonder2Effect effect) {
         super(effect);
-        this.power = effect.power;
-        this.toughness = effect.toughness;
     }
 
     @Override
@@ -139,26 +130,18 @@ class MultiformWonder2Effect extends ContinuousEffectImpl {
     }
 
     @Override
-    public void init(Ability source, Game game) {
-        super.init(source, game);
+    public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && sourceObject != null) {
+            int power = 2;
+            int toughness = -2;
             String message = "Should " + sourceObject.getLogName() + " get -2/+2 instead of +2/-2?";
             if (controller.chooseUse(Outcome.Neutral, message, source, game)) {
-                this.power *= -1;
-                this.toughness *= -1;
+                power *= -1;
+                toughness *= -1;
             }
-        }
-
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent sourceObject = game.getPermanent(source.getSourceId());
-        if (sourceObject != null) {
-            sourceObject.addPower(power);
-            sourceObject.addToughness(toughness);
+            game.addEffect(new BoostSourceEffect(power, toughness, Duration.EndOfTurn), source);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/u/UrzasAvenger.java
+++ b/Mage.Sets/src/mage/cards/u/UrzasAvenger.java
@@ -1,15 +1,12 @@
 
 package mage.cards.u;
 
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.keyword.BandingAbility;
 import mage.abilities.keyword.FirstStrikeAbility;
@@ -21,8 +18,11 @@ import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
 import mage.constants.*;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.players.Player;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  *
@@ -51,11 +51,9 @@ public final class UrzasAvenger extends CardImpl {
     }
 }
 
-class UrzasAvengerEffect extends ContinuousEffectImpl {
+class UrzasAvengerEffect extends OneShotEffect {
 
     private static final Set<String> choices = new LinkedHashSet<>();
-    private Ability gainedAbility;
-
     static {
         choices.add("Banding");
         choices.add("Flying");
@@ -64,7 +62,7 @@ class UrzasAvengerEffect extends ContinuousEffectImpl {
     }
 
     public UrzasAvengerEffect() {
-        super(Duration.EndOfTurn, Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, Outcome.AddAbility);
+        super(Outcome.AddAbility);
         this.staticText = "{this} gets -1/-1 and gains your choice of banding, flying, first strike, or trample until end of turn";
     }
 
@@ -76,16 +74,15 @@ class UrzasAvengerEffect extends ContinuousEffectImpl {
     public UrzasAvengerEffect copy() {
         return new UrzasAvengerEffect(this);
     }
-
     @Override
-    public void init(Ability source, Game game) {
-        super.init(source, game);
+    public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             Choice choice = new ChoiceImpl(true);
             choice.setMessage("Choose one");
             choice.setChoices(choices);
             if (controller.choose(outcome, choice, game)) {
+                Ability gainedAbility;
                 switch (choice.getChoice()) {
                     case "Banding":
                         gainedAbility = BandingAbility.getInstance();
@@ -100,18 +97,10 @@ class UrzasAvengerEffect extends ContinuousEffectImpl {
                         gainedAbility = TrampleAbility.getInstance();
                         break;
                 }
+                game.addEffect(new GainAbilitySourceEffect(gainedAbility, Duration.EndOfTurn), source);
+                game.addEffect(new BoostSourceEffect(-1, -1, Duration.EndOfTurn), source);
+                return true;
             }
-        }
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent sourceObject = game.getPermanent(source.getSourceId());
-        if (sourceObject != null) {
-            sourceObject.addPower(-1);
-            sourceObject.addToughness(-1);
-            game.addEffect(new GainAbilitySourceEffect(gainedAbility, Duration.EndOfTurn), source);
-            return true;
         }
         return false;
     }


### PR DESCRIPTION
Currently these cards will apply their boost/unboost effects after a zcc change since they're doing getPermanent with just the ID. This reworks them to be `OneShotEffect`s that add a `BoostSourceEffect`, which prevents that problem.