### PR TITLE
Fix duration on Basandra, Battle Seraph's effect

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BasandraBattleSeraph.java
+++ b/Mage.Sets/src/mage/cards/b/BasandraBattleSeraph.java
@@ -59,7 +59,7 @@ public final class BasandraBattleSeraph extends CardImpl {
 class BasandraBattleSeraphEffect extends ContinuousRuleModifyingEffectImpl {
     
     public BasandraBattleSeraphEffect() {
-        super(Duration.EndOfTurn, Outcome.Neutral);
+        super(Duration.WhileOnBattlefield, Outcome.Neutral);
         staticText = "Players can't cast spells during combat";
     }
     


### PR DESCRIPTION
I discovered that Basandra, Battle Seraph's ability preventing players from casting spells during combat was erroneously set to last only until the end of the turn it entered; this fixes that.