### PR TITLE
Fix addSimultaneousDamage to avoid adding damage events to existing DamagedBatchForOnePlayerEvent instances when they shouldn't

### DIFF
--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -834,6 +834,11 @@ public class GameState implements Serializable, Copyable<GameState> {
             } else if ((event instanceof DamagedBatchEvent)
                     && ((DamagedBatchEvent) event).getDamageClazz().isInstance(damagedEvent)) {
                 // per damage type
+                // If the batch event isn't DAMAGED_BATCH_FOR_ONE_PLAYER, the targetIDs need not match,
+                // since "event" is a generic batch in this case
+                // (either DAMAGED_BATCH_FOR_PERMANENTS or DAMAGED_BATCH_FOR_PLAYERS)
+                // Just needs to be a permanent-damaging event for DAMAGED_BATCH_FOR_PERMANENTS,
+                // or a player-damaging event for DAMAGED_BATCH_FOR_PLAYERS
                 ((DamagedBatchEvent) event).addEvent(damagedEvent);
                 isDamageBatchUsed = true;
             }

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -823,21 +823,19 @@ public class GameState implements Serializable, Copyable<GameState> {
         boolean isPlayerBatchUsed = false;
         for (GameEvent event : simultaneousEvents) {
 
-            // per damage type
-            if ((event instanceof DamagedBatchEvent)
-                    && ((DamagedBatchEvent) event).getDamageClazz().isInstance(damagedEvent)) {
-                ((DamagedBatchEvent) event).addEvent(damagedEvent);
-                isDamageBatchUsed = true;
-            }
-
-            // per player
             if (isPlayerDamage && event instanceof DamagedBatchForOnePlayerEvent) {
+                // per player
                 DamagedBatchForOnePlayerEvent oldPlayerBatch = (DamagedBatchForOnePlayerEvent) event;
                 if (oldPlayerBatch.getDamageClazz().isInstance(damagedEvent)
                         && event.getPlayerId().equals(damagedEvent.getTargetId())) {
                     oldPlayerBatch.addEvent(damagedEvent);
                     isPlayerBatchUsed = true;
                 }
+            } else if ((event instanceof DamagedBatchEvent)
+                    && ((DamagedBatchEvent) event).getDamageClazz().isInstance(damagedEvent)) {
+                // per damage type
+                ((DamagedBatchEvent) event).addEvent(damagedEvent);
+                isDamageBatchUsed = true;
             }
         }
 


### PR DESCRIPTION
Bug discovered in #11841 

Currently, `addSimultaneousDamage` checks to see if a given `GameEvent` in `simultaneousEvents` is a `DamagedBatchEvent` to add it to that batch, BEFORE doing the check to see if that batch event is actually a `DamagedBatchForOnePlayerEvent` and the target matches. because if that condition isn't satisfied, the `DamagedEvent` instance should NOT be added to that batch event

This results in `DamagedEvent` instances being added to `DamagedBatchForOnePlayerEvent` instances fired in the same timing window regardless of whether the targets match, possibly conglomerating more damage into the `DamagedBatchForOnePlayerEvent` than it should have.

This should fix that behavior.

I want to write a test to show this works, but i see no cards that would be affected by this bug. Most use "when combat damage to player happens, do <thing that doesn't care about how much damage it was>", and the ones that care about how much damage it was ([Quartzwood Crasher](https://scryfall.com/card/lcc/281/quartzwood-crasher), [Anowon, the Ruin Thief](https://scryfall.com/card/znc/1/anowon-the-ruin-thief), and [Lolth, Spider Queen](https://scryfall.com/card/afr/112/lolth-spider-queen)) still only care about combat damage, which wont let me test a scenario where different players are dealt damage by different targets at the same time.

Maybe there is no way that scenario could happen normally, but this behavior will be important for implementing `DamageBatchForOnePermanent`, where this happens all the time. Thoughts?