### PR TITLE
AI: Don't use Shielded By Faith's reattachment effect

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
+++ b/Mage.Sets/src/mage/cards/s/ShieldedByFaith.java
@@ -47,7 +47,7 @@ public final class ShieldedByFaith extends CardImpl {
         
         // Whenever a creature enters the battlefield, you may attach Shielded by Faith to that creature.
         this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-                Zone.BATTLEFIELD, new AttachEffect(Outcome.Benefit, "attach {this} to that creature"),
+                Zone.BATTLEFIELD, new AttachEffect(Outcome.AIDontUseIt, "attach {this} to that creature"),
                 StaticFilters.FILTER_PERMANENT_A_CREATURE, true, SetTargetPointer.PERMANENT));
     }
 


### PR DESCRIPTION
Fixes #6335

Preventing this card from attaching to opponent creatures is a good idea until this effect can be properly implemented.