### PR TITLE
Feature - Allow cards to be added to exile during a card test

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -268,7 +268,9 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
                 TestPlayer testPlayer = (TestPlayer) player;
                 currentGame.cheat(testPlayer.getId(), getCommands(testPlayer));
                 currentGame.cheat(testPlayer.getId(), getLibraryCards(testPlayer), getHandCards(testPlayer),
-                        getBattlefieldCards(testPlayer), getGraveCards(testPlayer), getCommandCards(testPlayer));
+                        getBattlefieldCards(testPlayer), getGraveCards(testPlayer), getCommandCards(testPlayer),
+                        getExiledCards(testPlayer));
+
             }
         }
 

--- a/Mage.Tests/src/test/java/org/mage/test/testapi/AddCardApiTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/testapi/AddCardApiTest.java
@@ -92,4 +92,26 @@ public class AddCardApiTest extends CardTestPlayerBase {
     public void test_CardNameWithSetCode_RaiseErrorOnUnknownSet() {
         addCard(Zone.BATTLEFIELD, playerA, "SS4-Plains", 1);
     }
+
+    // Add card to exile added for #11738
+    @Test
+    public void test_AddCardExiled() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
+        addCard(Zone.HAND, playerA, "Mind Raker");
+
+        addCard(Zone.EXILED, playerB, "Llanowar Elves");
+
+        checkExileCount("llanowar elves in exile", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Llanowar Elves", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Mind Raker");
+        setChoice(playerA, true);
+        addTarget(playerA, "Llanowar Elves");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertExileCount(playerB, "Llanowar Elves", 0);
+        assertGraveyardCount(playerB, "Llanowar Elves", 1);
+    }
 }

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -555,7 +555,7 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
 
     // game cheats (for tests only)
     void cheat(UUID ownerId, Map<Zone, String> commands);
-    void cheat(UUID ownerId, List<Card> library, List<Card> hand, List<PermanentCard> battlefield, List<Card> graveyard, List<Card> command);
+    void cheat(UUID ownerId, List<Card> library, List<Card> hand, List<PermanentCard> battlefield, List<Card> graveyard, List<Card> command, List<Card> exiled);
 
     // controlling the behaviour of replacement effects while permanents entering the battlefield
     void setScopeRelevant(boolean scopeRelevant);

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -3567,7 +3567,7 @@ public abstract class GameImpl implements Game {
     }
 
     @Override
-    public void cheat(UUID ownerId, List<Card> library, List<Card> hand, List<PermanentCard> battlefield, List<Card> graveyard, List<Card> command) {
+    public void cheat(UUID ownerId, List<Card> library, List<Card> hand, List<PermanentCard> battlefield, List<Card> graveyard, List<Card> command, List<Card> exiled) {
         // fake test ability for triggers and events
         Ability fakeSourceAbilityTemplate = new SimpleStaticAbility(Zone.OUTSIDE, new InfoEffect("adding testing cards"));
         fakeSourceAbilityTemplate.setControllerId(ownerId);
@@ -3579,6 +3579,7 @@ public abstract class GameImpl implements Game {
             loadCards(ownerId, battlefield);
             loadCards(ownerId, graveyard);
             loadCards(ownerId, command);
+            loadCards(ownerId, exiled);
 
             for (Card card : library) {
                 player.getLibrary().putOnTop(card, this);
@@ -3602,6 +3603,11 @@ public abstract class GameImpl implements Game {
                 }
             } else if (!command.isEmpty()) {
                 throw new IllegalArgumentException("Command zone supports in commander test games");
+            }
+
+            for (Card card : exiled) {
+                card.setZone(Zone.EXILED, this);
+                getExile().add(card);
             }
 
             for (PermanentCard permanentCard : battlefield) {


### PR DESCRIPTION
#11738 

The `cheat` method now processes cards that have been added to `Zone.EXILED`.