### PR TITLE
[MKM] Implement Voja, Jaws of the Conclave

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VojaJawsOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/v/VojaJawsOfTheConclave.java
@@ -4,9 +4,12 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.counter.AddCountersAllEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.TrampleAbility;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.abilities.keyword.WardAbility;
@@ -29,6 +32,11 @@ public final class VojaJawsOfTheConclave extends CardImpl {
     private static final FilterControlledPermanent filterElves = new FilterControlledPermanent(SubType.ELF);
     private static final FilterControlledPermanent filterWolves = new FilterControlledPermanent(SubType.WOLF);
 
+    private static final DynamicValue xValueElves = new PermanentsOnBattlefieldCount(filterElves);
+    private static final Hint hintElves = new ValueHint("Elves you control", xValueElves);
+    private static final DynamicValue xValueWolves = new PermanentsOnBattlefieldCount(filterWolves);
+    private static final Hint hintWolves = new ValueHint("Wolves you control", xValueWolves);
+
     public VojaJawsOfTheConclave(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}{G}{W}");
 
@@ -50,13 +58,14 @@ public final class VojaJawsOfTheConclave extends CardImpl {
         // where X is the number of Elves you control. Draw a card for each Wolf you control.
         Ability ability = new AttacksTriggeredAbility(
                 new AddCountersAllEffect(
-                        CounterType.P1P1.createInstance(0), // Set amount to 0, otherwise AddCountersAllEffect.apply() will default to amount = 1
-                        new PermanentsOnBattlefieldCount(filterElves),
+                        // Set amount to 0, otherwise AddCountersAllEffect.apply() will default to amount = 1 if xValueElves = 0
+                        CounterType.P1P1.createInstance(0),
+                        xValueElves,
                         StaticFilters.FILTER_CONTROLLED_CREATURE
                 ).setText("put X +1/+1 counters on each creature you control, where X is the number of Elves you control"));
-        ability.addEffect(new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filterWolves)));
+        ability.addEffect(new DrawCardSourceControllerEffect(xValueWolves));
 
-        this.addAbility(ability);
+        this.addAbility(ability.addHint(hintElves).addHint(hintWolves));
     }
 
     private VojaJawsOfTheConclave(final VojaJawsOfTheConclave card) {

--- a/Mage.Sets/src/mage/cards/v/VojaJawsOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/v/VojaJawsOfTheConclave.java
@@ -1,0 +1,70 @@
+package mage.cards.v;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.counter.AddCountersAllEffect;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.abilities.keyword.WardAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledPermanent;
+
+import java.util.UUID;
+
+/**
+ * @author Cguy7777
+ */
+public final class VojaJawsOfTheConclave extends CardImpl {
+
+    private static final FilterControlledPermanent filterElves = new FilterControlledPermanent(SubType.ELF);
+    private static final FilterControlledPermanent filterWolves = new FilterControlledPermanent(SubType.WOLF);
+
+    public VojaJawsOfTheConclave(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}{G}{W}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.WOLF);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Ward {3}
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{3}"), false));
+
+        // Whenever Voja, Jaws of the Conclave attacks, put X +1/+1 counters on each creature you control,
+        // where X is the number of Elves you control. Draw a card for each Wolf you control.
+        Ability ability = new AttacksTriggeredAbility(
+                new AddCountersAllEffect(
+                        CounterType.P1P1.createInstance(0), // Set amount to 0, otherwise AddCountersAllEffect.apply() will default to amount = 1
+                        new PermanentsOnBattlefieldCount(filterElves),
+                        StaticFilters.FILTER_CONTROLLED_CREATURE
+                ).setText("put X +1/+1 counters on each creature you control, where X is the number of Elves you control"));
+        ability.addEffect(new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filterWolves)));
+
+        this.addAbility(ability);
+    }
+
+    private VojaJawsOfTheConclave(final VojaJawsOfTheConclave card) {
+        super(card);
+    }
+
+    @Override
+    public VojaJawsOfTheConclave copy() {
+        return new VojaJawsOfTheConclave(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
@@ -91,6 +91,7 @@ public final class MurdersAtKarlovManor extends ExpansionSet {
         cards.add(new SetCardInfo("Undercity Sewers", 270, Rarity.RARE, mage.cards.u.UndercitySewers.class));
         cards.add(new SetCardInfo("Undercover Crocodelf", 239, Rarity.COMMON, mage.cards.u.UndercoverCrocodelf.class));
         cards.add(new SetCardInfo("Underground Mortuary", 271, Rarity.RARE, mage.cards.u.UndergroundMortuary.class));
+        cards.add(new SetCardInfo("Voja, Jaws of the Conclave", 432, Rarity.MYTHIC, mage.cards.v.VojaJawsOfTheConclave.class));
         cards.add(new SetCardInfo("Warleader's Call", 242, Rarity.RARE, mage.cards.w.WarleadersCall.class));
         cards.add(new SetCardInfo("Wojek Investigator", 36, Rarity.RARE, mage.cards.w.WojekInvestigator.class));
 


### PR DESCRIPTION
I noticed that, if you control no Elves (and will be putting no +1/+1 counters on your creatures), `AddCountersAllEffect` will still print messages in the log to let you know that you put zero counters on each creature you control. Perhaps that should not print for zero, to reduce log spam?