### PR TITLE
Clean up remaining non-static inner classes

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AvariceAmulet.java
+++ b/Mage.Sets/src/mage/cards/a/AvariceAmulet.java
@@ -1,15 +1,13 @@
-
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.DiesAttachedTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
@@ -17,9 +15,9 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetOpponent;
+
+import java.util.UUID;
 
 /**
  *
@@ -46,7 +44,7 @@ public final class AvariceAmulet extends CardImpl {
         this.addAbility(ability);
 
         // Whenever equipped creature dies, target opponent gains control of Avarice Amulet.
-        ability = new DiesAttachedTriggeredAbility(new AvariceAmuletChangeControlEffect(), "equipped creature", false);
+        ability = new DiesAttachedTriggeredAbility(new TargetPlayerGainControlSourceEffect(), "equipped creature", false);
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
 
@@ -62,31 +60,4 @@ public final class AvariceAmulet extends CardImpl {
     public AvariceAmulet copy() {
         return new AvariceAmulet(this);
     }
-}
-
-class AvariceAmuletChangeControlEffect extends ContinuousEffectImpl {
-
-    AvariceAmuletChangeControlEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "target opponent gains control of {this}";
-    }
-
-    private AvariceAmuletChangeControlEffect(final AvariceAmuletChangeControlEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public AvariceAmuletChangeControlEffect copy() {
-        return new AvariceAmuletChangeControlEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent != null) {
-            return permanent.changeControllerId(source.getFirstTarget(), game, source);
-        }
-        return false;
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/b/BloodbondMarch.java
+++ b/Mage.Sets/src/mage/cards/b/BloodbondMarch.java
@@ -38,47 +38,48 @@ public final class BloodbondMarch extends CardImpl {
         return new BloodbondMarch(this);
     }
 
-    private class BloodbondMarchEffect extends OneShotEffect {
+}
 
-        BloodbondMarchEffect() {
-            super(Outcome.Benefit);
-            staticText = "each player returns all cards with the same name as that spell from their graveyard to the battlefield";
+class BloodbondMarchEffect extends OneShotEffect {
+
+    BloodbondMarchEffect() {
+        super(Outcome.Benefit);
+        staticText = "each player returns all cards with the same name as that spell from their graveyard to the battlefield";
+    }
+
+    private BloodbondMarchEffect(final BloodbondMarchEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        if (controller == null || game.getPermanentOrLKIBattlefield(source.getSourceId()) == null) {
+            return false;
         }
 
-        private BloodbondMarchEffect(final BloodbondMarchEffect effect) {
-            super(effect);
+        Spell spell = game.getSpellOrLKIStack(this.getTargetPointer().getFirst(game, source));
+
+        if (spell == null) {
+            return false;
         }
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Player controller = game.getPlayer(source.getControllerId());
+        FilterCard filter = new FilterCard();
+        filter.add(new NamePredicate(spell.getName()));
 
-            if (controller == null || game.getPermanentOrLKIBattlefield(source.getSourceId()) == null) {
-                return false;
+        for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                player.moveCards(player.getGraveyard().getCards(filter, game), Zone.BATTLEFIELD, source, game);
             }
-
-            Spell spell = game.getSpellOrLKIStack(this.getTargetPointer().getFirst(game, source));
-
-            if (spell == null) {
-                return false;
-            }
-
-            FilterCard filter = new FilterCard();
-            filter.add(new NamePredicate(spell.getName()));
-
-            for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
-                Player player = game.getPlayer(playerId);
-                if (player != null) {
-                    player.moveCards(player.getGraveyard().getCards(filter, game), Zone.BATTLEFIELD, source, game);
-                }
-            }
-
-            return true;
         }
 
-        @Override
-        public BloodbondMarchEffect copy() {
-            return new BloodbondMarchEffect(this);
-        }
+        return true;
+    }
+
+    @Override
+    public BloodbondMarchEffect copy() {
+        return new BloodbondMarchEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/ChaosLord.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosLord.java
@@ -7,7 +7,7 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.condition.common.ControlsPermanentsComparedToOpponentsCondition;
 import mage.abilities.effects.AsThoughEffectImpl;
-import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.abilities.keyword.FirstStrikeAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -62,7 +62,7 @@ class ChaosLordTriggeredAbility extends BeginningOfUpkeepTriggeredAbility {
 
     ChaosLordTriggeredAbility() {
         super(Zone.BATTLEFIELD,
-                new GainControlSourceEffect(),
+                new TargetPlayerGainControlSourceEffect(),
                 TargetController.YOU,
                 false);
     }
@@ -96,39 +96,11 @@ class ChaosLordTriggeredAbility extends BeginningOfUpkeepTriggeredAbility {
 
 }
 
-class GainControlSourceEffect extends ContinuousEffectImpl {
-
-    GainControlSourceEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "target opponent gains control of {this}";
-    }
-
-    private GainControlSourceEffect(final GainControlSourceEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public GainControlSourceEffect copy() {
-        return new GainControlSourceEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent != null) {
-            return permanent.changeControllerId(source.getFirstTarget(), game, source);
-        } else {
-            discard();
-        }
-        return false;
-    }
-}
-
 class ChaosLordEffect extends AsThoughEffectImpl {
 
     ChaosLordEffect() {
         super(AsThoughEffectType.ATTACK_AS_HASTE, Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "Chaos Lord can attack as though it had haste unless it entered the battlefield this turn";
+        staticText = "{this} can attack as though it had haste unless it entered the battlefield this turn";
     }
 
     private ChaosLordEffect(final ChaosLordEffect effect) {

--- a/Mage.Sets/src/mage/cards/c/CovetedJewel.java
+++ b/Mage.Sets/src/mage/cards/c/CovetedJewel.java
@@ -1,18 +1,18 @@
 package mage.cards.c;
 
-import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.DrawCardTargetEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.abilities.effects.common.UntapSourceEffect;
 import mage.abilities.effects.mana.AddManaOfAnyColorEffect;
 import mage.abilities.mana.SimpleManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -59,7 +59,7 @@ class CovetedJewelTriggeredAbility extends TriggeredAbilityImpl {
 
     public CovetedJewelTriggeredAbility() {
         super(Zone.BATTLEFIELD, new DrawCardTargetEffect(3), false);
-        this.addEffect(new CovetedJewelControlEffect());
+        this.addEffect(new TargetPlayerGainControlSourceEffect());
         this.addEffect(new UntapSourceEffect());
     }
 
@@ -101,33 +101,5 @@ class CovetedJewelTriggeredAbility extends TriggeredAbilityImpl {
         return "Whenever one or more creatures an opponent controls attack you "
                 + "and aren't blocked, that player draws three cards "
                 + "and gains control of {this}. Untap it.";
-    }
-}
-
-class CovetedJewelControlEffect extends ContinuousEffectImpl {
-
-    CovetedJewelControlEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-    }
-
-    private CovetedJewelControlEffect(final CovetedJewelControlEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public CovetedJewelControlEffect copy() {
-        return new CovetedJewelControlEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getSourceId());
-        Player newControllingPlayer = game.getPlayer(getTargetPointer().getFirst(game, source));
-        if (permanent == null || newControllingPlayer == null || !newControllingPlayer.canRespond()) {
-            this.discard();
-            return false;
-        }
-        permanent.changeControllerId(getTargetPointer().getFirst(game, source), game, source);
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CragSaurian.java
+++ b/Mage.Sets/src/mage/cards/c/CragSaurian.java
@@ -1,21 +1,14 @@
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.SourceDealsDamageToThisTriggeredAbility;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
 
 /**
  *
@@ -30,7 +23,7 @@ public final class CragSaurian extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Whenever a source deals damage to Crag Saurian, that source's controller gains control of Crag Saurian.
-        this.addAbility(new SourceDealsDamageToThisTriggeredAbility(new CragSaurianEffect()));
+        this.addAbility(new SourceDealsDamageToThisTriggeredAbility(new TargetPlayerGainControlSourceEffect("that source's controller")));
     }
 
     private CragSaurian(final CragSaurian card) {
@@ -40,35 +33,5 @@ public final class CragSaurian extends CardImpl {
     @Override
     public CragSaurian copy() {
         return new CragSaurian(this);
-    }
-}
-
-class CragSaurianEffect extends OneShotEffect {
-
-    CragSaurianEffect() {
-        super(Outcome.GainControl);
-        this.staticText = "that source's controller gains control of {this}";
-    }
-
-    private CragSaurianEffect(final CragSaurianEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        Player newController = game.getPlayer(this.getTargetPointer().getFirst(game, source));
-        if (newController != null && controller != null && !controller.equals(newController)) {
-            ContinuousEffect effect = new GainControlTargetEffect(Duration.Custom, newController.getId());
-            effect.setTargetPointer(new FixedTarget(source.getSourceId(), game));
-            game.addEffect(effect, source);
-            return true;
-        }
-        return false;
-    }
-
-    @Override
-    public CragSaurianEffect copy() {
-        return new CragSaurianEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DivineIntervention.java
+++ b/Mage.Sets/src/mage/cards/d/DivineIntervention.java
@@ -32,7 +32,7 @@ public final class DivineIntervention extends CardImpl {
 
         // Divine Intervention enters the battlefield with 2 intervention counters on it.
         Effect effect = new AddCountersSourceEffect(CounterType.INTERVENTION.createInstance(2));
-        this.addAbility(new EntersBattlefieldAbility(effect, "with 2 intervention counters"));
+        this.addAbility(new EntersBattlefieldAbility(effect, "with 2 intervention counters on it"));
 
         // At the beginning of your upkeep, remove an intervention counter from Divine Intervention.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.INTERVENTION.createInstance()), TargetController.YOU, false));
@@ -50,69 +50,64 @@ public final class DivineIntervention extends CardImpl {
         return new DivineIntervention(this);
     }
 
-    class DivineInterventionAbility extends TriggeredAbilityImpl {
+}
 
-        public DivineInterventionAbility() {
-            super(Zone.BATTLEFIELD, new DivineAbilityEffect2(), false);
-        }
+class DivineInterventionAbility extends TriggeredAbilityImpl {
 
-        private DivineInterventionAbility(final DivineInterventionAbility ability) {
-            super(ability);
-        }
-
-        @Override
-        public DivineInterventionAbility copy() {
-            return new DivineInterventionAbility(this);
-        }
-
-        @Override
-        public boolean checkEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.COUNTERS_REMOVED;
-        }
-
-        @Override
-        public boolean checkTrigger(GameEvent event, Game game) {
-            return (event.getData().equals(CounterType.INTERVENTION.getName())
-                    && event.getTargetId().equals(this.getSourceId())
-                    && event.getPlayerId() != null
-                    && event.getPlayerId() == this.getControllerId());  // the controller of this removed the counter 
-        }
-
-        @Override
-        public String getRule() {
-            return "When you remove the last intervention counter from {this}, the game is drawn.";
-        }
+    DivineInterventionAbility() {
+        super(Zone.BATTLEFIELD, new DivineInterventionDrawEffect(), false);
+        setTriggerPhrase("When you remove the last intervention counter from {this}, ");
     }
 
-    class DivineAbilityEffect2 extends OneShotEffect {
+    private DivineInterventionAbility(final DivineInterventionAbility ability) {
+        super(ability);
+    }
 
-        public DivineAbilityEffect2() {
-            super(Outcome.Neutral);
-            this.staticText = "you draw the game";
-        }
+    @Override
+    public DivineInterventionAbility copy() {
+        return new DivineInterventionAbility(this);
+    }
 
-        private DivineAbilityEffect2(final DivineAbilityEffect2 effect) {
-            super(effect);
-        }
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.COUNTERS_REMOVED;
+    }
 
-        @Override
-        public DivineAbilityEffect2 copy() {
-            return new DivineAbilityEffect2(this);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Player controller = game.getPlayer(source.getControllerId());
-            Permanent sourcePermanent = game.getPermanentOrLKIBattlefield(source.getSourceId());
-            if (controller != null 
-                    && sourcePermanent != null) {
-                if (game.getState().getZone(sourcePermanent.getId()) == Zone.BATTLEFIELD
-                        && sourcePermanent.getCounters(game).getCount(CounterType.INTERVENTION) == 0) {
-                    game.setDraw(controller.getId());
-                }
-                return true;
-            }
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (!event.getData().equals(CounterType.INTERVENTION.getName())
+                || !this.getSourceId().equals(event.getTargetId())
+                || !this.getControllerId().equals(event.getPlayerId())) {
             return false;
         }
+        Permanent permanent = game.getPermanent(this.getSourceId());
+        return permanent != null && permanent.getCounters(game).getCount(CounterType.INTERVENTION) == 0;
+    }
+}
+
+class DivineInterventionDrawEffect extends OneShotEffect {
+
+    DivineInterventionDrawEffect() {
+        super(Outcome.Neutral);
+        this.staticText = "the game is a draw";
+    }
+
+    private DivineInterventionDrawEffect(final DivineInterventionDrawEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DivineInterventionDrawEffect copy() {
+        return new DivineInterventionDrawEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            game.setDraw(controller.getId());
+            return true;
+        }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DroolingOgre.java
+++ b/Mage.Sets/src/mage/cards/d/DroolingOgre.java
@@ -1,28 +1,19 @@
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.TriggeredAbilityImpl;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.abilities.common.SpellCastAllTriggeredAbility;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.SetTargetPointer;
 import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.stack.Spell;
-import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
- *
- * @author wetterlicht
+ * @author xenohedron
  */
 public final class DroolingOgre extends CardImpl {
 
@@ -33,7 +24,8 @@ public final class DroolingOgre extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever a player casts an artifact spell, that player gains control of Drooling Ogre.
-        this.addAbility(new DroolingOgreTriggeredAbility());
+        this.addAbility(new SpellCastAllTriggeredAbility(new TargetPlayerGainControlSourceEffect(),
+                StaticFilters.FILTER_SPELL_AN_ARTIFACT, false, SetTargetPointer.PLAYER));
     }
 
     private DroolingOgre(final DroolingOgre card) {
@@ -45,72 +37,4 @@ public final class DroolingOgre extends CardImpl {
         return new DroolingOgre(this);
     }
 
-    private static class DroolingOgreEffect extends OneShotEffect {
-
-        DroolingOgreEffect() {
-            super(Outcome.GainControl);
-            this.staticText = "that player gains control of {this}";
-        }
-
-        private DroolingOgreEffect(final DroolingOgreEffect effect) {
-            super(effect);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Player controller = game.getPlayer(source.getControllerId());
-            Player newController = game.getPlayer(this.getTargetPointer().getFirst(game, source));
-            if (newController != null 
-                    && controller != null 
-                    && !controller.equals(newController)) {
-                ContinuousEffect effect = new GainControlTargetEffect(Duration.Custom, newController.getId());
-                effect.setTargetPointer(new FixedTarget(source.getSourceId(), game));
-                game.addEffect(effect, source);
-                return true;
-            }
-            return false;
-        }
-
-        @Override
-        public DroolingOgreEffect copy() {
-            return new DroolingOgreEffect(this);
-        }
-
-    }
-
-    class DroolingOgreTriggeredAbility extends TriggeredAbilityImpl {
-
-        public DroolingOgreTriggeredAbility() {
-            super(Zone.BATTLEFIELD, new DroolingOgreEffect(), false);
-        }
-
-        private DroolingOgreTriggeredAbility(final DroolingOgreTriggeredAbility ability) {
-            super(ability);
-        }
-
-        @Override
-        public DroolingOgreTriggeredAbility copy() {
-            return new DroolingOgreTriggeredAbility(this);
-        }
-
-        @Override
-        public boolean checkEventType(GameEvent event, Game game) {
-            return event.getType() == GameEvent.EventType.SPELL_CAST;
-        }
-
-        @Override
-        public boolean checkTrigger(GameEvent event, Game game) {
-            Spell spell = game.getStack().getSpell(event.getTargetId());
-            if (spell != null && spell.isArtifact(game)) {
-                this.getEffects().get(0).setTargetPointer(new FixedTarget(event.getPlayerId()));
-                return true;
-            }
-            return false;
-        }
-
-        @Override
-        public String getRule() {
-            return "Whenever a player casts an artifact spell, that player gains control of {this}.";
-        }
-    }
 }

