### PR TITLE
[PIP] Implement Mr. House, President and CEO

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CyberneticaDatasmith.java
+++ b/Mage.Sets/src/mage/cards/c/CyberneticaDatasmith.java
@@ -15,7 +15,7 @@ import mage.constants.SubType;
 import mage.filter.FilterCard;
 import mage.filter.FilterPlayer;
 import mage.filter.predicate.other.AnotherTargetPredicate;
-import mage.game.permanent.token.RobotToken;
+import mage.game.permanent.token.RobotCantBlockToken;
 import mage.target.TargetPlayer;
 import mage.target.targetpointer.SecondTargetPointer;
 
@@ -48,7 +48,7 @@ public final class CyberneticaDatasmith extends CardImpl {
         // Field Reprogramming -- {U}, {T}: Target player draws a card. Another target player creates a 4/4 colorless Robot artifact creature token with "This creature can't block."
         Ability ability = new SimpleActivatedAbility(new DrawCardTargetEffect(1), new ManaCostsImpl<>("{U}"));
         ability.addCost(new TapSourceCost());
-        ability.addEffect(new CreateTokenTargetEffect(new RobotToken())
+        ability.addEffect(new CreateTokenTargetEffect(new RobotCantBlockToken())
                 .setTargetPointer(new SecondTargetPointer())
                 .concatBy("another"));
         ability.addTarget(new TargetPlayer()

--- a/Mage.Sets/src/mage/cards/m/MrHousePresidentAndCEO.java
+++ b/Mage.Sets/src/mage/cards/m/MrHousePresidentAndCEO.java
@@ -115,16 +115,15 @@ class MrHousePresidentAndCEOTokenEffect extends OneShotEffect {
         }
         int amount = (Integer) getValue("rolled");
 
+        if (amount >= 4) {
+            Token robotToken = new RobotToken();
+            robotToken.putOntoBattlefield(1, game, source);
+        }
         if (amount >= 6) {
             Token treasureToken = new TreasureToken();
             treasureToken.putOntoBattlefield(1, game, source);
         }
-        if (amount >= 4) {
-            Token robotToken = new RobotToken();
-            robotToken.putOntoBattlefield(1, game, source);
-            return true;
-        }
-        return false;
+        return amount >= 4;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/m/MrHousePresidentAndCEO.java
+++ b/Mage.Sets/src/mage/cards/m/MrHousePresidentAndCEO.java
@@ -1,0 +1,121 @@
+package mage.cards.m;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.game.Game;
+import mage.game.events.DieRolledEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.token.RobotToken;
+import mage.game.permanent.token.Token;
+import mage.game.permanent.token.TreasureToken;
+
+/**
+ *
+ * @author jimga150
+ */
+public final class MrHousePresidentAndCEO extends CardImpl {
+
+    public MrHousePresidentAndCEO(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{R}{W}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.power = new MageInt(0);
+        this.toughness = new MageInt(4);
+
+        // Whenever you roll a 4 or higher, create a 3/3 colorless Robot artifact creature token. If you rolled 6 or higher, instead create that token and a Treasure token.
+        this.addAbility(new MrHousePresidentAndCEOTriggeredAbility());
+
+        // {4}, {T}: Roll a six-sided die plus an additional six-sided die for each mana from Treasures spent to activate this ability.
+    }
+
+    private MrHousePresidentAndCEO(final MrHousePresidentAndCEO card) {
+        super(card);
+    }
+
+    @Override
+    public MrHousePresidentAndCEO copy() {
+        return new MrHousePresidentAndCEO(this);
+    }
+}
+
+// Based on As Luck Would Have It
+class MrHousePresidentAndCEOTriggeredAbility extends TriggeredAbilityImpl {
+
+    public MrHousePresidentAndCEOTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new MrHousePresidentAndCEOEffect(), false);
+    }
+
+    private MrHousePresidentAndCEOTriggeredAbility(final MrHousePresidentAndCEOTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public MrHousePresidentAndCEOTriggeredAbility copy() {
+        return new MrHousePresidentAndCEOTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DIE_ROLLED;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        DieRolledEvent drEvent = (DieRolledEvent) event;
+        if (this.isControlledBy(event.getPlayerId()) && drEvent.getRollDieType() == RollDieType.NUMERICAL) {
+            // looks for "result" instead "natural result"
+            int result = drEvent.getResult();
+            this.getEffects().setValue("rolled", result);
+            return result >= 4;
+        }
+        return false;
+    }
+
+    @Override
+    public String getRule(){
+        return "Whenever you roll a 4 or higher, create a 3/3 colorless Robot artifact creature token. " +
+                "If you rolled 6 or higher, instead create that token and a Treasure token.";
+    }
+}
+
+class MrHousePresidentAndCEOEffect extends OneShotEffect {
+
+    public MrHousePresidentAndCEOEffect() {
+        super(Outcome.Benefit);
+    }
+
+    private MrHousePresidentAndCEOEffect(final MrHousePresidentAndCEOEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MrHousePresidentAndCEOEffect copy() {
+        return new MrHousePresidentAndCEOEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        if (getValue("rolled") == null) {
+            return false;
+        }
+        int amount = (Integer) getValue("rolled");
+
+        if (amount >= 6){
+            Token treasureToken = new TreasureToken();
+            treasureToken.putOntoBattlefield(1, game, source);
+        }
+        if (amount >= 4){
+            Token robotToken = new RobotToken();
+            robotToken.putOntoBattlefield(1, game, source);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Fallout.java
+++ b/Mage.Sets/src/mage/sets/Fallout.java
@@ -28,6 +28,7 @@ public final class Fallout extends ExpansionSet {
         cards.add(new SetCardInfo("Intelligence Bobblehead", 134, Rarity.UNCOMMON, mage.cards.i.IntelligenceBobblehead.class));
         cards.add(new SetCardInfo("Island", 319, Rarity.LAND, mage.cards.basiclands.Island.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Mountain", 323, Rarity.LAND, mage.cards.basiclands.Mountain.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Mr. House, President and CEO", 7, Rarity.MYTHIC, mage.cards.m.MrHousePresidentAndCEO.class));
         cards.add(new SetCardInfo("Nuka-Cola Vending Machine", 137, Rarity.UNCOMMON, mage.cards.n.NukaColaVendingMachine.class));
         cards.add(new SetCardInfo("Plains", 317, Rarity.LAND, mage.cards.basiclands.Plains.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Radstorm", 37, Rarity.RARE, mage.cards.r.Radstorm.class));

--- a/Mage/src/main/java/mage/abilities/common/OneOrMoreDiceRolledTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/OneOrMoreDiceRolledTriggeredAbility.java
@@ -45,7 +45,7 @@ public class OneOrMoreDiceRolledTriggeredAbility extends TriggeredAbilityImpl {
         int maxRoll = ((DiceRolledEvent) event)
                 .getResults()
                 .stream()
-                .filter(Integer.class::isInstance) // only numerical die result can be masured
+                .filter(Integer.class::isInstance) // only numerical die result can be measured
                 .map(Integer.class::cast)
                 .mapToInt(Integer::intValue)
                 .max()
@@ -53,7 +53,7 @@ public class OneOrMoreDiceRolledTriggeredAbility extends TriggeredAbilityImpl {
         int totalRoll = ((DiceRolledEvent) event)
                 .getResults()
                 .stream()
-                .filter(Integer.class::isInstance) // only numerical die result can be masured
+                .filter(Integer.class::isInstance) // only numerical die result can be measured
                 .map(Integer.class::cast)
                 .mapToInt(Integer::intValue)
                 .sum();

--- a/Mage/src/main/java/mage/game/permanent/token/RobotCantBlockToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/RobotCantBlockToken.java
@@ -10,9 +10,9 @@ import mage.constants.SubType;
 /**
  * @author TheElk801
  */
-public final class RobotToken extends TokenImpl {
+public final class RobotCantBlockToken extends TokenImpl {
 
-    public RobotToken() {
+    public RobotCantBlockToken() {
         super("Robot Token", "4/4 colorless Robot artifact creature token with \"This creature can't block.\"");
         cardType.add(CardType.ARTIFACT);
         cardType.add(CardType.CREATURE);
@@ -25,11 +25,11 @@ public final class RobotToken extends TokenImpl {
         ));
     }
 
-    protected RobotToken(final RobotToken token) {
+    protected RobotCantBlockToken(final RobotCantBlockToken token) {
         super(token);
     }
 
-    public RobotToken copy() {
-        return new RobotToken(this);
+    public RobotCantBlockToken copy() {
+        return new RobotCantBlockToken(this);
     }
 }

--- a/Mage/src/main/java/mage/game/permanent/token/RobotToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/RobotToken.java
@@ -1,0 +1,28 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author TheElk801
+ */
+public final class RobotToken extends TokenImpl {
+
+    public RobotToken() {
+        super("Robot Token", "3/3 colorless Robot artifact creature token");
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        subtype.add(SubType.ROBOT);
+        power = new MageInt(3);
+        toughness = new MageInt(3);
+    }
+
+    protected RobotToken(final RobotToken token) {
+        super(token);
+    }
+
+    public RobotToken copy() {
+        return new RobotToken(this);
+    }
+}

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -1778,7 +1778,7 @@
 |Generate|TOK:40K|Insect|||InsectColorlessArtifactToken|
 |Generate|TOK:40K|Necron Warrior|||NecronWarriorToken|
 |Generate|TOK:40K|Plaguebearer of Nurgle|||PlaguebearerOfNurgleToken|
-|Generate|TOK:40K|Robot|||RobotToken|
+|Generate|TOK:40K|Robot|||RobotCantBlockToken|
 |Generate|TOK:40K|Soldier|1||SoldierToken|
 |Generate|TOK:40K|Soldier|2||SoldierToken|
 |Generate|TOK:40K|Soldier|3||SoldierToken|
@@ -2099,3 +2099,6 @@
 |Generate|TOK:WOC|Sorcerer|||SorcererRoleToken|
 |Generate|TOK:WOC|Spirit|||WhiteBlackSpiritToken|
 |Generate|TOK:WOC|Virtuous|||VirtuousRoleToken|
+
+# PIP
+|Generate|TOK:PIP|Robot|||RobotToken|


### PR DESCRIPTION
#11324 
I moved the existing `RobotToken` made by [Cybernetic Datasmith](https://scryfall.com/card/40k/114/cybernetica-datasmith) (which cant block and has a different power and toughness than the one [Mr. House, President and CEO](https://scryfall.com/card/pip/7/mr-house-president-and-ceo) makes) to a `RobotCantBlockToken` class, to put Mr. House's more generic token in its place.