### PR TITLE
[Refactor] Update GainAbilityControlledSpellsEffect to use nonland card filter

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbaddonTheDespoiler.java
+++ b/Mage.Sets/src/mage/cards/a/AbaddonTheDespoiler.java
@@ -18,9 +18,8 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicate;
-import mage.filter.predicate.Predicates;
 import mage.filter.predicate.card.CastFromZonePredicate;
 import mage.game.Game;
 import mage.watchers.common.PlayerLostLifeWatcher;
@@ -32,11 +31,10 @@ import java.util.UUID;
  */
 public final class AbaddonTheDespoiler extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard();
+    private static final FilterNonlandCard filter = new FilterNonlandCard();
 
     static {
         filter.add(new CastFromZonePredicate(Zone.HAND));
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
         filter.add(AbaddonTheDespoilerPredicate.instance);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaetusSeaTyrantOfSegovia.java
+++ b/Mage.Sets/src/mage/cards/c/CaetusSeaTyrantOfSegovia.java
@@ -13,7 +13,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.TargetController;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
 import mage.target.common.TargetCreaturePermanent;
@@ -25,11 +25,10 @@ import java.util.UUID;
  */
 public final class CaetusSeaTyrantOfSegovia extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("noncreature spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("noncreature spells you cast");
 
     static {
         filter.add(Predicates.not(CardType.CREATURE.getPredicate()));
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
         filter.add(Predicates.not(new AbilityPredicate(ConvokeAbility.class))); // So there are not redundant copies being added to each card
     }
 

--- a/Mage.Sets/src/mage/cards/c/CastThroughTime.java
+++ b/Mage.Sets/src/mage/cards/c/CastThroughTime.java
@@ -6,7 +6,7 @@ import mage.abilities.keyword.ReboundAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
 
@@ -17,7 +17,7 @@ import java.util.UUID;
  */
 public final class CastThroughTime extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("Instant and sorcery spells you control");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("Instant and sorcery spells you control");
 
     static {
         filter.add(Predicates.or(CardType.INSTANT.getPredicate(), CardType.SORCERY.getPredicate()));

--- a/Mage.Sets/src/mage/cards/c/ChiefEngineer.java
+++ b/Mage.Sets/src/mage/cards/c/ChiefEngineer.java
@@ -9,8 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
-import mage.filter.common.FilterArtifactCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
 
@@ -21,10 +20,10 @@ import java.util.UUID;
  */
 public final class ChiefEngineer extends CardImpl {
 
-    private static final FilterCard filter = new FilterArtifactCard("artifact spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("artifact spells you cast");
 
     static {
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
+        filter.add(CardType.ARTIFACT.getPredicate());
         filter.add(Predicates.not(new AbilityPredicate(ConvokeAbility.class))); // So there are not redundant copies being added to each card
     }
 

--- a/Mage.Sets/src/mage/cards/f/FallajiWayfarer.java
+++ b/Mage.Sets/src/mage/cards/f/FallajiWayfarer.java
@@ -10,8 +10,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
 import mage.filter.FilterMana;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
 import mage.filter.predicate.mageobject.MulticoloredPredicate;
@@ -23,11 +23,10 @@ import java.util.UUID;
  */
 public final class FallajiWayfarer extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("multicolored spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("multicolored spells you cast");
 
     static {
         filter.add(MulticoloredPredicate.instance);
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
         filter.add(Predicates.not(new AbilityPredicate(ConvokeAbility.class))); // So there are not redundant copies being added to each card
     }
 

--- a/Mage.Sets/src/mage/cards/f/FiresongAndSunspeaker.java
+++ b/Mage.Sets/src/mage/cards/f/FiresongAndSunspeaker.java
@@ -1,4 +1,3 @@
-
 package mage.cards.f;
 
 import java.util.UUID;
@@ -15,7 +14,7 @@ import mage.abilities.keyword.LifelinkAbility;
 import mage.constants.*;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.game.Game;
@@ -28,7 +27,7 @@ import mage.target.common.TargetCreatureOrPlayer;
  */
 public final class FiresongAndSunspeaker extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("red instant and sorcery spells you control");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("red instant and sorcery spells you control");
 
     static {
         filter.add(new ColorPredicate(ObjectColor.RED));
@@ -99,6 +98,6 @@ class FiresongAndSunspeakerTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public String getRule() {
-        return "Whenever a white instant or sorcery spell causes you to gain life, Firesong and Sunspeaker deals 3 damage to target creature or player.";
+        return "Whenever a white instant or sorcery spell causes you to gain life, {this} deals 3 damage to target creature or player.";
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FlamekinHerald.java
+++ b/Mage.Sets/src/mage/cards/f/FlamekinHerald.java
@@ -8,8 +8,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.FilterCard;
-import mage.filter.predicate.Predicates;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.mageobject.CommanderPredicate;
 
 import java.util.UUID;
@@ -19,11 +18,10 @@ import java.util.UUID;
  */
 public final class FlamekinHerald extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("Commander spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("Commander spells you cast");
 
     static {
         filter.add(CommanderPredicate.instance);
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
     }
 
     public FlamekinHerald(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/cards/h/HeartflameDuelist.java
+++ b/Mage.Sets/src/mage/cards/h/HeartflameDuelist.java
@@ -11,7 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetAnyTarget;
 
@@ -22,7 +22,7 @@ import java.util.UUID;
  */
 public final class HeartflameDuelist extends AdventureCard {
 
-    private static final FilterCard filter = new FilterCard("instant and sorcery spells you control");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("instant and sorcery spells you control");
 
     static {
         filter.add(Predicates.or(CardType.INSTANT.getPredicate(), CardType.SORCERY.getPredicate()));

--- a/Mage.Sets/src/mage/cards/h/HoardingBroodlord.java
+++ b/Mage.Sets/src/mage/cards/h/HoardingBroodlord.java
@@ -12,7 +12,7 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.card.CastFromZonePredicate;
 import mage.filter.predicate.mageobject.AbilityPredicate;
@@ -28,7 +28,7 @@ import java.util.UUID;
  */
 public final class HoardingBroodlord extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("spells you cast from exile");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("spells you cast from exile");
 
     static {
         filter.add(new CastFromZonePredicate(Zone.EXILED));

--- a/Mage.Sets/src/mage/cards/h/HuntingVelociraptor.java
+++ b/Mage.Sets/src/mage/cards/h/HuntingVelociraptor.java
@@ -11,8 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
-import mage.filter.predicate.Predicates;
+import mage.filter.common.FilterNonlandCard;
 
 /**
  *
@@ -20,10 +19,9 @@ import mage.filter.predicate.Predicates;
  */
 public final class HuntingVelociraptor extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("Dinosaur spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("Dinosaur spells you cast");
 
     static {
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
         filter.add(SubType.DINOSAUR.getPredicate());
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImotiCelebrantOfBounty.java
+++ b/Mage.Sets/src/mage/cards/i/ImotiCelebrantOfBounty.java
@@ -10,7 +10,7 @@ import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
 
 import java.util.UUID;
@@ -20,7 +20,7 @@ import java.util.UUID;
  */
 public final class ImotiCelebrantOfBounty extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("spells you cast with mana value 6 or greater");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("spells you cast with mana value 6 or greater");
 
     static {
         filter.add(new ManaValuePredicate(ComparisonType.MORE_THAN, 5));

--- a/Mage.Sets/src/mage/cards/i/InspiringStatuary.java
+++ b/Mage.Sets/src/mage/cards/i/InspiringStatuary.java
@@ -7,7 +7,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AbilityPredicate;
 
@@ -18,11 +18,10 @@ import java.util.UUID;
  */
 public final class InspiringStatuary extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("nonartifact spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("nonartifact spells you cast");
 
     static {
         filter.add(Predicates.not(CardType.ARTIFACT.getPredicate()));
-        filter.add(Predicates.not(CardType.LAND.getPredicate()));
         filter.add(Predicates.not(new AbilityPredicate(ImproviseAbility.class))); // So there are not redundant copies being added to each card
     }
 

--- a/Mage.Sets/src/mage/cards/m/MycosynthGolem.java
+++ b/Mage.Sets/src/mage/cards/m/MycosynthGolem.java
@@ -9,7 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 
 import java.util.UUID;
 
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public final class MycosynthGolem extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("Artifact creature spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("Artifact creature spells you cast");
 
     static {
         filter.add(CardType.ARTIFACT.getPredicate());

--- a/Mage.Sets/src/mage/cards/p/PestilentSpirit.java
+++ b/Mage.Sets/src/mage/cards/p/PestilentSpirit.java
@@ -10,7 +10,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 
 import java.util.UUID;
@@ -20,7 +20,7 @@ import java.util.UUID;
  */
 public final class PestilentSpirit extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("instant and sorcery spells you control");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("instant and sorcery spells you control");
 
     static {
         filter.add(Predicates.or(

--- a/Mage.Sets/src/mage/cards/r/RadiantScrollwielder.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantScrollwielder.java
@@ -14,8 +14,8 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -33,7 +33,7 @@ import java.util.UUID;
  */
 public final class RadiantScrollwielder extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("instant and sorcery spells you control");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("instant and sorcery spells you control");
 
     static {
         filter.add(Predicates.or(

--- a/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
+++ b/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
@@ -15,6 +15,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -29,7 +30,7 @@ import java.util.UUID;
  */
 public final class SoulfireGrandMaster extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("instant and sorcery spells you control");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("instant and sorcery spells you control");
 
     static {
         filter.add(Predicates.or(CardType.INSTANT.getPredicate(), CardType.SORCERY.getPredicate()));

--- a/Mage.Sets/src/mage/cards/t/TesakJudithsHellhound.java
+++ b/Mage.Sets/src/mage/cards/t/TesakJudithsHellhound.java
@@ -17,11 +17,10 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.permanent.CounterAnyPredicate;
 
 import java.util.UUID;
@@ -33,7 +32,7 @@ public final class TesakJudithsHellhound extends CardImpl {
 
     private static final FilterCreaturePermanent filter1 = new FilterCreaturePermanent(SubType.DOG, "Dogs");
     private static final FilterControlledCreaturePermanent filter2 = new FilterControlledCreaturePermanent("Creatures you control with counters on them");
-    private static final FilterCard filter3 = new FilterCreatureCard();
+    private static final FilterNonlandCard filter3 = new FilterNonlandCard();
 
     static {
         filter2.add(CounterAnyPredicate.instance);

--- a/Mage.Sets/src/mage/cards/t/TezzeretMasterOfTheBridge.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretMasterOfTheBridge.java
@@ -12,8 +12,8 @@ import mage.abilities.hint.common.ArtifactYouControlHint;
 import mage.abilities.keyword.AffinityForArtifactsAbility;
 import mage.cards.*;
 import mage.constants.*;
-import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.players.Player;
@@ -26,7 +26,7 @@ import java.util.UUID;
  */
 public final class TezzeretMasterOfTheBridge extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("creature and planeswalker spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("creature and planeswalker spells you cast");
 
     static {
         filter.add(Predicates.or(

--- a/Mage.Sets/src/mage/cards/t/TheFirstSliver.java
+++ b/Mage.Sets/src/mage/cards/t/TheFirstSliver.java
@@ -9,7 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 
 import java.util.UUID;
 
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public final class TheFirstSliver extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("Sliver spells you cast");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("Sliver spells you cast");
 
     static {
         filter.add(SubType.SLIVER.getPredicate());

--- a/Mage.Sets/src/mage/cards/t/ThrummingStone.java
+++ b/Mage.Sets/src/mage/cards/t/ThrummingStone.java
@@ -21,8 +21,10 @@ public final class ThrummingStone extends CardImpl {
         this.supertype.add(SuperType.LEGENDARY);
 
         // Spells you cast have ripple 4.
-        this.addAbility(new SimpleStaticAbility(new GainAbilityControlledSpellsEffect(new RippleAbility(4), StaticFilters.FILTER_CARD)
-                .setText("spells you cast have ripple 4")));
+        this.addAbility(new SimpleStaticAbility(new GainAbilityControlledSpellsEffect(new RippleAbility(4), StaticFilters.FILTER_CARD_NON_LAND)
+                .setText("Spells you cast have ripple 4. <i>(Whenever you cast a spell, you may reveal the top four cards " +
+                        "of your library. You may cast spells with the same name as that spell from among the revealed " +
+                        "cards without paying their mana costs. Put the rest on the bottom of your library.)</i>")));
     }
 
     private ThrummingStone(final ThrummingStone card) {

--- a/Mage.Sets/src/mage/cards/z/ZhulodokVoidGorger.java
+++ b/Mage.Sets/src/mage/cards/z/ZhulodokVoidGorger.java
@@ -8,7 +8,7 @@ import mage.abilities.keyword.CascadeAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.filter.predicate.card.CastFromZonePredicate;
 import mage.filter.predicate.mageobject.ColorlessPredicate;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
@@ -20,7 +20,7 @@ import java.util.UUID;
  */
 public final class ZhulodokVoidGorger extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("colorless spells you cast from your hand with mana value 7 or greater");
+    private static final FilterNonlandCard filter = new FilterNonlandCard("colorless spells you cast from your hand with mana value 7 or greater");
 
     static {
         filter.add(ColorlessPredicate.instance);

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityControlledSpellsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainAbilityControlledSpellsEffect.java
@@ -4,7 +4,7 @@ import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.cards.Card;
 import mage.constants.*;
-import mage.filter.FilterCard;
+import mage.filter.common.FilterNonlandCard;
 import mage.game.Game;
 import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
@@ -17,9 +17,9 @@ import mage.util.CardUtil;
 public class GainAbilityControlledSpellsEffect extends ContinuousEffectImpl {
 
     private final Ability ability;
-    private final FilterCard filter;
+    private final FilterNonlandCard filter;
 
-    public GainAbilityControlledSpellsEffect(Ability ability, FilterCard filter) {
+    public GainAbilityControlledSpellsEffect(Ability ability, FilterNonlandCard filter) {
         super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
         this.ability = ability;
         this.filter = filter;


### PR DESCRIPTION
Previously, GainAbilityControlledSpellsEffect would take in a FilterCard as a parameter, and it was down to the developer implementing a card with the effect to remember to have the filter they used filter out lands (so as to ensure only spell cards are included). Many implementations didn't do so, relying on other card types that are never (or almost never) associated with lands, such as instant/sorcery, creature, artifact, enchantment, etc, to functionally filter out lands.

However, there is a [land with the creature card type](https://scryfall.com/search?q=not%3Atoken+t%3Aland+t%3Acreature+not%3Adfc+not%3Afunny&unique=cards&as=grid&order=name), there are many [lands with the artifact card type](https://scryfall.com/search?q=not%3Atoken+t%3Aland+t%3Aartifact+not%3Adfc+not%3Afunny&unique=cards&as=grid&order=name), it is entirely feasible that there will be future lands with the enchantment card type, etc. This PR future-proofs this effect by forcing developers to use a FilterNonlandCard filter (which is the equivalent of a FilterSpellCard filter).