### PR TITLE
Decrease luminosity for LOG_TT_COLOR_MULTI

### DIFF
--- a/Mage/src/main/java/mage/util/GameLog.java
+++ b/Mage/src/main/java/mage/util/GameLog.java
@@ -28,7 +28,7 @@ public final class GameLog {
     static final String LOG_TT_COLOR_BLUE = "Blue";
     static final String LOG_TT_COLOR_BLACK = "Black";
     static final String LOG_TT_COLOR_WHITE = "#FDFFE6";
-    static final String LOG_TT_COLOR_MULTI = "#FFAC40";
+    static final String LOG_TT_COLOR_MULTI = "#A97A00";
     static final String LOG_TT_COLOR_COLORLESS = "#94A4BA";
     static final String LOG_COLOR_NEUTRAL = "#F0F8FF"; // AliceBlue
 


### PR DESCRIPTION
New:
![A97A00](https://github.com/magefree/mage/assets/17330088/d3ebc96a-5f75-4c6e-b47e-ea5834d48b7f)

Old:
![Screenshot 2024-01-15 233659x](https://github.com/magefree/mage/assets/17330088/fffb33b6-518f-4606-a58b-e9332138b314)

The old color at the bottom was barely readable. I decreased the luminosity to make it more readable.