### PR TITLE
Fix The Princess Takes Flight (Saga first chapter zcc)

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/woe/PrincessTakesFlightTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/woe/PrincessTakesFlightTest.java
@@ -1,0 +1,34 @@
+package org.mage.test.cards.single.woe;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author notgreat
+ */
+public class PrincessTakesFlightTest extends CardTestPlayerBase {
+    private static final String saga = "The Princess Takes Flight";
+    private static final String bear = "Grizzly Bears";
+
+    @Test
+    public void testReturn() {
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+        addCard(Zone.HAND, playerA, saga);
+        addCard(Zone.BATTLEFIELD, playerA, bear);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, saga);
+        addTarget(playerA, bear);
+
+        checkPermanentCount("Bear gone", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, bear, 0);
+
+        setStrictChooseMode(true);
+        setStopAt(5, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, bear, 1);
+        assertGraveyardCount(playerA, saga, 1);
+    }
+}

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -2061,7 +2061,11 @@ public abstract class GameImpl implements Game {
             TriggeredAbility newAbility = ability.copy();
             newAbility.newId();
             if (newAbility.getSourceObjectZoneChangeCounter() == 0) {
-                newAbility.setSourceObjectZoneChangeCounter(getState().getZoneChangeCounter(ability.getSourceId()));
+                int zcc = getState().getZoneChangeCounter(ability.getSourceId());
+                if (getPermanentEntering(ability.getSourceId()) != null){
+                    zcc += 1;
+                }
+                newAbility.setSourceObjectZoneChangeCounter(zcc);
             }
             if (!(newAbility instanceof DelayedTriggeredAbility)) {
                 newAbility.setSourcePermanentTransformCount(this);


### PR DESCRIPTION
Currently, The Princess Takes Flight will not return the creature it exiled. This is because for all sagas, the first chapter ability triggers occurs while the saga is entering the battlefield, before its zcc is updated.

This is an attempt at fixing this by incrementing the zcc of any triggered ability that triggers while a permanent is entering, need to investigate further to see if there's a better solution. Also need to investigate if this solution works when the saga is flickered and other unusual scenarios.