### PR TITLE
Fix Wrathful Raptor's ability trigger

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WrathfulRaptors.java
+++ b/Mage.Sets/src/mage/cards/w/WrathfulRaptors.java
@@ -20,6 +20,7 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetPermanentOrPlayer;
+import mage.util.CardUtil;
 
 /**
  * @author arcox
@@ -75,12 +76,12 @@ class WrathfulRaptorsTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.DAMAGED_PERMANENT;
+        return event.getType() == GameEvent.EventType.DAMAGED_BATCH_FOR_ONE_PERMANENT;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        Permanent dinosaur = game.getPermanent(event.getTargetId());
+        Permanent dinosaur = game.getPermanent((UUID) CardUtil.getEventTargets(event).toArray()[0]);
         int damage = event.getAmount();
         if (dinosaur == null || damage < 1
                 || !dinosaur.isControlledBy(getControllerId())

--- a/Mage.Sets/src/mage/cards/w/WrathfulRaptors.java
+++ b/Mage.Sets/src/mage/cards/w/WrathfulRaptors.java
@@ -81,8 +81,15 @@ class WrathfulRaptorsTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        Permanent dinosaur = game.getPermanent((UUID) CardUtil.getEventTargets(event).toArray()[0]);
+
+        UUID dinosaurUUID = CardUtil.getEventTargets(event)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        Permanent dinosaur = game.getPermanent(dinosaurUUID);
         int damage = event.getAmount();
+
         if (dinosaur == null || damage < 1
                 || !dinosaur.isControlledBy(getControllerId())
                 || !dinosaur.hasSubtype(SubType.DINOSAUR, game)) {


### PR DESCRIPTION
Continuation of work done in #11841 

This fixes wrathful raptor's custom ability so that it only triggers once when dealt damage simultaneously by multiple sources at the same time.

I intend to use the changes approved here as a template for fixing any cards or abilities that use DAMAGED_PERMANENT as a trigger when they should be using DAMAGED_BATCH_FOR_ONE_PERMANENT, like [Arcbond](https://scryfall.com/card/frf/91/arcbond) and `DealtDamageAttachedTriggeredAbility`. 

Regarding fetching the target ID of the batch damage event: right now my usage of `(UUID) CardUtil.getEventTargets(event).toArray()[0]` feels a little spaghetti. I was thinking of adding a `getTargetId()` getter for `DamagedBatchForOnePermanentEvent` that would just call the former (or something equivalent) under the hood, since we can safely assume that the target ID list for this event should always be exactly one. It also has the added benefit of allowing people to just call the same getter as a single damage event since that makes sense intuitively to me. Thoughts?