### PR TITLE
cleanup: CardsImpl and related

### DIFF
--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -462,7 +462,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                     break;
                 case EXILED:
                     if (game.getExile().getCard(getId(), game) != null) {
-                        removed = game.getExile().removeCard(this, game);
+                        removed = game.getExile().removeCard(this);
                     }
                     break;
                 case STACK:

--- a/Mage/src/main/java/mage/cards/Cards.java
+++ b/Mage/src/main/java/mage/cards/Cards.java
@@ -40,6 +40,9 @@ public interface Cards extends Set<UUID>, Serializable, Copyable<Cards> {
 
     Set<Card> getCards(Game game);
 
+    /**
+     * Warning: this method ignores ObjectSourcePlayer predicates in the filter
+     */
     Set<Card> getCards(FilterCard filter, Game game);
 
     Set<Card> getCards(FilterCard filter, UUID playerId, Ability source, Game game);
@@ -56,6 +59,9 @@ public interface Cards extends Set<UUID>, Serializable, Copyable<Cards> {
 
     Card getRandom(Game game);
 
+    /**
+     * Warning: this method ignores ObjectSourcePlayer predicates in the filter
+     */
     int count(FilterCard filter, Game game);
 
     int count(FilterCard filter, UUID playerId, Game game);

--- a/Mage/src/main/java/mage/game/Exile.java
+++ b/Mage/src/main/java/mage/game/Exile.java
@@ -45,11 +45,7 @@ public class Exile implements Serializable, Copyable<Exile> {
     }
 
     public ExileZone createZone(UUID id, String name) {
-        return createZone(id, name + " - Exile", false);
-    }
-
-    private ExileZone createZone(UUID id, String name, boolean hidden) {
-        return exileZones.computeIfAbsent(id, x -> new ExileZone(id, name, hidden));
+        return exileZones.computeIfAbsent(id, x -> new ExileZone(id, name + " - Exile"));
     }
 
     public ExileZone getExileZone(UUID id) {
@@ -77,10 +73,6 @@ public class Exile implements Serializable, Copyable<Exile> {
 
     /**
      * Return exiled cards owned by a specific player. Use it in effects to find all cards in range.
-     *
-     * @param game
-     * @param fromPlayerId
-     * @return
      */
     public List<Card> getAllCards(Game game, UUID fromPlayerId) {
         List<Card> res = new ArrayList<>();
@@ -102,7 +94,7 @@ public class Exile implements Serializable, Copyable<Exile> {
         return res;
     }
 
-    public boolean removeCard(Card card, Game game) {
+    public boolean removeCard(Card card) {
         for (ExileZone exile : exileZones.values()) {
             if (exile.contains(card.getId())) {
                 return exile.remove(card.getId());
@@ -113,10 +105,6 @@ public class Exile implements Serializable, Copyable<Exile> {
 
     /**
      * Move card from one exile zone to another. Use case example: create special zone for exiled and castable card.
-     *
-     * @param card
-     * @param game
-     * @param toZoneId
      */
     public void moveToAnotherZone(Card card, Game game, ExileZone exileZone) {
         if (getCard(card.getId(), game) == null) {
@@ -125,8 +113,7 @@ public class Exile implements Serializable, Copyable<Exile> {
         if (exileZone == null) {
             throw new IllegalArgumentException("Exile zone must exists: " + card.getIdName());
         }
-
-        removeCard(card, game);
+        removeCard(card);
         exileZone.add(card);
     }
 

--- a/Mage/src/main/java/mage/game/ExileZone.java
+++ b/Mage/src/main/java/mage/game/ExileZone.java
@@ -9,32 +9,20 @@ import java.util.UUID;
  */
 public class ExileZone extends CardsImpl {
 
-    private UUID id;
-    private String name;
-    private boolean hidden;
+    private final UUID id;
+    private final String name;
     private boolean cleanupOnEndTurn = false; // moved cards from that zone to default on end of turn (to cleanup exile windows)
 
     public ExileZone(UUID id, String name) {
-        this(id, name, false);
-    }
-
-    public ExileZone(UUID id, String name, boolean hidden) {
-        this(id, name, false, false);
-    }
-
-    public ExileZone(UUID id, String name, boolean hidden, boolean cleanupOnEndTurn) {
         super();
         this.id = id;
         this.name = name;
-        this.hidden = hidden;
-        this.cleanupOnEndTurn = cleanupOnEndTurn;
     }
 
     protected ExileZone(final ExileZone zone) {
         super(zone);
         this.id = zone.id;
         this.name = zone.name;
-        this.hidden = zone.hidden;
         this.cleanupOnEndTurn = zone.cleanupOnEndTurn;
     }
 
@@ -44,10 +32,6 @@ public class ExileZone extends CardsImpl {
 
     public String getName() {
         return name;
-    }
-
-    public boolean isHidden() {
-        return hidden;
     }
 
     public boolean isCleanupOnEndTurn() {

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -2338,7 +2338,7 @@ public abstract class GameImpl implements Game {
                 }
 
                 case EXILED: {
-                    getExile().removeCard(copiedCard, this);
+                    getExile().removeCard(copiedCard);
                     break;
                 }
 


### PR DESCRIPTION
This PR resolves #10548.

* Standardize `getCards()` overloaded methods to use LinkedHashSet and find Permanent before Card object
* Remove unused ownerId param from CardsImpl
* Remove unused hidden param from ExileZone and simplify constructors
* Add comments to warn about using filters without source param