### PR TITLE
[MIR] Implement Torrent of Lava

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TorrentOfLava.java
+++ b/Mage.Sets/src/mage/cards/t/TorrentOfLava.java
@@ -5,6 +5,7 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageAllEffect;
 import mage.abilities.effects.common.PreventDamageToSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
@@ -21,6 +22,7 @@ import mage.filter.predicate.mageobject.AbilityPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
+import mage.util.GameLog;
 
 import java.util.UUID;
 
@@ -60,7 +62,7 @@ class TorrentOfLavaGainAbilityEffect extends GainAbilityAllEffect {
 
     TorrentOfLavaGainAbilityEffect() {
         super(new SimpleActivatedAbility(
-                        new TorrentOfLavaPreventionEffect(null, 0, null), new TapSourceCost()),
+                        new TorrentOfLavaPreventionEffect(null, 0), new TapSourceCost()),
                 Duration.Custom,
                 StaticFilters.FILTER_PERMANENT_CREATURES);
         this.staticText = "As long as {this} is on the stack, " +
@@ -78,8 +80,13 @@ class TorrentOfLavaGainAbilityEffect extends GainAbilityAllEffect {
             return false;
         }
 
-        ability = new SimpleActivatedAbility(
-                new TorrentOfLavaPreventionEffect(spell.getId(), spell.getZoneChangeCounter(game), spell.getName()), new TapSourceCost());
+        Effect effect = new TorrentOfLavaPreventionEffect(spell.getId(), spell.getZoneChangeCounter(game));
+        // Display the id of the spell on the stack, not the card id
+        String idName = spell.getName() + " [" + spell.getId().toString().substring(0, 3) + "]";
+        effect.setText("Prevent the next 1 damage that would be dealt to {this} by "
+                + GameLog.getColoredObjectIdNameForTooltip(spell.getColor(game), idName) + " this turn");
+
+        ability = new SimpleActivatedAbility(effect, new TapSourceCost());
         return super.apply(game, source);
     }
 
