### PR TITLE
[WHO] Implement 4 cards, create generic EachOpponentPermanentTargetsAdjuster

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BiggerOnTheInside.java
+++ b/Mage.Sets/src/mage/cards/b/BiggerOnTheInside.java
@@ -1,0 +1,110 @@
+package mage.cards.b;
+
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
+import mage.abilities.effects.common.continuous.NextSpellCastHasAbilityEffect;
+import mage.abilities.effects.mana.AddManaOfAnyColorEffect;
+import mage.abilities.effects.mana.ManaEffect;
+import mage.abilities.keyword.CascadeAbility;
+import mage.abilities.keyword.EnchantAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.TargetPlayer;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class BiggerOnTheInside extends CardImpl {
+
+    private static final FilterPermanent filter
+            = new FilterPermanent("artifact or land");
+
+    static {
+        filter.add(Predicates.or(
+                CardType.ARTIFACT.getPredicate(),
+                CardType.LAND.getPredicate()
+        ));
+    }
+
+    public BiggerOnTheInside(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{R}{G}");
+        this.subtype.add(SubType.AURA);
+
+        // Enchant artifact or land
+        TargetPermanent auraTarget = new TargetPermanent(filter);
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.AddAbility));
+        this.addAbility(new EnchantAbility(auraTarget));
+
+        // Enchanted permanent has "{T}: Target player adds two mana of any one color. The next spell they cast this turn has cascade."
+        Ability gainedAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BiggerOnTheInsideEffect(), new TapSourceCost());
+        gainedAbility.addTarget(new TargetPlayer());
+        Effect effect = new GainAbilityAttachedEffect(gainedAbility, AttachmentType.AURA);
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, effect));
+    }
+
+    private BiggerOnTheInside(final BiggerOnTheInside card) {
+        super(card);
+    }
+
+    @Override
+    public BiggerOnTheInside copy() {
+        return new BiggerOnTheInside(this);
+    }
+}
+
+class BiggerOnTheInsideEffect extends OneShotEffect { //Not a mana ability since it targets
+
+    BiggerOnTheInsideEffect() {
+        super(Outcome.Benefit);
+        staticText = "Target player adds two mana of any one color. The next spell they cast this turn has cascade";
+    }
+
+    private BiggerOnTheInsideEffect(final BiggerOnTheInsideEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public BiggerOnTheInsideEffect copy() {
+        return new BiggerOnTheInsideEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
+        if (player == null) {
+            return false;
+        }
+        ContinuousEffect cascadeEffect = new NextSpellCastHasAbilityEffect(new CascadeAbility());
+
+        // Make a copy of the source ability with the target as controller
+        // a hack to allow use of the common class
+        Ability changedController = source.copy();
+        changedController.setControllerId(player.getId());
+        game.addEffect(cascadeEffect, changedController);
+
+        ManaEffect manaEffect = new AddManaOfAnyColorEffect(2);
+        Mana manaToAdd = manaEffect.produceMana(game, source);
+        if (manaToAdd != null && manaToAdd.count() > 0) {
+            player.getManaPool().addMana(manaToAdd, game, source);
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/b/BiggerOnTheInside.java
+++ b/Mage.Sets/src/mage/cards/b/BiggerOnTheInside.java
@@ -92,13 +92,8 @@ class BiggerOnTheInsideEffect extends OneShotEffect { //Not a mana ability since
         if (player == null) {
             return false;
         }
-        ContinuousEffect cascadeEffect = new NextSpellCastHasAbilityEffect(new CascadeAbility());
-
-        // Make a copy of the source ability with the target as controller
-        // a hack to allow use of the common class
-        Ability changedController = source.copy();
-        changedController.setControllerId(player.getId());
-        game.addEffect(cascadeEffect, changedController);
+        ContinuousEffect cascadeEffect = new NextSpellCastHasAbilityEffect(new CascadeAbility(), TargetController.SOURCE_TARGETS);
+        game.addEffect(cascadeEffect, source);
 
         ManaEffect manaEffect = new AddManaOfAnyColorEffect(2);
         Mana manaToAdd = manaEffect.produceMana(game, source);

--- a/Mage.Sets/src/mage/cards/b/BlatantThievery.java
+++ b/Mage.Sets/src/mage/cards/b/BlatantThievery.java
@@ -1,18 +1,12 @@
 package mage.cards.b;
 
-import mage.abilities.Ability;
 import mage.abilities.effects.common.continuous.GainControlTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.filter.FilterPermanent;
-import mage.filter.StaticFilters;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -29,7 +23,7 @@ public final class BlatantThievery extends CardImpl {
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.Custom, true)
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of target permanent that player controls"));
-        this.getSpellAbility().setTargetAdjuster(BlatantThieveryAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent()));
     }
 
     private BlatantThievery(final BlatantThievery card) {
@@ -39,27 +33,5 @@ public final class BlatantThievery extends CardImpl {
     @Override
     public BlatantThievery copy() {
         return new BlatantThievery(this);
-    }
-}
-
-enum BlatantThieveryAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null || game.getBattlefield().count(
-                    StaticFilters.FILTER_CONTROLLED_PERMANENT,
-                    opponentId, ability, game
-            ) < 1) {
-                continue;
-            }
-            FilterPermanent filter = new FilterPermanent("Permanent controlled by " + opponent.getName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            TargetPermanent targetPermanent = new TargetPermanent(filter);
-            ability.addTarget(targetPermanent);
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
+++ b/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
@@ -1,6 +1,5 @@
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
@@ -11,21 +10,21 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ExileUntilSourceLeavesEffect;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.cards.Card;
-import mage.constants.*;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.*;
 import mage.filter.FilterCard;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInExile;
+import mage.target.common.TargetNonlandPermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 import mage.util.CardUtil;
+
+import java.util.UUID;
 
 /**
  *
@@ -47,7 +46,7 @@ public final class BronzebeakForagers extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
-        etbAbility.setTargetAdjuster(BronzebeakForagerExileAdjuster.instance);
+        etbAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0, 1)));
         this.addAbility(etbAbility);
 
         // {X}{W}: Put target card with mana value X exiled with Bronzebeak Foragers into its owner's graveyard.
@@ -69,26 +68,6 @@ public final class BronzebeakForagers extends CardImpl {
     @Override
     public BronzebeakForagers copy() {
         return new BronzebeakForagers(this);
-    }
-}
-
-enum BronzebeakForagerExileAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterPermanent("nonland permanent controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            filter.add(Predicates.not(CardType.LAND.getPredicate()));
-            TargetPermanent target = new TargetPermanent(0, 1, filter, false);
-            ability.addTarget(target);
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/d/DecoyGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DecoyGambit.java
@@ -9,15 +9,12 @@ import mage.cards.CardsImpl;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 
 import java.util.Collection;
 import java.util.List;
@@ -36,7 +33,7 @@ public final class DecoyGambit extends CardImpl {
         // For each opponent, choose up to one target creature that player controls, 
         // then return that creature to its owner's hand unless its controller has you draw a card.
         this.getSpellAbility().addEffect(new DecoyGambitEffect());
-        this.getSpellAbility().setTargetAdjuster(DecoyGambitAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
     }
 
     private DecoyGambit(final DecoyGambit card) {
@@ -46,26 +43,6 @@ public final class DecoyGambit extends CardImpl {
     @Override
     public DecoyGambit copy() {
         return new DecoyGambit(this);
-    }
-}
-
-enum DecoyGambitAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        game.getOpponents(ability.getControllerId())
-                .stream()
-                .map(game::getPlayer)
-                .filter(Objects::nonNull)
-                .forEachOrdered(player -> {
-                    FilterPermanent filter = new FilterCreaturePermanent(
-                            "creature controlled by " + player.getName()
-                    );
-                    filter.add(new ControllerIdPredicate(player.getId()));
-                    ability.addTarget(new TargetPermanent(0, 1, filter, false));
-                });
     }
 }
 

--- a/Mage.Sets/src/mage/cards/d/DismantlingWave.java
+++ b/Mage.Sets/src/mage/cards/d/DismantlingWave.java
@@ -15,6 +15,7 @@ import mage.filter.common.FilterArtifactOrEnchantmentPermanent;
 import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.target.TargetPermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
@@ -33,7 +34,8 @@ public final class DismantlingWave extends CardImpl {
         this.getSpellAbility().addEffect(new DestroyTargetEffect()
                 .setTargetPointer(new EachTargetPointer())
                 .setText("For each opponent, destroy up to one target artifact or enchantment that player controls."));
-        this.getSpellAbility().setTargetAdjuster(DismantlingWaveAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(
+                new TargetPermanent(0, 1, StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT)));
 
         // Cycling {6}{W}{W}
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{6}{W}{W}")));

--- a/Mage.Sets/src/mage/cards/d/DismantlingWave.java
+++ b/Mage.Sets/src/mage/cards/d/DismantlingWave.java
@@ -1,6 +1,5 @@
 package mage.cards.d;
 
-import mage.abilities.Ability;
 import mage.abilities.common.CycleTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DestroyAllEffect;
@@ -9,17 +8,11 @@ import mage.abilities.keyword.CyclingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterArtifactOrEnchantmentPermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
 import mage.target.TargetPermanent;
 import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
-import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
-import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -51,25 +44,5 @@ public final class DismantlingWave extends CardImpl {
     @Override
     public DismantlingWave copy() {
         return new DismantlingWave(this);
-    }
-}
-
-enum DismantlingWaveAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        game.getOpponents(ability.getControllerId())
-                .stream()
-                .map(game::getPlayer)
-                .filter(Objects::nonNull)
-                .forEachOrdered(player -> {
-                    FilterPermanent filter = new FilterArtifactOrEnchantmentPermanent(
-                            "artifact or enchantment controlled by " + player.getName()
-                    );
-                    filter.add(new ControllerIdPredicate(player.getId()));
-                    ability.addTarget(new TargetPermanent(0, 1, filter, false));
-                });
     }
 }

--- a/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
+++ b/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
@@ -7,14 +7,10 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -29,7 +25,7 @@ public final class ElminstersSimulacrum extends CardImpl {
 
         // For each opponent, you create a token that's a copy of up to one target creature that player controls.
         this.getSpellAbility().addEffect(new ElminstersSimulacrumAdjusterEffect());
-        this.getSpellAbility().setTargetAdjuster(ElminstersSimulacrumAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
     }
 
     private ElminstersSimulacrum(final ElminstersSimulacrum card) {
@@ -39,24 +35,6 @@ public final class ElminstersSimulacrum extends CardImpl {
     @Override
     public ElminstersSimulacrum copy() {
         return new ElminstersSimulacrum(this);
-    }
-}
-
-enum ElminstersSimulacrumAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter, false));
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/e/EnigmaThief.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaThief.java
@@ -10,13 +10,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterNonlandPermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetNonlandPermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -44,7 +39,7 @@ public final class EnigmaThief extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new ReturnToHandTargetEffect()
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"));
-        ability.setTargetAdjuster(EnigmaThiefAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0,1)));
         this.addAbility(ability);
     }
 
@@ -58,20 +53,3 @@ public final class EnigmaThief extends CardImpl {
     }
 }
 
-enum EnigmaThiefAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterNonlandPermanent("nonland permanent controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter, false));
-        }
-    }
-}

--- a/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
@@ -1,0 +1,67 @@
+package mage.cards.e;
+
+import mage.MageObjectReference;
+import mage.abilities.effects.common.ExileAllEffect;
+import mage.abilities.keyword.ConvokeAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.util.CardUtil;
+
+import java.util.HashSet;
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class EverythingComesToDust extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("creatures except those that share a creature type with a creature that convoked this spell, all artifacts, and all enchantments");
+
+    static {
+        filter.add(EverythingComesToDustPredicate.instance);
+    }
+    public EverythingComesToDust(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{7}{W}{W}{W}");
+
+        // Convoke
+        this.addAbility(new ConvokeAbility());
+
+        // Exile all creatures except those that share a creature type with a creature that convoked this spell, all artifacts, and all enchantments.
+        this.getSpellAbility().addEffect(new ExileAllEffect(filter));
+    }
+
+    private EverythingComesToDust(final EverythingComesToDust card) {
+        super(card);
+    }
+
+    @Override
+    public EverythingComesToDust copy() {
+        return new EverythingComesToDust(this);
+    }
+}
+enum EverythingComesToDustPredicate implements ObjectSourcePlayerPredicate<Permanent> {
+    instance;
+    @Override
+    public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
+        Permanent p = input.getObject();
+        if (CardType.ARTIFACT.getPredicate().apply(p, game) || CardType.ENCHANTMENT.getPredicate().apply(p, game)){
+            return true;
+        }
+        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
+        for (MageObjectReference mor : set){
+            Permanent convoked = game.getPermanentOrLKIBattlefield(mor);
+            if (convoked.shareCreatureTypes(game, p)){
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
@@ -13,8 +13,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.util.CardUtil;
 
-import java.util.Collections;
-import java.util.Set;
+import java.util.HashSet;
 import java.util.UUID;
 
 /**
@@ -59,7 +58,7 @@ enum EverythingComesToDustPredicate implements ObjectSourcePlayerPredicate<Perma
         if (!p.isCreature(game)){
             return false;
         }
-        Set<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, Collections.emptySet());
+        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
         for (MageObjectReference mor : set){
             Permanent convoked = game.getPermanentOrLKIBattlefield(mor);
             if (convoked.shareCreatureTypes(game, p)){

--- a/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
@@ -9,12 +9,12 @@ import mage.constants.CardType;
 import mage.filter.FilterPermanent;
 import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
-import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.util.CardUtil;
 
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -47,18 +47,19 @@ public final class EverythingComesToDust extends CardImpl {
         return new EverythingComesToDust(this);
     }
 }
+
 enum EverythingComesToDustPredicate implements ObjectSourcePlayerPredicate<Permanent> {
     instance;
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
         Permanent p = input.getObject();
-        if (CardType.ARTIFACT.getPredicate().apply(p, game) || CardType.ENCHANTMENT.getPredicate().apply(p, game)){
+        if (p.isArtifact(game) || p.isEnchantment(game)){
             return true;
         }
-        if (!CardType.CREATURE.getPredicate().apply(p, game)){
+        if (!p.isCreature(game)){
             return false;
         }
-        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
+        Set<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, Collections.emptySet());
         for (MageObjectReference mor : set){
             Permanent convoked = game.getPermanentOrLKIBattlefield(mor);
             if (convoked.shareCreatureTypes(game, p)){

--- a/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
@@ -55,6 +55,9 @@ enum EverythingComesToDustPredicate implements ObjectSourcePlayerPredicate<Perma
         if (CardType.ARTIFACT.getPredicate().apply(p, game) || CardType.ENCHANTMENT.getPredicate().apply(p, game)){
             return true;
         }
+        if (!CardType.CREATURE.getPredicate().apply(p, game)){
+            return false;
+        }
         HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
         for (MageObjectReference mor : set){
             Permanent convoked = game.getPermanentOrLKIBattlefield(mor);

--- a/Mage.Sets/src/mage/cards/g/GraspOfFate.java
+++ b/Mage.Sets/src/mage/cards/g/GraspOfFate.java
@@ -6,13 +6,8 @@ import mage.abilities.effects.common.ExileUntilSourceLeavesEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetNonlandPermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -30,7 +25,7 @@ public final class GraspOfFate extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
-        ability.setTargetAdjuster(GraspOfFateAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0,1)));
         this.addAbility(ability);
     }
 
@@ -41,25 +36,5 @@ public final class GraspOfFate extends CardImpl {
     @Override
     public GraspOfFate copy() {
         return new GraspOfFate(this);
-    }
-}
-
-enum GraspOfFateAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterPermanent("nonland permanent from opponent " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            filter.add(Predicates.not(CardType.LAND.getPredicate()));
-            TargetPermanent target = new TargetPermanent(0, 1, filter, false);
-            ability.addTarget(target);
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
+++ b/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
@@ -1,7 +1,6 @@
 package mage.cards.h;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.abilities.keyword.MyriadAbility;
@@ -9,13 +8,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -41,7 +35,7 @@ public final class HammersOfMoradin extends CardImpl {
                 new TapTargetEffect()
                         .setTargetPointer(new EachTargetPointer())
                         .setText("for each opponent, tap up to one target creature that player controls")
-        ).setTargetAdjuster(HammersOfMoradinAdjuster.instance));
+        ).setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1))));
     }
 
     private HammersOfMoradin(final HammersOfMoradin card) {
@@ -51,24 +45,5 @@ public final class HammersOfMoradin extends CardImpl {
     @Override
     public HammersOfMoradin copy() {
         return new HammersOfMoradin(this);
-    }
-}
-
-enum HammersOfMoradinAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            TargetPermanent target = new TargetPermanent(0, 1, filter);
-            ability.addTarget(target);
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
+++ b/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
@@ -1,6 +1,5 @@
 package mage.cards.i;
 
-import mage.abilities.Ability;
 import mage.abilities.common.SagaAbility;
 import mage.abilities.effects.Effects;
 import mage.abilities.effects.common.CreateTokenEffect;
@@ -15,14 +14,9 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SagaChapter;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
 import mage.game.permanent.token.WraithToken;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -63,7 +57,7 @@ public final class InTheDarknessBindThem extends CardImpl {
                     ability.addEffect(new TheRingTemptsYouEffect());
 
                     ability.getEffects().setTargetPointer(new EachTargetPointer());
-                    ability.setTargetAdjuster(InTheDarknessBindThemAdjuster.instance);
+                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
                 }
         );
 
@@ -77,23 +71,5 @@ public final class InTheDarknessBindThem extends CardImpl {
     @Override
     public InTheDarknessBindThem copy() {
         return new InTheDarknessBindThem(this);
-    }
-}
-
-enum InTheDarknessBindThemAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player player = game.getPlayer(opponentId);
-            if (player == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + player.getName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
+++ b/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
@@ -10,13 +10,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -47,7 +42,7 @@ public final class JuvenileMistDragon extends CardImpl {
                         .setTargetPointer(new EachTargetPointer())
                         .setText("Each of those creatures doesn't untap during its controller's next untap step")
         );
-        ability.setTargetAdjuster(JuvenileMistDragonAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
         this.addAbility(ability.withFlavorWord("Confounding Clouds"));
     }
 
@@ -58,24 +53,5 @@ public final class JuvenileMistDragon extends CardImpl {
     @Override
     public JuvenileMistDragon copy() {
         return new JuvenileMistDragon(this);
-    }
-}
-
-enum JuvenileMistDragonAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            TargetPermanent target = new TargetPermanent(0, 1, filter, false);
-            ability.addTarget(target);
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
+++ b/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
@@ -11,15 +11,13 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Controllable;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -42,7 +40,7 @@ public final class LuminatePrimordial extends CardImpl {
         // When Luminate Primordial enters the battlefield, for each opponent, exile up to one target creature
         // that player controls and that player gains life equal to its power.
         Ability ability = new EntersBattlefieldTriggeredAbility(new LuminatePrimordialEffect(), false);
-        ability.setTargetAdjuster(LuminatePrimordialAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
         this.addAbility(ability);
     }
 
@@ -53,24 +51,6 @@ public final class LuminatePrimordial extends CardImpl {
     @Override
     public LuminatePrimordial copy() {
         return new LuminatePrimordial(this);
-    }
-}
-
-enum LuminatePrimordialAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent != null) {
-                FilterCreaturePermanent filter = new FilterCreaturePermanent("creature from opponent " + opponent.getLogName());
-                filter.add(new ControllerIdPredicate(opponentId));
-                TargetCreaturePermanent target = new TargetCreaturePermanent(0, 1, filter, false);
-                ability.addTarget(target);
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/m/MassMutiny.java
+++ b/Mage.Sets/src/mage/cards/m/MassMutiny.java
@@ -1,6 +1,5 @@
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
@@ -12,15 +11,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
 
 /**
  *
@@ -33,7 +31,7 @@ public final class MassMutiny extends CardImpl {
 
         // For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.
         this.getSpellAbility().addEffect(new MassMutinyEffect());
-        this.getSpellAbility().setTargetAdjuster(MassMutinyAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
     }
 
     private MassMutiny(final MassMutiny card) {
@@ -43,24 +41,6 @@ public final class MassMutiny extends CardImpl {
     @Override
     public MassMutiny copy() {
         return new MassMutiny(this);
-    }
-}
-
-enum MassMutinyAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent != null) {
-                FilterCreaturePermanent filter = new FilterCreaturePermanent("creature from opponent " + opponent.getName());
-                filter.add(new ControllerIdPredicate(opponentId));
-                TargetCreaturePermanent target = new TargetCreaturePermanent(0, 1, filter, false);
-                ability.addTarget(target);
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
@@ -15,14 +15,11 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
@@ -44,7 +41,7 @@ public final class MoltenPrimordial extends CardImpl {
 
         // When Molten Primordial enters the battlefield, for each opponent, take control of up to one target creature that player controls until end of turn. Untap those creatures. They have haste until end of turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(new MoltenPrimordialEffect(), false);
-        ability.setTargetAdjuster(MoltenPrimordialAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
         this.addAbility(ability);
     }
 
@@ -55,24 +52,6 @@ public final class MoltenPrimordial extends CardImpl {
     @Override
     public MoltenPrimordial copy() {
         return new MoltenPrimordial(this);
-    }
-}
-
-enum MoltenPrimordialAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent != null) {
-                FilterCreaturePermanent filter = new FilterCreaturePermanent("creature from opponent " + opponent.getLogName());
-                filter.add(new ControllerIdPredicate(opponentId));
-                TargetCreaturePermanent target = new TargetCreaturePermanent(0, 1, filter, false);
-                ability.addTarget(target);
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/r/ReverseThePolarity.java
+++ b/Mage.Sets/src/mage/cards/r/ReverseThePolarity.java
@@ -1,13 +1,8 @@
 package mage.cards.r;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-
 import mage.abilities.Ability;
 import mage.abilities.Mode;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ExileTargetEffect;
 import mage.abilities.effects.common.combat.CantBeBlockedAllEffect;
 import mage.abilities.effects.common.continuous.SwitchPowerToughnessAllEffect;
 import mage.cards.CardImpl;
@@ -20,6 +15,10 @@ import mage.game.Game;
 import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
 /**
  *
  * @author notgreat
@@ -31,7 +30,7 @@ public final class ReverseThePolarity extends CardImpl {
 
         // Choose one --
         // * Counter all other spells.
-        this.getSpellAbility().addEffect(new CounterAllEffect());
+        this.getSpellAbility().addEffect(new ReverseThePolarityCounterAllEffect());
         // * Switch each creature's power and toughness until end of turn.
         this.getSpellAbility().addMode(new Mode(new SwitchPowerToughnessAllEffect(Duration.EndOfTurn)));
         // * Creatures can't be blocked this turn.
@@ -48,14 +47,14 @@ public final class ReverseThePolarity extends CardImpl {
     }
 }
 //Based on Counterflux/Swift Silence
-class CounterAllEffect extends OneShotEffect {
+class ReverseThePolarityCounterAllEffect extends OneShotEffect {
 
-    CounterAllEffect() {
+    ReverseThePolarityCounterAllEffect() {
         super(Outcome.Detriment);
         staticText = "Counter all other spells.";
     }
 
-    private CounterAllEffect(final CounterAllEffect effect) {
+    private ReverseThePolarityCounterAllEffect(final ReverseThePolarityCounterAllEffect effect) {
         super(effect);
     }
 
@@ -74,8 +73,8 @@ class CounterAllEffect extends OneShotEffect {
     }
 
     @Override
-    public CounterAllEffect copy() {
-        return new CounterAllEffect(this);
+    public ReverseThePolarityCounterAllEffect copy() {
+        return new ReverseThePolarityCounterAllEffect(this);
     }
 
 }

--- a/Mage.Sets/src/mage/cards/r/ReverseThePolarity.java
+++ b/Mage.Sets/src/mage/cards/r/ReverseThePolarity.java
@@ -1,0 +1,81 @@
+package mage.cards.r;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.Mode;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ExileTargetEffect;
+import mage.abilities.effects.common.combat.CantBeBlockedAllEffect;
+import mage.abilities.effects.common.continuous.SwitchPowerToughnessAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.stack.Spell;
+import mage.game.stack.StackObject;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class ReverseThePolarity extends CardImpl {
+
+    public ReverseThePolarity(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{U}{U}");
+
+        // Choose one --
+        // * Counter all other spells.
+        this.getSpellAbility().addEffect(new CounterAllEffect());
+        // * Switch each creature's power and toughness until end of turn.
+        this.getSpellAbility().addMode(new Mode(new SwitchPowerToughnessAllEffect(Duration.EndOfTurn)));
+        // * Creatures can't be blocked this turn.
+        this.getSpellAbility().addMode(new Mode(new CantBeBlockedAllEffect(StaticFilters.FILTER_PERMANENT_CREATURES, Duration.EndOfTurn)));
+    }
+
+    private ReverseThePolarity(final ReverseThePolarity card) {
+        super(card);
+    }
+
+    @Override
+    public ReverseThePolarity copy() {
+        return new ReverseThePolarity(this);
+    }
+}
+//Based on Counterflux/Swift Silence
+class CounterAllEffect extends OneShotEffect {
+
+    CounterAllEffect() {
+        super(Outcome.Detriment);
+        staticText = "Counter all other spells.";
+    }
+
+    private CounterAllEffect(final CounterAllEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        List<Spell> spellsToCounter = new LinkedList<>();
+        for (StackObject stackObject : game.getStack()) {
+            if (stackObject instanceof Spell && !stackObject.getId().equals(source.getSourceObject(game).getId())) {
+                spellsToCounter.add((Spell) stackObject);
+            }
+        }
+        for (Spell spell : spellsToCounter) {
+            game.getStack().counter(spell.getId(), source, game);
+        }
+        return true;
+    }
+
+    @Override
+    public CounterAllEffect copy() {
+        return new CounterAllEffect(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
+++ b/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
@@ -1,0 +1,82 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.combat.CantBlockTargetEffect;
+import mage.abilities.effects.common.combat.GoadTargetEffect;
+import mage.abilities.keyword.BattalionAbility;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.target.common.TargetAnyTarget;
+import mage.target.targetadjustment.TargetAdjuster;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class SontaranGeneral extends CardImpl {
+
+    public SontaranGeneral(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{R}");
+        this.subtype.add(SubType.ALIEN);
+        this.subtype.add(SubType.SOLDIER);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Battalion -- Whenever Sontaran General and at least two other creatures attack, for each opponent,
+        // goad up to one target creature that player controls. Those creatures can't block this turn.
+        Ability ability = new BattalionAbility(new GoadTargetEffect()
+                .setText("for each opponent, goad up to one target creature that player controls."));
+        ability.addEffect(new CantBlockTargetEffect(Duration.EndOfTurn)
+                .setText("Those creatures can't block this turn."));
+        ability.setTargetAdjuster(SontaranGeneralAdjuster.instance);
+        this.addAbility(ability);
+    }
+
+    private SontaranGeneral(final SontaranGeneral card) {
+        super(card);
+    }
+
+    @Override
+    public SontaranGeneral copy() {
+        return new SontaranGeneral(this);
+    }
+}
+
+//From TheBalrogOfMoria
+enum SontaranGeneralAdjuster implements TargetAdjuster {
+    instance;
+
+    @Override
+    public void adjustTargets(Ability ability, Game game) {
+        ability.getTargets().clear();
+        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
+            Player opponent = game.getPlayer(opponentId);
+            if (opponent == null) {
+                continue;
+            }
+            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + opponent.getLogName());
+            filter.add(new ControllerIdPredicate(opponentId));
+            ability.addTarget(new TargetPermanent(0, 1, filter, false));
+        }
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
+++ b/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
@@ -1,27 +1,21 @@
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.combat.CantBlockTargetEffect;
 import mage.abilities.effects.common.combat.GoadTargetEffect;
 import mage.abilities.keyword.BattalionAbility;
-import mage.constants.Duration;
-import mage.constants.SubType;
-import mage.abilities.keyword.TrampleAbility;
 import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.common.TargetAnyTarget;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+
+import java.util.UUID;
 
 /**
  *
@@ -48,7 +42,7 @@ public final class SontaranGeneral extends CardImpl {
                 .setText("for each opponent, goad up to one target creature that player controls."));
         ability.addEffect(new CantBlockTargetEffect(Duration.EndOfTurn)
                 .setText("Those creatures can't block this turn."));
-        ability.setTargetAdjuster(SontaranGeneralAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0, 1)));
         this.addAbility(ability);
     }
 
@@ -59,24 +53,5 @@ public final class SontaranGeneral extends CardImpl {
     @Override
     public SontaranGeneral copy() {
         return new SontaranGeneral(this);
-    }
-}
-
-//From TheBalrogOfMoria
-enum SontaranGeneralAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter, false));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
@@ -15,14 +15,12 @@ import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterLandCard;
 import mage.filter.predicate.Predicates;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.Target;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 
 import java.util.UUID;
 
@@ -31,6 +29,11 @@ import java.util.UUID;
  */
 public final class SylvanPrimordial extends CardImpl {
 
+    private static final FilterPermanent filter = new FilterPermanent("noncreature permanent");
+
+    static {
+        filter.add(Predicates.not(CardType.CREATURE.getPredicate()));
+    }
     public SylvanPrimordial(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{G}{G}");
         this.subtype.add(SubType.AVATAR);
@@ -43,7 +46,7 @@ public final class SylvanPrimordial extends CardImpl {
 
         // When Sylvan Primordial enters the battlefield, for each opponent, destroy target noncreature permanent that player controls. For each permanent destroyed this way, search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new EntersBattlefieldTriggeredAbility(new SylvanPrimordialEffect(), false);
-        ability.setTargetAdjuster(SylvanPrimordialAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(filter)));
         this.addAbility(ability);
     }
 
@@ -54,25 +57,6 @@ public final class SylvanPrimordial extends CardImpl {
     @Override
     public SylvanPrimordial copy() {
         return new SylvanPrimordial(this);
-    }
-}
-
-enum SylvanPrimordialAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent != null) {
-                FilterPermanent filter = new FilterPermanent("noncreature permanent from opponent " + opponent.getLogName());
-                filter.add(new ControllerIdPredicate(opponentId));
-                filter.add(Predicates.not(CardType.CREATURE.getPredicate()));
-                TargetPermanent target = new TargetPermanent(0, 1, filter, false);
-                ability.addTarget(target);
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
+++ b/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
@@ -1,20 +1,15 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.effects.common.continuous.GainControlTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.constants.Duration;
-import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreatureOrPlaneswalkerPermanent;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -23,7 +18,11 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class TemptedByTheOriq extends CardImpl {
+    private static final FilterCreatureOrPlaneswalkerPermanent filter = new FilterCreatureOrPlaneswalkerPermanent("creature or planeswalker with mana value 3 or less");
 
+    static {
+        filter.add(new ManaValuePredicate(ComparisonType.OR_LESS, 3));
+    }
     public TemptedByTheOriq(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{U}{U}{U}");
 
@@ -32,7 +31,7 @@ public final class TemptedByTheOriq extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of up to one target creature " +
                         "or planeswalker that player controls with mana value 3 or less"));
-        this.getSpellAbility().setTargetAdjuster(TemptedByTheOriqAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0, 1, filter)));
     }
 
     private TemptedByTheOriq(final TemptedByTheOriq card) {
@@ -42,26 +41,5 @@ public final class TemptedByTheOriq extends CardImpl {
     @Override
     public TemptedByTheOriq copy() {
         return new TemptedByTheOriq(this);
-    }
-}
-
-enum TemptedByTheOriqAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreatureOrPlaneswalkerPermanent(
-                    "creature or planeswalker " + opponent.getName() + " controls with mana value 3 or less"
-            );
-            filter.add(new ControllerIdPredicate(opponentId));
-            filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, 4));
-            ability.addTarget(new TargetPermanent(0, 1, filter, false));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
+++ b/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
@@ -1,7 +1,6 @@
 package mage.cards.t;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.CycleTriggeredAbility;
 import mage.abilities.common.DiesSourceTriggeredAbility;
 import mage.abilities.common.delayed.ReflexiveTriggeredAbility;
@@ -18,14 +17,9 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
 import mage.game.permanent.token.TreasureToken;
-import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -57,7 +51,7 @@ public final class TheBalrogOfMoria extends CardImpl {
                 .setText("for each opponent, exile up to one target creature that player controls."),
             false
         );
-        reflexiveAbility.setTargetAdjuster(TheBalrogOfMoriaAdjuster.instance);
+        reflexiveAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
 
         this.addAbility(new DiesSourceTriggeredAbility(
             new DoWhenCostPaid(
@@ -81,23 +75,5 @@ public final class TheBalrogOfMoria extends CardImpl {
     @Override
     public TheBalrogOfMoria copy() {
         return new TheBalrogOfMoria(this);
-    }
-}
-
-enum TheBalrogOfMoriaAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent("creature controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter, false));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
+++ b/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
@@ -13,14 +13,11 @@ import mage.cards.CardSetInfo;
 import mage.cards.Cards;
 import mage.cards.CardsImpl;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreatureOrPlaneswalkerPermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.common.TargetCreatureOrPlaneswalker;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.Collection;
@@ -49,7 +46,7 @@ public final class TheTrueScriptures extends CardImpl {
                 ability -> {
                     ability.addEffect(new DestroyTargetEffect().setTargetPointer(new EachTargetPointer())
                             .setText("for each opponent, destroy up to one target creature or planeswalker that player controls"));
-                    ability.setTargetAdjuster(TheTrueScripturesAdjuster.instance);
+                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreatureOrPlaneswalker(0,1)));
                 }
         );
 
@@ -76,29 +73,6 @@ public final class TheTrueScriptures extends CardImpl {
     @Override
     public TheTrueScriptures copy() {
         return new TheTrueScriptures(this);
-    }
-}
-
-enum TheTrueScripturesAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID playerId : game.getOpponents(ability.getControllerId())) {
-            Player player = game.getPlayer(playerId);
-            if (player == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreatureOrPlaneswalkerPermanent(
-                    "creature or planeswalker controlled by " + player.getName()
-            );
-            filter.add(new ControllerIdPredicate(playerId));
-            if (game.getBattlefield().count(filter, ability.getControllerId(), ability, game) == 0) {
-                continue;
-            }
-            ability.addTarget(new TargetPermanent(0, 1, filter));
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/t/TolarianContempt.java
+++ b/Mage.Sets/src/mage/cards/t/TolarianContempt.java
@@ -14,12 +14,11 @@ import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.common.FilterOpponentsCreaturePermanent;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -31,6 +30,12 @@ public final class TolarianContempt extends CardImpl {
 
     private static final FilterPermanent filter
             = new FilterOpponentsCreaturePermanent("creature your opponents control");
+    private static final FilterPermanent filterRejection
+            = new FilterCreaturePermanent("creature with a rejection counter on it");
+
+    static {
+        filter.add(CounterType.REJECTION.getPredicate());
+    }
 
     public TolarianContempt(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{U}{U}");
@@ -43,7 +48,7 @@ public final class TolarianContempt extends CardImpl {
         // At the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.
         this.addAbility(new BeginningOfEndStepTriggeredAbility(
                 new TolarianContemptEffect(), TargetController.YOU, false
-        ).setTargetAdjuster(TolarianContemptAdjuster.instance));
+        ).setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0,1, filterRejection))));
     }
 
     private TolarianContempt(final TolarianContempt card) {
@@ -53,27 +58,6 @@ public final class TolarianContempt extends CardImpl {
     @Override
     public TolarianContempt copy() {
         return new TolarianContempt(this);
-    }
-}
-
-enum TolarianContemptAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterCreaturePermanent(
-                    "creature controlled by " + opponent.getName() + " with a rejection counter on it"
-            );
-            filter.add(CounterType.REJECTION.getPredicate());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter));
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
+++ b/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
@@ -29,6 +29,8 @@ import mage.game.Game;
 import mage.game.permanent.token.custom.CreatureToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
