### PR TITLE
[MKC] Implement Mirko, Obsessive Theorist

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MirkoObsessiveTheorist.java
+++ b/Mage.Sets/src/mage/cards/m/MirkoObsessiveTheorist.java
@@ -1,0 +1,85 @@
+package mage.cards.m;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.BeginningOfYourEndStepTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.SurveilTriggeredAbility;
+import mage.abilities.effects.common.InfoEffect;
+import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldWithCounterTargetEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.filter.common.FilterCreatureCard;
+import mage.filter.predicate.mageobject.PowerPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetCardInYourGraveyard;
+import mage.target.targetadjustment.TargetAdjuster;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class MirkoObsessiveTheorist extends CardImpl {
+
+    public MirkoObsessiveTheorist(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}{B}");
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.VAMPIRE, SubType.DETECTIVE);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Whenever you surveil, put a +1/+1 counter on Mirko, Obsessive Theorist.
+        this.addAbility(new SurveilTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance())));
+
+        // At the beginning of your end step, you may return target creature card with power less than Mirko's from your graveyard to the battlefield with a finality counter on it.
+        Ability ability = new BeginningOfYourEndStepTriggeredAbility(
+                new ReturnFromGraveyardToBattlefieldWithCounterTargetEffect(CounterType.FINALITY.createInstance()),true
+        );
+        ability.setTargetAdjuster(MirkoObsessiveTheoristAdjuster.instance);
+        this.addAbility(ability.setRuleVisible(false));
+
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new InfoEffect(
+                "At the beginning of your end step, you may return target creature card with power less than {this}'s " +
+                        "from your graveyard to the battlefield with a finality counter on it. <i>(If it would die, exile it instead.)</i>"
+        )));
+    }
+
+    private MirkoObsessiveTheorist(final MirkoObsessiveTheorist card) {
+        super(card);
+    }
+
+    @Override
+    public MirkoObsessiveTheorist copy() {
+        return new MirkoObsessiveTheorist(this);
+    }
+}
+
+enum MirkoObsessiveTheoristAdjuster implements TargetAdjuster {
+    instance;
+
+    @Override
+    public void adjustTargets(Ability ability, Game game) {
+        ability.getTargets().clear();
+        Permanent sourcePermanent = game.getPermanent(ability.getSourceId());
+        if (sourcePermanent == null) {
+            return;
+        }
+        int xValue = sourcePermanent.getPower().getValue();
+        FilterCreatureCard filter = new FilterCreatureCard("creature card with power less than " + xValue + " from your graveyard");
+        filter.add(new PowerPredicate(ComparisonType.FEWER_THAN, xValue));
+        ability.getTargets().add(new TargetCardInYourGraveyard(filter));
+    }
+}

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
@@ -149,6 +149,9 @@ public final class MurdersAtKarlovManorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Merchant of Truth", 11, Rarity.RARE, mage.cards.m.MerchantOfTruth.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Merchant of Truth", 322, Rarity.RARE, mage.cards.m.MerchantOfTruth.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Mind Stone", 232, Rarity.UNCOMMON, mage.cards.m.MindStone.class));
+        cards.add(new SetCardInfo("Mirko, Obsessive Theorist", 2, Rarity.MYTHIC, mage.cards.m.MirkoObsessiveTheorist.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Mirko, Obsessive Theorist", 50, Rarity.MYTHIC, mage.cards.m.MirkoObsessiveTheorist.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Mirko, Obsessive Theorist", 316, Rarity.MYTHIC, mage.cards.m.MirkoObsessiveTheorist.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Mirror Entity", 75, Rarity.RARE, mage.cards.m.MirrorEntity.class));
         cards.add(new SetCardInfo("Mission Briefing", 110, Rarity.RARE, mage.cards.m.MissionBriefing.class));
         cards.add(new SetCardInfo("Morska, Undersea Sleuth", 3, Rarity.MYTHIC, mage.cards.m.MorskaUnderseaSleuth.class));


### PR DESCRIPTION
I tried hard to get the text to generate nicely but I believe the use of the target adjuster was causing rules generation issues, and setting the rules text with `setText` resulted in excessively verbose instructions when *resolving* the ability, so I ended up using an info effect to spoof the rules text of the final ability. Other, less heavy-handed approaches all yielded inferior results, so this approach is prioritising UX at the cost of slight code elegance