### PR TITLE
[MKC] Implement Printlifter Ooze

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
+++ b/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
@@ -2,14 +2,12 @@ package mage.cards.p;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.TurnedFaceUpAllTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.abilities.keyword.DisguiseAbility;
 import mage.cards.CardImpl;
@@ -22,7 +20,6 @@ import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.token.OozeTrampleToken;
-import mage.game.permanent.token.Token;
 
 import java.util.UUID;
 
@@ -83,10 +80,8 @@ class PrintlifterOozeEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-        Token token = new OozeTrampleToken();
         int xVal = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, controller, source, game);
-        token.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), StaticValue.get(xVal), false)));
-        Effect effect = new CreateTokenEffect(token);
+        Effect effect = new CreateTokenEffect(new OozeTrampleToken(), StaticValue.get(1), false, false, CounterType.P1P1, StaticValue.get(xVal));
         return effect.apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
+++ b/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
@@ -81,7 +81,7 @@ class PrintlifterOozeEffect extends OneShotEffect {
             return false;
         }
         int xVal = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, controller, source, game);
-        Effect effect = new CreateTokenEffect(new OozeTrampleToken(), StaticValue.get(1), false, false, CounterType.P1P1, StaticValue.get(xVal));
+        Effect effect = new CreateTokenEffect(new OozeTrampleToken()).entersWithCounters(CounterType.P1P1, StaticValue.get(xVal));
         return effect.apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
+++ b/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
@@ -1,0 +1,87 @@
+package mage.cards.p;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.TurnedFaceUpAllTriggeredAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.keyword.DeathtouchAbility;
+import mage.abilities.keyword.DisguiseAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.game.Game;
+import mage.game.permanent.token.OozeTrampleToken;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class PrintlifterOoze extends CardImpl {
+
+    public PrintlifterOoze(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
+        this.subtype.add(SubType.OOZE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(2);
+
+        // Deathtouch
+        this.addAbility(DeathtouchAbility.getInstance());
+
+        // Whenever Printlifter Ooze or another creature you control is turned face up, create a 0/0 green Ooze creature token with trample.
+        // The token enters the battlefield with X +1/+1 counters on it, where X is the number of other creatures you control.
+        this.addAbility(new TurnedFaceUpAllTriggeredAbility(
+                new PrintlifterOozeEffect(), new FilterControlledCreaturePermanent("{this} or another creature you control")
+        ));
+
+        // Disguise {3}{G}
+        this.addAbility(new DisguiseAbility(this, new ManaCostsImpl<>("{3}{G}")));
+    }
+
+    private PrintlifterOoze(final PrintlifterOoze card) {
+        super(card);
+    }
+
+    @Override
+    public PrintlifterOoze copy() {
+        return new PrintlifterOoze(this);
+    }
+}
+
+class PrintlifterOozeEffect extends OneShotEffect {
+
+    PrintlifterOozeEffect() {
+        super(Outcome.PutCreatureInPlay);
+        staticText = "create a 0/0 green Ooze creature token with trample. The token enters the battlefield " +
+                "with X +1/+1 counters on it, where X is the number of other creatures you control";
+    }
+
+    private PrintlifterOozeEffect(final PrintlifterOozeEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PrintlifterOozeEffect copy() {
+        return new PrintlifterOozeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        UUID controller = source.getControllerId();
+        if (controller == null) {
+            return false;
+        }
+        int xVal = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, controller, source, game);
+        Effect effect = new CreateTokenEffect(new OozeTrampleToken(), StaticValue.get(1), false, false, CounterType.P1P1, StaticValue.get(xVal));
+        return effect.apply(game, source);
+    }
+}

--- a/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
+++ b/Mage.Sets/src/mage/cards/p/PrintlifterOoze.java
@@ -2,12 +2,14 @@ package mage.cards.p;
 
 import mage.MageInt;
 import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.TurnedFaceUpAllTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.abilities.keyword.DisguiseAbility;
 import mage.cards.CardImpl;
@@ -20,6 +22,7 @@ import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.token.OozeTrampleToken;
+import mage.game.permanent.token.Token;
 
 import java.util.UUID;
 
@@ -80,8 +83,10 @@ class PrintlifterOozeEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
+        Token token = new OozeTrampleToken();
         int xVal = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, controller, source, game);
-        Effect effect = new CreateTokenEffect(new OozeTrampleToken(), StaticValue.get(1), false, false, CounterType.P1P1, StaticValue.get(xVal));
+        token.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), StaticValue.get(xVal), false)));
+        Effect effect = new CreateTokenEffect(token);
         return effect.apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
