### PR TITLE
Add replaceable counter removal (single and multiple) events and use flag for damage

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/CounterRemovalTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/CounterRemovalTests.java
@@ -1,0 +1,194 @@
+package org.mage.test.cards.triggers;
+
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
+import mage.abilities.effects.common.counter.AddCountersPlayersEffect;
+import mage.constants.*;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommander4Players;
+
+public class CounterRemovalTests extends CardTestCommander4Players {
+
+    @Test
+    public void CounterRemovalTest(){
+
+        int nCountersToAdd = 3;
+
+        addCard(Zone.HAND, playerA, "Basri's Solidarity", nCountersToAdd);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 6);
+
+        // Remove all counters from all permanents and exile all tokens.
+        addCard(Zone.HAND, playerA, "Aether Snap");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+
+        Ability ability = new MultiCountersRemovedTriggeredAbility();
+        addCustomCardWithAbility("multicountertrigdcard", playerA, ability, null, CardType.CREATURE, "", Zone.BATTLEFIELD);
+
+        ability = new SingleCounterRemovedTriggeredAbility();
+        addCustomCardWithAbility("singlecountertrigdcard", playerA, ability, null, CardType.CREATURE, "", Zone.BATTLEFIELD);
+
+        ability = new SimpleStaticAbility(new MultiCountersRemoveReplacementEffect());
+        addCustomCardWithAbility("multicounterreplcard", playerA, ability, null, CardType.CREATURE, "", Zone.BATTLEFIELD);
+
+        ability = new SimpleStaticAbility(new SingleCounterRemoveReplacementEffect());
+        addCustomCardWithAbility("singlecounterreplcard", playerA, ability, null, CardType.CREATURE, "", Zone.BATTLEFIELD);
+
+        for (int i = 0; i < nCountersToAdd; ++i){
+            castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Basri's Solidarity", true);
+        }
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Aether Snap", true);
+
+        //choose the <nCountersToAdd> single counter triggers to go on the stack first
+        setChoice(playerA, "When a counter", nCountersToAdd);
+
+        setStrictChooseMode(true);
+        execute();
+
+        assertLife(playerA, currentGame.getStartingLife() - 1);
+        assertCounterCount(playerA, CounterType.ENERGY, nCountersToAdd);
+        assertCounterCount("multicounterreplcard", CounterType.P1P1, 1);
+        assertCounterCount("singlecounterreplcard", CounterType.P1P1, 2);
+
+    }
+
+}
+
+class SingleCounterRemoveReplacementEffect extends ReplacementEffectImpl {
+
+    SingleCounterRemoveReplacementEffect() {
+        super(Duration.Custom, Outcome.Benefit);
+        this.setText("When a counter would be removed from {this} that would bring it to less than 2 of that counter, that counter is not removed.");
+    }
+
+    private SingleCounterRemoveReplacementEffect(final SingleCounterRemoveReplacementEffect ability) {
+        super(ability);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        if (event.getTargetId().equals(source.getSourceId())) {
+            Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+            if (sourcePermanent != null) {
+                int countersCount = sourcePermanent.getCounters(game).getCount(event.getData());
+                return countersCount - 1 < 2;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.REMOVE_COUNTER;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        return true;
+    }
+
+    @Override
+    public SingleCounterRemoveReplacementEffect copy() {
+        return new SingleCounterRemoveReplacementEffect(this);
+    }
+
+}
+
+class MultiCountersRemoveReplacementEffect extends ReplacementEffectImpl {
+
+    MultiCountersRemoveReplacementEffect() {
+        super(Duration.Custom, Outcome.Benefit);
+        this.setText("When any number of counters would be removed from {this}, one less counter is removed.");
+    }
+
+    private MultiCountersRemoveReplacementEffect(final MultiCountersRemoveReplacementEffect ability) {
+        super(ability);
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        return false;
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.REMOVE_COUNTERS;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (event.getTargetId().equals(source.getSourceId())) {
+            event.setAmount(event.getAmount() - 1);
+        }
+        return false;
+    }
+
+    @Override
+    public MultiCountersRemoveReplacementEffect copy() {
+        return new MultiCountersRemoveReplacementEffect(this);
+    }
+
+}
+
+class MultiCountersRemovedTriggeredAbility extends TriggeredAbilityImpl {
+
+    MultiCountersRemovedTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new LoseLifeSourceControllerEffect(1));
+        this.setTriggerPhrase("When any number of counters are removed from {this}, ");
+    }
+
+    private MultiCountersRemovedTriggeredAbility(final MultiCountersRemovedTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public MultiCountersRemovedTriggeredAbility copy() {
+        return new MultiCountersRemovedTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.COUNTERS_REMOVED;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        return event.getTargetId().equals(this.getSourceId());
+    }
+
+}
+
+class SingleCounterRemovedTriggeredAbility extends TriggeredAbilityImpl {
+
+    SingleCounterRemovedTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new AddCountersPlayersEffect(CounterType.ENERGY.createInstance(), TargetController.YOU));
+        this.setTriggerPhrase("When a counter is removed from {this}, ");
+    }
+
+    private SingleCounterRemovedTriggeredAbility(final SingleCounterRemovedTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public SingleCounterRemovedTriggeredAbility copy() {
+        return new SingleCounterRemovedTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.COUNTER_REMOVED;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        return event.getTargetId().equals(this.getSourceId());
+    }
+
+}

