### PR TITLE
Fix issue #12008

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CranialExtraction.java
+++ b/Mage.Sets/src/mage/cards/c/CranialExtraction.java
@@ -1,7 +1,6 @@
 package mage.cards.c;
 
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.effects.common.ChooseACardNameEffect;
 import mage.abilities.effects.common.search.SearchTargetGraveyardHandLibraryForCardNameAndExileEffect;
 import mage.cards.CardImpl;
@@ -53,11 +52,12 @@ class CranialExtractionEffect extends SearchTargetGraveyardHandLibraryForCardNam
 
     @Override
     public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
         Player player = game.getPlayer(this.getTargetPointer().getFirst(game, source));
-        if (player == null) {
+        if (controller == null || player == null) {
             return true;
         }
-        String cardName = ChooseACardNameEffect.TypeOfName.NON_LAND_NAME.getChoice(player, game, source, false);
+        String cardName = ChooseACardNameEffect.TypeOfName.NON_LAND_NAME.getChoice(controller, game, source, false);
         if (cardName == null) {
             return false;
         }


### PR DESCRIPTION
Fixes #12008

Cranial Extraction uses the target player to make a choice rather than the spell controller.