+import mage.target.common.TargetNonlandPermanent;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
@@ -61,7 +63,7 @@ public final class VronosMaskedInquisitor extends CardImpl {
         // −2: For each opponent, return up to one target nonland permanent that player controls to its owner's hand.
         LoyaltyAbility ability2 = new LoyaltyAbility(new ReturnToHandTargetEffect().setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"), -2);
-        ability2.setTargetAdjuster(VronosMaskedInquisitorAdjuster.instance);
+        ability2.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0,1)));
         this.addAbility(ability2);
 
         // −7: Target artifact you control becomes a 9/9 Construct artifact creature and gains vigilance, indestructible, and "This creature can't be blocked."

--- a/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
+++ b/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
@@ -1,6 +1,5 @@
 package mage.cards.v;
 
-import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
@@ -19,19 +18,13 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPlaneswalkerPermanent;
-import mage.filter.common.FilterNonlandPermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.game.Game;
 import mage.game.permanent.token.custom.CreatureToken;
-import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetNonlandPermanent;
 import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
-import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -86,23 +79,5 @@ public final class VronosMaskedInquisitor extends CardImpl {
     @Override
     public VronosMaskedInquisitor copy() {
         return new VronosMaskedInquisitor(this);
-    }
-}
-
-enum VronosMaskedInquisitorAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterPermanent filter = new FilterNonlandPermanent("nonland permanent controlled by " + opponent.getLogName());
-            filter.add(new ControllerIdPredicate(opponentId));
-            ability.addTarget(new TargetPermanent(0, 1, filter, false));
-        }
     }
 }

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -192,6 +192,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Sol Ring", 245, Rarity.UNCOMMON, mage.cards.s.SolRing.class));
         cards.add(new SetCardInfo("Solemn Simulacrum", 246, Rarity.RARE, mage.cards.s.SolemnSimulacrum.class));
         cards.add(new SetCardInfo("Sonic Screwdriver", 184, Rarity.UNCOMMON, mage.cards.s.SonicScrewdriver.class));
