### PR TITLE
4x MKM cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
+++ b/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
@@ -1,0 +1,127 @@
+package mage.cards.a;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.*;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.filter.predicate.mageobject.NamePredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.common.TargetCardInHand;
+import mage.target.common.TargetCardInLibrary;
+import mage.target.common.TargetCardInYourGraveyard;
+
+import java.util.AbstractMap;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class AgencyOutfitter extends CardImpl {
+
+    public AgencyOutfitter(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{U}{U}");
+        this.subtype.add(SubType.SPHINX);
+        this.subtype.add(SubType.DETECTIVE);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // When Agency Outfitter enters the battlefield, you may search your graveyard, hand, and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new AgencyOutfitterEffect(), true));
+    }
+
+    private AgencyOutfitter(final AgencyOutfitter card) {
+        super(card);
+    }
+
+    @Override
+    public AgencyOutfitter copy() {
+        return new AgencyOutfitter(this);
+    }
+}
+
+//Based on Boonweaver Giant / Dark Supplicant / Gate to the Afterlife / Mishra, Artificer Prodigy
+class AgencyOutfitterEffect extends OneShotEffect {
+
+    AgencyOutfitterEffect() {
+        super(Outcome.UnboostCreature);
+        this.staticText = "you may search your graveyard, hand, and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.";
+    }
+
+    private AgencyOutfitterEffect(final AgencyOutfitterEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public AgencyOutfitterEffect copy() {
+        return new AgencyOutfitterEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+
+        //Uses AbstractMap.SimpleImmutableEntry as a generic Pair class
+        //Create a local lambda function to reduce code duplication
+        Function<String, AbstractMap.SimpleImmutableEntry<Card, Boolean>> searchEverywhereForCard = (name) -> {
+            FilterCard filter = new FilterCard(name);
+            filter.add(new NamePredicate(name));
+            Card card = null;
+            boolean searchedLibrary = false;
+
+            // Choose card from graveyard
+            if (controller.chooseUse(Outcome.Neutral, "Search your graveyard for "+name+"?", source, game)) {
+                TargetCardInYourGraveyard target = new TargetCardInYourGraveyard(filter);
+                if (controller.choose(Outcome.PutCardInPlay, controller.getGraveyard(), target, source, game)) {
+                    card = game.getCard(target.getFirstTarget());
+                }
+            }
+
+            // Choose card from your hand
+            if (card == null && controller.chooseUse(Outcome.Neutral, "Search your hand for "+name+"?", source, game)) {
+                TargetCardInHand target = new TargetCardInHand(filter);
+                if (controller.choose(Outcome.PutCardInPlay, controller.getHand(), target, source, game)) {
+                    card = game.getCard(target.getFirstTarget());
+                }
+            }
+
+            // Choose a card from your library
+            if (card == null && controller.chooseUse(Outcome.Neutral, "Search your library for "+name+"?", source, game)) {
+                TargetCardInLibrary target = new TargetCardInLibrary(filter);
+                if (controller.searchLibrary(target, source, game)) {
+                    card = game.getCard(target.getFirstTarget());
+                }
+                searchedLibrary = true;
+            }
+            return new AbstractMap.SimpleImmutableEntry<>(card, searchedLibrary);
+        };
+
+        Cards cards = new CardsImpl();
+        AbstractMap.SimpleImmutableEntry<Card, Boolean> card1 = searchEverywhereForCard.apply("Magnifying Glass");
+        cards.add(card1.getKey());
+        AbstractMap.SimpleImmutableEntry<Card, Boolean> card2 = searchEverywhereForCard.apply("Thinking Cap");
+        cards.add(card2.getKey());
+        if (!cards.isEmpty()) {
+            controller.moveCards(cards, Zone.BATTLEFIELD, source, game);
+        }
+        if (card1.getValue() || card2.getValue()) {
+            controller.shuffleLibrary(source, game);
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/b/BiteDownOnCrime.java
+++ b/Mage.Sets/src/mage/cards/b/BiteDownOnCrime.java
@@ -1,0 +1,73 @@
+package mage.cards.b;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.common.BargainedCondition;
+import mage.abilities.costs.CostAdjuster;
+import mage.abilities.costs.OptionalAdditionalCost;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.DamageWithPowerFromOneToAnotherTargetEffect;
+import mage.abilities.effects.common.InfoEffect;
+import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.keyword.CollectEvidenceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.target.common.TargetControlledCreaturePermanent;
+import mage.target.common.TargetCreaturePermanent;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class BiteDownOnCrime extends CardImpl {
+
+    public BiteDownOnCrime(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}");
+        
+
+        // As an additional cost to cast this spell, you may collect evidence 6. This spell costs {2} less to cast if evidence was collected.
+        this.addAbility(new CollectEvidenceAbility(6));
+
+        this.getSpellAbility().addEffect(new InfoEffect("this spell costs {2} less to cast if evidence was collected"));
+        this.getSpellAbility().setCostAdjuster(BiteDownOnCrimeAdjuster.instance);
+
+        // Target creature you control gets +2/+0 until end of turn.
+        Effect effect = new BoostTargetEffect(2, 0, Duration.EndOfTurn);
+        this.getSpellAbility().addEffect(effect);
+        this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
+
+        // It deals damage equal to its power to target creature you don't control.
+        this.getSpellAbility().addEffect(new DamageWithPowerFromOneToAnotherTargetEffect("It"));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL));
+    }
+
+    private BiteDownOnCrime(final BiteDownOnCrime card) {
+        super(card);
+    }
+
+    @Override
+    public BiteDownOnCrime copy() {
+        return new BiteDownOnCrime(this);
+    }
+}
+
+
+enum BiteDownOnCrimeAdjuster implements CostAdjuster {
+    instance;
+
+    private static final OptionalAdditionalCost collectEvidenceCost = CollectEvidenceAbility.makeCost(6);
+
+    @Override
+    public void adjustCosts(Ability ability, Game game) {
+        if (BargainedCondition.instance.apply(game, ability)
+                || (game.inCheckPlayableState() && collectEvidenceCost.canPay(ability, null, ability.getControllerId(), game))) {
+            CardUtil.reduceCost(ability, 2);
+        }
+    }
+}

--- a/Mage.Sets/src/mage/cards/b/BiteDownOnCrime.java
+++ b/Mage.Sets/src/mage/cards/b/BiteDownOnCrime.java
@@ -29,7 +29,6 @@ public final class BiteDownOnCrime extends CardImpl {
 
     public BiteDownOnCrime(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}");
-        
 
         // As an additional cost to cast this spell, you may collect evidence 6. This spell costs {2} less to cast if evidence was collected.
         this.addAbility(new CollectEvidenceAbility(6));

--- a/Mage.Sets/src/mage/cards/b/BubbleSmuggler.java
+++ b/Mage.Sets/src/mage/cards/b/BubbleSmuggler.java
@@ -1,0 +1,52 @@
+package mage.cards.b;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.AsTurnedFaceUpEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.constants.SubType;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.keyword.DisguiseAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class BubbleSmuggler extends CardImpl {
+
+    public BubbleSmuggler(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}");
+
+        this.subtype.add(SubType.OCTOPUS);
+        this.subtype.add(SubType.FISH);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // Disguise {5}{U}
+        this.addAbility(new DisguiseAbility(this, new ManaCostsImpl<>("{5}{U}")));
+
+        // As Bubble Smuggler is turned face up, put four +1/+1 counters on it.
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(4));
+        effect.setText("put four +1/+1 counters on it");
+        Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new AsTurnedFaceUpEffect(effect, false));
+        ability.setWorksFaceDown(true);
+        this.addAbility(ability);
+    }
+
+    private BubbleSmuggler(final BubbleSmuggler card) {
+        super(card);
+    }
+
+    @Override
+    public BubbleSmuggler copy() {
+        return new BubbleSmuggler(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FranticScapegoat.java
+++ b/Mage.Sets/src/mage/cards/f/FranticScapegoat.java
@@ -1,0 +1,156 @@
+package mage.cards.f;
+
+import mage.MageInt;
+import mage.MageItem;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.SuspectSourceEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.permanent.PermanentReferenceInCollectionPredicate;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.ZoneChangeGroupEvent;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.TargetPermanent;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ *
+ * @author notgreat
+ */
+public final class FranticScapegoat extends CardImpl {
+
+    public FranticScapegoat(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{R}");
+        
+        this.subtype.add(SubType.GOAT);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // When Frantic Scapegoat enters the battlefield, suspect it.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SuspectSourceEffect()));
+
+        // Whenever one or more other creatures enter the battlefield under your control, if Frantic Scapegoat is suspected, you may suspect one of the other creatures. If you do, Frantic Scapegoat is no longer suspected.
+        this.addAbility(new FranticScapegoatTriggeredAbility());
+
+    }
+
+    private FranticScapegoat(final FranticScapegoat card) {
+        super(card);
+    }
+
+    @Override
+    public FranticScapegoat copy() {
+        return new FranticScapegoat(this);
+    }
+}
+
+//Based on Ingenious Artillerist and Lightmine Field
+class FranticScapegoatTriggeredAbility extends TriggeredAbilityImpl {
+
+    FranticScapegoatTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new FranticScapegoatSuspectEffect(), true);
+    }
+
+    private FranticScapegoatTriggeredAbility(final FranticScapegoatTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ZONE_CHANGE_GROUP;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        if (!getSourcePermanentIfItStillExists(game).isSuspected()){
+            return false;
+        }
+        ZoneChangeGroupEvent zEvent = (ZoneChangeGroupEvent) event;
+        if (zEvent.getToZone() != Zone.BATTLEFIELD
+                || !this.controllerId.equals(event.getPlayerId())) {
+            return false;
+        }
+        Set<MageObjectReference> enteringCreatures = Stream.concat(
+                zEvent.getTokens()
+                        .stream(),
+                zEvent.getCards()
+                        .stream()
+                        .map(MageItem::getId)
+                        .map(game::getPermanent)
+                        .filter(Objects::nonNull)
+        ).filter(permanent -> permanent.isCreature(game)).map(s -> new MageObjectReference(s, game)).collect(Collectors.toSet());
+        if (enteringCreatures.size() > 0) {
+            this.getEffects().setValue("franticScapegoatEnteringCreatures", enteringCreatures);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public FranticScapegoatTriggeredAbility copy() {
+        return new FranticScapegoatTriggeredAbility(this);
+    }
+
+    @Override
+    public String getRule() {
+        return "Whenever one or more other creatures enter the battlefield under your control, if {this} is suspected, you may suspect one of the other creatures. If you do, {this} is no longer suspected.";
+    }
+}
+class FranticScapegoatSuspectEffect extends OneShotEffect {
+
+    public FranticScapegoatSuspectEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Suspect one of the other creatures";
+    }
+
+    private FranticScapegoatSuspectEffect(final FranticScapegoatSuspectEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public FranticScapegoatSuspectEffect copy() {
+        return new FranticScapegoatSuspectEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Set<MageObjectReference> enteringSet = (Set<MageObjectReference>) getValue("franticScapegoatEnteringCreatures");
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            if (enteringSet.size() > 1) {
+                FilterCreaturePermanent filter = new FilterCreaturePermanent("one of those creatures");
+                filter.add(new PermanentReferenceInCollectionPredicate(enteringSet));
+                Target target = new TargetPermanent(filter);
+                target.withNotTarget(true);
+                if (target.canChoose(source.getControllerId(), source, game)) {
+                    if (controller.choose(outcome, target, source, game)) {
+                        game.getPermanent(target.getFirstTarget()).setSuspected(true, game, source);
+                    }
+                }
+            } else {
+                enteringSet.forEach(s -> s.getPermanent(game).setSuspected(true, game, source));
+            }
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HoodedHydra.java
+++ b/Mage.Sets/src/mage/cards/h/HoodedHydra.java
@@ -49,7 +49,6 @@ public final class HoodedHydra extends CardImpl {
         // As Hooded Hydra is turned face up, put five +1/+1 counters on it.
         Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(5));
         effect.setText("put five +1/+1 counters on it");
-        // TODO: Does not work because the ability is still removed from permanent while the effect checks if the ability still exists.
         Ability ability = new SimpleStaticAbility(Zone.BATTLEFIELD, new AsTurnedFaceUpEffect(effect, false));
         ability.setWorksFaceDown(true);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
@@ -25,6 +25,7 @@ public final class MurdersAtKarlovManor extends ExpansionSet {
         cards.add(new SetCardInfo("Absolving Lammasu", 2, Rarity.UNCOMMON, mage.cards.a.AbsolvingLammasu.class));
         cards.add(new SetCardInfo("Aftermath Analyst", 148, Rarity.UNCOMMON, mage.cards.a.AftermathAnalyst.class));
         cards.add(new SetCardInfo("Agency Coroner", 75, Rarity.COMMON, mage.cards.a.AgencyCoroner.class));
+        cards.add(new SetCardInfo("Agency Outfitter", 38, Rarity.UNCOMMON, mage.cards.a.AgencyOutfitter.class));
         cards.add(new SetCardInfo("Agrus Kos, Spirit of Justice", 184, Rarity.MYTHIC, mage.cards.a.AgrusKosSpiritOfJustice.class));
         cards.add(new SetCardInfo("Airtight Alibi", 149, Rarity.COMMON, mage.cards.a.AirtightAlibi.class));
         cards.add(new SetCardInfo("Alley Assailant", 76, Rarity.COMMON, mage.cards.a.AlleyAssailant.class));

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
@@ -50,6 +50,7 @@ public final class MurdersAtKarlovManor extends ExpansionSet {
         cards.add(new SetCardInfo("Blood Spatter Analysis", 413, Rarity.RARE, mage.cards.b.BloodSpatterAnalysis.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Bolrac-Clan Basher", 112, Rarity.UNCOMMON, mage.cards.b.BolracClanBasher.class));
         cards.add(new SetCardInfo("Branch of Vitu-Ghazi", 258, Rarity.UNCOMMON, mage.cards.b.BranchOfVituGhazi.class));
+        cards.add(new SetCardInfo("Bubble Smuggler", 41, Rarity.COMMON, mage.cards.b.BubbleSmuggler.class));
         cards.add(new SetCardInfo("Burden of Proof", 42, Rarity.UNCOMMON, mage.cards.b.BurdenOfProof.class));
         cards.add(new SetCardInfo("Buried in the Garden", 191, Rarity.UNCOMMON, mage.cards.b.BuriedInTheGarden.class));
         cards.add(new SetCardInfo("Call a Surprise Witness", 6, Rarity.UNCOMMON, mage.cards.c.CallASurpriseWitness.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
@@ -45,6 +45,7 @@ public final class MurdersAtKarlovManor extends ExpansionSet {
         cards.add(new SetCardInfo("Basilica Stalker", 78, Rarity.COMMON, mage.cards.b.BasilicaStalker.class));
         cards.add(new SetCardInfo("Behind the Mask", 39, Rarity.COMMON, mage.cards.b.BehindTheMask.class));
         cards.add(new SetCardInfo("Benthic Criminologists", 40, Rarity.COMMON, mage.cards.b.BenthicCriminologists.class));
+        cards.add(new SetCardInfo("Bite Down on Crime", 154, Rarity.COMMON, mage.cards.b.BiteDownOnCrime.class));
         cards.add(new SetCardInfo("Blood Spatter Analysis", 189, Rarity.RARE, mage.cards.b.BloodSpatterAnalysis.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Blood Spatter Analysis", 413, Rarity.RARE, mage.cards.b.BloodSpatterAnalysis.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Bolrac-Clan Basher", 112, Rarity.UNCOMMON, mage.cards.b.BolracClanBasher.class));

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
@@ -121,6 +121,7 @@ public final class MurdersAtKarlovManor extends ExpansionSet {
         cards.add(new SetCardInfo("Forensic Researcher", 58, Rarity.UNCOMMON, mage.cards.f.ForensicResearcher.class));
         cards.add(new SetCardInfo("Forest", 276, Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Forum Familiar", 16, Rarity.UNCOMMON, mage.cards.f.ForumFamiliar.class));
+        cards.add(new SetCardInfo("Frantic Scapegoat", 126, Rarity.UNCOMMON, mage.cards.f.FranticScapegoat.class));
         cards.add(new SetCardInfo("Furtive Courier", 59, Rarity.UNCOMMON, mage.cards.f.FurtiveCourier.class));
         cards.add(new SetCardInfo("Fuss // Bother", 248, Rarity.UNCOMMON, mage.cards.f.FussBother.class));
         cards.add(new SetCardInfo("Gadget Technician", 204, Rarity.COMMON, mage.cards.g.GadgetTechnician.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MorphTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MorphTest.java
@@ -1294,4 +1294,23 @@ public class MorphTest extends CardTestPlayerBase {
         setStopAt(1, PhaseStep.END_TURN);
         execute();
     }
+
+    @Test
+    public void test_Morph_HoodedHydra() {
+        // Morph {2}
+        addCard(Zone.HAND, playerA, "Hooded Hydra");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3+5);
+
+        // prepare face down
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Hooded Hydra using Morph");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{3}{G}{G}: Turn this face-down permanent face up.");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertPermanentCount(playerA, "Hooded Hydra", 1);
+        assertPowerToughness(playerA, "Hooded Hydra", 5, 5);
+    }
 }


### PR DESCRIPTION
Implements [[Agency Outfitter]], [[Bite Down on Crime]], [[Bubble Smuggler]], and [[Frantic Scapegoat]].

Have not yet tested/checked things, making this PR mostly to claim the cards.