### PR TITLE
[MKM] Agency Outfitter

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
+++ b/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
@@ -94,7 +94,6 @@ class AgencyOutfitterEffect extends OneShotEffect {
         }
 
         if (glassCard == null || capCard == null) {
-            Cards cards = new CardsImpl();
             FilterCard filter;
             TargetCard target;
             if (glassCard == null && capCard == null) {
@@ -107,6 +106,7 @@ class AgencyOutfitterEffect extends OneShotEffect {
                 target = new TargetCard(0, 1, Zone.ALL, filter);
             }
             target.withNotTarget(true);
+            Cards cards = new CardsImpl();
             cards.addAllCards(controller.getHand().getCards(filter, source.getControllerId(), source, game));
             cards.addAllCards(controller.getGraveyard().getCards(filter, source.getControllerId(), source, game));
             if (!cards.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
+++ b/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
@@ -1,0 +1,135 @@
+package mage.cards.a;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.*;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.NamePredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetCardAndOrCard;
+import mage.target.common.TargetCardAndOrCardInLibrary;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+/**
+ * @author notgreat
+ */
+public final class AgencyOutfitter extends CardImpl {
+
+    public AgencyOutfitter(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{U}{U}");
+        this.subtype.add(SubType.SPHINX);
+        this.subtype.add(SubType.DETECTIVE);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // When Agency Outfitter enters the battlefield, you may search your graveyard, hand, and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new AgencyOutfitterEffect(), true));
+    }
+
+    private AgencyOutfitter(final AgencyOutfitter card) {
+        super(card);
+    }
+
+    @Override
+    public AgencyOutfitter copy() {
+        return new AgencyOutfitter(this);
+    }
+}
+
+class AgencyOutfitterEffect extends OneShotEffect {
+    private static final String glassName = "Magnifying Glass";
+    private static final String capName = "Thinking Cap";
+
+    AgencyOutfitterEffect() {
+        super(Outcome.UnboostCreature);
+        this.staticText = "you may search your graveyard, hand, and/or library for a card named Magnifying Glass and/or a card named Thinking Cap and put them onto the battlefield. If you search your library this way, shuffle.";
+    }
+
+    private AgencyOutfitterEffect(final AgencyOutfitterEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public AgencyOutfitterEffect copy() {
+        return new AgencyOutfitterEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+        Card glassCard = null;
+        Card capCard = null;
+        if (controller.chooseUse(Outcome.Neutral, "Search your library?", source, game)) {
+            TargetCardAndOrCardInLibrary libraryTarget = new TargetCardAndOrCardInLibrary(glassName, capName);
+            if (controller.searchLibrary(libraryTarget, source, game)) {
+                for (UUID id : libraryTarget.getTargets()) {
+                    Card card = game.getCard(id);
+                    if (CardUtil.haveSameNames(card, glassName, game)) {
+                        glassCard = card;
+                    } else if (CardUtil.haveSameNames(card, capName, game)) {
+                        capCard = card;
+                    }
+                }
+            }
+            controller.shuffleLibrary(source, game);
+        }
+
+        if (glassCard == null || capCard == null) {
+            Cards cards = new CardsImpl();
+            FilterCard filter = new FilterCard();
+            TargetCard target;
+            if (glassCard == null && capCard == null) {
+                filter.add(Predicates.or(
+                        new NamePredicate(glassName), new NamePredicate(capName)
+                ));
+                target = new TargetCardAndOrCard(glassName, capName);
+            } else if (glassCard == null) {
+                filter.add(new NamePredicate(glassName));
+                target = new TargetCard(0, 1, Zone.ALL, filter);
+            } else {
+                filter.add(new NamePredicate(capName));
+                target = new TargetCard(0, 1, Zone.ALL, filter);
+            }
+            target.withNotTarget(true);
+            cards.addAllCards(controller.getHand().getCards(filter, source.getControllerId(), source, game));
+            cards.addAllCards(controller.getGraveyard().getCards(filter, source.getControllerId(), source, game));
+            if (!cards.isEmpty()) {
+                controller.choose(outcome, cards, target, source, game);
+                for (UUID id : target.getTargets()) {
+                    Card card = game.getCard(id);
+                    if (CardUtil.haveSameNames(card, glassName, game)) {
+                        glassCard = card;
+                    } else if (CardUtil.haveSameNames(card, capName, game)) {
+                        capCard = card;
+                    }
+                }
+            }
+        }
+
+        Cards foundCards = new CardsImpl();
+        foundCards.add(glassCard);
+        foundCards.add(capCard);
+        if (!foundCards.isEmpty()) {
+            controller.moveCards(foundCards, Zone.BATTLEFIELD, source, game);
+        }
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
+++ b/Mage.Sets/src/mage/cards/a/AgencyOutfitter.java
@@ -11,7 +11,6 @@ import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.NamePredicate;
 import mage.game.Game;
 import mage.players.Player;
@@ -82,10 +81,12 @@ class AgencyOutfitterEffect extends OneShotEffect {
             if (controller.searchLibrary(libraryTarget, source, game)) {
                 for (UUID id : libraryTarget.getTargets()) {
                     Card card = game.getCard(id);
-                    if (CardUtil.haveSameNames(card, glassName, game)) {
-                        glassCard = card;
-                    } else if (CardUtil.haveSameNames(card, capName, game)) {
-                        capCard = card;
+                    if (card != null) {
+                        if (CardUtil.haveSameNames(card, glassName, game)) {
+                            glassCard = card;
+                        } else if (CardUtil.haveSameNames(card, capName, game)) {
+                            capCard = card;
+                        }
                     }
                 }
             }
@@ -94,18 +95,15 @@ class AgencyOutfitterEffect extends OneShotEffect {
 
         if (glassCard == null || capCard == null) {
             Cards cards = new CardsImpl();
-            FilterCard filter = new FilterCard();
+            FilterCard filter;
             TargetCard target;
             if (glassCard == null && capCard == null) {
-                filter.add(Predicates.or(
-                        new NamePredicate(glassName), new NamePredicate(capName)
-                ));
                 target = new TargetCardAndOrCard(glassName, capName);
-            } else if (glassCard == null) {
-                filter.add(new NamePredicate(glassName));
-                target = new TargetCard(0, 1, Zone.ALL, filter);
+                filter = target.getFilter();
             } else {
-                filter.add(new NamePredicate(capName));
+                String name = (glassCard == null ? glassName : capName);
+                filter = new FilterCard();
+                filter.add(new NamePredicate(name));
                 target = new TargetCard(0, 1, Zone.ALL, filter);
             }
             target.withNotTarget(true);
@@ -115,10 +113,12 @@ class AgencyOutfitterEffect extends OneShotEffect {
                 controller.choose(outcome, cards, target, source, game);
                 for (UUID id : target.getTargets()) {
                     Card card = game.getCard(id);
-                    if (CardUtil.haveSameNames(card, glassName, game)) {
-                        glassCard = card;
-                    } else if (CardUtil.haveSameNames(card, capName, game)) {
-                        capCard = card;
+                    if (card != null) {
+                        if (CardUtil.haveSameNames(card, glassName, game)) {
+                            glassCard = card;
+                        } else if (CardUtil.haveSameNames(card, capName, game)) {
+                            capCard = card;
+                        }
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/s/SludgeTitan.java
+++ b/Mage.Sets/src/mage/cards/s/SludgeTitan.java
@@ -75,7 +75,7 @@ class SludgeTitanEffect extends OneShotEffect {
         }
         Cards cards = controller.millCards(5, source, game);
         game.getState().processAction(game);
-        cards.removeIf(s -> !game.getState().getZone(s).isPublicZone());
+        cards.removeIf(card -> !game.getState().getZone(card).isPublicZone());
         if (!cards.isEmpty()) {
             TargetCard target = new TargetCardAndOrCard(CardType.CREATURE, CardType.LAND);
             controller.choose(Outcome.DrawCard, cards, target, source, game);

--- a/Mage.Sets/src/mage/cards/s/SludgeTitan.java
+++ b/Mage.Sets/src/mage/cards/s/SludgeTitan.java
@@ -16,7 +16,7 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
-import mage.target.common.TargetCardAndOrCardInGraveyard;
+import mage.target.common.TargetCardAndOrCard;
 
 import java.util.UUID;
 
@@ -76,7 +76,7 @@ class SludgeTitanEffect extends OneShotEffect {
         Cards cards = controller.millCards(5, source, game);
         game.getState().processAction(game);
         if (!cards.isEmpty()) {
-            TargetCard target = new TargetCardAndOrCardInGraveyard(CardType.CREATURE, CardType.LAND);
+            TargetCard target = new TargetCardAndOrCard(CardType.CREATURE, CardType.LAND);
             controller.choose(Outcome.DrawCard, cards, target, source, game);
             Cards toHand = new CardsImpl();
             toHand.addAll(target.getTargets());

--- a/Mage.Sets/src/mage/cards/s/SludgeTitan.java
+++ b/Mage.Sets/src/mage/cards/s/SludgeTitan.java
@@ -75,6 +75,7 @@ class SludgeTitanEffect extends OneShotEffect {
         }
         Cards cards = controller.millCards(5, source, game);
         game.getState().processAction(game);
+        cards.removeIf(s -> !game.getState().getZone(s).isPublicZone());
         if (!cards.isEmpty()) {
             TargetCard target = new TargetCardAndOrCard(CardType.CREATURE, CardType.LAND);
             controller.choose(Outcome.DrawCard, cards, target, source, game);

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManor.java
@@ -25,6 +25,7 @@ public final class MurdersAtKarlovManor extends ExpansionSet {
         cards.add(new SetCardInfo("Absolving Lammasu", 2, Rarity.UNCOMMON, mage.cards.a.AbsolvingLammasu.class));
         cards.add(new SetCardInfo("Aftermath Analyst", 148, Rarity.UNCOMMON, mage.cards.a.AftermathAnalyst.class));
         cards.add(new SetCardInfo("Agency Coroner", 75, Rarity.COMMON, mage.cards.a.AgencyCoroner.class));
+        cards.add(new SetCardInfo("Agency Outfitter", 38, Rarity.UNCOMMON, mage.cards.a.AgencyOutfitter.class));
         cards.add(new SetCardInfo("Agrus Kos, Spirit of Justice", 184, Rarity.MYTHIC, mage.cards.a.AgrusKosSpiritOfJustice.class));
         cards.add(new SetCardInfo("Airtight Alibi", 149, Rarity.COMMON, mage.cards.a.AirtightAlibi.class));
         cards.add(new SetCardInfo("Alley Assailant", 76, Rarity.COMMON, mage.cards.a.AlleyAssailant.class));

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -4704,6 +4704,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                         successfulMovedCards.add(permanent);
                         if (!game.isSimulation()) {
                             Player eventPlayer = game.getPlayer(info.event.getPlayerId());
+                            fromZone = info.event.getFromZone();
                             if (eventPlayer != null && fromZone != null) {
                                 game.informPlayers(eventPlayer.getLogName() + " puts "
                                         + GameLog.getColoredObjectIdName(permanent) + " from "

--- a/Mage/src/main/java/mage/target/common/TargetCardAndOrCard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardAndOrCard.java
@@ -6,10 +6,13 @@ import mage.cards.Card;
 import mage.cards.Cards;
 import mage.cards.CardsImpl;
 import mage.constants.CardType;
+import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.NamePredicate;
 import mage.game.Game;
+import mage.target.TargetCard;
 import mage.util.CardUtil;
 
 import java.util.HashSet;
@@ -21,7 +24,7 @@ import java.util.UUID;
  * <p>
  * almost identical to {@link TargetCardAndOrCardInLibrary}
  */
-public class TargetCardAndOrCardInGraveyard extends TargetCardInGraveyard {
+public class TargetCardAndOrCard extends TargetCard {
 
     private static FilterCard makeFilter(Predicate<? super Card> firstPredicate,
                                          Predicate<? super Card> secondPredicate,
@@ -42,25 +45,29 @@ public class TargetCardAndOrCardInGraveyard extends TargetCardInGraveyard {
     /**
      * a [firstType] card and/or a [secondType] card
      */
-    protected TargetCardAndOrCardInGraveyard(Predicate<? super Card> firstPredicate, Predicate<? super Card> secondPredicate, String filterText) {
-        super(0, 2, makeFilter(firstPredicate, secondPredicate, filterText));
+    protected TargetCardAndOrCard(Predicate<? super Card> firstPredicate, Predicate<? super Card> secondPredicate, String filterText) {
+        super(0, 2, Zone.ALL, makeFilter(firstPredicate, secondPredicate, filterText));
         this.assignment = new PredicateCardAssignment(firstPredicate, secondPredicate);
     }
 
-    public TargetCardAndOrCardInGraveyard(CardType firstType, CardType secondType) {
+    public TargetCardAndOrCard(String firstName, String secondName) {
+        this(new NamePredicate(firstName), new NamePredicate(secondName), "a card named " + firstName + " and/or a card named " + secondName);
+    }
+
+    public TargetCardAndOrCard(CardType firstType, CardType secondType) {
         this(firstType.getPredicate(), secondType.getPredicate(), makeFilterText(
                 CardUtil.getTextWithFirstCharLowerCase(firstType.toString()),
                 CardUtil.getTextWithFirstCharLowerCase(secondType.toString())));
     }
 
-    protected TargetCardAndOrCardInGraveyard(final TargetCardAndOrCardInGraveyard target) {
+    protected TargetCardAndOrCard(final TargetCardAndOrCard target) {
         super(target);
         this.assignment = target.assignment;
     }
 
     @Override
-    public TargetCardAndOrCardInGraveyard copy() {
-        return new TargetCardAndOrCardInGraveyard(this);
+    public TargetCardAndOrCard copy() {
+        return new TargetCardAndOrCard(this);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardAndOrCardInLibrary.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardAndOrCardInLibrary.java
@@ -10,6 +10,7 @@ import mage.constants.SubType;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.NamePredicate;
 import mage.game.Game;
 import mage.util.CardUtil;
 
@@ -50,6 +51,10 @@ public class TargetCardAndOrCardInLibrary extends TargetCardInLibrary {
         this(firstType.getPredicate(), secondType.getPredicate(), makeFilterText(
                 CardUtil.getTextWithFirstCharLowerCase(firstType.toString()),
                 CardUtil.getTextWithFirstCharLowerCase(secondType.toString())));
+    }
+
+    public TargetCardAndOrCardInLibrary(String firstName, String secondName) {
+        this(new NamePredicate(firstName), new NamePredicate(secondName), "a card named " + firstName + " and/or a card named " + secondName);
     }
 
     public TargetCardAndOrCardInLibrary(SubType firstType, SubType secondType) {


### PR DESCRIPTION
Unfortunately I had to separate out the library search interface because of Panglacial Wurm, which also made the code rather more complex and prevented me from truly genericizing the various search effects the way I wanted.

I did change `TargetCardAndOrCardInGraveyard` into `TargetCardAndOrCard`, both to let it be used here and because it's more rules correct:

> 701.13c An effect that refers to a milled card can find that card in the zone it moved to from the library, as long as that zone is a public zone.

In addition, I noticed that the log messages were incorrect during testing and fixed the issue.