--- a/Mage/src/main/java/mage/cards/Card.java
+++ b/Mage/src/main/java/mage/cards/Card.java
@@ -175,9 +175,17 @@ public interface Card extends MageObject, Ownerable {
 
     boolean addCounters(Counter counter, UUID playerAddingCounters, Ability source, Game game, List<UUID> appliedEffects, boolean isEffect, int maxCounters);
 
-    void removeCounters(String name, int amount, Ability source, Game game);
+    default void removeCounters(String name, int amount, Ability source, Game game){
+        removeCounters(name, amount, source, game, false);
+    }
 
-    void removeCounters(Counter counter, Ability source, Game game);
+    void removeCounters(String name, int amount, Ability source, Game game, boolean damage);
+
+    default void removeCounters(Counter counter, Ability source, Game game) {
+        removeCounters(counter, source, game, false);
+    }
+
+    void removeCounters(Counter counter, Ability source, Game game, boolean damage);
 
     @Override
     Card copy();

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -823,14 +823,9 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         int finalAmount = 0;
         for (int i = 0; i < removeCountersEvent.getAmount(); i++) {
 
-            GameEvent removeCounterEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTER, objectId, source, getControllerOrOwnerId(), 1, isDamage);
-            if (source != null
-                    && source.getControllerId() != null) {
-                removeCounterEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-            }
-            removeCounterEvent.setData(name);
+            GameEvent event = new RemoveCounterEvent(name, this, source, isDamage);
 
-            if (game.replaceEvent(removeCounterEvent)){
+            if (game.replaceEvent(event)){
                 continue;
             }
 
@@ -838,7 +833,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                 break;
             }
 
-            GameEvent event = new GameEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId(), 1, isDamage);
+            event = new GameEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId(), 1, isDamage);
             if (source != null
                     && source.getControllerId() != null) {
                 event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counter

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -830,7 +830,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
             }
             removeCounterEvent.setData(name);
 
-            if (game.replaceEvent(removeCountersEvent)){
+            if (game.replaceEvent(removeCounterEvent)){
                 continue;
             }
 

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -807,9 +807,9 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     @Override
-    public void removeCounters(String name, int amount, Ability source, Game game, boolean damage) {
+    public void removeCounters(String name, int amount, Ability source, Game game, boolean isDamage) {
 
-        GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, objectId, source, getControllerOrOwnerId(), amount, damage);
+        GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, objectId, source, getControllerOrOwnerId(), amount, isDamage);
         if (source != null
                 && source.getControllerId() != null) {
             removeCountersEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
@@ -823,7 +823,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         int finalAmount = 0;
         for (int i = 0; i < removeCountersEvent.getAmount(); i++) {
 
-            GameEvent removeCounterEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTER, objectId, source, getControllerOrOwnerId(), 1, damage);
+            GameEvent removeCounterEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTER, objectId, source, getControllerOrOwnerId(), 1, isDamage);
             if (source != null
                     && source.getControllerId() != null) {
                 removeCounterEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
@@ -838,7 +838,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                 break;
             }
 
-            GameEvent event = new GameEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId(), 1, damage);
+            GameEvent event = new GameEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId(), 1, isDamage);
             if (source != null
                     && source.getControllerId() != null) {
                 event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counter
@@ -848,7 +848,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
 
             finalAmount++;
         }