+        cards.add(new SetCardInfo("Sontaran General", 96, Rarity.UNCOMMON, mage.cards.s.SontaranGeneral.class));
         cards.add(new SetCardInfo("Star Whale", 55, Rarity.UNCOMMON, mage.cards.s.StarWhale.class));
         cards.add(new SetCardInfo("Start the TARDIS", 56, Rarity.UNCOMMON, mage.cards.s.StartTheTARDIS.class));
         cards.add(new SetCardInfo("Stormcarved Coast", 308, Rarity.RARE, mage.cards.s.StormcarvedCoast.class));

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -81,6 +81,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Duggan, Private Detective", 728, Rarity.RARE, mage.cards.d.DugganPrivateDetective.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Duggan, Private Detective", 1000, Rarity.RARE, mage.cards.d.DugganPrivateDetective.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Ecstatic Beauty", 83, Rarity.RARE, mage.cards.e.EcstaticBeauty.class));
+        cards.add(new SetCardInfo("Everything Comes to Dust", 19, Rarity.RARE, mage.cards.e.EverythingComesToDust.class));
         cards.add(new SetCardInfo("Evolving Wilds", 275, Rarity.COMMON, mage.cards.e.EvolvingWilds.class));
         cards.add(new SetCardInfo("Exotic Orchard", 276, Rarity.RARE, mage.cards.e.ExoticOrchard.class));
         cards.add(new SetCardInfo("Explore", 231, Rarity.COMMON, mage.cards.e.Explore.class));

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -35,6 +35,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Beast Within", 228, Rarity.UNCOMMON, mage.cards.b.BeastWithin.class));
         cards.add(new SetCardInfo("Become the Pilot", 37, Rarity.RARE, mage.cards.b.BecomeThePilot.class));
         cards.add(new SetCardInfo("Bessie, the Doctor's Roadster", 171, Rarity.RARE, mage.cards.b.BessieTheDoctorsRoadster.class));
