### PR TITLE
[SLP] Secret Lair Showdown (omitted set)

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -524,6 +524,7 @@ public class ScryfallImageSupportCards {
             add("ONE"); // Phyrexia: All Will Be One
             add("ONC"); // Phyrexia: All Will Be One Commander
             add("PL23"); // Year of the Rabbit 2023
+            add("SLP"); // Secret Lair Showdown
             add("MOM"); // March of the Machine
             add("MOC"); // March of the Machine Commander
             add("MAT"); // March of the Machine: The Aftermath

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -439,7 +439,7 @@ public class ScryfallImageSupportCards {
             add("ELD"); // Throne of Eldraine
             //add("PTG"); // Ponies: The Galloping
             add("CMB1"); // Mystery Booster Playtest Cards
-            add("MB1"); // Mystery Booster
+            //add("MB1"); // Mystery Booster
             add("GN2"); // Game Night 2019
             add("HA1"); // Historic Anthology 1
             //add("HHO"); // Happy Holidays
@@ -453,7 +453,7 @@ public class ScryfallImageSupportCards {
             add("PWOR"); // World Championship Promos
             add("PANA"); // MTG Arena Promos
             add("UND"); // Unsanctioned
-            add("FMB1"); // Mystery Booster Retail Edition Foils
+            //add("FMB1"); // Mystery Booster Retail Edition Foils
             add("HA2"); // Historic Anthology 2
             add("SLD"); // Secret Lair Drop
             add("PMEI"); // Magazine Inserts

--- a/Mage.Sets/src/mage/sets/SecretLairShowdown.java
+++ b/Mage.Sets/src/mage/sets/SecretLairShowdown.java
@@ -29,12 +29,15 @@ public class SecretLairShowdown extends ExpansionSet {
         cards.add(new SetCardInfo("Explore", 12, Rarity.RARE, mage.cards.e.Explore.class));
         cards.add(new SetCardInfo("Expressive Iteration", 13, Rarity.RARE, mage.cards.e.ExpressiveIteration.class));
         cards.add(new SetCardInfo("Fatal Push", 3, Rarity.RARE, mage.cards.f.FatalPush.class));
+        cards.add(new SetCardInfo("Goblin Guide", 23, Rarity.RARE, mage.cards.g.GoblinGuide.class));
         cards.add(new SetCardInfo("Murktide Regent", 17, Rarity.MYTHIC, mage.cards.m.MurktideRegent.class));
         cards.add(new SetCardInfo("Ponder", 19, Rarity.RARE, mage.cards.p.Ponder.class));
         cards.add(new SetCardInfo("Ragavan, Nimble Pilferer", 2, Rarity.MYTHIC, mage.cards.r.RagavanNimblePilferer.class));
         cards.add(new SetCardInfo("Relentless Rats", 10, Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Relentless Rats", 11, Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Seasoned Pyromancer", 24, Rarity.MYTHIC, mage.cards.s.SeasonedPyromancer.class));
         cards.add(new SetCardInfo("Spell Pierce", 18, Rarity.RARE, mage.cards.s.SpellPierce.class));
+        cards.add(new SetCardInfo("Springleaf Drum", 22, Rarity.RARE, mage.cards.s.SpringleafDrum.class));
         cards.add(new SetCardInfo("Ugin, the Spirit Dragon", 6, Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class));
         cards.add(new SetCardInfo("Unholy Heat", 4, Rarity.RARE, mage.cards.u.UnholyHeat.class));
         cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", 14, Rarity.RARE, mage.cards.v.ValakutTheMoltenPinnacle.class));

--- a/Mage.Sets/src/mage/sets/SecretLairShowdown.java
+++ b/Mage.Sets/src/mage/sets/SecretLairShowdown.java
@@ -20,24 +20,24 @@ public class SecretLairShowdown extends ExpansionSet {
         this.hasBoosters = false;
         this.hasBasicLands = false;
 		
-        cards.add(new SetCardInfo("An Offer You Can't Refuse", "7", Rarity.RARE, mage.cards.a.AnOfferYouCantRefuse.class));
-        cards.add(new SetCardInfo("Brainstorm", "1", Rarity.RARE, mage.cards.b.Brainstorm.class));
-        cards.add(new SetCardInfo("Dark Ritual", "16", Rarity.RARE, mage.cards.d.DarkRitual.class));
-        cards.add(new SetCardInfo("Death's Shadow", "8", Rarity.RARE, mage.cards.d.DeathsShadow.class));
-        cards.add(new SetCardInfo("Dragonlord Silumgar", "19", Rarity.MYTHIC, mage.cards.d.DragonlordSilumgar.class));
-        cards.add(new SetCardInfo("Eldritch Evolution", "5", Rarity.RARE, mage.cards.e.EldritchEvolution.class));
-        cards.add(new SetCardInfo("Explore", "12", Rarity.RARE, mage.cards.e.Explore.class));
-        cards.add(new SetCardInfo("Expressive Iteration", "13", Rarity.RARE, mage.cards.e.ExpressiveIteration.class));
-        cards.add(new SetCardInfo("Fatal Push", "3", Rarity.RARE, mage.cards.f.FatalPush.class));
-        cards.add(new SetCardInfo("Murktide Regent", "17", Rarity.MYTHIC, mage.cards.m.MurktideRegent.class));
-        cards.add(new SetCardInfo("Ponder", "19", Rarity.RARE, mage.cards.p.Ponder.class));
-        cards.add(new SetCardInfo("Ragavan, Nimble Pilferer", "2", Rarity.MYTHIC, mage.cards.r.RagavanNimblePilferer.class));
-        cards.add(new SetCardInfo("Relentless Rats", "10", Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Relentless Rats", "11", Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Spell Pierce", "18", Rarity.RARE, mage.cards.s.SpellPierce.class));
-        cards.add(new SetCardInfo("Ugin, the Spirit Dragon", "6", Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class));
-        cards.add(new SetCardInfo("Unholy Heat", "4", Rarity.RARE, mage.cards.u.UnholyHeat.class));
-        cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", "14", Rarity.RARE, mage.cards.v.ValakutTheMoltenPinnacle.class));
-        cards.add(new SetCardInfo("Wrenn and Six", "15", Rarity.MYTHIC, mage.cards.w.WrennAndSix.class));
+        cards.add(new SetCardInfo("An Offer You Can't Refuse", 7, Rarity.RARE, mage.cards.a.AnOfferYouCantRefuse.class));
+        cards.add(new SetCardInfo("Brainstorm", 1, Rarity.RARE, mage.cards.b.Brainstorm.class));
+        cards.add(new SetCardInfo("Dark Ritual", 16, Rarity.RARE, mage.cards.d.DarkRitual.class));
+        cards.add(new SetCardInfo("Death's Shadow", 8, Rarity.RARE, mage.cards.d.DeathsShadow.class));
+        cards.add(new SetCardInfo("Dragonlord Silumgar", 9, Rarity.MYTHIC, mage.cards.d.DragonlordSilumgar.class));
+        cards.add(new SetCardInfo("Eldritch Evolution", 5, Rarity.RARE, mage.cards.e.EldritchEvolution.class));
+        cards.add(new SetCardInfo("Explore", 12, Rarity.RARE, mage.cards.e.Explore.class));
+        cards.add(new SetCardInfo("Expressive Iteration", 13, Rarity.RARE, mage.cards.e.ExpressiveIteration.class));
+        cards.add(new SetCardInfo("Fatal Push", 3, Rarity.RARE, mage.cards.f.FatalPush.class));
+        cards.add(new SetCardInfo("Murktide Regent", 17, Rarity.MYTHIC, mage.cards.m.MurktideRegent.class));
+        cards.add(new SetCardInfo("Ponder", 19, Rarity.RARE, mage.cards.p.Ponder.class));
+        cards.add(new SetCardInfo("Ragavan, Nimble Pilferer", 2, Rarity.MYTHIC, mage.cards.r.RagavanNimblePilferer.class));
+        cards.add(new SetCardInfo("Relentless Rats", 10, Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Relentless Rats", 11, Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spell Pierce", 18, Rarity.RARE, mage.cards.s.SpellPierce.class));
+        cards.add(new SetCardInfo("Ugin, the Spirit Dragon", 6, Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class));
+        cards.add(new SetCardInfo("Unholy Heat", 4, Rarity.RARE, mage.cards.u.UnholyHeat.class));
+        cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", 14, Rarity.RARE, mage.cards.v.ValakutTheMoltenPinnacle.class));
+        cards.add(new SetCardInfo("Wrenn and Six", 15, Rarity.MYTHIC, mage.cards.w.WrennAndSix.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/SecretLairShowdown.java
+++ b/Mage.Sets/src/mage/sets/SecretLairShowdown.java
@@ -37,7 +37,7 @@ public class SecretLairShowdown extends ExpansionSet {
         cards.add(new SetCardInfo("Spell Pierce", "18", Rarity.RARE, mage.cards.s.SpellPierce.class));
         cards.add(new SetCardInfo("Ugin, the Spirit Dragon", "6", Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class));
         cards.add(new SetCardInfo("Unholy Heat", "4", Rarity.RARE, mage.cards.u.UnholyHeat.class));
-        cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", "14", Rarity.MYTHIC, mage.cards.v.ValakutTheMoltenPinnacle.class));
+        cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", "14", Rarity.RARE, mage.cards.v.ValakutTheMoltenPinnacle.class));
         cards.add(new SetCardInfo("Wrenn and Six", "15", Rarity.MYTHIC, mage.cards.w.WrennAndSix.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/SecretLairShowdown.java
+++ b/Mage.Sets/src/mage/sets/SecretLairShowdown.java
@@ -1,0 +1,43 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/slp
+ */
+public class SecretLairShowdown extends ExpansionSet {
+
+    private static final SecretLairShowdown instance = new SecretLairShowdown();
+
+    public static SecretLairShowdown getInstance() {
+        return instance;
+    }
+
+    private SecretLairShowdown() {
+        super("Secret Lair Showdown", "SLP", ExpansionSet.buildDate(2023, 2, 17), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+		
+        cards.add(new SetCardInfo("An Offer You Can't Refuse", "7", Rarity.RARE, mage.cards.a.AnOfferYouCantRefuse.class));
+        cards.add(new SetCardInfo("Brainstorm", "1", Rarity.RARE, mage.cards.b.Brainstorm.class));
+        cards.add(new SetCardInfo("Dark Ritual", "16", Rarity.RARE, mage.cards.d.DarkRitual.class));
+        cards.add(new SetCardInfo("Death's Shadow", "8", Rarity.RARE, mage.cards.d.DeathsShadow.class));
+        cards.add(new SetCardInfo("Dragonlord Silumgar", "19", Rarity.MYTHIC, mage.cards.d.DragonlordSilumgar.class));
+        cards.add(new SetCardInfo("Eldritch Evolution", "5", Rarity.RARE, mage.cards.e.EldritchEvolution.class));
+        cards.add(new SetCardInfo("Explore", "12", Rarity.RARE, mage.cards.e.Explore.class));
+        cards.add(new SetCardInfo("Expressive Iteration", "13", Rarity.RARE, mage.cards.e.ExpressiveIteration.class));
+        cards.add(new SetCardInfo("Fatal Push", "3", Rarity.RARE, mage.cards.f.FatalPush.class));
+        cards.add(new SetCardInfo("Murktide Regent", "17", Rarity.MYTHIC, mage.cards.m.MurktideRegent.class));
+        cards.add(new SetCardInfo("Ponder", "19", Rarity.RARE, mage.cards.p.Ponder.class));
+        cards.add(new SetCardInfo("Ragavan, Nimble Pilferer", "2", Rarity.MYTHIC, mage.cards.r.RagavanNimblePilferer.class));
+        cards.add(new SetCardInfo("Relentless Rats", "10", Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Relentless Rats", "11", Rarity.RARE, mage.cards.r.RelentlessRats.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spell Pierce", "18", Rarity.RARE, mage.cards.s.SpellPierce.class));
+        cards.add(new SetCardInfo("Ugin, the Spirit Dragon", "6", Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class));
+        cards.add(new SetCardInfo("Unholy Heat", "4", Rarity.RARE, mage.cards.u.UnholyHeat.class));
+        cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", "14", Rarity.MYTHIC, mage.cards.v.ValakutTheMoltenPinnacle.class));
+        cards.add(new SetCardInfo("Wrenn and Six", "15", Rarity.MYTHIC, mage.cards.w.WrennAndSix.class));
+    }
+}

--- a/Utils/known-sets.txt
+++ b/Utils/known-sets.txt
@@ -221,6 +221,7 @@ Saviors of Kamigawa|SaviorsOfKamigawa|
 Scars of Mirrodin|ScarsOfMirrodin|
 Scourge|Scourge|
 Secret Lair Drop|SecretLairDrop|
+Secret Lair Showdown|SecretLairShowdown|
 Seventh Edition|SeventhEdition|
 Shadowmoor|Shadowmoor|
 Shadows over Innistrad|ShadowsOverInnistrad|

--- a/Utils/mtg-sets-data.txt
+++ b/Utils/mtg-sets-data.txt
@@ -224,6 +224,7 @@ Starter Commander Decks|SCD|
 Strixhaven: School of Mages|STX|
 Scourge|SCG|
 Secret Lair|SLD|
+Secret Lair Showdown|SLP|
 Shadowmoor|SHM|
 Shadows over Innistrad|SOI|
 Saviors of Kamigawa|SOK|


### PR DESCRIPTION
https://github.com/magefree/mage/issues/11880

Also I noticed a discrepancy in Utils/mtg-sets-data.txt line 226 has "Secret Lair|SLD|" where everywhere else that set is referred to as "Secret Lair Drop" .