--- a/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
@@ -147,7 +147,7 @@ class EtherealValkyrieEffect extends OneShotEffect {
             foretellAbility.setControllerId(exileCard.getOwnerId());
             game.getState().addOtherAbility(exileCard, foretellAbility);
             foretellAbility.activate(game, true);
-            ContinuousEffect effect = foretellAbility.new ForetellAddCostEffect(new MageObjectReference(exileCard, game));
+            ContinuousEffect effect = new ForetellAbility.ForetellAddCostEffect(new MageObjectReference(exileCard, game));
             game.addEffect(effect, copiedSource);
             game.fireEvent(GameEvent.getEvent(GameEvent.EventType.FORETOLD, exileCard.getId(), null, null));
         }

--- a/Mage.Sets/src/mage/cards/h/HumbleDefector.java
+++ b/Mage.Sets/src/mage/cards/h/HumbleDefector.java
@@ -5,22 +5,20 @@ import mage.abilities.Ability;
 import mage.abilities.common.ActivateIfConditionActivatedAbility;
 import mage.abilities.condition.common.MyTurnCondition;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.ContinuousEffectImpl;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.abilities.hint.common.MyTurnHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.Zone;
 import mage.target.common.TargetOpponent;
 
 import java.util.UUID;
 
 /**
- * @author jeffwadsworth
+ * @author xenohedron
  */
 public final class HumbleDefector extends CardImpl {
 
@@ -32,7 +30,9 @@ public final class HumbleDefector extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {T}: Draw two cards. Target opponent gains control of Humble Defector. Activate this ability only during your turn.
-        Ability ability = new ActivateIfConditionActivatedAbility(Zone.BATTLEFIELD, new HumbleDefectorEffect(), new TapSourceCost(), MyTurnCondition.instance);
+        Ability ability = new ActivateIfConditionActivatedAbility(Zone.BATTLEFIELD,
+                new DrawCardSourceControllerEffect(2), new TapSourceCost(), MyTurnCondition.instance);
+        ability.addEffect(new TargetPlayerGainControlSourceEffect());
         ability.addTarget(new TargetOpponent());
         ability.addHint(MyTurnHint.instance);
         this.addAbility(ability);
@@ -46,68 +46,5 @@ public final class HumbleDefector extends CardImpl {
     @Override
     public HumbleDefector copy() {
         return new HumbleDefector(this);
-    }
-}
-
-class HumbleDefectorEffect extends OneShotEffect {
-
-    HumbleDefectorEffect() {
-        super(Outcome.Discard);
-        this.staticText = "Draw two cards. Target opponent gains control of {this}.";
-    }
-
-    private HumbleDefectorEffect(final HumbleDefectorEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public HumbleDefectorEffect copy() {
-        return new HumbleDefectorEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            controller.drawCards(2, source, game);
-        }
-        Permanent humbleDefector = source.getSourcePermanentIfItStillExists(game);
-        Player targetOpponent = game.getPlayer(getTargetPointer().getFirst(game, source));
-        if (targetOpponent != null && humbleDefector != null) {
-            ContinuousEffect effect = new HumbleDefectorControlSourceEffect();
-            game.addEffect(effect, source);
-            game.informPlayers(humbleDefector.getName() + " is now controlled by " + targetOpponent.getLogName());
-            return true;
-        }
-        return false;
-    }
-}
-
-class HumbleDefectorControlSourceEffect extends ContinuousEffectImpl {
-
-    HumbleDefectorControlSourceEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-    }
-
-    private HumbleDefectorControlSourceEffect(final HumbleDefectorControlSourceEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public HumbleDefectorControlSourceEffect copy() {
-        return new HumbleDefectorControlSourceEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player targetOpponent = game.getPlayer(source.getFirstTarget());
-        Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent != null && targetOpponent != null) {
-            permanent.changeControllerId(targetOpponent.getId(), game, source);
-        } else {
-            // no valid target exists, effect can be discarded
-            discard();
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/i/ImpendingDisaster.java
+++ b/Mage.Sets/src/mage/cards/i/ImpendingDisaster.java
@@ -1,21 +1,21 @@
-
 package mage.cards.i;
 
-import java.util.UUID;
-import mage.abilities.Ability;
 import mage.abilities.TriggeredAbility;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.condition.Condition;
+import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.DestroyAllEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.ComparisonType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
-import mage.filter.common.FilterLandPermanent;
-import mage.game.Game;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
  *
@@ -23,16 +23,16 @@ import mage.game.Game;
  */
 public final class ImpendingDisaster extends CardImpl {
 
+    private static final Condition condition = new PermanentsOnTheBattlefieldCondition(StaticFilters.FILTER_LAND, ComparisonType.OR_GREATER, 7, false);
+
     public ImpendingDisaster(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{R}");
 
-
         // At the beginning of your upkeep, if there are seven or more lands on the battlefield, sacrifice Impending Disaster and destroy all lands.
         TriggeredAbility ability  = new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, new SacrificeSourceEffect(), TargetController.YOU, false);
-        ability.addEffect(new DestroyAllEffect(new FilterLandPermanent()));
-        ImpendingDisasterCondition contition = new ImpendingDisasterCondition();
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, contition, "At the beginning of your upkeep, if there are seven or more lands on the battlefield, sacrifice {this} and destroy all lands"));
-        
+        ability.addEffect(new DestroyAllEffect(StaticFilters.FILTER_LANDS));
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, condition,
+                "At the beginning of your upkeep, if there are seven or more lands on the battlefield, sacrifice {this} and destroy all lands"));
     }
 
     private ImpendingDisaster(final ImpendingDisaster card) {
@@ -42,13 +42,5 @@ public final class ImpendingDisaster extends CardImpl {
     @Override
     public ImpendingDisaster copy() {
         return new ImpendingDisaster(this);
-    }
-    
-    class ImpendingDisasterCondition implements Condition {
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return game.getBattlefield().count(new FilterLandPermanent(), source.getControllerId(), source, game) >= 7;
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/j/JinxedChoker.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedChoker.java
@@ -6,10 +6,10 @@ import mage.abilities.common.OnEventTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DamageControllerEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.effects.common.counter.RemoveCounterSourceEffect;
 import mage.cards.CardImpl;
@@ -34,7 +34,7 @@ public final class JinxedChoker extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // At the beginning of your end step, target opponent gains control of Jinxed Choker and puts a charge counter on it.
-        Ability endStepAbility = new BeginningOfYourEndStepTriggeredAbility(new JinxedChokerChangeControllerEffect(), false);
+        Ability endStepAbility = new BeginningOfYourEndStepTriggeredAbility(new TargetPlayerGainControlSourceEffect(), false);
         endStepAbility.addEffect(new JinxedChokerAddCounterEffect());
         endStepAbility.addTarget(new TargetOpponent());
         this.addAbility(endStepAbility);
@@ -56,35 +56,6 @@ public final class JinxedChoker extends CardImpl {
     public JinxedChoker copy() {
         return new JinxedChoker(this);
     }
-}
-
-class JinxedChokerChangeControllerEffect extends ContinuousEffectImpl {
-
-    JinxedChokerChangeControllerEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "target opponent gains control of {this}";
-    }
-
-    private JinxedChokerChangeControllerEffect(final JinxedChokerChangeControllerEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public JinxedChokerChangeControllerEffect copy() {
-        return new JinxedChokerChangeControllerEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent != null) {
-            return permanent.changeControllerId(source.getFirstTarget(), game, source);
-        } else {
-            discard();
-        }
-        return false;
-    }
-
 }
 
 class JinxedChokerAddCounterEffect extends OneShotEffect {

--- a/Mage.Sets/src/mage/cards/j/JinxedIdol.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedIdol.java
@@ -1,22 +1,20 @@
-
 package mage.cards.j;
 
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.common.OnEventTriggeredAbility;
+import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.DamageControllerEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.TargetController;
+import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.events.GameEvent.EventType;
-import mage.game.permanent.Permanent;
-import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetOpponent;
+
+import java.util.UUID;
 
 /**
  *
@@ -28,10 +26,10 @@ public final class JinxedIdol extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // At the beginning of your upkeep, Jinxed Idol deals 2 damage to you.
-        this.addAbility(new OnEventTriggeredAbility(EventType.UPKEEP_STEP_PRE, "beginning of your upkeep", new DamageControllerEffect(2)));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new DamageControllerEffect(2), TargetController.YOU, false));
 
         // Sacrifice a creature: Target opponent gains control of Jinxed Idol.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new JinxedIdolEffect(),
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TargetPlayerGainControlSourceEffect(),
                 new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
@@ -44,35 +42,6 @@ public final class JinxedIdol extends CardImpl {
     @Override
     public JinxedIdol copy() {
         return new JinxedIdol(this);
-    }
-
-}
-
-class JinxedIdolEffect extends ContinuousEffectImpl {
-
-    JinxedIdolEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "Target opponent gains control of {this}";
-    }
-
-    private JinxedIdolEffect(final JinxedIdolEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public JinxedIdolEffect copy() {
-        return new JinxedIdolEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent != null) {
-            return permanent.changeControllerId(source.getFirstTarget(), game, source);
-        } else {
-            discard();
-        }
-        return false;
     }
 
 }

--- a/Mage.Sets/src/mage/cards/j/JinxedRing.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedRing.java
@@ -1,29 +1,21 @@
-
 package mage.cards.j;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.PutIntoGraveFromBattlefieldAllTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.DamageControllerEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-
 import mage.filter.predicate.permanent.TokenPredicate;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetOpponent;
+
+import java.util.UUID;
 
 /**
  *
@@ -44,7 +36,7 @@ public final class JinxedRing extends CardImpl {
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(new DamageControllerEffect(1), false, filter, false, true));
 
         // Sacrifice a creature: Target opponent gains control of Jinxed Ring.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new JinxedRingEffect(),
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TargetPlayerGainControlSourceEffect(),
                 new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
@@ -58,33 +50,4 @@ public final class JinxedRing extends CardImpl {
     public JinxedRing copy() {
         return new JinxedRing(this);
     }
-}
-
-class JinxedRingEffect extends ContinuousEffectImpl {
-
-    JinxedRingEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "Target opponent gains control of {this}";
-    }
-
-    private JinxedRingEffect(final JinxedRingEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public JinxedRingEffect copy() {
-        return new JinxedRingEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent != null) {
-            return permanent.changeControllerId(source.getFirstTarget(), game, source);
-        } else {
-            discard();
-        }
-        return false;
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/l/LoxodonPeacekeeper.java
+++ b/Mage.Sets/src/mage/cards/l/LoxodonPeacekeeper.java
@@ -1,4 +1,3 @@
-
 package mage.cards.l;
 
 import java.util.HashSet;
@@ -95,7 +94,7 @@ class LoxodonPeacekeeperEffect extends OneShotEffect {
                     }
                 }
                 
-                if (tiedPlayers.size() > 0) {
+                if (!tiedPlayers.isEmpty()) {
                     UUID newControllerId = null;
                     if (tiedPlayers.size() > 1) {
                         FilterPlayer filter = new FilterPlayer("a player tied for lowest life total");

--- a/Mage.Sets/src/mage/cards/m/MeasureOfWickedness.java
+++ b/Mage.Sets/src/mage/cards/m/MeasureOfWickedness.java
@@ -1,29 +1,22 @@
-
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.common.PutCardIntoGraveFromAnywhereAllTriggeredAbility;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
 import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.predicate.mageobject.AnotherPredicate;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.common.TargetOpponent;
+
+import java.util.UUID;
 
 /**
  *
@@ -50,7 +43,7 @@ public final class MeasureOfWickedness extends CardImpl {
 
         // Whenever another card is put into your graveyard from anywhere, target opponent gains control of Measure of Wickedness.
         ability = new PutCardIntoGraveFromAnywhereAllTriggeredAbility(
-                new MeasureOfWickednessControlSourceEffect(), false, filter, TargetController.YOU);
+                new TargetPlayerGainControlSourceEffect(), false, filter, TargetController.YOU);
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
 
@@ -63,35 +56,5 @@ public final class MeasureOfWickedness extends CardImpl {
     @Override
     public MeasureOfWickedness copy() {
         return new MeasureOfWickedness(this);
-    }
-}
-
-class MeasureOfWickednessControlSourceEffect extends ContinuousEffectImpl {
-
-    MeasureOfWickednessControlSourceEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "target opponent gains control of {this}";
-    }
-
-    private MeasureOfWickednessControlSourceEffect(final MeasureOfWickednessControlSourceEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public MeasureOfWickednessControlSourceEffect copy() {
-        return new MeasureOfWickednessControlSourceEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player targetOpponent = game.getPlayer(source.getFirstTarget());
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent != null && targetOpponent != null) {
-                permanent.changeControllerId(targetOpponent.getId(), game, source);
-        } else {
-            // no valid target exists, effect can be discarded
-            discard();
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/n/NaturalBalance.java
+++ b/Mage.Sets/src/mage/cards/n/NaturalBalance.java
@@ -43,66 +43,69 @@ public final class NaturalBalance extends CardImpl {
         return new NaturalBalance(this);
     }
 
-    class NaturalBalanceEffect extends OneShotEffect {
+}
 
-        public NaturalBalanceEffect() {
-            super(Outcome.PutCardInPlay);
-            this.staticText = "Each player who controls six or more lands chooses five lands they control and sacrifices the rest. Each player who controls four or fewer lands may search their library for up to X basic land cards and put them onto the battlefield, where X is five minus the number of lands they control. Then each player who searched their library this way shuffles.";
-        }
+class NaturalBalanceEffect extends OneShotEffect {
 
-        private NaturalBalanceEffect(final NaturalBalanceEffect effect) {
-            super(effect);
-        }
+    NaturalBalanceEffect() {
+        super(Outcome.PutCardInPlay);
+        this.staticText = "Each player who controls six or more lands chooses five lands they control and sacrifices the rest. " +
+                "Each player who controls four or fewer lands may search their library for up to X basic land cards and put them onto the battlefield, " +
+                "where X is five minus the number of lands they control. Then each player who searched their library this way shuffles.";
+    }
 
-        @Override
-        public NaturalBalanceEffect copy() {
-            return new NaturalBalanceEffect(this);
-        }
+    private NaturalBalanceEffect(final NaturalBalanceEffect effect) {
+        super(effect);
+    }
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Player controller = game.getPlayer(source.getControllerId());
-            if (controller != null) {
-                PlayerList players = game.getState().getPlayersInRange(controller.getId(), game);
-                for (UUID playerId : players) {
-                    Player player = game.getPlayer(playerId);
-                    if (player != null) {
-                        int landCount = game.getBattlefield().countAll(new FilterControlledLandPermanent(), player.getId(), game);
-                        if (landCount > 5) {
-                            // chooses five lands they control and sacrifices the rest
-                            TargetControlledPermanent target = new TargetControlledPermanent(5, 5, new FilterControlledLandPermanent("lands to keep"), true);
-                            if (target.choose(Outcome.Sacrifice, player.getId(), source.getSourceId(), source, game)) {
-                                for (Permanent permanent : game.getBattlefield().getAllActivePermanents(new FilterLandPermanent(), player.getId(), game)) {
-                                    if (!target.getTargets().contains(permanent.getId())) {
-                                        permanent.sacrifice(source, game);
-                                    }
+    @Override
+    public NaturalBalanceEffect copy() {
+        return new NaturalBalanceEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            PlayerList players = game.getState().getPlayersInRange(controller.getId(), game);
+            for (UUID playerId : players) {
+                Player player = game.getPlayer(playerId);
+                if (player != null) {
+                    int landCount = game.getBattlefield().countAll(new FilterControlledLandPermanent(), player.getId(), game);
+                    if (landCount > 5) {
+                        // chooses five lands they control and sacrifices the rest
+                        TargetControlledPermanent target = new TargetControlledPermanent(5, 5, new FilterControlledLandPermanent("lands to keep"), true);
+                        if (target.choose(Outcome.Sacrifice, player.getId(), source.getSourceId(), source, game)) {
+                            for (Permanent permanent : game.getBattlefield().getAllActivePermanents(new FilterLandPermanent(), player.getId(), game)) {
+                                if (!target.getTargets().contains(permanent.getId())) {
+                                    permanent.sacrifice(source, game);
                                 }
                             }
                         }
                     }
                 }
-                List<Player> toShuffle = new ArrayList<>();
-                for (UUID playerId : players) {
-                    Player player = game.getPlayer(playerId);
-                    if (player != null) {
-                        int landCount = game.getBattlefield().countAll(new FilterControlledLandPermanent(), player.getId(), game);
-                        int amount = 5 - landCount;
-                        if (landCount < 5 && player.chooseUse(outcome, "Search your library for up to " + amount + " basic land cards and put them onto the battlefield?", source, game)) {
-                            // Select lands and put them onto battlefield
-                            TargetCardInLibrary target = new TargetCardInLibrary(0, amount, StaticFilters.FILTER_CARD_BASIC_LAND);
-                            if (player.searchLibrary(target, source, game)) {
-                                player.moveCards(new CardsImpl(target.getTargets()).getCards(game), Zone.BATTLEFIELD, source, game);
-                            }
-                            toShuffle.add(player);
+            }
+            List<Player> toShuffle = new ArrayList<>();
+            for (UUID playerId : players) {
+                Player player = game.getPlayer(playerId);
+                if (player != null) {
+                    int landCount = game.getBattlefield().countAll(new FilterControlledLandPermanent(), player.getId(), game);
+                    int amount = 5 - landCount;
+                    if (landCount < 5 && player.chooseUse(outcome, "Search your library for up to " + amount + " basic land cards and put them onto the battlefield?", source, game)) {
+                        // Select lands and put them onto battlefield
+                        TargetCardInLibrary target = new TargetCardInLibrary(0, amount, StaticFilters.FILTER_CARD_BASIC_LAND);
+                        if (player.searchLibrary(target, source, game)) {
+                            player.moveCards(new CardsImpl(target.getTargets()).getCards(game), Zone.BATTLEFIELD, source, game);
                         }
+                        toShuffle.add(player);
                     }
                 }
-                for (Player player : toShuffle) {
-                    player.shuffleLibrary(source, game);
-                }
-                return true;
             }
-            return false;
+            for (Player player : toShuffle) {
+                player.shuffleLibrary(source, game);
+            }
+            return true;
         }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PureReflection.java
+++ b/Mage.Sets/src/mage/cards/p/PureReflection.java
@@ -37,50 +37,49 @@ public final class PureReflection extends CardImpl {
     public PureReflection copy() {
         return new PureReflection(this);
     }
+}
 
-    private class PureReflectionEffect extends OneShotEffect {
+class PureReflectionEffect extends OneShotEffect {
 
-        PureReflectionEffect() {
-            super(Outcome.Benefit);
-            staticText = "destroy all Reflections. Then that player creates an X/X white Reflection creature token, where X is the mana value of that spell.";
+    PureReflectionEffect() {
+        super(Outcome.Benefit);
+        staticText = "destroy all Reflections. Then that player creates an X/X white Reflection creature token, where X is the mana value of that spell.";
+    }
+
+    private PureReflectionEffect(final PureReflectionEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+
+        if (controller == null || game.getPermanentOrLKIBattlefield(source.getSourceId()) == null) {
+            return false;
         }
 
-        private PureReflectionEffect(final PureReflectionEffect effect) {
-            super(effect);
+        Spell spell = game.getSpellOrLKIStack(this.getTargetPointer().getFirst(game, source));
+
+        if (spell == null) {
+            return false;
         }
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Player controller = game.getPlayer(source.getControllerId());
+        // destroy all Reflections
+        FilterPermanent filter = new FilterPermanent("Reflections");
+        filter.add(SubType.REFLECTION.getPredicate());
+        game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)
+                .forEach(permanent -> permanent.destroy(source, game,false));
+        game.getState().processAction(game);
 
-            if (controller == null || game.getPermanentOrLKIBattlefield(source.getSourceId()) == null) {
-                return false;
-            }
+        // Then that player creates an X/X white Reflection creature token, where X is the converted mana cost of that spell.
+        ReflectionPureToken token = new ReflectionPureToken(spell.getManaValue());
+        token.putOntoBattlefield(1, game, source, spell.getControllerId());
 
-            Spell spell = game.getSpellOrLKIStack(this.getTargetPointer().getFirst(game, source));
+        return true;
+    }
 
-            if (spell == null) {
-                return false;
-            }
-
-            // destroy all Reflections
-            FilterPermanent filter = new FilterPermanent("Reflections");
-            filter.add(SubType.REFLECTION.getPredicate());
-            game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game).forEach((permanent) -> {
-                permanent.destroy(source, game,false);
-            });
-            game.getState().processAction(game);
-            
-            // Then that player creates an X/X white Reflection creature token, where X is the converted mana cost of that spell.
-            ReflectionPureToken token = new ReflectionPureToken(spell.getManaValue());
-            token.putOntoBattlefield(1, game, source, spell.getControllerId());
-
-            return true;
-        }
-
-        @Override
-        public PureReflectionEffect copy() {
-            return new PureReflectionEffect(this);
-        }
+    @Override
+    public PureReflectionEffect copy() {
+        return new PureReflectionEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RiskyMove.java
+++ b/Mage.Sets/src/mage/cards/r/RiskyMove.java
@@ -3,7 +3,6 @@ package mage.cards.r;
 import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.effects.ContinuousEffect;
@@ -100,7 +99,7 @@ class RiskyMoveGetControlEffect extends OneShotEffect {
 
 class RiskyMoveTriggeredAbility extends TriggeredAbilityImpl {
 
-    public RiskyMoveTriggeredAbility() {
+    RiskyMoveTriggeredAbility() {
         super(Zone.BATTLEFIELD, new RiskyMoveFlipCoinEffect(), false);
         setTriggerPhrase("When you gain control of {this} from another player, ");
     }
@@ -180,9 +179,9 @@ class RiskyMoveFlipCoinEffect extends OneShotEffect {
 
 class RiskyMoveCreatureGainControlEffect extends ContinuousEffectImpl {
 
-    private UUID controller;
+    private final UUID controller;
 
-    public RiskyMoveCreatureGainControlEffect(Duration duration, UUID controller) {
+    RiskyMoveCreatureGainControlEffect(Duration duration, UUID controller) {
         super(duration, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
         this.controller = controller;
         this.staticText = "If you lose the flip, that opponent gains control of that creature";

--- a/Mage.Sets/src/mage/cards/s/Shuriken.java
+++ b/Mage.Sets/src/mage/cards/s/Shuriken.java
@@ -80,7 +80,7 @@ class ShurikenEffect extends OneShotEffect {
         Permanent equipment = (Permanent) object;
         targetedPermanent.damage(2, equipment.getId(), source, game);
         Permanent attached = source.getSourcePermanentOrLKI(game);
-        if (attached != null && attached.hasSubtype(SubType.NINJA, game)) {
+        if (attached == null || attached.hasSubtype(SubType.NINJA, game)) {
             return true;
         }
         game.addEffect(new GainControlTargetEffect(

--- a/Mage.Sets/src/mage/cards/w/WitchEngine.java
+++ b/Mage.Sets/src/mage/cards/w/WitchEngine.java
@@ -1,27 +1,21 @@
-
 package mage.cards.w;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.common.TargetPlayerGainControlSourceEffect;
 import mage.abilities.effects.mana.BasicManaEffect;
 import mage.abilities.keyword.SwampwalkAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetOpponent;
+
+import java.util.UUID;
 
 /**
  *
@@ -40,7 +34,7 @@ public final class WitchEngine extends CardImpl {
 
         // {T}: Add {B}{B}{B}{B}. Target opponent gains control of Witch Engine. (Activate this ability only any time you could cast an instant.)
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.BlackMana(4)), new TapSourceCost());
-        ability.addEffect(new WitchEngineEffect());
+        ability.addEffect(new TargetPlayerGainControlSourceEffect());
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
     }
@@ -53,33 +47,4 @@ public final class WitchEngine extends CardImpl {
     public WitchEngine copy() {
         return new WitchEngine(this);
     }
-}
-
-class WitchEngineEffect extends ContinuousEffectImpl {
-
-    WitchEngineEffect() {
-        super(Duration.Custom, Layer.ControlChangingEffects_2, SubLayer.NA, Outcome.GainControl);
-        staticText = "target opponent gains control of {this}";
-    }
-
-    private WitchEngineEffect(final WitchEngineEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public WitchEngineEffect copy() {
-        return new WitchEngineEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent != null) {
-            return permanent.changeControllerId(source.getFirstTarget(), game, source);
-        } else {
-            discard();
-        }
-        return false;
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
+++ b/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
@@ -1,23 +1,23 @@
-
 package mage.cards.w;
 
 import mage.MageIdentifier;
 import mage.MageInt;
+import mage.MageObjectReference;
 import mage.abilities.Ability;
-import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
-import mage.abilities.effects.EntersBattlefieldEffect;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.counter.AddCounterEnteringCreatureEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
+import mage.game.events.GameEvent;
+import mage.game.stack.Spell;
 import mage.players.Player;
+import mage.watchers.Watcher;
 
 import java.util.UUID;
 
@@ -40,8 +40,7 @@ public final class WorldheartPhoenix extends CardImpl {
         // If you do, it enters the battlefield with two +1/+1 counters on it.
         Ability ability = new SimpleStaticAbility(Zone.ALL, new WorldheartPhoenixPlayEffect())
                 .setIdentifier(MageIdentifier.WorldheartPhoenixAlternateCast);
-        ability.addEffect(new EntersBattlefieldEffect(new WorldheartPhoenixEntersBattlefieldEffect(),
-                "If you do, it enters the battlefield with two +1/+1 counters on it"));
+        ability.addWatcher(new WorldheartPhoenixWatcher());
         this.addAbility(ability);
 
     }
@@ -54,80 +53,65 @@ public final class WorldheartPhoenix extends CardImpl {
     public WorldheartPhoenix copy() {
         return new WorldheartPhoenix(this);
     }
+}
 
-    class WorldheartPhoenixPlayEffect extends AsThoughEffectImpl {
+class WorldheartPhoenixPlayEffect extends AsThoughEffectImpl {
 
-        public WorldheartPhoenixPlayEffect() {
-            super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
-            staticText = "You may cast {this} from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost";
-        }
-
-        private WorldheartPhoenixPlayEffect(final WorldheartPhoenixPlayEffect effect) {
-            super(effect);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            return true;
-        }
-
-        @Override
-        public WorldheartPhoenixPlayEffect copy() {
-            return new WorldheartPhoenixPlayEffect(this);
-        }
-
-        @Override
-        public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
-            if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
-                if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
-                    Player player = game.getPlayer(affectedControllerId);
-                    if (player != null) {
-                        player.setCastSourceIdWithAlternateMana(
-                                sourceId, new ManaCostsImpl<>("{W}{U}{B}{R}{G}"), null,
-                                MageIdentifier.WorldheartPhoenixAlternateCast
-                        );
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
+    WorldheartPhoenixPlayEffect() {
+        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        staticText = "You may cast {this} from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost. " +
+                "If you do, it enters the battlefield with two +1/+1 counters on it";
     }
 
-    class WorldheartPhoenixEntersBattlefieldEffect extends OneShotEffect {
-
-        public WorldheartPhoenixEntersBattlefieldEffect() {
-            super(Outcome.BoostCreature);
-            staticText = "If you do, it enters the battlefield with two +1/+1 counters on it";
-        }
-
-        private WorldheartPhoenixEntersBattlefieldEffect(final WorldheartPhoenixEntersBattlefieldEffect effect) {
-            super(effect);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Permanent permanent = game.getPermanentEntering(source.getSourceId());
-            if (permanent != null) {
-                SpellAbility spellAbility = (SpellAbility) getValue(EntersBattlefieldEffect.SOURCE_CAST_SPELL_ABILITY);
-                if (spellAbility != null
-                        && spellAbility.getSourceId().equals(source.getSourceId())
-                        && permanent.getZoneChangeCounter(game) == spellAbility.getSourceObjectZoneChangeCounter()) {
-                    // TODO: No perfect solution because there could be other effects that allow to cast the card for this mana cost
-                    if (spellAbility.getManaCosts().getText().equals("{W}{U}{B}{R}{G}")) {
-                        permanent.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
-                    }
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public WorldheartPhoenixEntersBattlefieldEffect copy() {
-            return new WorldheartPhoenixEntersBattlefieldEffect(this);
-        }
-
+    private WorldheartPhoenixPlayEffect(final WorldheartPhoenixPlayEffect effect) {
+        super(effect);
     }
 
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public WorldheartPhoenixPlayEffect copy() {
+        return new WorldheartPhoenixPlayEffect(this);
+    }
+
+    @Override
+    public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+        if (sourceId.equals(source.getSourceId()) && source.isControlledBy(affectedControllerId)) {
+            if (game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD) {
+                Player player = game.getPlayer(affectedControllerId);
+                if (player != null) {
+                    player.setCastSourceIdWithAlternateMana(
+                            sourceId, new ManaCostsImpl<>("{W}{U}{B}{R}{G}"), null,
+                            MageIdentifier.WorldheartPhoenixAlternateCast
+                    );
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+}
+
+class WorldheartPhoenixWatcher extends Watcher {
+
+    WorldheartPhoenixWatcher() {
+        super(WatcherScope.GAME);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (GameEvent.EventType.SPELL_CAST.equals(event.getType())
+                && event.hasApprovingIdentifier(MageIdentifier.WorldheartPhoenixAlternateCast)) {
+            Spell target = game.getSpell(event.getTargetId());
+            if (target != null) {
+                game.getState().addEffect(new AddCounterEnteringCreatureEffect(new MageObjectReference(target.getCard(), game),
+                                CounterType.P1P1.createInstance(2), Outcome.BoostCreature),
+                        target.getSpellAbility());
+            }
+        }
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/asthough/PlayFromNonHandZoneTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/asthough/PlayFromNonHandZoneTest.java
@@ -2,6 +2,7 @@ package org.mage.test.cards.asthough;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.counters.CounterType;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
@@ -20,12 +21,13 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBaseWithAIHelps {
         addCard(Zone.HAND, playerA, "Worldheart Phoenix");
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Worldheart Phoenix"); // can only be cast by {W}{U}{B}{R}{G}
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Worldheart Phoenix");
 
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
 
         assertPowerToughness(playerA, "Worldheart Phoenix", 2, 2);
+        assertCounterCount(playerA, "Worldheart Phoenix", CounterType.P1P1, 0);
     }
 
     @Test
@@ -73,6 +75,7 @@ public class PlayFromNonHandZoneTest extends CardTestPlayerBaseWithAIHelps {
         execute();
 
         assertPermanentCount(playerA, "Worldheart Phoenix", 1);
+        assertCounterCount(playerA, "Worldheart Phoenix", CounterType.P1P1, 2);
     }
 
     @Test

--- a/Mage/src/main/java/mage/abilities/effects/common/TargetPlayerGainControlSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/TargetPlayerGainControlSourceEffect.java
@@ -1,0 +1,61 @@
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.abilities.Mode;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ * @author xenohedron
+ */
+public class TargetPlayerGainControlSourceEffect extends OneShotEffect {
+
+    private final String playerDescription;
+
+    public TargetPlayerGainControlSourceEffect() {
+        this("");
+    }
+
+    public TargetPlayerGainControlSourceEffect(String playerDescription) {
+        super(Outcome.Benefit);
+        this.playerDescription = playerDescription;
+    }
+
+    protected TargetPlayerGainControlSourceEffect(final TargetPlayerGainControlSourceEffect effect) {
+        super(effect);
+        this.playerDescription = effect.playerDescription;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
+        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
+        if (player == null || permanent == null) {
+            return false;
+        }
+        game.addEffect(new GainControlTargetEffect(
+                Duration.Custom, true, player.getId()
+        ).setTargetPointer(new FixedTarget(permanent, game)), source);
+        return true;
+    }
+
+    @Override
+    public TargetPlayerGainControlSourceEffect copy() {
+        return new TargetPlayerGainControlSourceEffect(this);
+    }
+
+    @Override
+    public String getText(Mode mode) {
+        if (staticText != null && !staticText.isEmpty()) {
+            return staticText;
+        }
+        return (playerDescription.isEmpty() ? getTargetPointer().describeTargets(mode.getTargets(), "that player") : playerDescription) +
+                " gains control of {this}";
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/AwakenAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/AwakenAbility.java
@@ -1,7 +1,6 @@
 package mage.abilities.keyword;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -20,7 +19,6 @@ import mage.target.Target;
 import mage.target.common.TargetControlledPermanent;
 import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
-import org.apache.log4j.Logger;
 
 import java.util.UUID;
 
@@ -29,12 +27,8 @@ import java.util.UUID;
  */
 public class AwakenAbility extends SpellAbility {
 
-    private static final Logger logger = Logger.getLogger(AwakenAbility.class);
-
-    private static final String filterMessage = "a land you control to awake";
-
     private final String rule;
-    private final int awakenValue;
+    private static final FilterControlledLandPermanent filter = new FilterControlledLandPermanent(AwakenEffect.filterMessage);
 
     public AwakenAbility(Card card, int awakenValue, String awakenCosts) {
         super(card.getSpellAbility());
@@ -47,9 +41,9 @@ public class AwakenAbility extends SpellAbility {
         this.clearManaCostsToPay();
         this.addCost(new ManaCostsImpl<>(awakenCosts));
 
-        this.addTarget(new TargetControlledPermanent(new FilterControlledLandPermanent(filterMessage)));
-        this.addEffect(new AwakenEffect());
-        this.awakenValue = awakenValue;
+        this.addTarget(new TargetControlledPermanent(filter));
+        this.addEffect(new AwakenEffect(awakenValue));
+
         rule = "Awaken " + awakenValue + "&mdash;" + awakenCosts
                 + " <i>(If you cast this spell for " + awakenCosts + ", also put "
                 + CardUtil.getOneOneCountersText(awakenValue)
@@ -58,7 +52,6 @@ public class AwakenAbility extends SpellAbility {
 
     protected AwakenAbility(final AwakenAbility ability) {
         super(ability);
-        this.awakenValue = ability.awakenValue;
         this.rule = ability.rule;
     }
 
@@ -77,56 +70,52 @@ public class AwakenAbility extends SpellAbility {
         return rule;
     }
 
-    class AwakenEffect extends OneShotEffect {
+}
 
-        private AwakenEffect() {
-            super(Outcome.BoostCreature);
-            this.staticText = "put " + CardUtil.getOneOneCountersText(awakenValue) +" on target land you control";
-        }
+class AwakenEffect extends OneShotEffect {
 
-        protected AwakenEffect(final AwakenEffect effect) {
-            super(effect);
-        }
+    static final String filterMessage = "a land you control to awake";
 
-        @Override
-        public AwakenEffect copy() {
-            return new AwakenEffect(this);
-        }
+    private final int awakenValue;
 
-        @Override
-        public boolean apply(Game game, Ability source) {
-            UUID targetId = null;
-            if (source != null && source.getTargets() != null) {
-                for (Target target : source.getTargets()) {
-                    if (target.getFilter() != null && target.getFilter().getMessage().equals(filterMessage)) {
-                        targetId = target.getFirstTarget();
-                    }
-                }
-                if (targetId != null) {
-                    FixedTarget fixedTarget = new FixedTarget(targetId, game);
-                    ContinuousEffect continuousEffect = new BecomesCreatureTargetEffect(new AwakenElementalToken(), false, true, Duration.Custom);
-                    continuousEffect.setTargetPointer(fixedTarget);
-                    game.addEffect(continuousEffect, source);
-                    Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(awakenValue));
-                    effect.setTargetPointer(fixedTarget);
-                    return effect.apply(game, source);
-                }
-            } else // source should never be null, but we are seeing a lot of NPEs from this section
-                if (source == null) {
-                    logger.fatal("Source was null in AwakenAbility: Create a bug report or fix the source code");
-                } else if (source.getTargets() == null) {
-                    MageObject sourceObj = source.getSourceObject(game);
-                    if (sourceObj != null) {
-                        Class<? extends MageObject> sourceClass = sourceObj.getClass();
-                        if (sourceClass != null) {
-                            logger.fatal("getTargets was null in AwakenAbility for " + sourceClass.toString() + " : Create a bug report or fix the source code");
-                        }
-                    }
-                }
-            return true;
-        }
+    AwakenEffect(int awakenValue) {
+        super(Outcome.BoostCreature);
+        this.awakenValue = awakenValue;
+        this.staticText = "put " + CardUtil.getOneOneCountersText(awakenValue) + " on target land you control and it becomes a 0/0 Elemental creature with haste";
     }
 
+    private AwakenEffect(final AwakenEffect effect) {
+        super(effect);
+        this.awakenValue = effect.awakenValue;
+    }
+
+    @Override
+    public AwakenEffect copy() {
+        return new AwakenEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        UUID targetId = null;
+        if (source != null && source.getTargets() != null) {
+            for (Target target : source.getTargets()) {
+                if (target.getFilter() != null && target.getFilter().getMessage().equals(filterMessage)) {
+                    targetId = target.getFirstTarget();
+                }
+            }
+            if (targetId != null) {
+                FixedTarget fixedTarget = new FixedTarget(targetId, game);
+                ContinuousEffect continuousEffect = new BecomesCreatureTargetEffect(new AwakenElementalToken(), false, true, Duration.Custom);
+                continuousEffect.setTargetPointer(fixedTarget);
+                game.addEffect(continuousEffect, source);
+                Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(awakenValue));
+                effect.setTargetPointer(fixedTarget);
+                effect.apply(game, source);
+            }
+            return true;
+        }
+        return false;
+    }
 }
 
 class AwakenElementalToken extends TokenImpl {

--- a/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
@@ -90,13 +90,13 @@ public class ForetellAbility extends SpecialAction {
         return " foretells a card from hand";
     }
 
-    public class ForetellExileEffect extends OneShotEffect {
+    static class ForetellExileEffect extends OneShotEffect {
 
         private final Card card;
         String foretellCost;
         String foretellSplitCost;
 
-        public ForetellExileEffect(Card card, String foretellCost, String foretellSplitCost) {
+        ForetellExileEffect(Card card, String foretellCost, String foretellSplitCost) {
             super(Outcome.Neutral);
             this.card = card;
             this.foretellCost = foretellCost;
@@ -150,9 +150,9 @@ public class ForetellAbility extends SpecialAction {
         }
     }
 
-    public class ForetellLookAtCardEffect extends AsThoughEffectImpl {
+    static class ForetellLookAtCardEffect extends AsThoughEffectImpl {
 
-        public ForetellLookAtCardEffect() {
+        ForetellLookAtCardEffect() {
             super(AsThoughEffectType.LOOK_AT_FACE_DOWN, Duration.EndOfGame, Outcome.AIDontUseIt);
         }
 
@@ -190,7 +190,7 @@ public class ForetellAbility extends SpecialAction {
         }
     }
 
-    public class ForetellAddCostEffect extends ContinuousEffectImpl {
+    public static class ForetellAddCostEffect extends ContinuousEffectImpl {
 
         private final MageObjectReference mor;
 
@@ -297,12 +297,12 @@ public class ForetellAbility extends SpecialAction {
         }
     }
 
-    public class ForetellCostAbility extends SpellAbility {
+    static class ForetellCostAbility extends SpellAbility {
 
         private String abilityName;
         private SpellAbility spellAbilityToResolve;
 
-        public ForetellCostAbility(String foretellCost) {
+        ForetellCostAbility(String foretellCost) {
             super(null, "Testing", Zone.EXILED, SpellAbilityType.BASE_ALTERNATE, SpellAbilityCastMode.NORMAL);
             // Needed for Dream Devourer and Ethereal Valkyrie reducing the cost of a colorless CMC 2 or less spell to 0
             // CardUtil.reduceCost returns an empty string in that case so we add a cost of 0 here
@@ -457,8 +457,6 @@ public class ForetellAbility extends SpecialAction {
         /**
          * Used for split card in PlayerImpl method:
          * getOtherUseableActivatedAbilities
-         *
-         * @param abilityName
          */
         public void setAbilityName(String abilityName) {
             this.abilityName = abilityName;

--- a/Mage/src/main/java/mage/cards/decks/importer/DeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/DeckImporter.java
@@ -9,7 +9,7 @@ import java.util.Scanner;
 
 public abstract class DeckImporter {
 
-    public class FixedInfo {
+    public static class FixedInfo {
         private final String originalLine;
         private String fixedLine;
         private Boolean canFix = true; // set false if deck have critical error and can't be auto-fixed

--- a/Mage/src/main/java/mage/game/draft/DraftCube.java
+++ b/Mage/src/main/java/mage/game/draft/DraftCube.java
@@ -15,7 +15,7 @@ import org.apache.log4j.Logger;
  */
 public abstract class DraftCube {
 
-    public class CardIdentity {
+    public static class CardIdentity {
 
         private final String name;
         private final String extension;
@@ -55,7 +55,7 @@ public abstract class DraftCube {
     protected List<CardIdentity> cubeCards = new ArrayList<>();
     protected List<CardIdentity> leftCubeCards = new ArrayList<>();
 
-    public DraftCube(String name) {
+    protected DraftCube(String name) {
         this.name = name;
         this.code = getClass().getSimpleName();
     }

--- a/Mage/src/main/java/mage/game/permanent/token/GutterGrimeToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/GutterGrimeToken.java
@@ -1,5 +1,3 @@
-
-
 package mage.game.permanent.token;
 
 import java.util.UUID;
@@ -35,7 +33,7 @@ public final class GutterGrimeToken extends TokenImpl {
         color.setGreen(true);
         power = new MageInt(0);
         toughness = new MageInt(0);
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new GutterGrimeCounters(sourceId))));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SetBasePowerToughnessSourceEffect(new GutterGrimeCountersCount(sourceId))));
     }
 
     private GutterGrimeToken(final GutterGrimeToken token) {
@@ -46,36 +44,37 @@ public final class GutterGrimeToken extends TokenImpl {
         return new GutterGrimeToken(this);
     }
 
-    class GutterGrimeCounters implements DynamicValue {
+}
 
-        private final UUID sourceId;
+class GutterGrimeCountersCount implements DynamicValue {
 
-        public GutterGrimeCounters(UUID sourceId) {
-            this.sourceId = sourceId;
+    private final UUID sourceId;
+
+    public GutterGrimeCountersCount(UUID sourceId) {
+        this.sourceId = sourceId;
+    }
+
+    @Override
+    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+        Permanent p = game.getPermanent(sourceId);
+        if (p != null) {
+            return p.getCounters(game).getCount(CounterType.SLIME);
         }
+        return 0;
+    }
 
-        @Override
-        public int calculate(Game game, Ability sourceAbility, Effect effect) {
-            Permanent p = game.getPermanent(sourceId);
-            if (p != null) {
-                return p.getCounters(game).getCount(CounterType.SLIME);
-            }
-            return 0;
-        }
+    @Override
+    public GutterGrimeCountersCount copy() {
+        return this;
+    }
 
-        @Override
-        public GutterGrimeCounters copy() {
-            return this;
-        }
+    @Override
+    public String getMessage() {
+        return "slime counters on Gutter Grime";
+    }
 
-        @Override
-        public String getMessage() {
-            return "slime counters on Gutter Grime";
-        }
-
-        @Override
-        public String toString() {
-            return "1";
-        }
+    @Override
+    public String toString() {
+        return "1";
     }
 }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1376,7 +1376,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         NOT_REQUIRED_NO_CHOICE,
     }
 
-    private class ApprovingObjectResult {
+    private static class ApprovingObjectResult {
         public final ApprovingObjectResultStatus status;
         public final ApprovingObject approvingObject; // not null iff status is CHOSEN
 


### PR DESCRIPTION
Lots of associated simplification, these are the sorts of things that get missed by find/replace over the years due to the additional layer of nesting.

There are still some remaining nested static classes but those are lower priority to de-nest.

With this PR, I believe all non-static inner classes in `Mage` and `Mage.Sets` have been addressed with the exception of `CircularList` (which as currently written can't be static, and is used only for `PlayerList`). I didn't look at the other parts of the source tree.