### PR TITLE
[MKC] Implement Experiment Twelve, changes to TargetPermanentPowerCount

### DIFF
--- a/Mage.Sets/src/mage/cards/e/ExperimentTwelve.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentTwelve.java
@@ -1,0 +1,59 @@
+package mage.cards.e;
+
+import java.util.UUID;
+
+import mage.MageInt;
+import mage.abilities.common.TurnedFaceUpAllTriggeredAbility;
+import mage.abilities.dynamicvalue.common.TargetPermanentPowerCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.constants.SubType;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.keyword.DisguiseAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.counters.CounterType;
+import mage.filter.common.FilterControlledCreaturePermanent;
+
+/**
+ * @author Cguy7777
+ */
+public final class ExperimentTwelve extends CardImpl {
+
+    public ExperimentTwelve(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
+
+        this.subtype.add(SubType.ELF);
+        this.subtype.add(SubType.LIZARD);
+        this.subtype.add(SubType.WARRIOR);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Whenever Experiment Twelve or another creature you control is turned face up, put +1/+1 counters on that creature equal to its power.
+        Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(0), TargetPermanentPowerCount.instance)
+                .setText("put +1/+1 counters on that creature equal to its power");
+
+        this.addAbility(new TurnedFaceUpAllTriggeredAbility(
+                effect,
+                new FilterControlledCreaturePermanent("{this} or another creature you control"),
+                true));
+
+        // Disguise {4}{G}
+        this.addAbility(new DisguiseAbility(this, new ManaCostsImpl<>("{4}{G}")));
+
+    }
+
+    private ExperimentTwelve(final ExperimentTwelve card) {
+        super(card);
+    }
+
+    @Override
+    public ExperimentTwelve copy() {
+        return new ExperimentTwelve(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/e/ExperimentTwelve.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentTwelve.java
@@ -15,12 +15,15 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.counters.CounterType;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.FilterPermanentThisOrAnother;
+import mage.filter.StaticFilters;
 
 /**
  * @author Cguy7777
  */
 public final class ExperimentTwelve extends CardImpl {
+
+    private static final FilterPermanentThisOrAnother filter = new FilterPermanentThisOrAnother(StaticFilters.FILTER_CONTROLLED_CREATURE, true);
 
     public ExperimentTwelve(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
@@ -37,11 +40,7 @@ public final class ExperimentTwelve extends CardImpl {
         // Whenever Experiment Twelve or another creature you control is turned face up, put +1/+1 counters on that creature equal to its power.
         Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(0), TargetPermanentPowerCount.instance)
                 .setText("put +1/+1 counters on that creature equal to its power");
-
-        this.addAbility(new TurnedFaceUpAllTriggeredAbility(
-                effect,
-                new FilterControlledCreaturePermanent("{this} or another creature you control"),
-                true));
+        this.addAbility(new TurnedFaceUpAllTriggeredAbility(effect, filter, true));
 
         // Disguise {4}{G}
         this.addAbility(new DisguiseAbility(this, new ManaCostsImpl<>("{4}{G}")));

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
@@ -12,7 +12,7 @@ import java.util.List;
  */
 public final class MurdersAtKarlovManorCommander extends ExpansionSet {
 
-    private static final List<String> unfinished = Arrays.asList("Boltbender", "Experiment Twelve", "True Identity", "Ransom Note", "Unexplained Absence", "Veiled Ascension");
+    private static final List<String> unfinished = Arrays.asList("Boltbender", "True Identity", "Ransom Note", "Unexplained Absence", "Veiled Ascension");
 
     private static final MurdersAtKarlovManorCommander instance = new MurdersAtKarlovManorCommander();
 
@@ -103,6 +103,8 @@ public final class MurdersAtKarlovManorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Everflowing Chalice", 227, Rarity.UNCOMMON, mage.cards.e.EverflowingChalice.class));
         cards.add(new SetCardInfo("Exalted Angel", 63, Rarity.RARE, mage.cards.e.ExaltedAngel.class));
         cards.add(new SetCardInfo("Exotic Orchard", 260, Rarity.RARE, mage.cards.e.ExoticOrchard.class));
+        cards.add(new SetCardInfo("Experiment Twelve", 37, Rarity.RARE, mage.cards.e.ExperimentTwelve.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Experiment Twelve", 347, Rarity.RARE, mage.cards.e.ExperimentTwelve.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Farewell", 64, Rarity.RARE, mage.cards.f.Farewell.class));
         cards.add(new SetCardInfo("Fell the Mighty", 65, Rarity.RARE, mage.cards.f.FellTheMighty.class));
         cards.add(new SetCardInfo("Fellwar Stone", 228, Rarity.UNCOMMON, mage.cards.f.FellwarStone.class));

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/TargetPermanentPowerCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/TargetPermanentPowerCount.java
@@ -4,7 +4,6 @@ package mage.abilities.dynamicvalue.common;
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -16,10 +15,7 @@ public enum TargetPermanentPowerCount implements DynamicValue {
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Permanent targetPermanent = game.getPermanent(effect.getTargetPointer().getFirst(game, sourceAbility));
-        if (targetPermanent == null) {
-            targetPermanent = (Permanent) game.getLastKnownInformation(effect.getTargetPointer().getFirst(game, sourceAbility), Zone.BATTLEFIELD);
-        }
+        Permanent targetPermanent = effect.getTargetPointer().getFirstTargetPermanentOrLKI(game, sourceAbility);
         if (targetPermanent != null) {
             return targetPermanent.getPower().getValue();
         }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/TargetPermanentPowerCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/TargetPermanentPowerCount.java
@@ -16,12 +16,12 @@ public enum TargetPermanentPowerCount implements DynamicValue {
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Permanent sourcePermanent = game.getPermanent(sourceAbility.getFirstTarget());
-        if (sourcePermanent == null) {
-            sourcePermanent = (Permanent) game.getLastKnownInformation(sourceAbility.getFirstTarget(), Zone.BATTLEFIELD);
+        Permanent targetPermanent = game.getPermanent(effect.getTargetPointer().getFirst(game, sourceAbility));
+        if (targetPermanent == null) {
+            targetPermanent = (Permanent) game.getLastKnownInformation(effect.getTargetPointer().getFirst(game, sourceAbility), Zone.BATTLEFIELD);
         }
-        if (sourcePermanent != null) {
-            return sourcePermanent.getPower().getValue();
+        if (targetPermanent != null) {
+            return targetPermanent.getPower().getValue();
         }
 
         return 0;


### PR DESCRIPTION
While working on Experiment Twelve, I originally wrote a custom count to use the effect's target pointer rather than the source ability's target (`effect.getTargetPointer().getFirst(game, sourceAbility)` instead of `sourceAbility.getFirstTarget()`). That way, we could set a target pointer with `TurnedFaceUpAllTriggeredAbility` and use it.

After consideration, I think it's better to just make `TargetPermanentPowerCount` work like that, for the benefit of cards with target pointers in their effects, but not directly on their abilities. I tested every card currently using this count, and everything seems to work right. Please let me know if there's something I'm missing with this approach.

PS: Thanks for the invitation into the project! It's nice being able to check things off myself. :-)