### PR TITLE
update Suspend Ability for optional casting

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SuspendTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SuspendTest.java
@@ -29,6 +29,9 @@ public class SuspendTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Epochrasite");
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Lightning Bolt", "Epochrasite");
 
+        setChoice(playerA, true); // choose yes to cast
+
+        setStrictChooseMode(true);
         setStopAt(7, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -55,6 +58,9 @@ public class SuspendTest extends CardTestPlayerBase {
         activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}, Exile a nonland card from your hand: Put four time counters on the exiled card. If it doesn't have suspend, it gains suspend");
         setChoice(playerA, "Silvercoat Lion");
 
+        setChoice(playerA, true); // choose yes to cast
+
+        setStrictChooseMode(true);
         setStopAt(11, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -87,6 +93,9 @@ public class SuspendTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Silvercoat Lion");
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Delay", "Silvercoat Lion");
 
+        setChoice(playerA, true); // choose yes to cast
+
+        setStrictChooseMode(true);
         setStopAt(7, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -109,6 +118,7 @@ public class SuspendTest extends CardTestPlayerBase {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Suspend");
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Lightning Bolt", playerA);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 
@@ -128,6 +138,7 @@ public class SuspendTest extends CardTestPlayerBase {
         checkPlayableAbility("Can't cast directly", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Ancestral", false);
 //        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ancestral Vision", playerA);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -150,6 +161,7 @@ public class SuspendTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, "Suppression Field", 1);
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Suspend");
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -183,8 +195,10 @@ public class SuspendTest extends CardTestPlayerBase {
 
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Knowledge Pool");
 
+        setChoice(playerA, true); // choose yes to cast
         addTarget(playerA, playerB);
 
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -226,6 +240,7 @@ public class SuspendTest extends CardTestPlayerBase {
         checkExileCount("after counter", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", 1);
 
         // 3 time counters removes on upkeep (3, 5, 7) and cast again
+        setChoice(playerA, true); // choose yes to cast
         addTarget(playerA, playerB);
         checkLife("after suspend", 7, PhaseStep.PRECOMBAT_MAIN, playerB, 20 - 3);
         checkGraveyardCount("after suspend", 7, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", 1);
@@ -259,6 +274,7 @@ public class SuspendTest extends CardTestPlayerBase {
         checkExileCount("after counter", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wear // Tear", 1);
 
         // 3 time counters removes on upkeep (3, 5, 7) and cast again
+        setChoice(playerA, true); // choose yes to cast
         addTarget(playerA, "Bident of Thassa");
         checkPermanentCount("after suspend", 7, PhaseStep.PRECOMBAT_MAIN, playerB, "Bident of Thassa", 0);
         checkPermanentCount("after suspend", 7, PhaseStep.PRECOMBAT_MAIN, playerB, "Bow of Nylea", 1);
@@ -300,6 +316,7 @@ public class SuspendTest extends CardTestPlayerBase {
         checkExileCount("after counter", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Wear // Tear", 1);
 
         // 3 time counters removes on upkeep (3, 5, 7) and cast again (fused cards can't be played from exile zone, so select split spell only)
+        setChoice(playerA, true); // choose yes to cast
         setChoice(playerA, "Cast Wear");
         addTarget(playerA, "Bident of Thassa");
         checkPermanentCount("after suspend", 7, PhaseStep.PRECOMBAT_MAIN, playerB, "Bident of Thassa", 0);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ncc/SinisterConciergeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ncc/SinisterConciergeTest.java
@@ -1,9 +1,6 @@
 package org.mage.test.cards.single.ncc;
 
-import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.keyword.SuspendAbility;
 import mage.constants.PhaseStep;
-import mage.constants.TimingRule;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import org.junit.Test;
@@ -29,6 +26,7 @@ public class SinisterConciergeTest extends CardTestPlayerBase {
      */
     @Test
     public void testWorking() {
+        // TODO: remove multiple calls to execute()
         addCard(Zone.HAND, playerA, lightningBolt);
         addCard(Zone.BATTLEFIELD, playerA, sinisterConcierge);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain");
@@ -59,12 +57,14 @@ public class SinisterConciergeTest extends CardTestPlayerBase {
         assertExileCount(playerB, bondedConstruct, 1);
         assertCounterOnExiledCardCount(bondedConstruct, CounterType.TIME, 1);
 
+        setChoice(playerB, true); // yes to cast
         setStopAt(6, PhaseStep.PRECOMBAT_MAIN);
         execute();
         assertExileCount(playerA, sinisterConcierge, 1);
         assertExileCount(playerB, bondedConstruct, 0);
         assertPermanentCount(playerB, bondedConstruct, 1);
 
+        setChoice(playerA, true); // yes to cast
         setStopAt(7, PhaseStep.PRECOMBAT_MAIN);
         execute();
         assertExileCount(playerA, sinisterConcierge, 0);


### PR DESCRIPTION
per latest rules update

702.62. [Suspend](https://yawgatog.com/resources/magic-rules/#suspend)
702.62a. [Suspend](https://yawgatog.com/resources/magic-rules/#suspend) is a keyword that represents three [abilities](https://yawgatog.com/resources/magic-rules/#ability). The first is a [static ability](https://yawgatog.com/resources/magic-rules/#static_ability) that functions while the [card](https://yawgatog.com/resources/magic-rules/#card) with [suspend](https://yawgatog.com/resources/magic-rules/#suspend) is in a [player](https://yawgatog.com/resources/magic-rules/#player)'s [hand](https://yawgatog.com/resources/magic-rules/#hand). The second and third are [triggered abilities](https://yawgatog.com/resources/magic-rules/#triggered_ability) that function in the [exile](https://yawgatog.com/resources/magic-rules/#exile) [zone](https://yawgatog.com/resources/magic-rules/#zone). "[Suspend](https://yawgatog.com/resources/magic-rules/#suspend) N--[[cost](https://yawgatog.com/resources/magic-rules/#cost)]" means "If [you](https://yawgatog.com/resources/magic-rules/#you_your) could begin to [cast](https://yawgatog.com/resources/magic-rules/#cast) this [card](https://yawgatog.com/resources/magic-rules/#card) by putting it onto the [stack](https://yawgatog.com/resources/magic-rules/#stack) from [your](https://yawgatog.com/resources/magic-rules/#you_your) [hand](https://yawgatog.com/resources/magic-rules/#hand), [you](https://yawgatog.com/resources/magic-rules/#you_your) may [pay](https://yawgatog.com/resources/magic-rules/#pay) [[cost](https://yawgatog.com/resources/magic-rules/#cost)] and [exile](https://yawgatog.com/resources/magic-rules/#exile) it with N time [counters](https://yawgatog.com/resources/magic-rules/#counter) on it. This action doesn't use the [stack](https://yawgatog.com/resources/magic-rules/#stack)," and "At the beginning of [your](https://yawgatog.com/resources/magic-rules/#you_your) upkeep, if this [card](https://yawgatog.com/resources/magic-rules/#card) is suspended, remove a time [counter](https://yawgatog.com/resources/magic-rules/#counter) from it," and "When the last time [counter](https://yawgatog.com/resources/magic-rules/#counter) is [removed](https://yawgatog.com/resources/magic-rules/#remove_from_the_game_removed_removed-from-the-game_zone) from this [card](https://yawgatog.com/resources/magic-rules/#card), if it's exiled, [you](https://yawgatog.com/resources/magic-rules/#you_your) may [play](https://yawgatog.com/resources/magic-rules/#play) it without paying its [mana cost](https://yawgatog.com/resources/magic-rules/#mana_cost) if able. If [you](https://yawgatog.com/resources/magic-rules/#you_your) don't, it remains exiled. If [you](https://yawgatog.com/resources/magic-rules/#you_your) [cast](https://yawgatog.com/resources/magic-rules/#cast) a [creature](https://yawgatog.com/resources/magic-rules/#creature) [spell](https://yawgatog.com/resources/magic-rules/#spell) this way, it gains [haste](https://yawgatog.com/resources/magic-rules/#haste) until [you](https://yawgatog.com/resources/magic-rules/#you_your) lose [control](https://yawgatog.com/resources/magic-rules/#control_controller) of the [spell](https://yawgatog.com/resources/magic-rules/#spell) or the [permanent](https://yawgatog.com/resources/magic-rules/#permanent) it [becomes](https://yawgatog.com/resources/magic-rules/#becomes)."
702.62b. A [card](https://yawgatog.com/resources/magic-rules/#card) is "suspended" if it's in the [exile](https://yawgatog.com/resources/magic-rules/#exile) [zone](https://yawgatog.com/resources/magic-rules/#zone), has [suspend](https://yawgatog.com/resources/magic-rules/#suspend), and has a time [counter](https://yawgatog.com/resources/magic-rules/#counter) on it.
702.62c. While determining if [you](https://yawgatog.com/resources/magic-rules/#you_your) could begin to [cast](https://yawgatog.com/resources/magic-rules/#cast) a [card](https://yawgatog.com/resources/magic-rules/#card) with [suspend](https://yawgatog.com/resources/magic-rules/#suspend), take into consideration any [effects](https://yawgatog.com/resources/magic-rules/#effect) that would prohibit that [card](https://yawgatog.com/resources/magic-rules/#card) from being [cast](https://yawgatog.com/resources/magic-rules/#cast).
702.62d. Casting a [spell](https://yawgatog.com/resources/magic-rules/#spell) as an [effect](https://yawgatog.com/resources/magic-rules/#effect) of its [suspend](https://yawgatog.com/resources/magic-rules/#suspend) [ability](https://yawgatog.com/resources/magic-rules/#ability) follows the rules for paying [alternative costs](https://yawgatog.com/resources/magic-rules/#alternative_cost) in rules [601.2b](https://yawgatog.com/resources/magic-rules/#R6012b) and [601.2f](https://yawgatog.com/resources/magic-rules/#R6012f)-h.


Also update associated tests to strict choose mode with added choice