@@ -190,6 +190,8 @@ public final class MurdersAtKarlovManorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Port of Karfell", 280, Rarity.UNCOMMON, mage.cards.p.PortOfKarfell.class));
         cards.add(new SetCardInfo("Prairie Stream", 281, Rarity.RARE, mage.cards.p.PrairieStream.class));
         cards.add(new SetCardInfo("Price of Fame", 135, Rarity.UNCOMMON, mage.cards.p.PriceOfFame.class));
+        cards.add(new SetCardInfo("Printlifter Ooze", 40, Rarity.RARE, mage.cards.p.PrintlifterOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Printlifter Ooze", 350, Rarity.RARE, mage.cards.p.PrintlifterOoze.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Promise of Loyalty", 79, Rarity.RARE, mage.cards.p.PromiseOfLoyalty.class));
         cards.add(new SetCardInfo("Psychosis Crawler", 234, Rarity.RARE, mage.cards.p.PsychosisCrawler.class));
         cards.add(new SetCardInfo("Ravenous Chupacabra", 136, Rarity.UNCOMMON, mage.cards.r.RavenousChupacabra.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenCopyTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenCopyTargetEffect.java
@@ -274,9 +274,8 @@ public class CreateTokenCopyTargetEffect extends OneShotEffect {
             Permanent tokenPermanent = game.getPermanent(tokenId);
             if (tokenPermanent != null) {
                 addedTokenPermanents.add(tokenPermanent);
-                // add counters if necessary ie Ochre Jelly
-                if (counter != null
-                        && numberOfCounters > 0) {
+                // TODO: Workaround to add counters to all created tokens, necessary for correct interactions with cards like Chatterfang, Squirrel General and Ochre Jelly / Printlifter Ooze. See #10786
+                if (counter != null && numberOfCounters > 0) {
                     tokenPermanent.addCounters(counter.createInstance(numberOfCounters), source.getControllerId(), source, game);
                 }
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
@@ -30,8 +30,8 @@ public class CreateTokenEffect extends OneShotEffect {
     private final boolean attacking;
     private String additionalRules;
     private List<UUID> lastAddedTokenIds = new ArrayList<>();
-    private final CounterType counterType;
-    private final DynamicValue numberOfCounters;
+    private CounterType counterType;
+    private DynamicValue numberOfCounters;
 
     public CreateTokenEffect(Token token) {
         this(token, StaticValue.get(1));
@@ -54,17 +54,11 @@ public class CreateTokenEffect extends OneShotEffect {
     }
 
     public CreateTokenEffect(Token token, DynamicValue amount, boolean tapped, boolean attacking) {
-        this(token, amount, tapped, attacking, null, StaticValue.get(0));
-    }
-
-    public CreateTokenEffect(Token token, DynamicValue amount, boolean tapped, boolean attacking, CounterType counterType, DynamicValue numberOfCounters) {
         super(Outcome.PutCreatureInPlay);
         this.token = token;
         this.amount = amount.copy();
         this.tapped = tapped;
         this.attacking = attacking;
-        this.counterType = counterType;
-        this.numberOfCounters = numberOfCounters;
         setText();
     }
 
@@ -78,6 +72,12 @@ public class CreateTokenEffect extends OneShotEffect {
         this.counterType = effect.counterType;
         this.numberOfCounters = effect.numberOfCounters;
         this.additionalRules = effect.additionalRules;
+    }
+
+    public CreateTokenEffect entersWithCounters(CounterType counterType, DynamicValue numberOfCounters) {
+        this.counterType = counterType;
+        this.numberOfCounters = numberOfCounters;
+        return this;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
@@ -90,6 +90,7 @@ public class CreateTokenEffect extends OneShotEffect {
         int value = amount.calculate(game, source, this);
         token.putOntoBattlefield(value, game, source, source.getControllerId(), tapped, attacking);
         this.lastAddedTokenIds = token.getLastAddedTokenIds();
+        // TODO: Workaround to add counters to all created tokens, necessary for correct interactions with cards like Chatterfang, Squirrel General and Ochre Jelly / Printlifter Ooze. See #10786
         if (counterType != null) {
             for (UUID tokenId : lastAddedTokenIds) {
                 Permanent tokenPermanent = game.getPermanent(tokenId);


### PR DESCRIPTION
Confirmed with a judge that "where X is the number of other creatures you control" is talking about creatures other than the created token, not creatures other than Printlifter Ooze.

This PR also modifies `CreateTokenEffect` to accommodate having tokens enter the battlefield with counters on them via a new constructor, functionality that was already possessed by `CreateTokenCopyTargetEffect`.