### PR TITLE
[don't merge - see #11841 instead] [WHO] Implement Donna Noble

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DonnaNoble.java
+++ b/Mage.Sets/src/mage/cards/d/DonnaNoble.java
@@ -79,7 +79,7 @@ class DonnaNobleTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         this.getTargets().clear();
         DamagedBatchForPermanentsEvent dEvent = (DamagedBatchForPermanentsEvent) event;
-        return checkTriggerThis(dEvent) || checkTriggerPaired(dEvent, game);
+        return checkTriggerThis(dEvent) | checkTriggerPaired(dEvent, game);
     }
 
     boolean checkTriggerThis(DamagedBatchForPermanentsEvent dEvent) {

--- a/Mage.Sets/src/mage/cards/d/DonnaNoble.java
+++ b/Mage.Sets/src/mage/cards/d/DonnaNoble.java
@@ -1,0 +1,139 @@
+package mage.cards.d;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.constants.*;
+import mage.abilities.keyword.SoulbondAbility;
+import mage.abilities.keyword.DoctorsCompanionAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.common.TargetOpponent;
+
+/**
+ *
+ * @author jimga150
+ */
+public final class DonnaNoble extends CardImpl {
+
+    public DonnaNoble(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Soulbond
+        this.addAbility(new SoulbondAbility());
+
+        // Whenever Donna or a creature it's paired with is dealt damage, Donna deals that much damage to target opponent.
+        Ability ability = new DonnaNobleTriggeredAbility();
+        this.addAbility(ability);
+
+        // Doctor's companion
+        this.addAbility(DoctorsCompanionAbility.getInstance());
+
+    }
+
+    private DonnaNoble(final DonnaNoble card) {
+        super(card);
+    }
+
+    @Override
+    public DonnaNoble copy() {
+        return new DonnaNoble(this);
+    }
+}
+
+// Based on WrathfulRaptorsTriggeredAbility
+class DonnaNobleTriggeredAbility extends TriggeredAbilityImpl {
+
+    DonnaNobleTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new DonnaNobleEffect());
+        this.addTarget(new TargetOpponent());
+    }
+
+    private DonnaNobleTriggeredAbility(final DonnaNobleTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public DonnaNobleTriggeredAbility copy() {
+        return new DonnaNobleTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.DAMAGED_PERMANENT;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        Permanent damagedPermanent = game.getPermanent(event.getTargetId());
+        int damage = event.getAmount();
+        if (damagedPermanent == null || damage < 1) {
+            return false;
+        }
+
+        Permanent paired = null;
+        Permanent permanent = game.getPermanent(getSourceId());
+        if (permanent != null && permanent.getPairedCard() != null) {
+            paired = permanent.getPairedCard().getPermanent(game);
+        }
+        boolean isPaired = paired != null && paired.getPairedCard() != null &&
+                paired.getPairedCard().equals(new MageObjectReference(permanent, game));
+
+        if (getSourceId().equals(event.getTargetId()) || (isPaired && paired.getId().equals(event.getTargetId()))){
+            this.getEffects().setValue("damagedPermanentUUID", event.getTargetId());
+            this.getEffects().setValue("damage", damage);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String getRule() {
+        return "Whenever {this} or a creature it's paired with is dealt damage, " +
+                "{this} deals that much damage to target opponent.";
+    }
+}
+
+//Based on WrathfulRaptorsEffect
+class DonnaNobleEffect extends OneShotEffect {
+
+    DonnaNobleEffect() {
+        super(Outcome.Benefit);
+    }
+
+    private DonnaNobleEffect(final DonnaNobleEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DonnaNobleEffect copy() {
+        return new DonnaNobleEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent damagedPermanent = game.getPermanent((UUID) getValue("damagedPermanentUUID"));
+        Integer damage = (Integer) getValue("damage");
+        if (damagedPermanent == null || damage == null) {
+            return false;
+        }
+        UUID targetId = getTargetPointer().getFirst(game, source);
+        Player player = game.getPlayer(targetId);
+        if (player != null) {
+            return player.damage(damage, source.getSourcePermanentOrLKI(game).getId(), source, game) > 0;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/d/DonnaNoble.java
+++ b/Mage.Sets/src/mage/cards/d/DonnaNoble.java
@@ -110,13 +110,13 @@ class DonnaNobleTriggeredAbility extends TriggeredAbilityImpl {
                 return false;
             }
         } else {
-            paired = null;
+            return false;
         }
 
         int damage = dEvent
                 .getEvents()
                 .stream()
-                .filter(damagedEvent -> paired != null && paired.getId().equals(damagedEvent.getTargetId()))
+                .filter(damagedEvent -> paired.getId().equals(damagedEvent.getTargetId()))
                 .mapToInt(GameEvent::getAmount)
                 .sum();
         if (damage < 1) {

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -72,6 +72,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Desolate Lighthouse", 271, Rarity.RARE, mage.cards.d.DesolateLighthouse.class));
         cards.add(new SetCardInfo("Dinosaurs on a Spaceship", 122, Rarity.RARE, mage.cards.d.DinosaursOnASpaceship.class));
         cards.add(new SetCardInfo("Displaced Dinosaurs", 100, Rarity.UNCOMMON, mage.cards.d.DisplacedDinosaurs.class));
+        cards.add(new SetCardInfo("Donna Noble", 82, Rarity.RARE, mage.cards.d.DonnaNoble.class));
         cards.add(new SetCardInfo("Dragonskull Summit", 272, Rarity.RARE, mage.cards.d.DragonskullSummit.class));
         cards.add(new SetCardInfo("Dreamroot Cascade", 273, Rarity.RARE, mage.cards.d.DreamrootCascade.class));
         cards.add(new SetCardInfo("Drowned Catacomb", 274, Rarity.RARE, mage.cards.d.DrownedCatacomb.class));


### PR DESCRIPTION
#10653 

I initially tried modifying `DealtDamageToSourceTriggeredAbility`, but i don't know how to get a single ability to do two different checks for two trigger conditions. This is relevant because:

> If Donna is paired with another creature and they are both dealt damage at the same time, the second ability triggers twice. (2023-10-13)

So if Donna is paired with a creature, and something like [Cinderclasm](https://scryfall.com/card/znr/136/cinderclasm) is cast (with no kick), Donna should trigger twice for 1 damage both times, rather than 2 damage once. 

This is currently the case, but the way i implemented it uses the method in [Wrathful Raptors](https://scryfall.com/card/lcc/88/wrathful-raptors). This uses the `DAMAGED_PERMANENT` event trigger, which causes multiple triggers if its damaged by multiple sources at the same time, like being blocked by multiple creatures. [This isnt how it should work according to the MTG wiki](https://mtg.fandom.com/wiki/Enrage#Rulings):

> If multiple sources deal damage to a creature with an enrage ability at the same time, most likely because multiple creatures blocked that creature, the enrage ability triggers only once.

Question is, how can this be implemented to use the `DAMAGED_BATCH_FOR_PERMANENTS` event, while causing separate damage events for the damages dealt to donna and the (possibly) paired creature? Is there an example of a card causing multiple effects targeting different things, one or more of which might not trigger and therefore doesnt need a target?