-        GameEvent event = new GameEvent(GameEvent.EventType.COUNTERS_REMOVED, objectId, source, getControllerOrOwnerId(), 1, damage);
+        GameEvent event = new GameEvent(GameEvent.EventType.COUNTERS_REMOVED, objectId, source, getControllerOrOwnerId(), 1, isDamage);
         if (source != null
                 && source.getControllerId() != null) {
             event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
@@ -859,9 +859,9 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     @Override
-    public void removeCounters(Counter counter, Ability source, Game game, boolean damage) {
+    public void removeCounters(Counter counter, Ability source, Game game, boolean isDamage) {
         if (counter != null) {
-            removeCounters(counter.getName(), counter.getCount(), source, game, damage);
+            removeCounters(counter.getName(), counter.getCount(), source, game, isDamage);
         }
     }
 

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -826,12 +826,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                 break;
             }
 
-            event = new GameEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId(), 1, isDamage);
-            if (source != null
-                    && source.getControllerId() != null) {
-                event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counter
-            }
-            event.setData(name);
+            event = new CounterRemovedEvent(name, this, source, isDamage);
             game.fireEvent(event);
 
             finalAmount++;

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -809,13 +809,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     @Override
     public void removeCounters(String name, int amount, Ability source, Game game, boolean isDamage) {
 
-        GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, objectId, source, getControllerOrOwnerId(), amount, isDamage);
-        if (source != null
-                && source.getControllerId() != null) {
-            removeCountersEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-        }
-        removeCountersEvent.setData(name);
-
+        GameEvent removeCountersEvent = new RemoveCountersEvent(name, this, source, amount, isDamage);
         if (game.replaceEvent(removeCountersEvent)){
             return;
         }
@@ -824,7 +818,6 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         for (int i = 0; i < removeCountersEvent.getAmount(); i++) {
 
             GameEvent event = new RemoveCounterEvent(name, this, source, isDamage);
-
             if (game.replaceEvent(event)){
                 continue;
             }

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -831,13 +831,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
 
             finalAmount++;
         }
