### PR TITLE
AI: Hostage Taker's effect is detrimental

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HostageTaker.java
+++ b/Mage.Sets/src/mage/cards/h/HostageTaker.java
@@ -61,7 +61,7 @@ public final class HostageTaker extends CardImpl {
 class HostageTakerExileEffect extends OneShotEffect {
 
     HostageTakerExileEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.Detriment);
         this.staticText = "exile another target creature or artifact until {this} leaves the battlefield. "
                 + "You may cast that card for as long as it remains exiled, "
                 + "and you may spend mana as though it were mana of any type to cast that spell";


### PR DESCRIPTION
This stops Hostage Taker from targeting its controller's permanents. 