### PR TITLE
Sword of Light and Shadow: auto-return selected card to hand

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SwordOfLightAndShadow.java
+++ b/Mage.Sets/src/mage/cards/s/SwordOfLightAndShadow.java
@@ -82,8 +82,6 @@ class SwordOfLightAndShadowEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         Card card = game.getCard(targetPointer.getFirst(game, source));
-        return controller != null && card != null && controller.chooseUse(
-                outcome, "Return " + card.getName() + " from your graveyard to your hand?", source, game
-        ) && controller.moveCards(card, Zone.HAND, source, game);
+        return controller != null && card != null && controller.moveCards(card, Zone.HAND, source, game);
     }
 }


### PR DESCRIPTION
[[Sword of Light and Shadow]]

Selects up to one creature card. I don't see a reason to select a creature and then not return it to the hand so I think we can skip the return to hand prompt.