### PR TITLE
Fix DIE_ROLLED event to set targetID to player who rolled the die

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AsLuckWouldHaveIt.java
+++ b/Mage.Sets/src/mage/cards/a/AsLuckWouldHaveIt.java
@@ -74,7 +74,7 @@ class AsLuckWouldHaveItTriggeredAbility extends TriggeredAbilityImpl {
         // Any die roll with a numerical result will add luck counters to As Luck Would Have It.
         // Rolling the planar die will not cause the second ability to trigger.
         // (2018-01-19)
-        if (this.isControlledBy(event.getPlayerId()) && drEvent.getRollDieType() == RollDieType.NUMERICAL) {
+        if (this.isControlledBy(event.getTargetId()) && drEvent.getRollDieType() == RollDieType.NUMERICAL) {
             // silver border card must look for "result" instead "natural result"
             this.getEffects().setValue("rolled", drEvent.getResult());
             return true;

--- a/Mage.Sets/src/mage/cards/c/ChitteringDoom.java
+++ b/Mage.Sets/src/mage/cards/c/ChitteringDoom.java
@@ -60,7 +60,7 @@ class ChitteringDoomTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
         // silver border card must look for "result" instead "natural result"
-        return this.isControlledBy(event.getPlayerId()) && drEvent.getResult() >= 4;
+        return this.isControlledBy(event.getTargetId()) && drEvent.getResult() >= 4;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CriticalHit.java
+++ b/Mage.Sets/src/mage/cards/c/CriticalHit.java
@@ -62,7 +62,7 @@ class CriticalHitTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
-        return isControlledBy(event.getPlayerId())
+        return isControlledBy(event.getTargetId())
                 && drEvent.getNaturalResult() == 20;
     }
 

--- a/Mage.Sets/src/mage/cards/g/GroundPounder.java
+++ b/Mage.Sets/src/mage/cards/g/GroundPounder.java
@@ -104,7 +104,7 @@ class GroundPounderTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
         // silver border card must look for "result" instead "natural result"
-        return this.isControlledBy(event.getPlayerId()) && drEvent.getResult() >= 5;
+        return this.isControlledBy(event.getTargetId()) && drEvent.getResult() >= 5;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HammerJammer.java
+++ b/Mage.Sets/src/mage/cards/h/HammerJammer.java
@@ -110,7 +110,7 @@ class HammerJammerTriggeredAbility extends TriggeredAbilityImpl {
         DieRolledEvent drEvent = (DieRolledEvent) event;
         // silver border card must look for "result" instead "natural result"
         // planar die will trigger it with 0 amount
-        if (this.isControlledBy(drEvent.getPlayerId())) {
+        if (this.isControlledBy(drEvent.getTargetId())) {
             this.getEffects().setValue("rolled", drEvent.getResult());
             return true;
         }

--- a/Mage.Sets/src/mage/cards/m/MonoxaMidwayManager.java
+++ b/Mage.Sets/src/mage/cards/m/MonoxaMidwayManager.java
@@ -77,7 +77,7 @@ class MonoxaMidwayManagerTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         int result = ((DieRolledEvent) event).getResult();
-        if (!isControlledBy(event.getPlayerId()) || result < 3) {
+        if (!isControlledBy(event.getTargetId()) || result < 3) {
             return false;
         }
         this.getEffects().setValue("dieRoll", result);

--- a/Mage.Sets/src/mage/cards/m/MrHousePresidentAndCEO.java
+++ b/Mage.Sets/src/mage/cards/m/MrHousePresidentAndCEO.java
@@ -77,7 +77,7 @@ class MrHousePresidentAndCEOTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
-        if (this.isControlledBy(event.getPlayerId()) && drEvent.getRollDieType() == RollDieType.NUMERICAL) {
+        if (this.isControlledBy(event.getTargetId()) && drEvent.getRollDieType() == RollDieType.NUMERICAL) {
             // looks for "result" instead "natural result"
             int result = drEvent.getResult();
             this.getEffects().setValue("rolled", result);

--- a/Mage.Sets/src/mage/cards/n/NetheresePuzzleWard.java
+++ b/Mage.Sets/src/mage/cards/n/NetheresePuzzleWard.java
@@ -91,7 +91,7 @@ class NetheresePuzzleWardTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
-        return isControlledBy(drEvent.getPlayerId())
+        return isControlledBy(drEvent.getTargetId())
                 && drEvent.getNaturalResult() == drEvent.getSides();
     }
 

--- a/Mage.Sets/src/mage/cards/s/SteelSquirrel.java
+++ b/Mage.Sets/src/mage/cards/s/SteelSquirrel.java
@@ -75,7 +75,7 @@ class SteelSquirrelTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
         // silver border card must look for "result" instead "natural result"
-        if (this.isControlledBy(event.getPlayerId()) && drEvent.getResult() < 5) {
+        if (this.isControlledBy(event.getTargetId()) && drEvent.getResult() < 5) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/t/TheSpaceFamilyGoblinson.java
+++ b/Mage.Sets/src/mage/cards/t/TheSpaceFamilyGoblinson.java
@@ -104,7 +104,7 @@ class TheSpaceFamilyGoblinsonWatcher extends Watcher {
     @Override
     public void watch(GameEvent event, Game game) {
         if (event.getType() == GameEvent.EventType.DIE_ROLLED) {
-            map.compute(event.getPlayerId(), CardUtil::setOrIncrementValue);
+            map.compute(event.getTargetId(), CardUtil::setOrIncrementValue);
         }
     }
 
@@ -146,7 +146,7 @@ class TheSpaceFamilyGoblinsonTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        return isControlledBy(event.getPlayerId());
+        return isControlledBy(event.getTargetId());
     }
 
 }

--- a/Mage.Sets/src/mage/cards/w/WillingTestSubject.java
+++ b/Mage.Sets/src/mage/cards/w/WillingTestSubject.java
@@ -80,7 +80,7 @@ class WillingTestSubjectTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         DieRolledEvent drEvent = (DieRolledEvent) event;
         // silver border card must look for "result" instead "natural result"
-        return this.isControlledBy(event.getPlayerId()) && drEvent.getResult() >= 4;
+        return this.isControlledBy(event.getTargetId()) && drEvent.getResult() >= 4;
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/events/DieRolledEvent.java
+++ b/Mage/src/main/java/mage/game/events/DieRolledEvent.java
@@ -4,6 +4,8 @@ import mage.abilities.Ability;
 import mage.constants.PlanarDieRollResult;
 import mage.constants.RollDieType;
 
+import java.util.UUID;
+
 /**
  * @author TheElk801, JayDi85
  */
@@ -20,8 +22,22 @@ public class DieRolledEvent extends GameEvent {
     private final int naturalResult; // planar die returns 0 values in result and natural result
     private final PlanarDieRollResult planarResult;
 
-    public DieRolledEvent(Ability source, RollDieType rollDieType, int sides, int naturalResult, int modifier, PlanarDieRollResult planarResult) {
-        super(EventType.DIE_ROLLED, source.getControllerId(), source, source.getControllerId(), naturalResult + modifier, false);
+    /**
+     * The target ID is used to keep track of the distinction between the player who controls the ability that
+     * started the dice roll and the player who does the rolling.
+     * <p>
+     * The only times this distinction matters is for Chaos Dragon and Ricochet.
+     *
+     * @param source  The ability causing the die roll
+     * @param targetId  The player who rolled the die
+     * @param rollDieType
+     * @param sides
+     * @param naturalResult  the result of the die roll before any modifiers
+     * @param modifier  the sum of all modifiers
+     * @param planarResult
+     */
+    public DieRolledEvent(Ability source, UUID targetId, RollDieType rollDieType, int sides, int naturalResult, int modifier, PlanarDieRollResult planarResult) {
+        super(EventType.DIE_ROLLED, targetId, source, source.getControllerId(), naturalResult + modifier, false);
         this.rollDieType = rollDieType;
         this.sides = sides;
         this.naturalResult = naturalResult;

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3293,7 +3293,7 @@ public abstract class PlayerImpl implements Player, Serializable {
 
         // raise affected roll events
         for (RollDieResult result : dieRolls) {
-            game.fireEvent(new DieRolledEvent(source, rollDiceEvent.getRollDieType(), rollDiceEvent.getSides(), result.naturalResult, result.modifier, result.planarResult));
+            game.fireEvent(new DieRolledEvent(source, this.getId(), rollDiceEvent.getRollDieType(), rollDiceEvent.getSides(), result.naturalResult, result.modifier, result.planarResult));
         }
         game.fireEvent(new DiceRolledEvent(rollDiceEvent.getSides(), dieResults, source, this.getId()));
 

--- a/Mage/src/main/java/mage/watchers/common/PlanarRollWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/PlanarRollWatcher.java
@@ -29,7 +29,7 @@ public class PlanarRollWatcher extends Watcher {
     public void watch(GameEvent event, Game game) {
         if (event.getType() == GameEvent.EventType.DIE_ROLLED) {
             DieRolledEvent drEvent = (DieRolledEvent) event;
-            UUID playerId = drEvent.getPlayerId();
+            UUID playerId = drEvent.getTargetId();
             if (playerId != null && drEvent.getRollDieType() == RollDieType.PLANAR) {
                 Integer amount = numberTimesPlanarDieRolled.get(playerId);
                 if (amount == null) {


### PR DESCRIPTION
This allows distinction between the controller of the ability causing the die roll and the player who does the rolling. this matters for several cards.

Fixing issue raised in #11976 revealed that despite this distinction being made for `DiceRolledEvent`, it hasnt been done for its single variant