### PR TITLE
As Foretold alt cost only applies to SpellAbilities

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AsForetold.java
+++ b/Mage.Sets/src/mage/cards/a/AsForetold.java
@@ -3,6 +3,7 @@ package mage.cards.a;
 import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.Condition;
@@ -71,8 +72,8 @@ class SpellWithManaCostLessThanOrEqualToCondition implements Condition {
     public boolean apply(Game game, Ability source) {
         MageObject object = game.getObject(source);
         return object != null
-                && !object.isLand(game)
-                && object.getManaValue() <= counters;
+                && object.getManaValue() <= counters
+                && source instanceof SpellAbility;
     }
 }
 


### PR DESCRIPTION
- I don't see the point of checking that [[As Foretold]] 's target isn't a land. Lands aren't cast. Tested this PR in a game with [[Dryad Arbor]] and other lands and things work as expected.
- Make sure the source is an instanceof SpellAbility. Before this PR, the alt cost would try to be applied to stack abilities (like drawing a card from being the monarch or [[Murderous Rider // Swift End]] returning to the deck.