### PR TITLE
[MKC] Implement Tesak, Judith's Hellhound

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TesakJudithsHellhound.java
+++ b/Mage.Sets/src/mage/cards/t/TesakJudithsHellhound.java
@@ -1,0 +1,79 @@
+package mage.cards.t;
+
+import mage.MageInt;
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledSpellsEffect;
+import mage.abilities.effects.mana.DynamicManaEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.UnleashAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterCreatureCard;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.CounterAnyPredicate;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class TesakJudithsHellhound extends CardImpl {
+
+    private static final FilterCreaturePermanent filter1 = new FilterCreaturePermanent(SubType.DOG, "Dogs");
+    private static final FilterControlledCreaturePermanent filter2 = new FilterControlledCreaturePermanent("Creatures you control with counters on  them");
+    private static final FilterCard filter3 = new FilterCreatureCard();
+
+    static {
+        filter2.add(CounterAnyPredicate.instance);
+        filter3.add(SubType.DOG.getPredicate());
+    }
+
+    public TesakJudithsHellhound(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}");
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ELEMENTAL, SubType.DOG);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Unleash
+        this.addAbility(new UnleashAbility());
+
+        // Other Dogs you control have unleash.
+        Ability ability = new SimpleStaticAbility(new GainAbilityControlledEffect(
+                new UnleashAbility(), Duration.WhileOnBattlefield, filter1, true
+        ));
+        ability.addEffect(new GainAbilityControlledSpellsEffect(new UnleashAbility(), filter3).setText(""));
+        this.addAbility(ability);
+
+        // Creatures you control with counters on them have haste.
+        this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(
+                HasteAbility.getInstance(), Duration.WhileOnBattlefield, filter2
+        )));
+
+        // Whenever Tesak, Judith's Hellhound attacks, add {R} for each attacking creature.
+        this.addAbility(new AttacksTriggeredAbility(
+                new DynamicManaEffect(Mana.RedMana(1), new PermanentsOnBattlefieldCount(StaticFilters.FILTER_ATTACKING_CREATURE))
+        ));
+    }
+
+    private TesakJudithsHellhound(final TesakJudithsHellhound card) {
+        super(card);
+    }
+
+    @Override
+    public TesakJudithsHellhound copy() {
+        return new TesakJudithsHellhound(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
@@ -257,6 +257,8 @@ public final class MurdersAtKarlovManorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Temple of Triumph", 306, Rarity.RARE, mage.cards.t.TempleOfTriumph.class));
         cards.add(new SetCardInfo("Temple of the False God", 305, Rarity.UNCOMMON, mage.cards.t.TempleOfTheFalseGod.class));
         cards.add(new SetCardInfo("Temur War Shaman", 187, Rarity.RARE, mage.cards.t.TemurWarShaman.class));
+        cards.add(new SetCardInfo("Tesak, Judith's Hellhound", 36, Rarity.RARE, mage.cards.t.TesakJudithsHellhound.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Tesak, Judith's Hellhound", 346, Rarity.RARE, mage.cards.t.TesakJudithsHellhound.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Tezzeret, Betrayer of Flesh", 120, Rarity.MYTHIC, mage.cards.t.TezzeretBetrayerOfFlesh.class));
         cards.add(new SetCardInfo("Thelonite Hermit", 188, Rarity.RARE, mage.cards.t.TheloniteHermit.class));
         cards.add(new SetCardInfo("Thought Monitor", 121, Rarity.RARE, mage.cards.t.ThoughtMonitor.class));

--- a/Mage/src/main/java/mage/abilities/keyword/UnleashAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/UnleashAbility.java
@@ -39,7 +39,7 @@ public class UnleashAbility extends SimpleStaticAbility {
 
     @Override
     public String getRule() {
-        return "Unleash <i>(You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)</i>";
+        return "unleash <i>(You may have this creature enter the battlefield with a +1/+1 counter on it. It can't block as long as it has a +1/+1 counter on it.)</i>";
     }
 }
 


### PR DESCRIPTION
Slight hitch on the "Other Dogs you control have unleash" ability. Reminiscent of the Blood Moon problem, this ability needs to affect the permanent both while it's on the battlefield and while it's entering the battlefield. Applying the `GainAbilityControlledEffect` to dog permanents only affects those permanents while they're on the battlefield which means, much like in the case of Blood Moon, it misses cards as they are *entering* the battlefield. The workaround to this problem in this case is applying the unleash ability to dog cards in hand so that the "You may have this creature enter the battlefield with a +1/+1 counter on it" effect is correctly applied. The downside is that dog cards in hand have unleash's ability text on them whilst in hand.