### PR TITLE
[don't merge] Implemented (2, 18) UTM according to paper

### DIFF
--- a/Mage.Server/config/init.txt
+++ b/Mage.Server/config/init.txt
@@ -1,0 +1,142 @@
+[@clear hands]
+[@clear libraries]
+
+[A0. Set up tape (tokens). End tokens must share power with neighbors due to SharedTriumph]
+token:Bobb:LhurgoyfGreenToken:3:1
+token:Bobb:ElfGreenToken:3:1
+token:Bobb:HarpyGreenToken:2:1
+token:Bobb:SliverWhiteToken:3:1
+token:Bobb:RatWhiteToken:3:1
+
+[A1. Add q1 state transition creatures (Rotlung and Xathrid)]
+battlefield:Bobb:Rotlung Reanimator Aetherborn-White-Sliver:1
+battlefield:Bobb:Rotlung Reanimator Basilisk-Green-Elf:1
+battlefield:Bobb:Rotlung Reanimator Cephalid-White-Sliver:1
+battlefield:Bobb:Rotlung Reanimator Demon-Green-Aetherborn:1
+battlefield:Bobb:Rotlung Reanimator Elf-White-Demon:1
+battlefield:Bobb:Rotlung Reanimator Faerie-Green-Harpy:1
+battlefield:Bobb:Rotlung Reanimator Giant-Green-Juggernaut:1
+battlefield:Bobb:Rotlung Reanimator Harpy-White-Faerie:1
+battlefield:Bobb:Rotlung Reanimator Illusion-Green-Faerie:1
+battlefield:Bobb:Rotlung Reanimator Juggernaut-White-Illusion:1
+battlefield:Bobb:Xathrid Necromancer Kavu-White-Leviathan:1
+battlefield:Bobb:Xathrid Necromancer Leviathan-White-Illusion:1
+battlefield:Bobb:Xathrid Necromancer Myr-White-Basilisk:1
+battlefield:Bobb:Rotlung Reanimator Noggle-Green-Orc:1
+battlefield:Bobb:Rotlung Reanimator Orc-White-Pegasus:1
+battlefield:Bobb:Xathrid Necromancer Pegasus-Green-Rhino:1
+battlefield:Bobb:Rotlung Reanimator Rhino-Blue-Assassin:1
+battlefield:Bobb:Rotlung Reanimator Sliver-Green-Cephalid:1
+
+[A1a. Add program transition cards (Cloak of Invisibility)]
+hand:Alice:Cloak of Invisibility:18
+battlefield:Alice:Island:18
+
+[A1b. During Alice pre-combat: Apply Cloaks of Invisibility to Bobb's Rotlungs and Xathrids (18 Island)]
+
+[A1c. Add land to both libraries]
+library:Bobb:Island:1
+library:Alice:Island:1
+
+[A1d. Skip Alice -> Skip Bobb -> Begin Alice pre-combat (Phase out q1 creatures)]
+
+[@clear hands]
+
+[A2. Add q2 state transition creatures (Rotlung and Xathrid)]
+battlefield:Bobb:Rotlung Reanimator Aetherborn-Green-Cephalid:1
+battlefield:Bobb:Rotlung Reanimator Basilisk-Green-Cephalid:1
+battlefield:Bobb:Rotlung Reanimator Cephalid-White-Basilisk:1
+battlefield:Bobb:Rotlung Reanimator Demon-Green-Elf:1
+battlefield:Bobb:Rotlung Reanimator Elf-White-Aetherborn:1
+battlefield:Bobb:Xathrid Necromancer Faerie-Green-Kavu:1
+battlefield:Bobb:Rotlung Reanimator Giant-Green-Harpy:1
+battlefield:Bobb:Rotlung Reanimator Harpy-White-Giant:1
+battlefield:Bobb:Rotlung Reanimator Illusion-Green-Juggernaut:1
+battlefield:Bobb:Rotlung Reanimator Juggernaut-White-Giant:1
+battlefield:Bobb:Xathrid Necromancer Kavu-Green-Faerie:1
+battlefield:Bobb:Rotlung Reanimator Leviathan-Green-Juggernaut:1
+battlefield:Bobb:Rotlung Reanimator Myr-Green-Orc:1
+battlefield:Bobb:Rotlung Reanimator Noggle-Green-Orc:1
+battlefield:Bobb:Rotlung Reanimator Orc-White-Noggle:1
+battlefield:Bobb:Rotlung Reanimator Pegasus-Green-Sliver:1
+battlefield:Bobb:Xathrid Necromancer Rhino-White-Sliver:1
+battlefield:Bobb:Rotlung Reanimator Sliver-White-Myr:1
+
+[A2a. Add second program transition cards (Cloak of Invisibility)]
+hand:Alice:Cloak of Invisibility:18
+
+[A2b. During Alice pre-combat: Apply Cloaks of Invisibility to Bobb's Rotlungs and Xathrids (18 Island)]
+
+[A2c. Add land to both libraries]
+library:Bobb:Island:1
+library:Alice:Island:1
+
+[A2d. Add Illusory Gains to Alice's hand]
+hand:Alice:Illusory Gains:1
+battlefield:Alice:Island:5
+
+[A2e. During Alice pre-combat: Cast Illusory Gains on Bobb's 3/3 token (5 Island)]
+
+[A2f. Add machine control cards]
+hand:Alice:Shared Triumph:2
+battlefield:Alice:Plains:4
+hand:Alice:Wheel of Sun and Moon:1
+hand:Alice:Steely Resolve:1
+battlefield:Alice:Forest:4
+
+[A2g. Add Armageddon]
+hand:Alice:Armageddon:1
+battlefield:Alice:Plains:4
+
+[A2h. During Alice pre-combat: Cast Shared Triumphs (target: Lhurgoyf, Rat; 2 Plains each)]
+[A2i. During Alice pre-combat: Cast Wheel of Sun and Moon (target: Alice; 2 Forest)]
+[A2j. During Alice pre-combat: Cast Steely Resolve (target: Assembly-Worker; 2 Forest)]
+[A2k. During Alice pre-combat: Cast Armageddon]
+
+[@clear libraries]
+
+[A2l. During Alice pre-combat: Add Island to battlefield]
+battlefield:Alice:Island:1
+
+[A2m. During Alice pre-combat: Tap island]
+
+[A2n. Cast Prismatic Omen for Alice]
+battlefield:Alice:Prismatic Omen:1
+
+[A2o. Add Alice State change cards]
+battlefield:Alice:Mesmeric Orb:1
+battlefield:Alice:Dread of Night Black:2
+battlefield:Alice:Choke:1
+
+[A2p. Add Unmodified creatures - Rotlung Reanimators - Fungus Sliver - Vigor]
+battlefield:Alice:Rotlung Reanimator Lhurgoyf-Black-Cephalid:1
+battlefield:Bobb:Rotlung Reanimator Lhurgoyf-Green-Lhurgoyf:1
+battlefield:Alice:Rotlung Reanimator Rat-Black-Cephalid:1
+battlefield:Bobb:Rotlung Reanimator Rat-White-Rat:1
+battlefield:Alice:Fungus Sliver Incarnation:1
+battlefield:Alice:Vigor AssemblyWorker:1
+battlefield:Bobb:Vigor AssemblyWorker:1
+battlefield:Alice:Blazing Archon AssemblyWorker:1
+battlefield:Bobb:Blazing Archon:1
+
+[A2q. Add land to Bobb's library]
+library:Bobb:Island:1
+
+[A2f. Skip to Bobb's turn pre-combat phase]
+
+[@clear hands]
+
+[B2a. During Bobb pre-combat: Enchantments]
+battlefield:Bobb:Privileged Position:1
+battlefield:Bobb:Wild Evocation:1
+battlefield:Bobb:Recycle:1
+
+[B2b. Add State change cards to Alice's library in draw order]
+library:Alice:Soul Snuffers:1
+library:Alice:Coalition Victory:1
+library:Alice:Cleansing Beam:1
+
+[B2c. Alice Infest to hand]
+hand:Alice:Infest:1
+
+[B2d. Skip Bobb's turn. Alice's Infest should automatically trigger q1 changes]

--- a/Mage.Sets/src/mage/cards/b/BlazingArchonAssemblyWorker.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingArchonAssemblyWorker.java
@@ -1,0 +1,52 @@
+
+package mage.cards.b;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.combat.CantAttackYouAllEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.Zone;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class BlazingArchonAssemblyWorker extends CardImpl {
+
+    public BlazingArchonAssemblyWorker(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{6}{W}{W}{W}");
+        this.subtype.add(SubType.ARCHON);
+        this.subtype.add(SubType.ASSEMBLY_WORKER); // Apply Olivia Voldaren
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(7);
+        this.toughness = new MageInt(8);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Creatures can't attack you.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantAttackYouAllEffect(Duration.WhileOnBattlefield)));
+    }
+
+    private BlazingArchonAssemblyWorker(final BlazingArchonAssemblyWorker card) {
+        super(card);
+    }
+
+    @Override
+    public BlazingArchonAssemblyWorker copy() {
+        return new BlazingArchonAssemblyWorker(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/d/DreadOfNightB.java
+++ b/Mage.Sets/src/mage/cards/d/DreadOfNightB.java
@@ -1,0 +1,42 @@
+
+package mage.cards.d;
+
+import java.util.UUID;
+import mage.ObjectColor;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.continuous.BoostAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.ColorPredicate;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class DreadOfNightB extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Black creatures");
+
+    static {
+        filter.add(new ColorPredicate(ObjectColor.BLACK));
+    }
+
+    public DreadOfNightB(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{B}");
+
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostAllEffect(-1, -1, Duration.WhileOnBattlefield, filter, false)));
+    }
+
+    private DreadOfNightB(final DreadOfNightB card) {
+        super(card);
+    }
+
+    @Override
+    public DreadOfNightB copy() {
+        return new DreadOfNightB(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FungusSliverI.java
+++ b/Mage.Sets/src/mage/cards/f/FungusSliverI.java
@@ -1,0 +1,62 @@
+
+package mage.cards.f;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DealtDamageToSourceTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import mage.filter.common.FilterCreaturePermanent;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class FungusSliverI extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
+    static {
+        filter.add(SubType.INCARNATION.getPredicate());
+    }
+
+    public FungusSliverI(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{G}");
+        this.subtype.add(SubType.FUNGUS);
+        this.subtype.add(SubType.SLIVER);
+        this.subtype.add(SubType.ASSEMBLY_WORKER); // Apply Olivia Voldaren
+
+        // Absorb initial Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // All Sliver creatures have "Whenever this creature is dealt damage, put a +1/+1 counter on it."
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityAllEffect(
+                new DealtDamageToSourceTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), false),
+                Duration.WhileOnBattlefield,
+                filter,
+                "All Incarnation creatures have \"Whenever this creature is dealt damage, put a +1/+1 counter on it.\""))); 
+    }
+
+    private FungusSliverI(final FungusSliverI card) {
+        super(card);
+    }
+
+    @Override
+    public FungusSliverI copy() {
+        return new FungusSliverI(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorACG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorACG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.CephalidGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorACG extends CardImpl {
+    
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.AETHERBORN, "Aetherborn");
+
+    public RotlungReanimatorACG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Aetherborn dies, create a 2/2 green Cephalid creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new CephalidGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorACG(final RotlungReanimatorACG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorACG copy() {
+        return new RotlungReanimatorACG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorASW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorASW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.SliverWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorASW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.AETHERBORN, "Aetherborn");
+
+    public RotlungReanimatorASW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Aetherborn dies, create a 2/2 white Sliver creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new SliverWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorASW(final RotlungReanimatorASW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorASW copy() {
+        return new RotlungReanimatorASW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorBCG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorBCG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.CephalidGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorBCG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.BASILISK, "Basilisk");
+
+    public RotlungReanimatorBCG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Basilisk dies, create a 2/2 green Cephalid creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new CephalidGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorBCG(final RotlungReanimatorBCG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorBCG copy() {
+        return new RotlungReanimatorBCG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorBEG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorBEG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.ElfGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorBEG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.BASILISK, "Basilisk");
+
+    public RotlungReanimatorBEG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Basilisk dies, create a 2/2 green Elf creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new ElfGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorBEG(final RotlungReanimatorBEG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorBEG copy() {
+        return new RotlungReanimatorBEG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorCBW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorCBW.java
@@ -1,0 +1,49 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.BasiliskWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorCBW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.CEPHALID, "Cephalid");
+    public RotlungReanimatorCBW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Cephalid dies, create a 2/2 white Basilisk creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new BasiliskWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorCBW(final RotlungReanimatorCBW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorCBW copy() {
+        return new RotlungReanimatorCBW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorCSW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorCSW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.SliverWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorCSW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.CEPHALID, "Cephalid");
+
+    public RotlungReanimatorCSW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Cephalid dies, create a 2/2 white Sliver creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new SliverWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorCSW(final RotlungReanimatorCSW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorCSW copy() {
+        return new RotlungReanimatorCSW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorDAG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorDAG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.AetherbornGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorDAG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.DEMON, "Demon");
+
+    public RotlungReanimatorDAG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Demon dies, create a 2/2 green Aetherborn creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new AetherbornGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorDAG(final RotlungReanimatorDAG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorDAG copy() {
+        return new RotlungReanimatorDAG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorDEG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorDEG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.ElfGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorDEG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.DEMON, "Demon");
+
+    public RotlungReanimatorDEG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Demon dies, create a 2/2 green Elf creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new ElfGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorDEG(final RotlungReanimatorDEG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorDEG copy() {
+        return new RotlungReanimatorDEG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorEAW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorEAW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.AetherbornWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorEAW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ELF, "Elf");
+
+    public RotlungReanimatorEAW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Elf dies, create a 2/2 white Aetherborn creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new AetherbornWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorEAW(final RotlungReanimatorEAW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorEAW copy() {
+        return new RotlungReanimatorEAW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorEDW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorEDW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.DemonWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorEDW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ELF, "Elf");
+
+    public RotlungReanimatorEDW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Elf dies, create a 2/2 white Demon creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new DemonWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorEDW(final RotlungReanimatorEDW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorEDW copy() {
+        return new RotlungReanimatorEDW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorFHG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorFHG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.HarpyGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorFHG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.FAERIE, "Faerie");
+
+    public RotlungReanimatorFHG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Faerie dies, create a 2/2 green Harpy creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new HarpyGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorFHG(final RotlungReanimatorFHG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorFHG copy() {
+        return new RotlungReanimatorFHG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorGHG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorGHG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.HarpyGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorGHG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.GIANT, "Giant");
+
+    public RotlungReanimatorGHG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Giant dies, create a 2/2 green Harpy creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new HarpyGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorGHG(final RotlungReanimatorGHG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorGHG copy() {
+        return new RotlungReanimatorGHG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorGJG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorGJG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.JuggernautGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorGJG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.GIANT, "Giant");
+
+    public RotlungReanimatorGJG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Giant dies, create a 2/2 green Juggernaut creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new JuggernautGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorGJG(final RotlungReanimatorGJG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorGJG copy() {
+        return new RotlungReanimatorGJG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorHFW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorHFW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.FaerieWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorHFW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.HARPY, "Harpy");
+
+    public RotlungReanimatorHFW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Harpy dies, create a 2/2 white Faerie creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new FaerieWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorHFW(final RotlungReanimatorHFW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorHFW copy() {
+        return new RotlungReanimatorHFW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorHGW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorHGW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.GiantWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorHGW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.HARPY, "Harpy");
+
+    public RotlungReanimatorHGW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Harpy dies, create a 2/2 white Giant creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new GiantWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorHGW(final RotlungReanimatorHGW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorHGW copy() {
+        return new RotlungReanimatorHGW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorIFG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorIFG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.FaerieGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorIFG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ILLUSION, "Illusion");
+
+    public RotlungReanimatorIFG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Illusion dies, create a 2/2 green Faerie creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new FaerieGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorIFG(final RotlungReanimatorIFG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorIFG copy() {
+        return new RotlungReanimatorIFG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorIJG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorIJG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.JuggernautGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorIJG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ILLUSION, "Illusion");
+
+    public RotlungReanimatorIJG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Illusion dies, create a 2/2 green Juggernaut creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new JuggernautGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorIJG(final RotlungReanimatorIJG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorIJG copy() {
+        return new RotlungReanimatorIJG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorJGW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorJGW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.GiantWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorJGW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.JUGGERNAUT, "Juggernaut");
+
+    public RotlungReanimatorJGW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Juggernaut dies, create a 2/2 white Giant creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new GiantWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorJGW(final RotlungReanimatorJGW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorJGW copy() {
+        return new RotlungReanimatorJGW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorJIW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorJIW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.IllusionWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorJIW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.JUGGERNAUT, "Juggernaut");
+
+    public RotlungReanimatorJIW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Juggernaut dies, create a 2/2 white Illusion creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new IllusionWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorJIW(final RotlungReanimatorJIW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorJIW copy() {
+        return new RotlungReanimatorJIW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorLCB.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorLCB.java
@@ -1,0 +1,52 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.CephalidBlackToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorLCB extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.LHURGOYF, "Lhurgoyf");
+
+    public RotlungReanimatorLCB(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        this.subtype.add(SubType.ASSEMBLY_WORKER); // Apply Olivia Voldaren
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Lhurgoyf dies, create a 2/2 black Cephalid creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new CephalidBlackToken()), false, filter));
+    }
+
+    private RotlungReanimatorLCB(final RotlungReanimatorLCB card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorLCB copy() {
+        return new RotlungReanimatorLCB(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorLJG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorLJG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.JuggernautGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorLJG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.LEVIATHAN, "Leviathan");
+
+    public RotlungReanimatorLJG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Leviathan dies, create a 2/2 green Juggernaut creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new JuggernautGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorLJG(final RotlungReanimatorLJG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorLJG copy() {
+        return new RotlungReanimatorLJG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorLLG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorLLG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.LhurgoyfGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorLLG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.LHURGOYF, "Lhurgoyf");
+
+    public RotlungReanimatorLLG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Lhurgoyf dies, create a 2/2 green Lhurgoyf creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new LhurgoyfGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorLLG(final RotlungReanimatorLLG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorLLG copy() {
+        return new RotlungReanimatorLLG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorMOG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorMOG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.OrcGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorMOG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.MYR, "Myr");
+
+    public RotlungReanimatorMOG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Myr dies, create a 2/2 green Orc creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new OrcGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorMOG(final RotlungReanimatorMOG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorMOG copy() {
+        return new RotlungReanimatorMOG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorNOG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorNOG.java
@@ -1,0 +1,49 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.OrcGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorNOG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.NOGGLE, "Noggle");
+    public RotlungReanimatorNOG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Noggle dies, create a 2/2 green Orc creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new OrcGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorNOG(final RotlungReanimatorNOG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorNOG copy() {
+        return new RotlungReanimatorNOG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorONW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorONW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.NoggleWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorONW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ORC, "Orc");
+
+    public RotlungReanimatorONW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Orc dies, create a 2/2 white Noggle creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new NoggleWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorONW(final RotlungReanimatorONW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorONW copy() {
+        return new RotlungReanimatorONW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorOPW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorOPW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.PegasusWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorOPW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ORC, "Orc");
+
+    public RotlungReanimatorOPW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Orc dies, create a 2/2 white Pegasus creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new PegasusWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorOPW(final RotlungReanimatorOPW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorOPW copy() {
+        return new RotlungReanimatorOPW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorPSG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorPSG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.SliverGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorPSG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.PEGASUS, "Pegasus");
+
+    public RotlungReanimatorPSG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Pegasus dies, create a 2/2 green Sliver creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new SliverGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorPSG(final RotlungReanimatorPSG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorPSG copy() {
+        return new RotlungReanimatorPSG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorRAB.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorRAB.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.AssassinBlueToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorRAB extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.RHINO, "Rhino");
+
+    public RotlungReanimatorRAB(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Rhino dies, create a 2/2 blue Assassin creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new AssassinBlueToken()), false, filter));
+    }
+
+    private RotlungReanimatorRAB(final RotlungReanimatorRAB card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorRAB copy() {
+        return new RotlungReanimatorRAB(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorRCB.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorRCB.java
@@ -1,0 +1,52 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.CephalidBlackToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorRCB extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.RAT, "Rat");
+
+    public RotlungReanimatorRCB(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        this.subtype.add(SubType.ASSEMBLY_WORKER); // Apply Olivia Voldaren
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Rat dies, create a 2/2 black Cephalid creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new CephalidBlackToken()), false, filter));
+    }
+
+    private RotlungReanimatorRCB(final RotlungReanimatorRCB card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorRCB copy() {
+        return new RotlungReanimatorRCB(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorRRW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorRRW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.RatWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorRRW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.RAT, "Rat");
+
+    public RotlungReanimatorRRW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Rat dies, create a 2/2 white Rat creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new RatWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorRRW(final RotlungReanimatorRRW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorRRW copy() {
+        return new RotlungReanimatorRRW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorSCG.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorSCG.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.CephalidGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorSCG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.SLIVER, "Sliver");
+
+    public RotlungReanimatorSCG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Sliver dies, create a 2/2 green Cephalid creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new CephalidGreenToken()), false, filter));
+    }
+
+    private RotlungReanimatorSCG(final RotlungReanimatorSCG card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorSCG copy() {
+        return new RotlungReanimatorSCG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RotlungReanimatorSMW.java
+++ b/Mage.Sets/src/mage/cards/r/RotlungReanimatorSMW.java
@@ -1,0 +1,50 @@
+
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.MyrWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class RotlungReanimatorSMW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.SLIVER, "Sliver");
+
+    public RotlungReanimatorSMW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.CLERIC);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Rotlung Reanimator or another Sliver dies, create a 2/2 white Myr creature token.
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new CreateTokenEffect(new MyrWhiteToken()), false, filter));
+    }
+
+    private RotlungReanimatorSMW(final RotlungReanimatorSMW card) {
+        super(card);
+    }
+
+    @Override
+    public RotlungReanimatorSMW copy() {
+        return new RotlungReanimatorSMW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/v/VigorAssemblyWorker.java
+++ b/Mage.Sets/src/mage/cards/v/VigorAssemblyWorker.java
@@ -1,0 +1,108 @@
+package mage.cards.v;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.PutIntoGraveFromAnywhereSourceTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.ShuffleIntoLibrarySourceEffect;
+import mage.abilities.keyword.TrampleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.events.DamageEvent;
+import mage.game.events.GameEvent;
+import mage.game.events.PreventDamageEvent;
+import mage.game.events.PreventedDamageEvent;
+import mage.game.permanent.Permanent;
+
+import java.util.UUID;
+
+/**
+ * @author mschatz
+ */
+public final class VigorAssemblyWorker extends CardImpl {
+
+    public VigorAssemblyWorker(UUID ownerId, CardSetInfo setInfo) {
+    super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}{G}{G}");
+    this.subtype.add(SubType.ELEMENTAL);
+    this.subtype.add(SubType.INCARNATION);
+    this.subtype.add(SubType.ASSEMBLY_WORKER); // Apply Olivia Voldaren
+
+    this.power = new MageInt(6);
+    this.toughness = new MageInt(6);
+
+    // Apply Prismatic Lace
+    this.color.setBlack(true);
+    this.color.setGreen(true);
+    this.color.setRed(true);
+    this.color.setWhite(true);
+
+    // Trample
+    this.addAbility(TrampleAbility.getInstance());
+
+    // If damage would be dealt to a creature you control other than Vigor, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way.
+    this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new VigorAssemblyWorkerReplacementEffect()));
+
+    // When Vigor is put into a graveyard from anywhere, shuffle it into its owner's library.
+    this.addAbility(new PutIntoGraveFromAnywhereSourceTriggeredAbility(new ShuffleIntoLibrarySourceEffect()));
+    }
+
+    private VigorAssemblyWorker(final VigorAssemblyWorker card) {
+        super(card);
+    }
+
+    @Override
+    public VigorAssemblyWorker copy() {
+        return new VigorAssemblyWorker(this);
+    }
+}
+
+class VigorAssemblyWorkerReplacementEffect extends ReplacementEffectImpl {
+
+    VigorAssemblyWorkerReplacementEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.BoostCreature);
+        staticText = "If damage would be dealt to a creature you control other than {this}, prevent that damage. Put a +1/+1 counter on that creature for each 1 damage prevented this way";
+    }
+
+    VigorAssemblyWorkerReplacementEffect(final VigorAssemblyWorkerReplacementEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        GameEvent preventEvent = new PreventDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), event.getAmount(), ((DamageEvent) event).isCombatDamage());
+        if (!game.replaceEvent(preventEvent)) {
+            int preventedDamage = event.getAmount();
+            event.setAmount(0);
+            Permanent permanent = game.getPermanent(event.getTargetId());
+            if (permanent != null) {
+                permanent.addCounters(CounterType.P1P1.createInstance(preventedDamage), source.getControllerId(), source, game);
+            }
+            game.fireEvent(new PreventedDamageEvent(event.getTargetId(), source.getSourceId(), source, source.getControllerId(), preventedDamage));
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGE_PERMANENT;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        return permanent != null
+                && permanent.isCreature(game)
+                && permanent.isControlledBy(source.getControllerId())
+                && !event.getTargetId().equals(source.getSourceId());
+    }
+
+    @Override
+    public VigorAssemblyWorkerReplacementEffect copy() {
+        return new VigorAssemblyWorkerReplacementEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerFKG.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerFKG.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.KavuGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerFKG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Faerie creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.FAERIE.getPredicate());
+    }
+
+    public XathridNecromancerFKG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Faerie creature you control dies, create a tapped 2/2 green Kavu creature token.
+        Effect effect = new CreateTokenEffect(new KavuGreenToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerFKG(final XathridNecromancerFKG card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerFKG copy() {
+        return new XathridNecromancerFKG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerKFG.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerKFG.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.FaerieGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerKFG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Kavu creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.KAVU.getPredicate());
+    }
+
+    public XathridNecromancerKFG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Kavu creature you control dies, create a tapped 2/2 green Faerie creature token.
+        Effect effect = new CreateTokenEffect(new FaerieGreenToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerKFG(final XathridNecromancerKFG card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerKFG copy() {
+        return new XathridNecromancerKFG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerKLW.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerKLW.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.LeviathanWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerKLW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Kavu creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.KAVU.getPredicate());
+    }
+
+    public XathridNecromancerKLW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Kavu creature you control dies, create a tapped 2/2 white Leviathan creature token.
+        Effect effect = new CreateTokenEffect(new LeviathanWhiteToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerKLW(final XathridNecromancerKLW card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerKLW copy() {
+        return new XathridNecromancerKLW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerLIW.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerLIW.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.IllusionWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerLIW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Leviathan creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.LEVIATHAN.getPredicate());
+    }
+
+    public XathridNecromancerLIW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Leviathan creature you control dies, create a tapped 2/2 white Illusion creature token.
+        Effect effect = new CreateTokenEffect(new IllusionWhiteToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerLIW(final XathridNecromancerLIW card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerLIW copy() {
+        return new XathridNecromancerLIW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerMBW.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerMBW.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.BasiliskWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerMBW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Myr creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.MYR.getPredicate());
+    }
+
+    public XathridNecromancerMBW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Myr creature you control dies, create a tapped 2/2 white Basilisk creature token.
+        Effect effect = new CreateTokenEffect(new BasiliskWhiteToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerMBW(final XathridNecromancerMBW card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerMBW copy() {
+        return new XathridNecromancerMBW(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerPRG.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerPRG.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.RhinoGreenToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerPRG extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Pegasus creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.PEGASUS.getPredicate());
+    }
+
+    public XathridNecromancerPRG(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Pegasus creature you control dies, create a tapped 2/2 green Rhino creature token.
+        Effect effect = new CreateTokenEffect(new RhinoGreenToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerPRG(final XathridNecromancerPRG card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerPRG copy() {
+        return new XathridNecromancerPRG(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/x/XathridNecromancerRSW.java
+++ b/Mage.Sets/src/mage/cards/x/XathridNecromancerRSW.java
@@ -1,0 +1,61 @@
+
+package mage.cards.x;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DiesThisOrAnotherCreatureTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.TargetController;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.permanent.token.SliverWhiteToken;
+
+/**
+ *
+ * @author mschatz
+ */
+public final class XathridNecromancerRSW extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Rhino creature you control");
+
+    static {
+        filter.add(TargetController.YOU.getControllerPredicate());
+        filter.add(SubType.RHINO.getPredicate());
+    }
+
+    public XathridNecromancerRSW(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{B}");
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+
+        // Absorb initial Infest and Dread of Night Black
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        // Apply Prismatic Lace
+        this.color.setBlack(true);
+        this.color.setGreen(true);
+        this.color.setRed(true);
+        this.color.setWhite(true);
+
+        // Whenever Xathrid Necromancer or another Rhino creature you control dies, create a tapped 2/2 white Sliver creature token.
+        Effect effect = new CreateTokenEffect(new SliverWhiteToken(), 1, true, false);
+        Ability ability = new DiesThisOrAnotherCreatureTriggeredAbility(effect, false, filter);
+        this.addAbility(ability);
+
+    }
+
+    private XathridNecromancerRSW(final XathridNecromancerRSW card) {
+        super(card);
+    }
+
+    @Override
+    public XathridNecromancerRSW copy() {
+        return new XathridNecromancerRSW(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Turing.java
+++ b/Mage.Sets/src/mage/sets/Turing.java
@@ -1,0 +1,73 @@
+package mage.sets;
+
+import mage.ObjectColor;
+import mage.cards.CardGraphicInfo;
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+public final class Turing extends ExpansionSet {
+
+    private static final Turing instance = new Turing();
+
+    public static Turing getInstance() {
+        return instance;
+    }
+
+    private Turing() {
+        super("Turing", "TNG", ExpansionSet.buildDate(2022, 2, 19), SetType.EXPANSION);
+        this.blockName = "Turing";
+        this.hasBoosters = false;
+        this.numBoosterLands = 0;
+        this.numBoosterCommon = 0;
+        this.numBoosterUncommon = 0;
+        this.numBoosterRare = 0;
+        this.ratioBoosterMythic = 0;
+	cards.add(new SetCardInfo("Rotlung Reanimator Aetherborn-White-Sliver", 1, Rarity.COMMON, mage.cards.r.RotlungReanimatorASW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Basilisk-Green-Elf", 2, Rarity.COMMON, mage.cards.r.RotlungReanimatorBEG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Cephalid-White-Sliver", 3, Rarity.COMMON, mage.cards.r.RotlungReanimatorCSW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Demon-Green-Aetherborn", 4, Rarity.COMMON, mage.cards.r.RotlungReanimatorDAG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Elf-White-Demon", 5, Rarity.COMMON, mage.cards.r.RotlungReanimatorEDW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Faerie-Green-Harpy", 6, Rarity.COMMON, mage.cards.r.RotlungReanimatorFHG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Giant-Green-Juggernaut", 7, Rarity.COMMON, mage.cards.r.RotlungReanimatorGJG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Harpy-White-Faerie", 8, Rarity.COMMON, mage.cards.r.RotlungReanimatorHFW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Illusion-Green-Faerie", 9, Rarity.COMMON, mage.cards.r.RotlungReanimatorIFG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Juggernaut-White-Illusion", 10, Rarity.COMMON, mage.cards.r.RotlungReanimatorJIW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Noggle-Green-Orc", 11, Rarity.COMMON, mage.cards.r.RotlungReanimatorNOG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Orc-White-Pegasus", 12, Rarity.COMMON, mage.cards.r.RotlungReanimatorOPW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Rhino-Blue-Assassin", 13, Rarity.COMMON, mage.cards.r.RotlungReanimatorRAB.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Sliver-Green-Cephalid", 14, Rarity.COMMON, mage.cards.r.RotlungReanimatorSCG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Aetherborn-Green-Cephalid", 15, Rarity.COMMON, mage.cards.r.RotlungReanimatorACG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Basilisk-Green-Cephalid", 16, Rarity.COMMON, mage.cards.r.RotlungReanimatorBCG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Cephalid-White-Basilisk", 17, Rarity.COMMON, mage.cards.r.RotlungReanimatorCBW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Demon-Green-Elf", 18, Rarity.COMMON, mage.cards.r.RotlungReanimatorDEG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Elf-White-Aetherborn", 19, Rarity.COMMON, mage.cards.r.RotlungReanimatorEAW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Giant-Green-Harpy", 20, Rarity.COMMON, mage.cards.r.RotlungReanimatorGHG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Harpy-White-Giant", 21, Rarity.COMMON, mage.cards.r.RotlungReanimatorHGW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Illusion-Green-Juggernaut", 22, Rarity.COMMON, mage.cards.r.RotlungReanimatorIJG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Juggernaut-White-Giant", 23, Rarity.COMMON, mage.cards.r.RotlungReanimatorJGW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Leviathan-Green-Juggernaut", 24, Rarity.COMMON, mage.cards.r.RotlungReanimatorLJG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Myr-Green-Orc", 25, Rarity.COMMON, mage.cards.r.RotlungReanimatorMOG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Noggle-Green-Orc", 26, Rarity.COMMON, mage.cards.r.RotlungReanimatorNOG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Orc-White-Noggle", 27, Rarity.COMMON, mage.cards.r.RotlungReanimatorONW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Pegasus-Green-Sliver", 28, Rarity.COMMON, mage.cards.r.RotlungReanimatorPSG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Sliver-White-Myr", 29, Rarity.COMMON, mage.cards.r.RotlungReanimatorSMW.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Lhurgoyf-Black-Cephalid", 30, Rarity.COMMON, mage.cards.r.RotlungReanimatorLCB.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Lhurgoyf-Green-Lhurgoyf", 31, Rarity.COMMON, mage.cards.r.RotlungReanimatorLLG.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Rat-Black-Cephalid", 32, Rarity.COMMON, mage.cards.r.RotlungReanimatorRCB.class));
+	cards.add(new SetCardInfo("Rotlung Reanimator Rat-White-Rat", 33, Rarity.COMMON, mage.cards.r.RotlungReanimatorRRW.class));
+
+	cards.add(new SetCardInfo("Xathrid Necromancer Kavu-White-Leviathan", 34, Rarity.COMMON, mage.cards.x.XathridNecromancerKLW.class));
+	cards.add(new SetCardInfo("Xathrid Necromancer Leviathan-White-Illusion", 35, Rarity.COMMON, mage.cards.x.XathridNecromancerLIW.class));
+	cards.add(new SetCardInfo("Xathrid Necromancer Myr-White-Basilisk", 36, Rarity.COMMON, mage.cards.x.XathridNecromancerMBW.class));
+	cards.add(new SetCardInfo("Xathrid Necromancer Pegasus-Green-Rhino", 37, Rarity.COMMON, mage.cards.x.XathridNecromancerPRG.class));
+	cards.add(new SetCardInfo("Xathrid Necromancer Faerie-Green-Kavu", 38, Rarity.COMMON, mage.cards.x.XathridNecromancerFKG.class));
+	cards.add(new SetCardInfo("Xathrid Necromancer Kavu-Green-Faerie", 39, Rarity.COMMON, mage.cards.x.XathridNecromancerKFG.class));
+	cards.add(new SetCardInfo("Xathrid Necromancer Rhino-White-Sliver", 40, Rarity.COMMON, mage.cards.x.XathridNecromancerRSW.class));
+
+	cards.add(new SetCardInfo("Fungus Sliver Incarnation", 41, Rarity.COMMON, mage.cards.f.FungusSliverI.class));
+	cards.add(new SetCardInfo("Dread of Night Black", 42, Rarity.COMMON, mage.cards.d.DreadOfNightB.class));
+	cards.add(new SetCardInfo("Blazing Archon AssemblyWorker", 43, Rarity.COMMON, mage.cards.b.BlazingArchonAssemblyWorker.class));
+	cards.add(new SetCardInfo("Vigor AssemblyWorker", 44, Rarity.COMMON, mage.cards.v.VigorAssemblyWorker.class));
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/AetherbornGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AetherbornGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class AetherbornGreenToken extends TokenImpl {
+
+    public AetherbornGreenToken(int power_val, int toughness_val) {
+        super("AetherbornGreen", power_val + "/" + toughness_val + " green Aetherborn creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.AETHERBORN );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public AetherbornGreenToken() {
+        this(2, 2);
+    }
+
+    public AetherbornGreenToken(final AetherbornGreenToken token) {
+        super(token);
+    }
+
+    public AetherbornGreenToken copy() {
+        return new AetherbornGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/AetherbornWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AetherbornWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class AetherbornWhiteToken extends TokenImpl {
+
+    public AetherbornWhiteToken(int power_val, int toughness_val) {
+        super("AetherbornWhite", power_val + "/" + toughness_val + " white Aetherborn creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.AETHERBORN );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public AetherbornWhiteToken() {
+        this(2, 2);
+    }
+
+    public AetherbornWhiteToken(final AetherbornWhiteToken token) {
+        super(token);
+    }
+
+    public AetherbornWhiteToken copy() {
+        return new AetherbornWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/AssassinBlueToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AssassinBlueToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class AssassinBlueToken extends TokenImpl {
+
+    public AssassinBlueToken(int power_val, int toughness_val) {
+        super("AssassinBlue", power_val + "/" + toughness_val + " blue Assassin creature token");
+        cardType.add(CardType.CREATURE);
+        color.setBlue(true);
+        subtype.add(SubType.ASSASSIN );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public AssassinBlueToken() {
+        this(2, 2);
+    }
+
+    public AssassinBlueToken(final AssassinBlueToken token) {
+        super(token);
+    }
+
+    public AssassinBlueToken copy() {
+        return new AssassinBlueToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/BasiliskWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/BasiliskWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class BasiliskWhiteToken extends TokenImpl {
+
+    public BasiliskWhiteToken(int power_val, int toughness_val) {
+        super("BasiliskWhite", power_val + "/" + toughness_val + " white Basilisk creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.BASILISK );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public BasiliskWhiteToken() {
+        this(2, 2);
+    }
+
+    public BasiliskWhiteToken(final BasiliskWhiteToken token) {
+        super(token);
+    }
+
+    public BasiliskWhiteToken copy() {
+        return new BasiliskWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/CephalidBlackToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/CephalidBlackToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class CephalidBlackToken extends TokenImpl {
+
+    public CephalidBlackToken(int power_val, int toughness_val) {
+        super("CephalidBlack", power_val + "/" + toughness_val + " black Cephalid creature token");
+        cardType.add(CardType.CREATURE);
+        color.setBlack(true);
+        subtype.add(SubType.CEPHALID );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public CephalidBlackToken() {
+        this(2, 2);
+    }
+
+    public CephalidBlackToken(final CephalidBlackToken token) {
+        super(token);
+    }
+
+    public CephalidBlackToken copy() {
+        return new CephalidBlackToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/CephalidGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/CephalidGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class CephalidGreenToken extends TokenImpl {
+
+    public CephalidGreenToken(int power_val, int toughness_val) {
+        super("CephalidGreen", power_val + "/" + toughness_val + " green Cephalid creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.CEPHALID );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public CephalidGreenToken() {
+        this(2, 2);
+    }
+
+    public CephalidGreenToken(final CephalidGreenToken token) {
+        super(token);
+    }
+
+    public CephalidGreenToken copy() {
+        return new CephalidGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/DemonWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/DemonWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class DemonWhiteToken extends TokenImpl {
+
+    public DemonWhiteToken(int power_val, int toughness_val) {
+        super("DemonWhite", power_val + "/" + toughness_val + " white Demon creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.DEMON );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public DemonWhiteToken() {
+        this(2, 2);
+    }
+
+    public DemonWhiteToken(final DemonWhiteToken token) {
+        super(token);
+    }
+
+    public DemonWhiteToken copy() {
+        return new DemonWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/ElfGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/ElfGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class ElfGreenToken extends TokenImpl {
+
+    public ElfGreenToken(int power_val, int toughness_val) {
+        super("ElfGreen", power_val + "/" + toughness_val + " green Elf creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.ELF );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public ElfGreenToken() {
+        this(2, 2);
+    }
+
+    public ElfGreenToken(final ElfGreenToken token) {
+        super(token);
+    }
+
+    public ElfGreenToken copy() {
+        return new ElfGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/FaerieGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/FaerieGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class FaerieGreenToken extends TokenImpl {
+
+    public FaerieGreenToken(int power_val, int toughness_val) {
+        super("FaerieGreen", power_val + "/" + toughness_val + " green Faerie creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.FAERIE );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public FaerieGreenToken() {
+        this(2, 2);
+    }
+
+    public FaerieGreenToken(final FaerieGreenToken token) {
+        super(token);
+    }
+
+    public FaerieGreenToken copy() {
+        return new FaerieGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/FaerieWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/FaerieWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class FaerieWhiteToken extends TokenImpl {
+
+    public FaerieWhiteToken(int power_val, int toughness_val) {
+        super("FaerieWhite", power_val + "/" + toughness_val + " white Faerie creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.FAERIE );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public FaerieWhiteToken() {
+        this(2, 2);
+    }
+
+    public FaerieWhiteToken(final FaerieWhiteToken token) {
+        super(token);
+    }
+
+    public FaerieWhiteToken copy() {
+        return new FaerieWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/GiantWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/GiantWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class GiantWhiteToken extends TokenImpl {
+
+    public GiantWhiteToken(int power_val, int toughness_val) {
+        super("GiantWhite", power_val + "/" + toughness_val + " white Giant creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.GIANT );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public GiantWhiteToken() {
+        this(2, 2);
+    }
+
+    public GiantWhiteToken(final GiantWhiteToken token) {
+        super(token);
+    }
+
+    public GiantWhiteToken copy() {
+        return new GiantWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/HarpyGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/HarpyGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class HarpyGreenToken extends TokenImpl {
+
+    public HarpyGreenToken(int power_val, int toughness_val) {
+        super("HarpyGreen", power_val + "/" + toughness_val + " green Harpy creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.HARPY );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public HarpyGreenToken() {
+        this(2, 2);
+    }
+
+    public HarpyGreenToken(final HarpyGreenToken token) {
+        super(token);
+    }
+
+    public HarpyGreenToken copy() {
+        return new HarpyGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/IllusionWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/IllusionWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class IllusionWhiteToken extends TokenImpl {
+
+    public IllusionWhiteToken(int power_val, int toughness_val) {
+        super("IllusionWhite", power_val + "/" + toughness_val + " white Illusion creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.ILLUSION );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public IllusionWhiteToken() {
+        this(2, 2);
+    }
+
+    public IllusionWhiteToken(final IllusionWhiteToken token) {
+        super(token);
+    }
+
+    public IllusionWhiteToken copy() {
+        return new IllusionWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/JuggernautGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/JuggernautGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class JuggernautGreenToken extends TokenImpl {
+
+    public JuggernautGreenToken(int power_val, int toughness_val) {
+        super("JuggernautGreen", power_val + "/" + toughness_val + " green Juggernaut creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.JUGGERNAUT);
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public JuggernautGreenToken() {
+        this(2, 2);
+    }
+
+    public JuggernautGreenToken(final JuggernautGreenToken token) {
+        super(token);
+    }
+
+    public JuggernautGreenToken copy() {
+        return new JuggernautGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/KavuGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/KavuGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class KavuGreenToken extends TokenImpl {
+
+    public KavuGreenToken(int power_val, int toughness_val) {
+        super("KavuGreen", power_val + "/" + toughness_val + " green Kavu creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.KAVU );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public KavuGreenToken() {
+        this(2, 2);
+    }
+
+    public KavuGreenToken(final KavuGreenToken token) {
+        super(token);
+    }
+
+    public KavuGreenToken copy() {
+        return new KavuGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/LeviathanWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/LeviathanWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class LeviathanWhiteToken extends TokenImpl {
+
+    public LeviathanWhiteToken(int power_val, int toughness_val) {
+        super("LeviathanWhite", power_val + "/" + toughness_val + " white Leviathan creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.LEVIATHAN );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public LeviathanWhiteToken() {
+        this(2, 2);
+    }
+
+    public LeviathanWhiteToken(final LeviathanWhiteToken token) {
+        super(token);
+    }
+
+    public LeviathanWhiteToken copy() {
+        return new LeviathanWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/LhurgoyfGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/LhurgoyfGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class LhurgoyfGreenToken extends TokenImpl {
+
+    public LhurgoyfGreenToken(int power_val, int toughness_val) {
+        super("LhurgoyfGreen", power_val + "/" + toughness_val + " green Lhurgoyf creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.LHURGOYF );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public LhurgoyfGreenToken() {
+        this(1, 1);
+    }
+
+    public LhurgoyfGreenToken(final LhurgoyfGreenToken token) {
+        super(token);
+    }
+
+    public LhurgoyfGreenToken copy() {
+        return new LhurgoyfGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/MyrWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/MyrWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class MyrWhiteToken extends TokenImpl {
+
+    public MyrWhiteToken(int power_val, int toughness_val) {
+        super("MyrWhite", power_val + "/" + toughness_val + " white Myr creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.MYR );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public MyrWhiteToken() {
+        this(2, 2);
+    }
+
+    public MyrWhiteToken(final MyrWhiteToken token) {
+        super(token);
+    }
+
+    public MyrWhiteToken copy() {
+        return new MyrWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/NoggleWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/NoggleWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class NoggleWhiteToken extends TokenImpl {
+
+    public NoggleWhiteToken(int power_val, int toughness_val) {
+        super("NoggleWhite", power_val + "/" + toughness_val + " white Noggle creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.NOGGLE );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public NoggleWhiteToken() {
+        this(2, 2);
+    }
+
+    public NoggleWhiteToken(final NoggleWhiteToken token) {
+        super(token);
+    }
+
+    public NoggleWhiteToken copy() {
+        return new NoggleWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/OrcGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/OrcGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class OrcGreenToken extends TokenImpl {
+
+    public OrcGreenToken(int power_val, int toughness_val) {
+        super("OrcGreen", power_val + "/" + toughness_val + " green Orc creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.ORC );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public OrcGreenToken() {
+        this(2, 2);
+    }
+
+    public OrcGreenToken(final OrcGreenToken token) {
+        super(token);
+    }
+
+    public OrcGreenToken copy() {
+        return new OrcGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/PegasusWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/PegasusWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class PegasusWhiteToken extends TokenImpl {
+
+    public PegasusWhiteToken(int power_val, int toughness_val) {
+        super("PegasusWhite", power_val + "/" + toughness_val + " white Pegasus creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.PEGASUS );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public PegasusWhiteToken() {
+        this(2, 2);
+    }
+
+    public PegasusWhiteToken(final PegasusWhiteToken token) {
+        super(token);
+    }
+
+    public PegasusWhiteToken copy() {
+        return new PegasusWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/RatWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/RatWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class RatWhiteToken extends TokenImpl {
+
+    public RatWhiteToken(int power_val, int toughness_val) {
+        super("RatWhite", power_val + "/" + toughness_val + " white Rat creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.RAT );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public RatWhiteToken() {
+        this(1, 1);
+    }
+
+    public RatWhiteToken(final RatWhiteToken token) {
+        super(token);
+    }
+
+    public RatWhiteToken copy() {
+        return new RatWhiteToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/RhinoGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/RhinoGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class RhinoGreenToken extends TokenImpl {
+
+    public RhinoGreenToken(int power_val, int toughness_val) {
+        super("RhinoGreen", power_val + "/" + toughness_val + " green Rhino creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.RHINO );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public RhinoGreenToken() {
+        this(2, 2);
+    }
+
+    public RhinoGreenToken(final RhinoGreenToken token) {
+        super(token);
+    }
+
+    public RhinoGreenToken copy() {
+        return new RhinoGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/SliverGreenToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/SliverGreenToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class SliverGreenToken extends TokenImpl {
+
+    public SliverGreenToken(int power_val, int toughness_val) {
+        super("SliverGreen", power_val + "/" + toughness_val + " green Sliver creature token");
+        cardType.add(CardType.CREATURE);
+        color.setGreen(true);
+        subtype.add(SubType.SLIVER );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public SliverGreenToken() {
+        this(2, 2);
+    }
+
+    public SliverGreenToken(final SliverGreenToken token) {
+        super(token);
+    }
+
+    public SliverGreenToken copy() {
+        return new SliverGreenToken(this);
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/SliverWhiteToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/SliverWhiteToken.java
@@ -1,0 +1,32 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author mschatz
+ */
+public final class SliverWhiteToken extends TokenImpl {
+
+    public SliverWhiteToken(int power_val, int toughness_val) {
+        super("SliverWhite", power_val + "/" + toughness_val + " white Sliver creature token");
+        cardType.add(CardType.CREATURE);
+        color.setWhite(true);
+        subtype.add(SubType.SLIVER );
+        power = new MageInt(power_val);
+        toughness = new MageInt(toughness_val);
+    }
+
+    public SliverWhiteToken() {
+        this(2, 2);
+    }
+
+    public SliverWhiteToken(final SliverWhiteToken token) {
+        super(token);
+    }
+
+    public SliverWhiteToken copy() {
+        return new SliverWhiteToken(this);
+    }
+}


### PR DESCRIPTION
Hi,

A [recent paper](https://arxiv.org/pdf/1904.09828.pdf) by Churchill, Biderman, and Herrick demonstrated Turing Completeness of that Magic: The Gathering.  This PR implements necessary features to operate their machine and provides a guide on how to initialize and compute with the machine (via an init.txt file) in Mage's server test mode.

The authors' construction relies on text manipulation cards which were not implemented when this project began (Olivia Voldaren, Glamerdye, Artificial Evolution), so instead I created static versions of the cards with the necessary changes.

For testing, I spot checked that the state transitions followed what was outlined in the paper and verified that the board state didn't degrade.  There was one detail that needed to be corrected in the paper in order to prevent an unintended halt. If there are better ways to more thoroughly test this to ensure everything is stable, please let me know.  Since setup is pretty involved, it would be especially handy if there were a way to load the board from a previous state.

The single caveat in the paper is in regards to the interaction between Soul Snuffers and Fungus Sliver on the Vigor creature.  Vigor is pretty critical to maintaining the state of the tape.  The paper intends for Fungus Sliver to keep Vigor healthy any time Soul Snuffers is brought into the battlefield and affects it with its -1/-1 counter; however, this is not considered damage and so it never triggers the ability.  As a result, Vigor can wither and cause the machine to behave strangely.  To avoid this, I hacked the Vigor creature as if it were modified by Prismatic Lace in the same way that the Rotlung Reanimators are modified.  It seems to get around the issue, but I'm not particularly well versed in the rules of the game.

Other than that, I gave the hacked creatures a little extra health to survive past the setup phase; this seemed fine since it just boosted the P/T of creatures on the board.

I'm sure this PR is pretty unrelated to anything else that the Mage project is focused on, but I'd welcome any suggestions on how this could be easily maintained along side improvements to the broader project.  I figure it might be neat for others to play around with.

Thanks :).

Repro instructions:
1. Start a test match between Alice and Bobb with cheats enabled.
2. Select Alice as the starting player and skip to her pre-combat phase.
3. Follow the steps in the init.txt file beginning with the top CLEAR HANDS and CLEAR LIBRARIES commands.  The steps are labeled according to the player taking the action and their turn.
4. The 2/2 token designates the current position of the Controller head and indicates how the machine will behave once it is destroyed by the forced casing of Infest by Alice.  The machine starts with state q1.

Summary of changes:
* Included hacked cards
  * (BlazingArchon|Vigor)AssemblyWorker - Modified to have AssemblyWorker type, health added
  * DreadOfNightB - Text modified to apply to Black creatures
  * FungusSliverI - Text modified to apply to Incarnation creatures
  * RotlungReanimator{A}{B}{C} - Text modified to "Whenever {A} dies, create a 2/2 {B} {C} token", health added
  * XathridNecromancer{A}{B}{C} - Text modified to "Whenever {A} dies, create a tapped 2/2 {B} {C} token", health added
   * Tokens added according to needed symbols in construction
* Added cheat parsing for tokens with given P/T
* Included Clear hands and Clear libraries cheats (I may have gotten these changes from an existing PR, forgive me for losing the reference).