### PR TITLE
Minor improvements to AddCountersAllEffect

### DIFF
--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
@@ -60,9 +60,9 @@ public class AddCountersAllEffect extends OneShotEffect {
                     }
 
                     permanent.addCounters(newCounter, source.getControllerId(), source, game);
-                    if (!game.isSimulation()) {
+                    if (!game.isSimulation() && newCounter.getCount() > 0) {
                         game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts " + newCounter.getCount() + ' ' + newCounter.getName()
-                                + " counter on " + permanent.getLogName());
+                                + (newCounter.getCount() == 1 ? " counter" : " counters") + " on " + permanent.getLogName());
                     }
                 }
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
@@ -2,7 +2,6 @@ package mage.abilities.effects.common.counter;
 
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
@@ -12,7 +11,6 @@ import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
-import mage.util.CardUtil;
 
 /**
  * @author North
@@ -20,7 +18,7 @@ import mage.util.CardUtil;
 public class AddCountersAllEffect extends OneShotEffect {
 
     private final Counter counter;
-    private DynamicValue amount;
+    private final DynamicValue amount;
     private final FilterPermanent filter;
 
     public AddCountersAllEffect(Counter counter, FilterPermanent filter) {
@@ -50,7 +48,7 @@ public class AddCountersAllEffect extends OneShotEffect {
             if (counter != null) {
                 for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
                     Counter newCounter = counter.copy();
-                    int calculated = amount.calculate(game, source, this); // 0 -- you must use default couner
+                    int calculated = amount.calculate(game, source, this); // 0 -- you must use default counter
                     if (calculated < 0) {
                         continue;
                     } else if (calculated == 0) {


### PR DESCRIPTION
This reduces log spam from `AddCountersAllEffect`, as mentioned in #11685, as well as pluralizing the word "counter" when needed, plus some minor cleanup since I was in there.

I didn't want to change it without asking, but I feel like having `0` as a special value for `DynamicValue amount` is a bit of a gotcha that can easily result in bugs. I discovered that [[Gruff Triplets]], the only card which currently uses the relevant constructor, doesn't work properly if it somehow has zero power when it dies due to this. Perhaps this should be refactored?