-        GameEvent event = new GameEvent(GameEvent.EventType.COUNTERS_REMOVED, objectId, source, getControllerOrOwnerId(), 1, isDamage);
-        if (source != null
-                && source.getControllerId() != null) {
-            event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-        }
-        event.setData(name);
-        event.setAmount(finalAmount);
+        GameEvent event = new CountersRemovedEvent(name, this, source, finalAmount, isDamage);
         game.fireEvent(event);
     }
 

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -809,6 +809,14 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     @Override
     public void removeCounters(String name, int amount, Ability source, Game game, boolean isDamage) {
 
+        if (amount <= 0){
+            return;
+        }
+
+        if (getCounters(game).getCount(name) <= 0){
+            return;
+        }
+
         GameEvent removeCountersEvent = new RemoveCountersEvent(name, this, source, amount, isDamage);
         if (game.replaceEvent(removeCountersEvent)){
             return;

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -807,15 +807,18 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     @Override
-    public void removeCounters(String name, int amount, Ability source, Game game) {
+    public void removeCounters(String name, int amount, Ability source, Game game){
+        removeCounters(name, amount, source, game, false);
+    }
 
-        GameEvent removeCountersEvent = GameEvent.getEvent(GameEvent.EventType.REMOVE_COUNTERS, objectId, source, getControllerOrOwnerId());
+    public void removeCounters(String name, int amount, Ability source, Game game, boolean damage) {
+
+        GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, objectId, source, getControllerOrOwnerId(), amount, damage);
         if (source != null
                 && source.getControllerId() != null) {
             removeCountersEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
         }
         removeCountersEvent.setData(name);
-        removeCountersEvent.setAmount(amount);
 
         if (game.replaceEvent(removeCountersEvent)){
             return;
@@ -824,7 +827,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         int finalAmount = 0;
         for (int i = 0; i < removeCountersEvent.getAmount(); i++) {
 
-            GameEvent removeCounterEvent = GameEvent.getEvent(GameEvent.EventType.REMOVE_COUNTER, objectId, source, getControllerOrOwnerId());
+            GameEvent removeCounterEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTER, objectId, source, getControllerOrOwnerId(), 1, damage);
             if (source != null
                     && source.getControllerId() != null) {
                 removeCounterEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
@@ -839,7 +842,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                 break;
             }
 
-            GameEvent event = GameEvent.getEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId());
+            GameEvent event = new GameEvent(GameEvent.EventType.COUNTER_REMOVED, objectId, source, getControllerOrOwnerId(), 1, damage);
             if (source != null
                     && source.getControllerId() != null) {
                 event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counter
@@ -849,7 +852,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
 
             finalAmount++;
         }
-        GameEvent event = GameEvent.getEvent(GameEvent.EventType.COUNTERS_REMOVED, objectId, source, getControllerOrOwnerId());
+        GameEvent event = new GameEvent(GameEvent.EventType.COUNTERS_REMOVED, objectId, source, getControllerOrOwnerId(), 1, damage);
         if (source != null
                 && source.getControllerId() != null) {
             event.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
@@ -861,8 +864,12 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
 
     @Override
     public void removeCounters(Counter counter, Ability source, Game game) {
+        removeCounters(counter, source, game, false);
+    }
+
+    public void removeCounters(Counter counter, Ability source, Game game, boolean damage) {
         if (counter != null) {
-            removeCounters(counter.getName(), counter.getCount(), source, game);
+            removeCounters(counter.getName(), counter.getCount(), source, game, damage);
         }
     }
 

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -807,10 +807,6 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     @Override
-    public void removeCounters(String name, int amount, Ability source, Game game){
-        removeCounters(name, amount, source, game, false);
-    }
-
     public void removeCounters(String name, int amount, Ability source, Game game, boolean damage) {
 
         GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, objectId, source, getControllerOrOwnerId(), amount, damage);
@@ -863,10 +859,6 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
     }
 
     @Override
-    public void removeCounters(Counter counter, Ability source, Game game) {
-        removeCounters(counter, source, game, false);
-    }
-
     public void removeCounters(Counter counter, Ability source, Game game, boolean damage) {
         if (counter != null) {
             removeCounters(counter.getName(), counter.getCount(), source, game, damage);

--- a/Mage/src/main/java/mage/game/events/CounterRemovedEvent.java
+++ b/Mage/src/main/java/mage/game/events/CounterRemovedEvent.java
@@ -1,0 +1,25 @@
+package mage.game.events;
+
+import mage.abilities.Ability;
+import mage.cards.Card;
+import mage.players.Player;
+
+public class CounterRemovedEvent extends GameEvent {
+
+    public CounterRemovedEvent(String name, Card targetCard, Ability source, boolean isDamage){
+        super(EventType.COUNTER_REMOVED, targetCard.getId(), source,
+                targetCard.getControllerOrOwnerId(), 1, isDamage);
+
+        if (source != null && source.getControllerId() != null) {
+            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
+        }
+        setData(name);
+    }
+
+    public CounterRemovedEvent(String name, Player targetPlayer, Ability source, boolean isDamage){
+        super(EventType.COUNTER_REMOVED, targetPlayer.getId(), source,
+                (source == null ? null : source.getControllerId()), 1, isDamage);
+        setData(name);
+    }
+
+}

--- a/Mage/src/main/java/mage/game/events/CounterRemovedEvent.java
+++ b/Mage/src/main/java/mage/game/events/CounterRemovedEvent.java
@@ -10,11 +10,7 @@ public class CounterRemovedEvent extends GameEvent {
 
     public CounterRemovedEvent(String name, Card targetCard, Ability source, boolean isDamage){
         super(EventType.COUNTER_REMOVED, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId());
-
-        if (source != null && source.getControllerId() != null) {
-            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-        }
+                (source == null ? null : source.getControllerId()));
         setData(name);
         this.isDamage = isDamage;
     }

--- a/Mage/src/main/java/mage/game/events/CounterRemovedEvent.java
+++ b/Mage/src/main/java/mage/game/events/CounterRemovedEvent.java
@@ -6,20 +6,28 @@ import mage.players.Player;
 
 public class CounterRemovedEvent extends GameEvent {
 
+    boolean isDamage;
+
     public CounterRemovedEvent(String name, Card targetCard, Ability source, boolean isDamage){
         super(EventType.COUNTER_REMOVED, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId(), 1, isDamage);
+                targetCard.getControllerOrOwnerId());
 
         if (source != null && source.getControllerId() != null) {
             setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
         }
         setData(name);
+        this.isDamage = isDamage;
     }
 
     public CounterRemovedEvent(String name, Player targetPlayer, Ability source, boolean isDamage){
         super(EventType.COUNTER_REMOVED, targetPlayer.getId(), source,
-                (source == null ? null : source.getControllerId()), 1, isDamage);
+                (source == null ? null : source.getControllerId()));
         setData(name);
+        this.isDamage = isDamage;
+    }
+
+    boolean counterRemovedDueToDamage(){
+        return this.isDamage;
     }
 
 }

--- a/Mage/src/main/java/mage/game/events/CountersRemovedEvent.java
+++ b/Mage/src/main/java/mage/game/events/CountersRemovedEvent.java
@@ -10,11 +10,7 @@ public class CountersRemovedEvent extends GameEvent {
 
     public CountersRemovedEvent(String name, Card targetCard, Ability source, int amount, boolean isDamage){
         super(EventType.COUNTERS_REMOVED, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId(), amount, false);
-
-        if (source != null && source.getControllerId() != null) {
-            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-        }
+                (source == null ? null : source.getControllerId()), amount, false);
         setData(name);
         this.isDamage = isDamage;
     }

--- a/Mage/src/main/java/mage/game/events/CountersRemovedEvent.java
+++ b/Mage/src/main/java/mage/game/events/CountersRemovedEvent.java
@@ -6,20 +6,28 @@ import mage.players.Player;
 
 public class CountersRemovedEvent extends GameEvent {
 
+    boolean isDamage;
+
     public CountersRemovedEvent(String name, Card targetCard, Ability source, int amount, boolean isDamage){
         super(EventType.COUNTERS_REMOVED, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId(), amount, isDamage);
+                targetCard.getControllerOrOwnerId(), amount, false);
 
         if (source != null && source.getControllerId() != null) {
             setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
         }
         setData(name);
+        this.isDamage = isDamage;
     }
 
     public CountersRemovedEvent(String name, Player targetPlayer, Ability source, int amount, boolean isDamage){
         super(EventType.COUNTERS_REMOVED, targetPlayer.getId(), source,
-                (source == null ? null : source.getControllerId()), amount, isDamage);
+                (source == null ? null : source.getControllerId()), amount, false);
         setData(name);
+        this.isDamage = isDamage;
+    }
+
+    boolean counterRemovedDueToDamage(){
+        return this.isDamage;
     }
 
 }

--- a/Mage/src/main/java/mage/game/events/CountersRemovedEvent.java
+++ b/Mage/src/main/java/mage/game/events/CountersRemovedEvent.java
@@ -1,0 +1,25 @@
+package mage.game.events;
+
+import mage.abilities.Ability;
+import mage.cards.Card;
+import mage.players.Player;
+
+public class CountersRemovedEvent extends GameEvent {
+
+    public CountersRemovedEvent(String name, Card targetCard, Ability source, int amount, boolean isDamage){
+        super(EventType.COUNTERS_REMOVED, targetCard.getId(), source,
+                targetCard.getControllerOrOwnerId(), amount, isDamage);
+
+        if (source != null && source.getControllerId() != null) {
+            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
+        }
+        setData(name);
+    }
+
+    public CountersRemovedEvent(String name, Player targetPlayer, Ability source, int amount, boolean isDamage){
+        super(EventType.COUNTERS_REMOVED, targetPlayer.getId(), source,
+                (source == null ? null : source.getControllerId()), amount, isDamage);
+        setData(name);
+    }
+
+}

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -499,7 +499,6 @@ public class GameEvent implements Serializable {
          playerId    player who controls the ability removing the counters, or if not applicable,
                      the controller of the permanent losing counter(s), or if neither are applicable, null.
          amount      number of counters being removed
-         flag        true = removed due to any type of damage
          data        name of the counter(s) being removed
          */
         REMOVE_COUNTER, REMOVE_COUNTERS,

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -496,8 +496,7 @@ public class GameEvent implements Serializable {
         /* REMOVE_COUNTER, REMOVE_COUNTERS, COUNTER_REMOVED, COUNTERS_REMOVED
          targetId    id of the permanent or player losing counter(s)
          sourceId    id of the ability removing them
-         playerId    player who controls the ability removing the counters, or if not applicable,
-                     the controller of the permanent losing counter(s), or if neither are applicable, null.
+         playerId    player who controls the ability removing the counters
          amount      number of counters being removed
          data        name of the counter(s) being removed
          */

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -493,6 +493,13 @@ public class GameEvent implements Serializable {
         STAY_ATTACHED,
         ADD_COUNTER, COUNTER_ADDED,
         ADD_COUNTERS, COUNTERS_ADDED,
+        /* REMOVE_COUNTER, REMOVE_COUNTERS
+         targetId    id of the permanent who lost counter(s)
+         sourceId    id of the ability removing them
+         playerId    player who controls the permanent losing counters
+         amount      number of counters being removed
+         flag        true = removed due to any type of damage
+         */
         REMOVE_COUNTER, REMOVE_COUNTERS,
         COUNTER_REMOVED, COUNTERS_REMOVED,
         LOSE_CONTROL,

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -493,6 +493,7 @@ public class GameEvent implements Serializable {
         STAY_ATTACHED,
         ADD_COUNTER, COUNTER_ADDED,
         ADD_COUNTERS, COUNTERS_ADDED,
+        REMOVE_COUNTER, REMOVE_COUNTERS,
         COUNTER_REMOVED, COUNTERS_REMOVED,
         LOSE_CONTROL,
         /* LOST_CONTROL

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -493,12 +493,14 @@ public class GameEvent implements Serializable {
         STAY_ATTACHED,
         ADD_COUNTER, COUNTER_ADDED,
         ADD_COUNTERS, COUNTERS_ADDED,
-        /* REMOVE_COUNTER, REMOVE_COUNTERS
+        /* REMOVE_COUNTER, REMOVE_COUNTERS, COUNTER_REMOVED, COUNTERS_REMOVED
          targetId    id of the permanent or player losing counter(s)
          sourceId    id of the ability removing them
-         playerId    player who controls the permanent losing counters, or the player losing counter(s)
+         playerId    player who controls the ability removing the counters, or if not applicable,
+                     the controller of the permanent losing counter(s), or if neither are applicable, null.
          amount      number of counters being removed
          flag        true = removed due to any type of damage
+         data        name of the counter(s) being removed
          */
         REMOVE_COUNTER, REMOVE_COUNTERS,
         COUNTER_REMOVED, COUNTERS_REMOVED,

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -494,9 +494,9 @@ public class GameEvent implements Serializable {
         ADD_COUNTER, COUNTER_ADDED,
         ADD_COUNTERS, COUNTERS_ADDED,
         /* REMOVE_COUNTER, REMOVE_COUNTERS
-         targetId    id of the permanent who lost counter(s)
+         targetId    id of the permanent or player losing counter(s)
          sourceId    id of the ability removing them
-         playerId    player who controls the permanent losing counters
+         playerId    player who controls the permanent losing counters, or the player losing counter(s)
          amount      number of counters being removed
          flag        true = removed due to any type of damage
          */

--- a/Mage/src/main/java/mage/game/events/RemoveCounterEvent.java
+++ b/Mage/src/main/java/mage/game/events/RemoveCounterEvent.java
@@ -10,11 +10,7 @@ public class RemoveCounterEvent extends GameEvent {
 
     public RemoveCounterEvent(String name, Card targetCard, Ability source, boolean isDamage){
         super(GameEvent.EventType.REMOVE_COUNTER, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId());
-
-        if (source != null && source.getControllerId() != null) {
-            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-        }
+                (source == null ? null : source.getControllerId()));
         setData(name);
         this.isDamage = isDamage;
     }

--- a/Mage/src/main/java/mage/game/events/RemoveCounterEvent.java
+++ b/Mage/src/main/java/mage/game/events/RemoveCounterEvent.java
@@ -1,0 +1,25 @@
+package mage.game.events;
+
+import mage.abilities.Ability;
+import mage.cards.Card;
+import mage.players.Player;
+
+public class RemoveCounterEvent extends GameEvent {
+
+    public RemoveCounterEvent(String name, Card targetCard, Ability source, boolean isDamage){
+        super(GameEvent.EventType.REMOVE_COUNTER, targetCard.getId(), source,
+                targetCard.getControllerOrOwnerId(), 1, isDamage);
+
+        if (source != null && source.getControllerId() != null) {
+            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
+        }
+        setData(name);
+    }
+
+    public RemoveCounterEvent(String name, Player targetPlayer, Ability source, boolean isDamage){
+        super(GameEvent.EventType.REMOVE_COUNTER, targetPlayer.getId(), source,
+                (source == null ? null : source.getControllerId()), 1, isDamage);
+        setData(name);
+    }
+
+}

--- a/Mage/src/main/java/mage/game/events/RemoveCounterEvent.java
+++ b/Mage/src/main/java/mage/game/events/RemoveCounterEvent.java
@@ -6,20 +6,28 @@ import mage.players.Player;
 
 public class RemoveCounterEvent extends GameEvent {
 
+    boolean isDamage;
+
     public RemoveCounterEvent(String name, Card targetCard, Ability source, boolean isDamage){
         super(GameEvent.EventType.REMOVE_COUNTER, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId(), 1, isDamage);
+                targetCard.getControllerOrOwnerId());
 
         if (source != null && source.getControllerId() != null) {
             setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
         }
         setData(name);
+        this.isDamage = isDamage;
     }
 
     public RemoveCounterEvent(String name, Player targetPlayer, Ability source, boolean isDamage){
         super(GameEvent.EventType.REMOVE_COUNTER, targetPlayer.getId(), source,
-                (source == null ? null : source.getControllerId()), 1, isDamage);
+                (source == null ? null : source.getControllerId()));
         setData(name);
+        this.isDamage = isDamage;
+    }
+
+    boolean counterRemovedDueToDamage(){
+        return this.isDamage;
     }
 
 }

--- a/Mage/src/main/java/mage/game/events/RemoveCountersEvent.java
+++ b/Mage/src/main/java/mage/game/events/RemoveCountersEvent.java
@@ -6,20 +6,28 @@ import mage.players.Player;
 
 public class RemoveCountersEvent extends GameEvent {
 
+    boolean isDamage;
+
     public RemoveCountersEvent(String name, Card targetCard, Ability source, int amount, boolean isDamage){
         super(EventType.REMOVE_COUNTERS, targetCard.getId(), source,
-                targetCard.getControllerOrOwnerId(), amount, isDamage);
+                targetCard.getControllerOrOwnerId(), amount, false);
 
         if (source != null && source.getControllerId() != null) {
             setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
         }
         setData(name);
+        this.isDamage = isDamage;
     }
 
     public RemoveCountersEvent(String name, Player targetPlayer, Ability source, int amount, boolean isDamage){
         super(EventType.REMOVE_COUNTERS, targetPlayer.getId(), source,
-                (source == null ? null : source.getControllerId()), amount, isDamage);
+                (source == null ? null : source.getControllerId()), amount, false);
         setData(name);
+        this.isDamage = isDamage;
+    }
+
+    boolean counterRemovedDueToDamage(){
+        return this.isDamage;
     }
 
 }

--- a/Mage/src/main/java/mage/game/events/RemoveCountersEvent.java
+++ b/Mage/src/main/java/mage/game/events/RemoveCountersEvent.java
@@ -1,0 +1,25 @@
+package mage.game.events;
+
+import mage.abilities.Ability;
+import mage.cards.Card;
+import mage.players.Player;
+
+public class RemoveCountersEvent extends GameEvent {
+
+    public RemoveCountersEvent(String name, Card targetCard, Ability source, int amount, boolean isDamage){
+        super(EventType.REMOVE_COUNTERS, targetCard.getId(), source,
+                targetCard.getControllerOrOwnerId(), amount, isDamage);
+
+        if (source != null && source.getControllerId() != null) {
+            setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
+        }
+        setData(name);
+    }
+
+    public RemoveCountersEvent(String name, Player targetPlayer, Ability source, int amount, boolean isDamage){
+        super(EventType.REMOVE_COUNTERS, targetPlayer.getId(), source,
+                (source == null ? null : source.getControllerId()), amount, isDamage);
+        setData(name);
+    }
+
+}

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -1053,7 +1053,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             if (attacker != null && markDamage) {
                 markDamage(CounterType.LOYALTY.createInstance(countersToRemove), attacker, false);
             } else {
-                removeCounters(CounterType.LOYALTY.getName(), countersToRemove, source, game);
+                removeCounters(CounterType.LOYALTY.getName(), countersToRemove, source, game, true);
             }
         }
         if (this.isBattle(game)) {
@@ -1062,7 +1062,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             if (attacker != null && markDamage) {
                 markDamage(CounterType.DEFENSE.createInstance(countersToRemove), attacker, false);
             } else {
-                removeCounters(CounterType.DEFENSE.getName(), countersToRemove, source, game);
+                removeCounters(CounterType.DEFENSE.getName(), countersToRemove, source, game, true);
             }
         }
         DamagedEvent damagedEvent = new DamagedPermanentEvent(this.getId(), attackerId, this.getControllerId(), actualDamageDone, combat);
@@ -1176,7 +1176,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             if (mdi.addCounters) {
                 addCounters(mdi.counter, game.getControllerId(mdi.sourceObject.getId()), source, game);
             } else {
-                removeCounters(mdi.counter, source, game);
+                removeCounters(mdi.counter, source, game, true);
             }
         }
         markedDamage.clear();

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -1168,8 +1168,10 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                 /* Tokens don't have a spellAbility. We must make a phony one as the source so the events in addCounters
                  * can trace the source back to an object/controller.
                  */
