### PR TITLE
[WHO] Implement Bigger on the Inside

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BiggerOnTheInside.java
+++ b/Mage.Sets/src/mage/cards/b/BiggerOnTheInside.java
@@ -1,0 +1,94 @@
+package mage.cards.b;
+
+import java.util.UUID;
+
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.NextSpellCastHasAbilityEffect;
+import mage.abilities.keyword.CascadeAbility;
+import mage.choices.ChoiceColor;
+import mage.constants.*;
+import mage.abilities.effects.common.AttachEffect;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPermanent;
+import mage.abilities.keyword.EnchantAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.target.TargetPlayer;
+import mage.constants.Outcome;
+
+/**
+ *
+ * @author Skiwkr
+ */
+public final class BiggerOnTheInside extends CardImpl {
+
+    public BiggerOnTheInside(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{R}{G}");
+        
+        this.subtype.add(SubType.AURA);
+
+        // Enchant artifact or land
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_LAND);
+        this.getSpellAbility().addTarget(auraTarget);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BoostCreature));
+        this.addAbility(new EnchantAbility(auraTarget));
+
+        // Enchanted permanent has "{T}: Target player adds two mana of any one color. The next spell they cast this turn has cascade."
+
+        Ability ability = new SimpleActivatedAbility(new BiggerOnTheInsideEffect(), new TapSourceCost());
+        ability.addTarget(new TargetPlayer());
+        ability.addEffect(new NextSpellCastHasAbilityEffect(new CascadeAbility()));
+        this.addAbility(ability);
+    }
+
+    private BiggerOnTheInside(final BiggerOnTheInside card) {
+        super(card);
+    }
+
+    @Override
+    public BiggerOnTheInside copy() {
+        return new BiggerOnTheInside(this);
+    }
+}
+
+class BiggerOnTheInsideEffect extends OneShotEffect {
+
+    BiggerOnTheInsideEffect() {
+        super(Outcome.Benefit);
+        staticText = "Target player adds two mana of any one color. The next spell they cast this turn has cascade.";
+    }
+
+    private BiggerOnTheInsideEffect(final BiggerOnTheInsideEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public BiggerOnTheInsideEffect copy() {
+        return new BiggerOnTheInsideEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Player player = game.getPlayer(source.getFirstTarget());
+
+        if (controller == null || player == null) {
+            return false;
+        }
+
+        Mana mana = new Mana();
+        ChoiceColor choiceColor = new ChoiceColor();
+        choiceColor.setMessage("Choose a color");
+        controller.choose(Outcome.Benefit, choiceColor, game);
+        choiceColor.increaseMana(mana);//Surely there's a way to do this in one line
+        choiceColor.increaseMana(mana);
+        player.getManaPool().addMana(mana, game, source);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/t/TARDIS.java
+++ b/Mage.Sets/src/mage/cards/t/TARDIS.java
@@ -3,7 +3,6 @@ package mage.cards.t;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.common.CastOnlyIfConditionIsTrueAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition;
 import mage.abilities.effects.common.PlaneswalkEffect;
@@ -11,7 +10,6 @@ import mage.abilities.effects.common.continuous.NextSpellCastHasAbilityEffect;
 import mage.abilities.hint.ConditionHint;
 import mage.abilities.hint.Hint;
 import mage.abilities.keyword.CascadeAbility;
-import mage.constants.ComparisonType;
 import mage.constants.SubType;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.CrewAbility;
@@ -27,10 +25,9 @@ import mage.filter.common.FilterControlledPermanent;
  * @author Skiwkr
  */
 public final class TARDIS extends CardImpl {
-    private static final FilterControlledPermanent TimeLordFilter = new FilterControlledPermanent();
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.TIME_LORD);
 
-    static {TimeLordFilter.add(SubType.TIME_LORD.getPredicate());}
-    private static final Condition condition = new PermanentsOnTheBattlefieldCondition(TimeLordFilter, ComparisonType.MORE_THAN, 1);
+    private static final Condition condition = new PermanentsOnTheBattlefieldCondition(filter);
 
     private static final Hint hint = new ConditionHint(condition, "You control a Time Lord");
 
@@ -43,16 +40,18 @@ public final class TARDIS extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever TARDIS attacks, if you control a Time Lord, the next spell you cast this turn has cascade, and you may planeswalk.
-        Ability TardisAttackTrigger = new ConditionalInterveningIfTriggeredAbility(
+        Ability ability = new ConditionalInterveningIfTriggeredAbility(
                 new AttacksTriggeredAbility(new NextSpellCastHasAbilityEffect(new CascadeAbility()), false),
-                new PermanentsOnTheBattlefieldCondition(TimeLordFilter),
-                "Whenever TARDIS attacks, if you control a Time Lord, the next spell you cast this turn has cascade, and you may planeswalk.");
-        TardisAttackTrigger.addEffect(new PlaneswalkEffect(true));
-		this.addAbility(TardisAttackTrigger);
+                new PermanentsOnTheBattlefieldCondition(filter),
+                "Whenever {this} attacks, if you control a Time Lord, the next spell you cast this turn has cascade, and you may planeswalk.");
+
+        ability.addEffect(new PlaneswalkEffect(true));
+
+        ability.addHint(hint);
+
+		this.addAbility(ability);
         // Crew 2
         this.addAbility(new CrewAbility(2));
-
-        this.addAbility(new CastOnlyIfConditionIsTrueAbility(condition).addHint(hint));
 
     }
 

--- a/Mage.Sets/src/mage/cards/t/TARDIS.java
+++ b/Mage.Sets/src/mage/cards/t/TARDIS.java
@@ -1,0 +1,67 @@
+package mage.cards.t;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.CastOnlyIfConditionIsTrueAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.condition.common.PermanentsOnTheBattlefieldCondition;
+import mage.abilities.effects.common.PlaneswalkEffect;
+import mage.abilities.effects.common.continuous.NextSpellCastHasAbilityEffect;
+import mage.abilities.hint.ConditionHint;
+import mage.abilities.hint.Hint;
+import mage.abilities.keyword.CascadeAbility;
+import mage.constants.ComparisonType;
+import mage.constants.SubType;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.filter.common.FilterControlledPermanent;
+
+/**
+ *
+ * @author Skiwkr
+ */
+public final class TARDIS extends CardImpl {
+    private static final FilterControlledPermanent TimeLordFilter = new FilterControlledPermanent();
+
+    static {TimeLordFilter.add(SubType.TIME_LORD.getPredicate());}
+    private static final Condition condition = new PermanentsOnTheBattlefieldCondition(TimeLordFilter, ComparisonType.MORE_THAN, 1);
+
+    private static final Hint hint = new ConditionHint(condition, "You control a Time Lord");
+
+    public TARDIS(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Whenever TARDIS attacks, if you control a Time Lord, the next spell you cast this turn has cascade, and you may planeswalk.
+        Ability TardisAttackTrigger = new ConditionalInterveningIfTriggeredAbility(
+                new AttacksTriggeredAbility(new NextSpellCastHasAbilityEffect(new CascadeAbility()), false),
+                new PermanentsOnTheBattlefieldCondition(TimeLordFilter),
+                "Whenever TARDIS attacks, if you control a Time Lord, the next spell you cast this turn has cascade, and you may planeswalk.");
+        TardisAttackTrigger.addEffect(new PlaneswalkEffect(true));
+		this.addAbility(TardisAttackTrigger);
+        // Crew 2
+        this.addAbility(new CrewAbility(2));
+
+        this.addAbility(new CastOnlyIfConditionIsTrueAbility(condition).addHint(hint));
+
+    }
+
+    private TARDIS(final TARDIS card) {
+        super(card);
+    }
+
+    @Override
+    public TARDIS copy() {
+        return new TARDIS(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -200,6 +200,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Surge of Brilliance", 57, Rarity.UNCOMMON, mage.cards.s.SurgeOfBrilliance.class));
         cards.add(new SetCardInfo("Swamp", 200, Rarity.LAND, mage.cards.basiclands.Swamp.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Swords to Plowshares", 212, Rarity.UNCOMMON, mage.cards.s.SwordsToPlowshares.class));
+        cards.add(new SetCardInfo("TARDIS", 187, Rarity.UNCOMMON, mage.cards.t.TARDIS.class));
         cards.add(new SetCardInfo("Talisman of Conviction", 247, Rarity.UNCOMMON, mage.cards.t.TalismanOfConviction.class));
         cards.add(new SetCardInfo("Talisman of Creativity", 248, Rarity.UNCOMMON, mage.cards.t.TalismanOfCreativity.class));
         cards.add(new SetCardInfo("Talisman of Curiosity", 249, Rarity.UNCOMMON, mage.cards.t.TalismanOfCuriosity.class));

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -35,6 +35,7 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Beast Within", 228, Rarity.UNCOMMON, mage.cards.b.BeastWithin.class));
         cards.add(new SetCardInfo("Become the Pilot", 37, Rarity.RARE, mage.cards.b.BecomeThePilot.class));
         cards.add(new SetCardInfo("Bessie, the Doctor's Roadster", 171, Rarity.RARE, mage.cards.b.BessieTheDoctorsRoadster.class));
+        cards.add(new SetCardInfo("Bigger on the Inside", 115, Rarity.UNCOMMON, mage.cards.b.BiggerOnTheInside.class));
         cards.add(new SetCardInfo("Blasphemous Act", 224, Rarity.RARE, mage.cards.b.BlasphemousAct.class));
         cards.add(new SetCardInfo("Canopy Vista", 258, Rarity.RARE, mage.cards.c.CanopyVista.class));
         cards.add(new SetCardInfo("Canyon Slough", 259, Rarity.RARE, mage.cards.c.CanyonSlough.class));

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -369,6 +369,16 @@ public final class StaticFilters {
         FILTER_PERMANENT_ARTIFACT_CREATURE_ENCHANTMENT_OR_LAND.setLockedFilter(true);
     }
 
+    public static final FilterPermanent FILTER_PERMANENT_ARTIFACT_OR_LAND = new FilterPermanent("artifact or land");
+
+    static {
+        FILTER_PERMANENT_ARTIFACT_OR_LAND.add(Predicates.or(
+                CardType.ARTIFACT.getPredicate(),
+                CardType.LAND.getPredicate()
+        ));
+        FILTER_PERMANENT_ARTIFACT_OR_LAND.setLockedFilter(true);
+    }
+
     public static final FilterControlledPermanent FILTER_CONTROLLED_PERMANENT = new FilterControlledPermanent();
 
     static {


### PR DESCRIPTION
#10653 
This card is 99% of the way there in terms of functionality, it functions as an activated ability instead of a mana ability, and cascade triggers properly if you give the mana to yourself, which I would expect to be how it would be used in the vast majority of the time.  
However, if you give the mana to someone else (You still get to choose the mana), the cascade keyword gets added to your cards instead of the opponents cards.  I think the issue is that NextSpellCastHasAbilityEffect can only be called to target the player that utilizes the ability, so I'm not sure how to give that to another player.  If there are any suggestions for other cards that give other players a delayed conditional ability on casting spells, please let me know, I've just been unsuccessful in finding cards that put delayed effects on other players like this.
Also, if it's possible to just merge with a bug and then just open an issue, I can do that too.  