### PR TITLE
Rename combat damage checker on single life loss event

### DIFF
--- a/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostBatchEvent.java
@@ -48,7 +48,7 @@ public class LifeLostBatchEvent extends GameEvent implements BatchGameEvent<Life
     }
 
     public boolean isLifeLostByCombatDamage() {
-        return events.stream().anyMatch(LifeLostEvent::isCombatDamage);
+        return events.stream().anyMatch(LifeLostEvent::isLifeLostByCombatDamage);
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/events/LifeLostEvent.java
+++ b/Mage/src/main/java/mage/game/events/LifeLostEvent.java
@@ -13,7 +13,7 @@ public class LifeLostEvent extends GameEvent{
                 playerId, source, playerId, amount, atCombat);
     }
 
-    public boolean isCombatDamage() {
+    public boolean isLifeLostByCombatDamage() {
         return flag;
     }
 }


### PR DESCRIPTION
redoing work rolled back in #11991 