### PR TITLE
GUI: Improved rendering of Class cards

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
@@ -413,6 +413,15 @@ public class TestCardRenderDialog extends MageDialog {
         cardViews.add(createHandCard(game, playerYou.getId(), "ZNR", "134")); // Akoum Warrior
         //*/
 
+        //* test case, class and saga cards in hands
+        cardViews.add(createHandCard(game, playerYou.getId(), "MKM", "113")); // Case of the Burning Masks
+        cardViews.add(createHandCard(game, playerYou.getId(), "MKM", "155")); // Case of the Locked Hothouse
+        cardViews.add(createHandCard(game, playerYou.getId(), "AFR", "6")); // Cleric Class
+        cardViews.add(createHandCard(game, playerYou.getId(), "AFR", "230")); // Rogue Class
+        cardViews.add(createHandCard(game, playerYou.getId(), "DOM", "90")); // The Eldest Reborn
+        cardViews.add(createHandCard(game, playerYou.getId(), "MH2", "259")); // Urza's Saga
+        //*/
+
         /* test meld cards in hands and battlefield
         cardViews.add(createHandCard(game, playerYou.getId(), "EMN", "204")); // Hanweir Battlements
         cardViews.add(createHandCard(game, playerYou.getId(), "EMN", "130a")); // Hanweir Garrison
@@ -441,7 +450,7 @@ public class TestCardRenderDialog extends MageDialog {
         //cardViews.add(createPermanentCard(game, playerYou.getId(), "KHM", "50", 1, 1, 0, true, false, additionalIcons)); // Cosima, God of the Voyage
         //*/
 
-        //* test tokens
+        /* test tokens
         // normal
         cardViews.add(createToken(game, playerYou.getId(), new ZombieToken(), "10E", 0, false, false));
         cardViews.add(createToken(game, playerYou.getId(), new ZombieToken(), "XXX", 1, false, false));
@@ -826,7 +835,7 @@ public class TestCardRenderDialog extends MageDialog {
     }//GEN-LAST:event_comboRenderModeItemStateChanged
 
     private void sliderSizeStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_sliderSizeStateChanged
-        // from DragCardGrid         
+        // from DragCardGrid
         // Fraction in [-1, 1]
         float sliderFrac = ((float) (sliderSize.getValue() - 50)) / 50;
         // Convert to frac in [0.5, 2.0] exponentially

--- a/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/ModernCardRenderer.java
@@ -328,12 +328,11 @@ public class ModernCardRenderer extends CardRenderer {
             rect = new Rectangle2D.Float(.079f, .11f, .84f, .84f);
         } else if (isUnstableFullArtLand()) {
             rect = new Rectangle2D.Float(.0f, .0f, 1.0f, 1.0f);
+        } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_LEFT ||
+                cardView.getArtRect() == ArtRect.FULL_LENGTH_RIGHT) {
+            rect = cardView.getArtRect().rect;
         } else if (cardView.getFrameStyle().isFullArt() || (cardView.isToken())) {
             rect = new Rectangle2D.Float(.079f, .11f, .84f, .63f);
-        } else if (cardView.getSubTypes().contains(SubType.SAGA)) {
-            rect = ArtRect.SAGA.rect;
-        } else if (cardView.getSubTypes().contains(SubType.CASE)) {
-            rect = ArtRect.CASE.rect;
         } else {
             rect = ArtRect.NORMAL.rect;
         }
@@ -345,8 +344,8 @@ public class ModernCardRenderer extends CardRenderer {
             return TYPE_LINE_Y_FRAC_TOKEN;
         } else if (cardView.getFrameStyle().isFullArt()) {
             return TYPE_LINE_Y_FRAC_FULL_ART;
-        } else if (cardView.getSubTypes().contains(SubType.SAGA) ||
-                cardView.getSubTypes().contains(SubType.CASE)) {
+        } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_LEFT ||
+                cardView.getArtRect() == ArtRect.FULL_LENGTH_RIGHT) {
             return TYPE_LINE_Y_FRAC_BOTTOM;
         } else {
             return TYPE_LINE_Y_FRAC;
@@ -432,12 +431,12 @@ public class ModernCardRenderer extends CardRenderer {
                         contentWidth - 2, typeLineY - totalContentInset - boxHeight,
                         alternate_height,
                         sourceRect, shouldPreserveAspect);
-            } else if (cardView.getSubTypes().contains(SubType.SAGA)) {
+            } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_RIGHT) {
                 drawArtIntoRect(g,
                         contentWidth / 2 + totalContentInset + 1, totalContentInset + boxHeight,
                         contentWidth / 2 - 1, typeLineY - totalContentInset - boxHeight,
                         sourceRect, false);
-            } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+            } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_LEFT) {
                 drawArtIntoRect(g,
                         totalContentInset + 1, totalContentInset + boxHeight,
                         contentWidth / 2 - 1, typeLineY - totalContentInset - boxHeight,
@@ -492,10 +491,10 @@ public class ModernCardRenderer extends CardRenderer {
             g.setPaint(textboxPaint);
         }
 
-        if (cardView.getSubTypes().contains(SubType.SAGA)) {
+        if (cardView.getArtRect() == ArtRect.FULL_LENGTH_RIGHT) {
             g.fillRect(totalContentInset + 2, totalContentInset + boxHeight,
                     contentWidth / 2 - 2, typeLineY - totalContentInset - boxHeight + 2);
-        } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+        } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_LEFT) {
             g.fillRect(contentWidth / 2 + totalContentInset + 1, totalContentInset + boxHeight,
                     contentWidth / 2 - 2, typeLineY - totalContentInset - boxHeight + 2);
         } else if (!isZenUst) {
@@ -693,11 +692,11 @@ public class ModernCardRenderer extends CardRenderer {
             drawUSTCurves(g, image, x, y, w, h,
                     0, 0,
                     additionalBoxColor, borderPaint);
-        } else if (cardView.getSubTypes().contains(SubType.SAGA)) {
+        } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_RIGHT) {
             drawRulesText(g, textboxKeywords, textboxRules,
                     totalContentInset + 4, totalContentInset + boxHeight + 2,
                     contentWidth / 2 - 8, typeLineY - totalContentInset - boxHeight - 6, false);
-        } else if (cardView.getSubTypes().contains(SubType.CASE)) {
+        } else if (cardView.getArtRect() == ArtRect.FULL_LENGTH_LEFT) {
             drawRulesText(g, textboxKeywords, textboxRules,
                     contentWidth / 2 + totalContentInset + 4, totalContentInset + boxHeight + 2,
                     contentWidth / 2 - 8, typeLineY - totalContentInset - boxHeight - 6, false);

--- a/Mage.Common/src/main/java/mage/view/CardView.java
+++ b/Mage.Common/src/main/java/mage/view/CardView.java
@@ -527,7 +527,6 @@ public class CardView extends SimpleCardView {
             // Determine what part of the art to slice out for spells on the stack which originate
             // from a split, fuse, or aftermath split card.
             // Modal double faces cards draws as normal cards
-            // Sagas and cases have completely different layouts
             SpellAbilityType ty = spell.getSpellAbility().getSpellAbilityType();
             if (ty == SpellAbilityType.SPLIT_RIGHT || ty == SpellAbilityType.SPLIT_LEFT || ty == SpellAbilityType.SPLIT_FUSED) {
                 // Needs a special art rect
@@ -548,10 +547,6 @@ public class CardView extends SimpleCardView {
                         artRect = ArtRect.SPLIT_LEFT;
                     }
                 }
-            } else if (spell.getSubtype().contains(SubType.SAGA)) {
-                artRect = ArtRect.SAGA;
-            } else if (spell.getSubtype().contains(SubType.CASE)) {
-                artRect = ArtRect.CASE;
             }
 
             // show for modal spell, which mode was chosen
@@ -578,6 +573,14 @@ public class CardView extends SimpleCardView {
                 }
 
             }
+        }
+
+        // Cases, classes and sagas have portrait art
+        if (card.getSubtype().contains(SubType.CASE) ||
+                card.getSubtype().contains(SubType.CLASS)) {
+            artRect = ArtRect.FULL_LENGTH_LEFT;
+        } else if (card.getSubtype().contains(SubType.SAGA)) {
+            artRect = ArtRect.FULL_LENGTH_RIGHT;
         }
 
         // Frame color
@@ -791,6 +794,12 @@ public class CardView extends SimpleCardView {
             this.rarity = Rarity.SPECIAL;
             this.rules = new ArrayList<>();
             this.rules.add(stackAbility.getRule());
+        }
+        if (object.getSubtype().contains(SubType.CASE) ||
+                object.getSubtype().contains(SubType.CLASS)) {
+            artRect = ArtRect.FULL_LENGTH_LEFT;
+        } else if (object.getSubtype().contains(SubType.SAGA)) {
+            artRect = ArtRect.FULL_LENGTH_RIGHT;
         }
         // Frame color
         this.frameColor = object.getFrameColor(game).copy();

--- a/Mage/src/main/java/mage/cards/ArtRect.java
+++ b/Mage/src/main/java/mage/cards/ArtRect.java
@@ -12,8 +12,8 @@ public enum ArtRect {
     SPLIT_LEFT(new Rectangle2D.Double(0.152, 0.539, 0.386, 0.400)),
     SPLIT_RIGHT(new Rectangle2D.Double(0.152, 0.058, 0.386, 0.400)),
     SPLIT_FUSED(null),
-    SAGA(new Rectangle2D.Double(0.497, 0.11, 0.426, 0.727)),
-    CASE(new Rectangle2D.Double(0.069, 0.11, 0.426, 0.727));
+    FULL_LENGTH_LEFT(new Rectangle2D.Double(0.069, 0.11, 0.426, 0.727)),
+    FULL_LENGTH_RIGHT(new Rectangle2D.Double(0.497, 0.11, 0.426, 0.727));
 
     public final Rectangle2D rect;
 


### PR DESCRIPTION
Case and Saga cards are now using a layout closer to the printed cards and utilizing the full art (issue #11762). Class cards have an almost identical layout to Case cards. The rendering has been updated to include them.

![classes](https://github.com/magefree/mage/assets/1636645/7f27e814-b9d7-4f94-8c38-780b416a1bfe)
