### PR TITLE
Add life lost event and batch event to implement Ob Nixilis, Captive Kingpin

### DIFF
--- a/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
@@ -4,15 +4,12 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.constants.SubType;
-import mage.constants.SuperType;
+import mage.abilities.effects.common.ExileTopXMayPlayUntilEffect;
+import mage.constants.*;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.*;
 import mage.util.CardUtil;
@@ -38,7 +35,10 @@ public final class ObNixilisCaptiveKingpin extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.
-        this.addAbility(new ObNixilisCaptiveKingpinAbility(new DrawCardSourceControllerEffect(1)));
+        this.addAbility(new ObNixilisCaptiveKingpinAbility(
+                new ExileTopXMayPlayUntilEffect(1, Duration.UntilYourNextEndStep)
+                .withTextOptions("that card", false)
+        ));
     }
 
     private ObNixilisCaptiveKingpin(final ObNixilisCaptiveKingpin card) {

--- a/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
@@ -53,12 +53,8 @@ public final class ObNixilisCaptiveKingpin extends CardImpl {
 
 class ObNixilisCaptiveKingpinAbility extends TriggeredAbilityImpl {
     
-    public ObNixilisCaptiveKingpinAbility(Effect effect) {
-        this(Zone.BATTLEFIELD, effect, false);
-    }
-    
-    public ObNixilisCaptiveKingpinAbility(Zone zone, Effect effect, boolean optional) {
-        super(zone, effect, optional);
+    ObNixilisCaptiveKingpinAbility(Effect effect) {
+        super(Zone.BATTLEFIELD, effect);
         setTriggerPhrase("Whenever one or more opponents each lose exactly 1 life, ");
     }
 

--- a/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
@@ -2,14 +2,17 @@ package mage.cards.o;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.ExileTopXMayPlayUntilEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.constants.*;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.*;
 import mage.util.CardUtil;
@@ -35,10 +38,14 @@ public final class ObNixilisCaptiveKingpin extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.
-        this.addAbility(new ObNixilisCaptiveKingpinAbility(
-                new ExileTopXMayPlayUntilEffect(1, Duration.UntilYourNextEndStep)
-                .withTextOptions("that card", false)
-        ));
+        Ability ability = new ObNixilisCaptiveKingpinAbility(
+            new AddCountersSourceEffect(CounterType.P1P1.createInstance())
+        );
+        ability.addEffect(new ExileTopXMayPlayUntilEffect(1, Duration.UntilYourNextEndStep)
+                .withTextOptions("that card", false));
+
+        this.addAbility(ability);
+
     }
 
     private ObNixilisCaptiveKingpin(final ObNixilisCaptiveKingpin card) {

--- a/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
@@ -89,7 +89,7 @@ class ObNixilisCaptiveKingpinAbility extends TriggeredAbilityImpl {
             }
             opponentLostLife = true;
 
-            int lifelost = lifeLostBatchEvent.getAmount(targetPlayer);
+            int lifelost = lifeLostBatchEvent.getLifeLostByPlayer(targetPlayer);
             if (lifelost != 1){
                 allis1 = false;
                 break;

--- a/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
@@ -81,7 +81,7 @@ class ObNixilisCaptiveKingpinAbility extends TriggeredAbilityImpl {
 
         for (UUID targetPlayer : CardUtil.getEventTargets(lifeLostBatchEvent)){
             // skip controller
-            if (targetPlayer == getControllerId()){
+            if (targetPlayer.equals(getControllerId())){
                 continue;
             }
             opponentLostLife = true;

--- a/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
+++ b/Mage.Sets/src/mage/cards/o/ObNixilisCaptiveKingpin.java
@@ -1,0 +1,102 @@
+package mage.cards.o;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.TrampleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.*;
+import mage.util.CardUtil;
+
+/**
+ *
+ * @author jimga150
+ */
+public final class ObNixilisCaptiveKingpin extends CardImpl {
+
+    public ObNixilisCaptiveKingpin(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}{R}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.DEMON);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Whenever one or more opponents each lose exactly 1 life, put a +1/+1 counter on Ob Nixilis, Captive Kingpin. Exile the top card of your library. Until your next end step, you may play that card.
+        this.addAbility(new ObNixilisCaptiveKingpinAbility(new DrawCardSourceControllerEffect(1)));
+    }
+
+    private ObNixilisCaptiveKingpin(final ObNixilisCaptiveKingpin card) {
+        super(card);
+    }
+
+    @Override
+    public ObNixilisCaptiveKingpin copy() {
+        return new ObNixilisCaptiveKingpin(this);
+    }
+}
+
+class ObNixilisCaptiveKingpinAbility extends TriggeredAbilityImpl {
+    
+    public ObNixilisCaptiveKingpinAbility(Effect effect) {
+        this(Zone.BATTLEFIELD, effect, false);
+    }
+    
+    public ObNixilisCaptiveKingpinAbility(Zone zone, Effect effect, boolean optional) {
+        super(zone, effect, optional);
+        setTriggerPhrase("Whenever one or more opponents each lose exactly 1 life, ");
+    }
+
+    private ObNixilisCaptiveKingpinAbility(final ObNixilisCaptiveKingpinAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.LOST_LIFE_BATCH;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+
+        LifeLostBatchEvent lifeLostBatchEvent = (LifeLostBatchEvent) event;
+
+        boolean opponentLostLife = false;
+        boolean allis1 = true;
+
+        for (UUID targetPlayer : CardUtil.getEventTargets(lifeLostBatchEvent)){
+            // skip controller
+            if (targetPlayer == getControllerId()){
+                continue;
+            }
+            opponentLostLife = true;
+
+            int lifelost = lifeLostBatchEvent.getAmount(targetPlayer);
+            if (lifelost != 1){
+                allis1 = false;
+                break;
+            }
+        }
+        return opponentLostLife && allis1;
+    }
+
+    @Override
+    public ObNixilisCaptiveKingpinAbility copy() {
+        return new ObNixilisCaptiveKingpinAbility(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MarchOfTheMachineTheAftermath.java
+++ b/Mage.Sets/src/mage/sets/MarchOfTheMachineTheAftermath.java
@@ -150,6 +150,7 @@ public final class MarchOfTheMachineTheAftermath extends ExpansionSet {
         cards.add(new SetCardInfo("Niv-Mizzet, Supreme", 219, Rarity.RARE, mage.cards.n.NivMizzetSupreme.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Niv-Mizzet, Supreme", 40, Rarity.RARE, mage.cards.n.NivMizzetSupreme.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Niv-Mizzet, Supreme", 90, Rarity.RARE, mage.cards.n.NivMizzetSupreme.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Ob Nixilis, Captive Kingpin", 41, Rarity.MYTHIC, mage.cards.o.ObNixilisCaptiveKingpin.class));
         cards.add(new SetCardInfo("Open the Way", 123, Rarity.RARE, mage.cards.o.OpenTheWay.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Open the Way", 163, Rarity.RARE, mage.cards.o.OpenTheWay.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Open the Way", 23, Rarity.RARE, mage.cards.o.OpenTheWay.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/ObNixilisCaptiveKingpinTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/ObNixilisCaptiveKingpinTest.java
@@ -1,0 +1,174 @@
+package org.mage.test.cards.triggers.damage;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommander4Players;
+
+public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
+
+    @Test
+    public void damageController1Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerD, "Memnite");
+
+        attack(2, playerD, "Memnite", playerA);
+
+        setStopAt(2, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
+    }
+
+    @Test
+    public void damage1Opp1Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite");
+
+        attack(1, playerA, "Memnite", playerB);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void damage1Opp2Points() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Expedition Envoy");
+
+        attack(1, playerA, "Expedition Envoy", playerB);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
+    }
+
+    @Test
+    public void damage2Opp1Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite", 2);
+
+        attack(1, playerA, "Memnite", playerB);
+        attack(1, playerA, "Memnite", playerC);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void damage2Opp2Points() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Expedition Envoy", 2);
+
+        attack(1, playerA, "Expedition Envoy", playerB);
+        attack(1, playerA, "Expedition Envoy", playerC);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
+    }
+
+    @Test
+    public void payLife1Opp1Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Arid Mesa");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerB, "{T}, Pay 1 life");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void payLife1Opp2Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2);
+
+        // {2}, Pay 2 life: Draw a card.
+        addCard(Zone.BATTLEFIELD, playerB, "Book of Rass");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerB, "{2}, Pay 2 life");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
+    }
+
+    @Test
+    public void loseLife1Opp1Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+
+        // {1}{B}, {T}: Target player loses 1 life.
+        addCard(Zone.BATTLEFIELD, playerA, "Acolyte of Xathrid");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{B}, {T}");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void loseLife1Opp2Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+
+        // Target player draws two cards and loses 2 life.
+        addCard(Zone.HAND, playerA, "Blood Pact");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Blood Pact");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
+    }
+
+    @Test
+    public void loseLifeAll1Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+
+        // {2}{W}: Target player gains 1 life.
+        // {2}{B}: Each player loses 1 life.
+        addCard(Zone.BATTLEFIELD, playerA, "Orzhov Guildmage");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{B}");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
+    }
+
+    @Test
+    public void loseLifeAll2Point() {
+        addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
+
+        // Each player loses 2 life. You draw two cards.
+        addCard(Zone.HAND, playerA, "Crushing Disappointment");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Crushing Disappointment");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
+    }
+
+}
+

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/ObNixilisCaptiveKingpinTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/ObNixilisCaptiveKingpinTest.java
@@ -28,6 +28,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         attack(2, playerD, "Memnite", playerA);
 
         setStopAt(2, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
@@ -41,6 +42,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         attack(1, playerA, "Memnite", playerB);
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
@@ -54,6 +56,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         attack(1, playerA, "Expedition Envoy", playerB);
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
@@ -68,6 +71,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         attack(1, playerA, "Memnite", playerC);
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
@@ -82,6 +86,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         attack(1, playerA, "Expedition Envoy", playerC);
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
@@ -91,10 +96,14 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
     public void payLife1Opp1Point() {
         addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);
         addCard(Zone.BATTLEFIELD, playerB, "Arid Mesa");
+//        addCard(Zone.LIBRARY, playerA, "Mountain");
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerB, "{T}, Pay 1 life");
 
+        addTarget(playerB, "Mountain");
+
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
@@ -112,6 +121,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerB, "{2}, Pay 2 life");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
@@ -125,9 +135,12 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         // {1}{B}, {T}: Target player loses 1 life.
         addCard(Zone.BATTLEFIELD, playerA, "Acolyte of Xathrid");
 
+        addTarget(playerA, playerC);
+
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{B}, {T}");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
@@ -141,9 +154,12 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         // Target player draws two cards and loses 2 life.
         addCard(Zone.HAND, playerA, "Blood Pact");
 
+        addTarget(playerA, playerD);
+
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Blood Pact");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);
@@ -161,6 +177,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{B}");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 1);
@@ -177,6 +194,7 @@ public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Crushing Disappointment");
 
         setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
         execute();
 
         assertCounterCount("Ob Nixilis, Captive Kingpin", CounterType.P1P1, 0);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/ObNixilisCaptiveKingpinTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/ObNixilisCaptiveKingpinTest.java
@@ -8,6 +8,18 @@ import org.mage.test.serverside.base.CardTestCommander4Players;
 
 public class ObNixilisCaptiveKingpinTest extends CardTestCommander4Players {
 
+    //  - 1 opponent dealt 1 damage -> Ob Nixilis triggers
+    //  - 1 opponent dealt 2 damage -> No trigger
+    //  - 2 opponents dealt 1 damage each -> Ob Nixilis triggers
+    //  - 2 opponents dealt 2 damage each -> No trigger
+    //  - opponent pays 1 life-> Ob Nixilis triggers
+    //  - opponent pays 2 life -> No trigger
+    //  - 1 opponent loses 1 life -> Ob Nixilis triggers
+    //  - 1 opponent loses 2 life -> No trigger
+    //  - 2 opponents lose 1 life each -> Ob Nixilis triggers
+    //  - 2 opponents lose 2 life each -> No trigger
+    //  - controller loses 1 life -> No trigger
+
     @Test
     public void damageController1Point() {
         addCard(Zone.BATTLEFIELD, playerA, "Ob Nixilis, Captive Kingpin", 1);

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -808,7 +808,7 @@ public class GameState implements Serializable, Copyable<GameState> {
         return !simultaneousEvents.isEmpty();
     }
 
-    public void addSimultaneousLifeLoss(LifeLostEvent lifeLossEvent, Game game) {
+    public void addSimultaneousLifeLossEventToBatches(LifeLostEvent lifeLossEvent, Game game) {
         // Combine multiple life loss events in the single event (batch)
         // see GameEvent.LOST_LIFE_BATCH
 

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -808,6 +808,25 @@ public class GameState implements Serializable, Copyable<GameState> {
         return !simultaneousEvents.isEmpty();
     }
 
+    public void addSimultaneousLifeLoss(LifeLostEvent lifeLossEvent, Game game) {
+        // Combine multiple life loss events in the single event (batch)
+        // see GameEvent.LOST_LIFE_BATCH
+
+        // existing batch
+        boolean isLifeLostBatchUsed = false;
+        for (GameEvent event : simultaneousEvents) {
+            if (event instanceof LifeLostBatchEvent) {
+                ((LifeLostBatchEvent) event).addEvent(lifeLossEvent);
+                isLifeLostBatchUsed = true;
+            }
+        }
+
+        // new batch
+        if (!isLifeLostBatchUsed) {
+            addSimultaneousEvent(new LifeLostBatchEvent(lifeLossEvent), game);
+        }
+    }
+
     public void addSimultaneousDamage(DamagedEvent damagedEvent, Game game) {
         // Combine multiple damage events in the single event (batch)
         // * per damage type (see GameEvent.DAMAGED_BATCH_FOR_PERMANENTS, GameEvent.DAMAGED_BATCH_FOR_PLAYERS)

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -142,6 +142,10 @@ public class GameEvent implements Serializable {
          amount      amount of life loss
          flag        true = from combat damage - other from non combat damage
          */
+        LOST_LIFE_BATCH,
+        /* LOST_LIFE_BATCH
+         combines all player life lost events to a single batch (event)
+        */
         PLAY_LAND, LAND_PLAYED,
         CREATURE_CHAMPIONED,
         /* CREATURE_CHAMPIONED

--- a/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
@@ -42,7 +42,7 @@ public class LifeLostBatchEvent extends GameEvent implements BatchGameEvent<Life
     public int getAmount(UUID targetID) {
         return events
                 .stream()
-                .filter(ev -> ev.getTargetId() == targetID)
+                .filter(ev -> ev.getTargetId().equals(targetID))
                 .mapToInt(GameEvent::getAmount)
                 .sum();
     }

--- a/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
@@ -47,7 +47,7 @@ public class LifeLostBatchEvent extends GameEvent implements BatchGameEvent<Life
                 .sum();
     }
 
-    public boolean isCombatDamage() {
+    public boolean isLifeLostByCombatDamage() {
         return events.stream().anyMatch(LifeLostEvent::isCombatDamage);
     }
 

--- a/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
@@ -39,10 +39,10 @@ public class LifeLostBatchEvent extends GameEvent implements BatchGameEvent<Life
                 .sum();
     }
 
-    public int getAmount(UUID targetID) {
+    public int getLifeLostByPlayer(UUID playerID) {
         return events
                 .stream()
-                .filter(ev -> ev.getTargetId().equals(targetID))
+                .filter(ev -> ev.getTargetId().equals(playerID))
                 .mapToInt(GameEvent::getAmount)
                 .sum();
     }

--- a/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
@@ -1,0 +1,69 @@
+package mage.game.events;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * @author jimga150
+ */
+public class LifeLostBatchEvent extends GameEvent implements BatchGameEvent<LifeLostEvent> {
+
+    private final Set<LifeLostEvent> events = new HashSet<>();
+
+    public LifeLostBatchEvent(LifeLostEvent event) {
+        super(EventType.LOST_LIFE_BATCH, null, null, null);
+        addEvent(event);
+    }
+
+    @Override
+    public Set<LifeLostEvent> getEvents() {
+        return events;
+    }
+
+    @Override
+    public Set<UUID> getTargets() {
+        return events.stream()
+                .map(GameEvent::getTargetId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public int getAmount() {
+        return events
+                .stream()
+                .mapToInt(GameEvent::getAmount)
+                .sum();
+    }
+
+    public int getAmount(UUID targetID) {
+        return events
+                .stream()
+                .filter(ev -> ev.getTargetId() == targetID)
+                .mapToInt(GameEvent::getAmount)
+                .sum();
+    }
+
+    public boolean isCombatDamage() {
+        return events.stream().anyMatch(LifeLostEvent::isCombatDamage);
+    }
+
+    @Override
+    @Deprecated // events can store a diff value, so search it from events list instead
+    public UUID getTargetId() {
+        throw new IllegalStateException("Wrong code usage. Must search value from a getEvents list or use CardUtil.getEventTargets(event)");
+    }
+
+    @Override
+    @Deprecated // events can store a diff value, so search it from events list instead
+    public UUID getSourceId() {
+        throw new IllegalStateException("Wrong code usage. Must search value from a getEvents list.");
+    }
+
+    public void addEvent(LifeLostEvent event) {
+        this.events.add(event);
+    }
+}

--- a/Mage/src/main/java/mage/game/events/LifeLostEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostEvent.java
@@ -4,6 +4,9 @@ import mage.abilities.Ability;
 
 import java.util.UUID;
 
+/**
+ * @author jimga150
+ */
 public class LifeLostEvent extends GameEvent{
     public LifeLostEvent(UUID playerId, Ability source, int amount, boolean atCombat){
         super(GameEvent.EventType.LOST_LIFE,

--- a/Mage/src/main/java/mage/game/events/LifeLostEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostEvent.java
@@ -1,0 +1,16 @@
+package mage.game.events;
+
+import mage.abilities.Ability;
+
+import java.util.UUID;
+
+public class LifeLostEvent extends GameEvent{
+    public LifeLostEvent(UUID playerId, Ability source, int amount, boolean atCombat){
+        super(GameEvent.EventType.LOST_LIFE,
+                playerId, source, playerId, amount, atCombat);
+    }
+
+    public boolean isCombatDamage() {
+        return flag;
+    }
+}

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2175,8 +2175,9 @@ public abstract class PlayerImpl implements Player, Serializable {
                         + (atCombat ? " at combat" : "") + CardUtil.getSourceLogName(game, " from ", needId, "", ""));
             }
             if (event.getAmount() > 0) {
-                game.fireEvent(new GameEvent(GameEvent.EventType.LOST_LIFE,
-                        playerId, source, playerId, event.getAmount(), atCombat));
+                LifeLostEvent lifeLostEvent = new LifeLostEvent(playerId, source, event.getAmount(), atCombat);
+                game.fireEvent(lifeLostEvent);
+                game.getState().addSimultaneousLifeLoss(lifeLostEvent, game);
             }
             return event.getAmount();
         }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2177,7 +2177,7 @@ public abstract class PlayerImpl implements Player, Serializable {
             if (event.getAmount() > 0) {
                 LifeLostEvent lifeLostEvent = new LifeLostEvent(playerId, source, event.getAmount(), atCombat);
                 game.fireEvent(lifeLostEvent);
-                game.getState().addSimultaneousLifeLoss(lifeLostEvent, game);
+                game.getState().addSimultaneousLifeLossEventToBatches(lifeLostEvent, game);
             }
             return event.getAmount();
         }


### PR DESCRIPTION
#10020 

In order to get this card to work properly, i implemented a `LifeLostEvent` that gets batched into `LifeLostBatchEvent`, similar to `DamagedBatchEvent` and `DamagedEvent`. It _looks_ like batching the `LOST_LIFE` event is the only thing necessary to ensure this card sees all the triggers it should, since any form of damage, life paying costs, as well as "lose life" effects all fire the `LOST_LIFE` event.

So far i have playtested all of these with one and two opponents losing 1 and 2 or more life due to

- combat damage
- pay life effects
- lose life effects

The card seems to work as intended.
