### PR TITLE
Improve rendering of Saga and Case cards

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
@@ -171,6 +171,7 @@ public class ModernCardRenderer extends CardRenderer {
     protected static final float TYPE_LINE_Y_FRAC = 0.57f; // x cardHeight
     protected static final float TYPE_LINE_Y_FRAC_TOKEN = 0.70f;
     protected static final float TYPE_LINE_Y_FRAC_FULL_ART = 0.74f;
+    protected static final float TYPE_LINE_Y_FRAC_BOTTOM = 0.89f;
     protected int typeLineY;
 
     // Possible sizes of rules text font
@@ -329,6 +330,10 @@ public class ModernCardRenderer extends CardRenderer {
             rect = new Rectangle2D.Float(.0f, .0f, 1.0f, 1.0f);
         } else if (cardView.getFrameStyle().isFullArt() || (cardView.isToken())) {
             rect = new Rectangle2D.Float(.079f, .11f, .84f, .63f);
+        } else if (cardView.getSubTypes().contains(SubType.SAGA)) {
+            rect = ArtRect.SAGA.rect;
+        } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+            rect = ArtRect.CASE.rect;
         } else {
             rect = ArtRect.NORMAL.rect;
         }
@@ -340,6 +345,9 @@ public class ModernCardRenderer extends CardRenderer {
             return TYPE_LINE_Y_FRAC_TOKEN;
         } else if (cardView.getFrameStyle().isFullArt()) {
             return TYPE_LINE_Y_FRAC_FULL_ART;
+        } else if (cardView.getSubTypes().contains(SubType.SAGA) ||
+                cardView.getSubTypes().contains(SubType.CASE)) {
+            return TYPE_LINE_Y_FRAC_BOTTOM;
         } else {
             return TYPE_LINE_Y_FRAC;
         }
@@ -424,6 +432,16 @@ public class ModernCardRenderer extends CardRenderer {
                         contentWidth - 2, typeLineY - totalContentInset - boxHeight,
                         alternate_height,
                         sourceRect, shouldPreserveAspect);
+            } else if (cardView.getSubTypes().contains(SubType.SAGA)) {
+                drawArtIntoRect(g,
+                        contentWidth / 2 + totalContentInset + 1, totalContentInset + boxHeight,
+                        contentWidth / 2 - 1, typeLineY - totalContentInset - boxHeight,
+                        sourceRect, false);
+            } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+                drawArtIntoRect(g,
+                        totalContentInset + 1, totalContentInset + boxHeight,
+                        contentWidth / 2 - 1, typeLineY - totalContentInset - boxHeight,
+                        sourceRect, false);
             } else if (!isZendikarFullArtLand()) {
                 drawArtIntoRect(g,
                         totalContentInset + 1, totalContentInset + boxHeight,
@@ -474,7 +492,13 @@ public class ModernCardRenderer extends CardRenderer {
             g.setPaint(textboxPaint);
         }
 
-        if (!isZenUst) {
+        if (cardView.getSubTypes().contains(SubType.SAGA)) {
+            g.fillRect(totalContentInset + 2, totalContentInset + boxHeight,
+                    contentWidth / 2 - 2, typeLineY - totalContentInset - boxHeight + 2);
+        } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+            g.fillRect(contentWidth / 2 + totalContentInset + 1, totalContentInset + boxHeight,
+                    contentWidth / 2 - 2, typeLineY - totalContentInset - boxHeight + 2);
+        } else if (!isZenUst) {
             if (cardView.getCardTypes().contains(CardType.LAND)) {
                 int total_height_of_box = cardHeight - borderWidth * 3 - typeLineY - 2 - boxHeight;
 
@@ -669,6 +693,14 @@ public class ModernCardRenderer extends CardRenderer {
             drawUSTCurves(g, image, x, y, w, h,
                     0, 0,
                     additionalBoxColor, borderPaint);
+        } else if (cardView.getSubTypes().contains(SubType.SAGA)) {
+            drawRulesText(g, textboxKeywords, textboxRules,
+                    totalContentInset + 4, totalContentInset + boxHeight + 2,
+                    contentWidth / 2 - 8, typeLineY - totalContentInset - boxHeight - 6, false);
+        } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+            drawRulesText(g, textboxKeywords, textboxRules,
+                    contentWidth / 2 + totalContentInset + 4, totalContentInset + boxHeight + 2,
+                    contentWidth / 2 - 8, typeLineY - totalContentInset - boxHeight - 6, false);
         } else if (!isZenUst) {
             drawRulesText(g, textboxKeywords, textboxRules,
                     totalContentInset + 2, typeLineY + boxHeight + 2,

--- a/Mage.Common/src/main/java/mage/view/CardView.java
+++ b/Mage.Common/src/main/java/mage/view/CardView.java
@@ -527,6 +527,7 @@ public class CardView extends SimpleCardView {
             // Determine what part of the art to slice out for spells on the stack which originate
             // from a split, fuse, or aftermath split card.
             // Modal double faces cards draws as normal cards
+            // Sagas and cases have completely different layouts
             SpellAbilityType ty = spell.getSpellAbility().getSpellAbilityType();
             if (ty == SpellAbilityType.SPLIT_RIGHT || ty == SpellAbilityType.SPLIT_LEFT || ty == SpellAbilityType.SPLIT_FUSED) {
                 // Needs a special art rect
@@ -547,6 +548,10 @@ public class CardView extends SimpleCardView {
                         artRect = ArtRect.SPLIT_LEFT;
                     }
                 }
+            } else if (spell.getSubtype().contains(SubType.SAGA)) {
+                artRect = ArtRect.SAGA;
+            } else if (spell.getSubtype().contains(SubType.CASE)) {
+                artRect = ArtRect.CASE;
             }
 
             // show for modal spell, which mode was chosen

--- a/Mage/src/main/java/mage/cards/ArtRect.java
+++ b/Mage/src/main/java/mage/cards/ArtRect.java
@@ -11,7 +11,9 @@ public enum ArtRect {
     AFTERMATH_BOTTOM(new Rectangle2D.Double(0.546, 0.562, 0.272, 0.346)),
     SPLIT_LEFT(new Rectangle2D.Double(0.152, 0.539, 0.386, 0.400)),
     SPLIT_RIGHT(new Rectangle2D.Double(0.152, 0.058, 0.386, 0.400)),
-    SPLIT_FUSED(null);
+    SPLIT_FUSED(null),
+    SAGA(new Rectangle2D.Double(0.497, 0.11, 0.426, 0.727)),
+    CASE(new Rectangle2D.Double(0.069, 0.11, 0.426, 0.727));
 
     public final Rectangle2D rect;
 


### PR DESCRIPTION
With Sagas seeming to be a deciduous mechanic and Case cards arriving in MKM (#11516 ), which have a similar layout, it would be nice to have the cards rendered so you can see the art and the rules in the correct layout.

This changes the layout for these cards and extracts the correct part of the art to be drawn.