+        cards.add(new SetCardInfo("Bigger on the Inside", 115, Rarity.UNCOMMON, mage.cards.b.BiggerOnTheInside.class));
         cards.add(new SetCardInfo("Blasphemous Act", 224, Rarity.RARE, mage.cards.b.BlasphemousAct.class));
         cards.add(new SetCardInfo("Canopy Vista", 258, Rarity.RARE, mage.cards.c.CanopyVista.class));
         cards.add(new SetCardInfo("Canyon Slough", 259, Rarity.RARE, mage.cards.c.CanyonSlough.class));

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -165,6 +165,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Reliquary Tower", 296, Rarity.UNCOMMON, mage.cards.r.ReliquaryTower.class));
         cards.add(new SetCardInfo("Renegade Silent", 53, Rarity.UNCOMMON, mage.cards.r.RenegadeSilent.class));
         cards.add(new SetCardInfo("Return to Dust", 211, Rarity.UNCOMMON, mage.cards.r.ReturnToDust.class));
+        cards.add(new SetCardInfo("Reverse the Polarity", 54, Rarity.RARE, mage.cards.r.ReverseThePolarity.class));
         cards.add(new SetCardInfo("River of Tears", 297, Rarity.RARE, mage.cards.r.RiverOfTears.class));
         cards.add(new SetCardInfo("Rockfall Vale", 298, Rarity.RARE, mage.cards.r.RockfallVale.class));
         cards.add(new SetCardInfo("Rogue's Passage", 299, Rarity.UNCOMMON, mage.cards.r.RoguesPassage.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/NextSpellCastHasAbilityEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/NextSpellCastHasAbilityEffect.java
@@ -13,6 +13,8 @@ import mage.players.Player;
 import mage.util.CardUtil;
 import mage.watchers.common.SpellsCastWatcher;
 
+import java.util.UUID;
+
 /**
  * @author xenohedron
  */
@@ -21,17 +23,25 @@ public class NextSpellCastHasAbilityEffect extends ContinuousEffectImpl {
     private int spellsCast;
     private final Ability ability;
     private final FilterCard filter;
+    private final TargetController targetController;
 
     public NextSpellCastHasAbilityEffect(Ability ability) {
         this(ability, StaticFilters.FILTER_CARD);
     }
-
     public NextSpellCastHasAbilityEffect(Ability ability, FilterCard filter) {
+        this(ability, StaticFilters.FILTER_CARD, TargetController.SOURCE_CONTROLLER);
+    }
+    public NextSpellCastHasAbilityEffect(Ability ability, TargetController targetController) {
+        this(ability, StaticFilters.FILTER_CARD, targetController);
+    }
+    public NextSpellCastHasAbilityEffect(Ability ability, FilterCard filter, TargetController targetController) {
         super(Duration.EndOfTurn, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
         this.ability = ability;
         this.filter = filter;
+        this.targetController = targetController;
         staticText = "the next " + filter.getMessage().replace("card", "spell")
-                + " you cast this turn has " + CardUtil.getTextWithFirstCharLowerCase(CardUtil.stripReminderText(ability.getRule()));
+                + (targetController == TargetController.SOURCE_CONTROLLER ? "you cast" : "target player casts")
+                + " this turn has " + CardUtil.getTextWithFirstCharLowerCase(CardUtil.stripReminderText(ability.getRule()));
     }
 
     private NextSpellCastHasAbilityEffect(final NextSpellCastHasAbilityEffect effect) {
@@ -39,6 +49,7 @@ public class NextSpellCastHasAbilityEffect extends ContinuousEffectImpl {
         this.spellsCast = effect.spellsCast;
         this.ability = effect.ability;
         this.filter = effect.filter;
+        this.targetController = effect.targetController;
     }
 
     @Override
@@ -57,17 +68,28 @@ public class NextSpellCastHasAbilityEffect extends ContinuousEffectImpl {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getControllerId());
+        UUID playerId;
+        switch (targetController){
+            case SOURCE_TARGETS:
+                playerId = source.getFirstTarget();
+                break;
+            case SOURCE_CONTROLLER:
+                playerId = source.getControllerId();
+                break;
+            default:
+                throw new UnsupportedOperationException("Value for targetController in NextSpellCastHasAbilityEffect not supported: " + targetController);
+        }
+        Player player = game.getPlayer(playerId);
         SpellsCastWatcher watcher = game.getState().getWatcher(SpellsCastWatcher.class);
         if (player == null || watcher == null) {
             return false;
         }
         //check if a spell was cast before
-        if (watcher.getCount(source.getControllerId()) > spellsCast) {
+        if (watcher.getCount(playerId) > spellsCast) {
             discard(); // only one use
             return false;
         }
-        for (Card card : game.getExile().getAllCardsByRange(game, source.getControllerId())) {
+        for (Card card : game.getExile().getAllCardsByRange(game, playerId)) {
             if (filter.match(card, game)) {
                 game.getState().addOtherAbility(card, ability);
             }
@@ -94,7 +116,7 @@ public class NextSpellCastHasAbilityEffect extends ContinuousEffectImpl {
                 .forEach(card -> game.getState().addOtherAbility(card, ability));
 
         for (StackObject stackObject : game.getStack()) {
-            if (!(stackObject instanceof Spell) || !stackObject.isControlledBy(source.getControllerId())) {
+            if (!(stackObject instanceof Spell) || !stackObject.isControlledBy(playerId)) {
                 continue;
             }
             // TODO: Distinguish "you cast" to exclude copies

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/NextSpellCastHasAbilityEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/NextSpellCastHasAbilityEffect.java
@@ -40,7 +40,7 @@ public class NextSpellCastHasAbilityEffect extends ContinuousEffectImpl {
         this.filter = filter;
         this.targetController = targetController;
         staticText = "the next " + filter.getMessage().replace("card", "spell")
-                + (targetController == TargetController.SOURCE_CONTROLLER ? "you cast" : "target player casts")
+                + (targetController == TargetController.SOURCE_CONTROLLER ? " you cast" : " target player casts")
                 + " this turn has " + CardUtil.getTextWithFirstCharLowerCase(CardUtil.stripReminderText(ability.getRule()));
     }
 

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -7,7 +7,6 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.util.Copyable;
 
 import java.util.UUID;
 
@@ -15,15 +14,11 @@ import java.util.UUID;
  *
  * @author notgreat
  */
-public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster, Copyable<TargetAdjuster> {
-    TargetPermanent baseTarget;
+public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
+    private final TargetPermanent baseTarget;
 
     public EachOpponentPermanentTargetsAdjuster(TargetPermanent baseTarget) {
         this.baseTarget = baseTarget;
-    }
-
-    protected EachOpponentPermanentTargetsAdjuster(final EachOpponentPermanentTargetsAdjuster targetAdjuster) {
-        this.baseTarget = targetAdjuster.baseTarget.copy();
     }
 
     @Override
@@ -42,10 +37,5 @@ public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster, Cop
                 ability.addTarget(newTarget);
             }
         }
-    }
-
-    @Override
-    public EachOpponentPermanentTargetsAdjuster copy() {
-        return new EachOpponentPermanentTargetsAdjuster(this);
     }
 }

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -17,8 +17,15 @@ import java.util.UUID;
 public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
     private final TargetPermanent blueprintTarget;
 
-    public EachOpponentPermanentTargetsAdjuster(TargetPermanent baseTarget) {
-        this.blueprintTarget = baseTarget.copy();
+    /**
+     * Duplicates the permanent target for each opponent.
+     * Filtering of permanent's controllers will be handled inside, so
+     * do not pass a blueprint target with a controller restriction filter/predicate.
+     *
+     * @param blueprintTarget The target to be duplicated per opponent
+     */
+    public EachOpponentPermanentTargetsAdjuster(TargetPermanent blueprintTarget) {
+        this.blueprintTarget = blueprintTarget.copy();
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -1,0 +1,51 @@
+package mage.target.targetadjustment;
+
+import mage.abilities.Ability;
+import mage.filter.Filter;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.util.Copyable;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster, Copyable<TargetAdjuster> {
+    TargetPermanent baseTarget;
+
+    public EachOpponentPermanentTargetsAdjuster(TargetPermanent baseTarget) {
+        this.baseTarget = baseTarget;
+    }
+
+    protected EachOpponentPermanentTargetsAdjuster(final EachOpponentPermanentTargetsAdjuster targetAdjuster) {
+        this.baseTarget = targetAdjuster.baseTarget.copy();
+    }
+
+    @Override
+    public void adjustTargets(Ability ability, Game game) {
+        ability.getTargets().clear();
+        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
+            Player opponent = game.getPlayer(opponentId);
+            if (opponent == null) {
+                continue;
+            }
+            TargetPermanent newTarget = baseTarget.copy();
+            Filter<Permanent> filter = newTarget.getFilter();
+            filter.add(new ControllerIdPredicate(opponentId));
+            if (newTarget.canChoose(ability.getControllerId(), ability, game)) {
+                filter.setMessage(filter.getMessage()+" controlled by " + opponent.getLogName());
+                ability.addTarget(newTarget);
+            }
+        }
+    }
+
+    @Override
+    public EachOpponentPermanentTargetsAdjuster copy() {
+        return new EachOpponentPermanentTargetsAdjuster(this);
+    }
+}

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -25,7 +25,7 @@ public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
      * @param blueprintTarget The target to be duplicated per opponent
      */
     public EachOpponentPermanentTargetsAdjuster(TargetPermanent blueprintTarget) {
-        this.blueprintTarget = blueprintTarget.copy();
+        this.blueprintTarget = blueprintTarget.copy(); //Defensively copy the blueprint to ensure immutability
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -15,10 +15,10 @@ import java.util.UUID;
  * @author notgreat
  */
 public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
-    private final TargetPermanent baseTarget;
+    private final TargetPermanent blueprintTarget;
 
     public EachOpponentPermanentTargetsAdjuster(TargetPermanent baseTarget) {
-        this.baseTarget = baseTarget;
+        this.blueprintTarget = baseTarget.copy();
     }
 
     @Override
@@ -29,7 +29,7 @@ public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
             if (opponent == null) {
                 continue;
             }
-            TargetPermanent newTarget = baseTarget.copy();
+            TargetPermanent newTarget = blueprintTarget.copy();
             Filter<Permanent> filter = newTarget.getFilter();
             filter.add(new ControllerIdPredicate(opponentId));
             if (newTarget.canChoose(ability.getControllerId(), ability, game)) {

--- a/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
@@ -11,5 +11,8 @@ import java.io.Serializable;
 @FunctionalInterface
 public interface TargetAdjuster extends Serializable {
 
+    // Please note that if refactoring and a copy() method is to be added, you must also
+    // refactor subclasses which are not enums. Currently only EachOpponentPermanentTargetsAdjuster.
+
     void adjustTargets(Ability ability, Game game);
 }

--- a/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
@@ -11,8 +11,6 @@ import java.io.Serializable;
 @FunctionalInterface
 public interface TargetAdjuster extends Serializable {
 
-    // Please note that if refactoring and a copy() method is to be added, you must also
-    // refactor subclasses which are not enums. Currently only EachOpponentPermanentTargetsAdjuster.
-
+    // Warning: This is not Copyable, do not use changeable data inside (only use static objects like Filter)
     void adjustTargets(Ability ability, Game game);
 }


### PR DESCRIPTION
#10653

While implementing [[Sontaran General]] I noticed that there were a lot of cards using almost exactly the same TargetAdjuster, so I created a generic class to handle it.

Currently untested except for [[Bigger on the Inside]], will un-draft after testing the cards more. I also would like to add automated tests for that card and maybe [[Everything Comes to Dust]] as well.

In particular I'd like to check if the hack I used for _Bigger on the Inside_ is acceptable.