-                source = new SpellAbility(null, ((PermanentToken) mdi.sourceObject).name);
-                source.setSourceId(((PermanentToken) mdi.sourceObject).objectId);
+                PermanentToken sourceToken = (PermanentToken) mdi.sourceObject;
+                source = new SpellAbility(null, sourceToken.name);
+                source.setSourceId(sourceToken.objectId);
+                source.setControllerId(sourceToken.controllerId);
             } else if (mdi.sourceObject instanceof Permanent) {
                 source = ((Permanent) mdi.sourceObject).getSpellAbility();
             }

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -1090,13 +1090,13 @@ public class Spell extends StackObjectImpl implements Card {
     }
 
     @Override
-    public void removeCounters(String name, int amount, Ability source, Game game) {
-        card.removeCounters(name, amount, source, game);
+    public void removeCounters(String name, int amount, Ability source, Game game, boolean isDamage) {
+        card.removeCounters(name, amount, source, game, isDamage);
     }
 
     @Override
-    public void removeCounters(Counter counter, Ability source, Game game) {
-        card.removeCounters(counter, source, game);
+    public void removeCounters(Counter counter, Ability source, Game game, boolean isDamage) {
+        card.removeCounters(counter, source, game, isDamage);
     }
 
     public Card getCard() {

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2394,13 +2394,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     @Override
     public void removeCounters(String name, int amount, Ability source, Game game) {
 
-        GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, playerId, source, playerId, amount, false);
-        if (source != null
-                && source.getControllerId() != null) {
-            removeCountersEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-        }
-        removeCountersEvent.setData(name);
-
+        GameEvent removeCountersEvent = new RemoveCountersEvent(name, this, source, amount, false);
         if (game.replaceEvent(removeCountersEvent)){
             return;
         }
@@ -2409,7 +2403,6 @@ public abstract class PlayerImpl implements Player, Serializable {
         for (int i = 0; i < amount; i++) {
 
             GameEvent event = new RemoveCounterEvent(name, this, source, false);
-
             if (game.replaceEvent(event)){
                 continue;
             }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2414,10 +2414,7 @@ public abstract class PlayerImpl implements Player, Serializable {
             game.fireEvent(event);
             finalAmount++;
         }
-        GameEvent event = GameEvent.getEvent(GameEvent.EventType.COUNTERS_REMOVED,
-                getId(), source, (source == null ? null : source.getControllerId()));
-        event.setData(name);
-        event.setAmount(finalAmount);
+        GameEvent event = new CountersRemovedEvent(name, this, source, finalAmount, false);
         game.fireEvent(event);
     }
 

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2410,10 +2410,7 @@ public abstract class PlayerImpl implements Player, Serializable {
             if (!counters.removeCounter(name, 1)) {
                 break;
             }
-            event = GameEvent.getEvent(GameEvent.EventType.COUNTER_REMOVED,
-                    getId(), source, (source == null ? null : source.getControllerId()));
-            event.setData(name);
-            event.setAmount(1);
+            event = new CounterRemovedEvent(name, this, source, false);
             game.fireEvent(event);
             finalAmount++;
         }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2393,8 +2393,32 @@ public abstract class PlayerImpl implements Player, Serializable {
 
     @Override
     public void removeCounters(String name, int amount, Ability source, Game game) {
+
+        GameEvent removeCountersEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTERS, playerId, source, playerId, amount, false);
+        if (source != null
+                && source.getControllerId() != null) {
+            removeCountersEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
+        }
+        removeCountersEvent.setData(name);
+
+        if (game.replaceEvent(removeCountersEvent)){
+            return;
+        }
+
         int finalAmount = 0;
         for (int i = 0; i < amount; i++) {
+
+            GameEvent removeCounterEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTER, playerId, source, playerId, 1, false);
+            if (source != null
+                    && source.getControllerId() != null) {
+                removeCounterEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
+            }
+            removeCounterEvent.setData(name);
+
+            if (game.replaceEvent(removeCountersEvent)){
+                continue;
+            }
+
             if (!counters.removeCounter(name, 1)) {
                 break;
             }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2408,21 +2408,16 @@ public abstract class PlayerImpl implements Player, Serializable {
         int finalAmount = 0;
         for (int i = 0; i < amount; i++) {
 
-            GameEvent removeCounterEvent = new GameEvent(GameEvent.EventType.REMOVE_COUNTER, playerId, source, playerId, 1, false);
-            if (source != null
-                    && source.getControllerId() != null) {
-                removeCounterEvent.setPlayerId(source.getControllerId()); // player who controls the source ability that removed the counters
-            }
-            removeCounterEvent.setData(name);
+            GameEvent event = new RemoveCounterEvent(name, this, source, false);
 
-            if (game.replaceEvent(removeCountersEvent)){
+            if (game.replaceEvent(event)){
                 continue;
             }
 
             if (!counters.removeCounter(name, 1)) {
                 break;
             }
-            GameEvent event = GameEvent.getEvent(GameEvent.EventType.COUNTER_REMOVED,
+            event = GameEvent.getEvent(GameEvent.EventType.COUNTER_REMOVED,
                     getId(), source, (source == null ? null : source.getControllerId()));
             event.setData(name);
             event.setAmount(1);


### PR DESCRIPTION
All of this will be in service of implementing [Deification](https://scryfall.com/search?q=!deification), but there's an unknown in this change that i'd like to resolve before pulling in that card too.

Should this be its own set of event objects, and does this general strategy for flagging damage-caused counter removal look sound?