@@ -94,11 +101,10 @@ class TorrentOfLavaPreventionEffect extends PreventDamageToSourceEffect {
     private final UUID preventDamageFromId;
     private final int zoneChangeCounter;
 
-    TorrentOfLavaPreventionEffect(UUID preventDamageFromId, int zoneChangeCounter, String preventDamageFromName) {
+    TorrentOfLavaPreventionEffect(UUID preventDamageFromId, int zoneChangeCounter) {
         super(Duration.EndOfTurn, 1);
         this.preventDamageFromId = preventDamageFromId;
         this.zoneChangeCounter = zoneChangeCounter;
-        this.staticText = "Prevent the next 1 damage that would be dealt to {this} by " + preventDamageFromName + " this turn";
     }
 
     private TorrentOfLavaPreventionEffect(final TorrentOfLavaPreventionEffect effect) {

--- a/Mage.Sets/src/mage/cards/t/TorrentOfLava.java
+++ b/Mage.Sets/src/mage/cards/t/TorrentOfLava.java
@@ -1,0 +1,128 @@
+package mage.cards.t;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.effects.common.DamageAllEffect;
+import mage.abilities.effects.common.PreventDamageToSourceEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Zone;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AbilityPredicate;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.stack.Spell;
+
+import java.util.UUID;
+
+/**
+ * @author Cguy7777
+ */
+public final class TorrentOfLava extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature without flying");
+
+    static {
+        filter.add(Predicates.not(new AbilityPredicate(FlyingAbility.class)));
+    }
+
+    public TorrentOfLava(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{R}{R}");
+
+        // Torrent of Lava deals X damage to each creature without flying.
+        this.getSpellAbility().addEffect(new DamageAllEffect(ManacostVariableValue.REGULAR, filter));
+
+        // As long as Torrent of Lava is on the stack, each creature has
+        // "{tap}: Prevent the next 1 damage that would be dealt to this creature by Torrent of Lava this turn."
+        this.addAbility(new SimpleStaticAbility(Zone.STACK, new TorrentOfLavaGainAbilityEffect()));
+    }
+
+    private TorrentOfLava(final TorrentOfLava card) {
+        super(card);
+    }
+
+    @Override
+    public TorrentOfLava copy() {
+        return new TorrentOfLava(this);
+    }
+}
+
+class TorrentOfLavaGainAbilityEffect extends GainAbilityAllEffect {
+
+    TorrentOfLavaGainAbilityEffect() {
+        super(new SimpleActivatedAbility(
+                        new TorrentOfLavaPreventionEffect(null, 0, null), new TapSourceCost()),
+                Duration.Custom,
+                StaticFilters.FILTER_PERMANENT_CREATURES);
+        this.staticText = "As long as {this} is on the stack, " +
+                "each creature has \"{T}: Prevent the next 1 damage that would be dealt to this creature by {this} this turn.\"";
+    }
+
+    private TorrentOfLavaGainAbilityEffect(final TorrentOfLavaGainAbilityEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Spell spell = game.getStack().getSpell(source.getSourceId());
+        if (spell == null) {
+            return false;
+        }
+
+        ability = new SimpleActivatedAbility(
+                new TorrentOfLavaPreventionEffect(spell.getId(), spell.getZoneChangeCounter(game), spell.getName()), new TapSourceCost());
+        return super.apply(game, source);
+    }
+
+    @Override
+    public TorrentOfLavaGainAbilityEffect copy() {
+        return new TorrentOfLavaGainAbilityEffect(this);
+    }
+}
+
+class TorrentOfLavaPreventionEffect extends PreventDamageToSourceEffect {
+
+    private final UUID preventDamageFromId;
+    private final int zoneChangeCounter;
+
+    TorrentOfLavaPreventionEffect(UUID preventDamageFromId, int zoneChangeCounter, String preventDamageFromName) {
+        super(Duration.EndOfTurn, 1);
+        this.preventDamageFromId = preventDamageFromId;
+        this.zoneChangeCounter = zoneChangeCounter;
+        this.staticText = "Prevent the next 1 damage that would be dealt to {this} by " + preventDamageFromName + " this turn";
+    }
+
+    private TorrentOfLavaPreventionEffect(final TorrentOfLavaPreventionEffect effect) {
+        super(effect);
+        this.preventDamageFromId = effect.preventDamageFromId;
+        this.zoneChangeCounter = effect.zoneChangeCounter;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (!super.applies(event, source, game) || preventDamageFromId == null) {
+            return false;
+        }
+
+        Spell spell = game.getStack().getSpell(event.getSourceId());
+        if (spell == null) {
+            return false;
+        }
+
+        return spell.getId().equals(preventDamageFromId) && spell.getZoneChangeCounter(game) == zoneChangeCounter;
+    }
+
+    @Override
+    public TorrentOfLavaPreventionEffect copy() {
+        return new TorrentOfLavaPreventionEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Mirage.java
+++ b/Mage.Sets/src/mage/sets/Mirage.java
@@ -329,6 +329,7 @@ public final class Mirage extends ExpansionSet {
         cards.add(new SetCardInfo("Thirst", 99, Rarity.COMMON, mage.cards.t.Thirst.class));
         cards.add(new SetCardInfo("Tidal Wave", 100, Rarity.UNCOMMON, mage.cards.t.TidalWave.class));
         cards.add(new SetCardInfo("Tombstone Stairwell", 149, Rarity.RARE, mage.cards.t.TombstoneStairwell.class));
+        cards.add(new SetCardInfo("Torrent of Lava", 199, Rarity.RARE, mage.cards.t.TorrentOfLava.class));
         cards.add(new SetCardInfo("Tranquil Domain", 245, Rarity.COMMON, mage.cards.t.TranquilDomain.class));
         cards.add(new SetCardInfo("Tropical Storm", 246, Rarity.UNCOMMON, mage.cards.t.TropicalStorm.class));
         cards.add(new SetCardInfo("Uktabi Faerie", 247, Rarity.COMMON, mage.cards.u.UktabiFaerie.class));

--- a/Mage/src/main/java/mage/util/GameLog.java
+++ b/Mage/src/main/java/mage/util/GameLog.java
@@ -111,7 +111,11 @@ public final class GameLog {
     }
 
     public static String getColoredObjectIdNameForTooltip(MageObject mageObject) {
-        return "<font color='" + getTooltipColorName(mageObject.getColor(null)) + "'>" + mageObject.getIdName() + "</font>";
+        return getColoredObjectIdNameForTooltip(mageObject.getColor(null), mageObject.getIdName());
+    }
+
+    public static String getColoredObjectIdNameForTooltip(ObjectColor color, String idName) {
+        return "<font color='" + getTooltipColorName(color) + "'>" + idName + "</font>";
     }
 
     public static String getNeutralColoredText(String text) {


### PR DESCRIPTION
New PR due to git mishap.

I got around to fixing this, after I ran into an issue where the abilities Torrent of Lava grants would incorrectly apply to different objects.

I can look into writing tests for this. One scenario I would want to check is when there are multiple copies of ToL on the stack. When that happens, every creature will have multiple copies of the ability, with identical text. They *are* different though, since each ability refers to a different ToL on the stack. How would one write the test to specifically specify which ability is being activated?

The identical text can be confusing for players too, although which ability is activated won't matter most of the time. Should we disambiguate, perhaps by having the specific ToL's log name in the ability text? I'm not sure what the desired solution would be.