### PR TITLE
Fix Wrathful Raptors AI

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WrathfulRaptors.java
+++ b/Mage.Sets/src/mage/cards/w/WrathfulRaptors.java
@@ -102,7 +102,7 @@ class WrathfulRaptorsTriggeredAbility extends TriggeredAbilityImpl {
 class WrathfulRaptorsEffect extends OneShotEffect {
 
     WrathfulRaptorsEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.Damage);
     }
 
     private WrathfulRaptorsEffect(final WrathfulRaptorsEffect effect) {


### PR DESCRIPTION
Currently the `WrathfulRaptorsEffect` is given the `Benefit` outcome, meaning the AI will choose itself or its own permanents when assigning damage targets with [Wrathful Raptors](https://scryfall.com/card/lcc/88/wrathful-raptors).