### PR TITLE
[don't merge] Clear commandersIds when ending game

### DIFF
--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -411,6 +411,8 @@ public abstract class PlayerImpl implements Player, Serializable {
         init(game, false);
     }
 
+    // TODO: New Player object would be better than resetting everything.
+    //  See https://github.com/magefree/mage/pull/11628#issuecomment-1890435356
     @Override
     public void init(Game game, boolean testMode) {
         this.abort = false;
@@ -461,6 +463,8 @@ public abstract class PlayerImpl implements Player, Serializable {
         this.phyrexianColors = null;
 
         this.designations.clear();
+
+        this.commandersIds.clear();
     }
 
     /**


### PR DESCRIPTION
Possibly fixes #11081

As far as I can tell, UUIDs in `commandersIds` aren't cleared after a game ends. This can cause us to try to get a watcher for an old UUID in future games. I think we should clear `commandersIds` on game end.