### PR TITLE
Cleanup and Test TargetsPlayerPredicate & [AVR] Outwit.

### DIFF
--- a/Mage.Sets/src/mage/cards/e/ErthaJoFrontierMentor.java
+++ b/Mage.Sets/src/mage/cards/e/ErthaJoFrontierMentor.java
@@ -16,6 +16,7 @@ import mage.filter.FilterStackObject;
 import mage.filter.StaticFilters;
 import mage.filter.predicate.ObjectSourcePlayer;
 import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.filter.predicate.mageobject.TargetsPermanentOrPlayerPredicate;
 import mage.filter.predicate.mageobject.TargetsPermanentPredicate;
 import mage.filter.predicate.mageobject.TargetsPlayerPredicate;
 import mage.game.Game;
@@ -56,35 +57,12 @@ public final class ErthaJoFrontierMentor extends CardImpl {
     }
 }
 
-
-// Predicates.or is not handling well 2 ObjectSourcePlayerPredicate<StackObject> children,
-// so this is just a custom or.
-enum ErthaJoFrontierMentorPredicate implements ObjectSourcePlayerPredicate<StackObject> {
-    instance;
-
-    private static final TargetsPermanentPredicate permanentPredicate =
-            new TargetsPermanentPredicate(StaticFilters.FILTER_PERMANENT_CREATURE);
-
-    private static final TargetsPlayerPredicate playerPredicate =
-            new TargetsPlayerPredicate(new FilterPlayer());
-
-    @Override
-    public boolean apply(ObjectSourcePlayer<StackObject> input, Game game) {
-        return permanentPredicate.apply(input, game) || playerPredicate.apply(input, game);
-    }
-
-    @Override
-    public String toString() {
-        return "Or(" + permanentPredicate + ", " + playerPredicate + ')';
-    }
-}
-
 class ErthaJoFrontierMentorTriggeredAbility extends TriggeredAbilityImpl {
 
     private static final FilterStackObject filter = new FilterStackObject("ability that targets a creature or player");
 
     static {
-        filter.add(ErthaJoFrontierMentorPredicate.instance);
+        filter.add(new TargetsPermanentOrPlayerPredicate(StaticFilters.FILTER_PERMANENT_CREATURE, new FilterPlayer()));
     }
 
     public ErthaJoFrontierMentorTriggeredAbility() {

--- a/Mage.Sets/src/mage/cards/e/ErthaJoFrontierMentor.java
+++ b/Mage.Sets/src/mage/cards/e/ErthaJoFrontierMentor.java
@@ -1,7 +1,6 @@
 package mage.cards.e;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.effects.common.CopyStackObjectEffect;
@@ -12,6 +11,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.Zone;
+import mage.filter.FilterPlayer;
 import mage.filter.FilterStackObject;
 import mage.filter.StaticFilters;
 import mage.filter.predicate.ObjectSourcePlayer;
@@ -22,7 +22,6 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.token.MercenaryToken;
 import mage.game.stack.StackObject;
-import mage.target.common.TargetAnyTarget;
 
 import java.util.UUID;
 
@@ -57,18 +56,21 @@ public final class ErthaJoFrontierMentor extends CardImpl {
     }
 }
 
-// Some abstract type is confused there, so not using Predicates.or
-enum ErthaJoFrontierMentorPredicate implements ObjectSourcePlayerPredicate<MageObject> {
+
+// Predicates.or is not handling well 2 ObjectSourcePlayerPredicate<StackObject> children,
+// so this is just a custom or.
+enum ErthaJoFrontierMentorPredicate implements ObjectSourcePlayerPredicate<StackObject> {
     instance;
 
     private static final TargetsPermanentPredicate permanentPredicate =
             new TargetsPermanentPredicate(StaticFilters.FILTER_PERMANENT_CREATURE);
 
-    private static final TargetsPlayerPredicate playerPredicate = new TargetsPlayerPredicate();
+    private static final TargetsPlayerPredicate playerPredicate =
+            new TargetsPlayerPredicate(new FilterPlayer());
 
     @Override
-    public boolean apply(ObjectSourcePlayer<MageObject> o, Game game) {
-        return permanentPredicate.apply(o, game) || playerPredicate.apply(o, game);
+    public boolean apply(ObjectSourcePlayer<StackObject> input, Game game) {
+        return permanentPredicate.apply(input, game) || playerPredicate.apply(input, game);
     }
 
     @Override
@@ -87,7 +89,6 @@ class ErthaJoFrontierMentorTriggeredAbility extends TriggeredAbilityImpl {
 
     public ErthaJoFrontierMentorTriggeredAbility() {
         super(Zone.BATTLEFIELD, new CopyStackObjectEffect(), false);
-        this.addTarget(new TargetAnyTarget());
         setTriggerPhrase("Whenever you activate an ability that targets a creature or player, ");
     }
 

--- a/Mage.Sets/src/mage/cards/o/Outwit.java
+++ b/Mage.Sets/src/mage/cards/o/Outwit.java
@@ -1,42 +1,35 @@
 
 package mage.cards.o;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
-import mage.abilities.Ability;
 import mage.abilities.effects.common.CounterTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
-import mage.filter.Filter;
+import mage.filter.FilterPlayer;
 import mage.filter.FilterSpell;
-import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
-import mage.players.Player;
-import mage.target.Target;
-import mage.target.TargetObject;
+import mage.filter.predicate.mageobject.TargetsPlayerPredicate;
+import mage.target.TargetSpell;
 
+import java.util.UUID;
 
 
 /**
- *
- * @author jeffwadsworth
+ * @author Susucr
  */
 public final class Outwit extends CardImpl {
 
     private static FilterSpell filter = new FilterSpell("spell that targets a player");
 
-    public Outwit(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{U}");
+    static {
+        filter.add(new TargetsPlayerPredicate(new FilterPlayer()));
+    }
 
+    public Outwit(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{U}");
 
         // Counter target spell that targets a player.
         this.getSpellAbility().addEffect(new CounterTargetEffect());
-        this.getSpellAbility().addTarget(new CustomTargetSpell(filter));
+        this.getSpellAbility().addTarget(new TargetSpell(filter));
     }
 
     private Outwit(final Outwit card) {
@@ -46,112 +39,5 @@ public final class Outwit extends CardImpl {
     @Override
     public Outwit copy() {
         return new Outwit(this);
-    }
-
-    private static class CustomTargetSpell extends TargetObject {
-
-        protected FilterSpell filter;
-
-        public CustomTargetSpell() {
-            this(1, 1, StaticFilters.FILTER_SPELL);
-        }
-
-        public CustomTargetSpell(FilterSpell filter) {
-            this(1, 1, filter);
-        }
-
-        public CustomTargetSpell(int numTargets, FilterSpell filter) {
-            this(numTargets, numTargets, filter);
-        }
-
-        public CustomTargetSpell(int minNumTargets, int maxNumTargets, FilterSpell filter) {
-            this.minNumberOfTargets = minNumTargets;
-            this.maxNumberOfTargets = maxNumTargets;
-            this.zone = Zone.STACK;
-            this.filter = filter;
-            this.targetName = filter.getMessage();
-        }
-
-        private CustomTargetSpell(final CustomTargetSpell target) {
-            super(target);
-            this.filter = target.filter.copy();
-        }
-
-        @Override
-        public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-            return canChoose(sourceControllerId, game);
-        }
-
-        @Override
-        public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-            return possibleTargets(sourceControllerId, game);
-        }
-
-        @Override
-        public boolean canTarget(UUID id, Ability source, Game game) {
-            if (super.canTarget(id, source, game)) {
-                if (targetsPlayer(id, game)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public boolean canChoose(UUID sourceControllerId, Game game) {
-            int count = 0;
-            for (StackObject stackObject : game.getStack()) {
-                if (stackObject instanceof Spell && filter.match(stackObject, game)) {
-                    if (targetsPlayer(stackObject.getId(), game)) {
-                        count++;
-                        if (count >= this.minNumberOfTargets) {
-                            return true;
-                        }
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-            Set<UUID> possibleTargets = new HashSet<>();
-            for (StackObject stackObject : game.getStack()) {
-                if (stackObject instanceof Spell && filter.match(stackObject, game)) {
-                    if (targetsPlayer(stackObject.getId(), game)) {
-                        possibleTargets.add(stackObject.getId());
-                    }
-                }
-            }
-            return possibleTargets;
-        }
-
-        @Override
-        public Filter getFilter() {
-                return filter;
-        }
-
-        private boolean targetsPlayer(UUID id, Game game) {
-            StackObject spell = game.getStack().getStackObject(id);
-            if (spell != null) {
-                Ability ability = spell.getStackAbility();
-                if (ability != null && !ability.getTargets().isEmpty()) {
-                    for (Target target : ability.getTargets()) {
-                        for (UUID playerId : target.getTargets()) {
-                            Player player = game.getPlayer(playerId);
-                            if (player != null) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-            return false;
-        }
-
-        @Override
-        public CustomTargetSpell copy() {
-            return new CustomTargetSpell(this);
-        }
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/OutwitTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/OutwitTest.java
@@ -1,0 +1,64 @@
+package org.mage.test.cards.single.avr;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class OutwitTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.o.Outwit Outwit} {U}
+     * Instant
+     * Counter target spell that targets a player.
+     */
+    private static final String outwit = "Outwit";
+
+    @Test
+    public void test_BoltTargettingPlayer() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 1);
+        addCard(Zone.HAND, playerB, outwit);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, outwit, "Lightning Bolt");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerB, 20);
+        assertGraveyardCount(playerA, "Lightning Bolt", 1);
+        assertGraveyardCount(playerB, outwit, 1);
+    }
+
+    @Test
+    public void test_BoltTargettingCreature_CantCastOutwit() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 1);
+        addCard(Zone.HAND, playerB, outwit);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        addCard(Zone.HAND, playerA, "Lightning Bolt");
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", "Memnite");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, outwit, "Lightning Bolt");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertEquals(
+                    "Shouldn't be able to cast Outwit on Lightning Bolt targetting a creature",
+                    "Can't find ability to activate command: Cast Outwit$target=Lightning Bolt", e.getMessage()
+            );
+        }
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/OutwitTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/avr/OutwitTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.avr;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -28,6 +27,7 @@ public class OutwitTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Lightning Bolt");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
+        checkPlayableAbility("Outwit castable", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Cast Outwit", true);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, outwit, "Lightning Bolt");
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -49,16 +49,12 @@ public class OutwitTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Memnite");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Bolt", "Memnite");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, outwit, "Lightning Bolt");
+        checkPlayableAbility("Outwit not castable without valid target", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Cast Outwit", false);
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
-        try {
-            execute();
-        } catch (AssertionError e) {
-            Assert.assertEquals(
-                    "Shouldn't be able to cast Outwit on Lightning Bolt targetting a creature",
-                    "Can't find ability to activate command: Cast Outwit$target=Lightning Bolt", e.getMessage()
-            );
-        }
+        execute();
+
+        assertGraveyardCount(playerA, "Memnite", 1);
+        assertGraveyardCount(playerA, "Lightning Bolt", 1);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/otj/ErthaJoFrontierMentorTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/otj/ErthaJoFrontierMentorTest.java
@@ -1,0 +1,76 @@
+package org.mage.test.cards.single.otj;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class ErthaJoFrontierMentorTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.e.ErthaJoFrontierMentor Ertha Jo, Frontier Mentor} {2}{R}{W}
+     * Legendary Creature — Kor Advisor
+     * When Ertha Jo, Frontier Mentor enters the battlefield, create a 1/1 red Mercenary creature token with “{T}: Target creature you control gets +1/+0 until end of turn. Activate only as a sorcery.”
+     * Whenever you activate an ability that targets a creature or player, copy that ability. You may choose new targets for the copy.
+     * 2/4
+     */
+    private static final String ertha = "Ertha Jo, Frontier Mentor";
+
+    @Test
+    public void Test_TargetPlayer() {
+        setStrictChooseMode(true);
+
+        // Sacrifice Bile Urchin: Target player loses 1 life.
+        addCard(Zone.BATTLEFIELD, playerA, "Bile Urchin", 1);
+        addCard(Zone.BATTLEFIELD, playerA, ertha, 1);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Sacrifice", playerB);
+        setChoice(playerA, true); // choose to change the targets for the copy
+        addTarget(playerA, playerA); // have the copy target playerA
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertLife(playerA, 19);
+        assertLife(playerB, 19);
+    }
+
+    @Test
+    public void Test_TargetCreature() {
+        setStrictChooseMode(true);
+
+        // {T}: Target creature gets +1/+1 until end of turn.
+        addCard(Zone.BATTLEFIELD, playerA, "Wyluli Wolf", 1);
+        addCard(Zone.BATTLEFIELD, playerA, ertha, 1);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}", ertha);
+        setChoice(playerA, false); // choose not to change the targets for the copy
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, ertha, 2 + 2, 4 + 2);
+    }
+
+    @Test
+    public void Test_TargetLand_NoCopy() {
+        setStrictChooseMode(true);
+
+        // {2}{R}, {T}: Destroy target nonbasic land.
+        addCard(Zone.BATTLEFIELD, playerA, "Dwarven Miner", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        addCard(Zone.BATTLEFIELD, playerB, "Plateau", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Tropical Island", 1);
+        addCard(Zone.BATTLEFIELD, playerA, ertha, 1);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{R}", "Plateau");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerB, "Plateau", 1);
+    }
+}

--- a/Mage/src/main/java/mage/filter/predicate/mageobject/TargetsPermanentOrPlayerPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/mageobject/TargetsPermanentOrPlayerPredicate.java
@@ -1,0 +1,61 @@
+package mage.filter.predicate.mageobject;
+
+import mage.abilities.Mode;
+import mage.filter.FilterPermanent;
+import mage.filter.FilterPlayer;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.stack.StackObject;
+import mage.players.Player;
+import mage.target.Target;
+
+import java.util.UUID;
+
+/**
+ * @author Susucr
+ */
+public class TargetsPermanentOrPlayerPredicate implements ObjectSourcePlayerPredicate<StackObject> {
+
+    private final FilterPermanent targetFilterPermanent;
+    private final FilterPlayer targetFilterPlayer;
+
+    public TargetsPermanentOrPlayerPredicate(FilterPermanent targetFilterPermanent, FilterPlayer targetFilterPlayer) {
+        this.targetFilterPermanent = targetFilterPermanent;
+        this.targetFilterPlayer = targetFilterPlayer;
+    }
+
+    @Override
+    public boolean apply(ObjectSourcePlayer<StackObject> input, Game game) {
+        StackObject object = game.getStack().getStackObject(input.getObject().getId());
+        if (object != null) {
+            for (UUID modeId : object.getStackAbility().getModes().getSelectedModes()) {
+                Mode mode = object.getStackAbility().getModes().get(modeId);
+                for (Target target : mode.getTargets()) {
+                    if (target.isNotTarget()) {
+                        continue;
+                    }
+                    for (UUID targetId : target.getTargets()) {
+                        // Try for permanent
+                        Permanent permanent = game.getPermanent(targetId);
+                        if (targetFilterPermanent.match(permanent, input.getPlayerId(), input.getSource(), game)) {
+                            return true;
+                        }
+                        // Try for player
+                        Player player = game.getPlayer(targetId);
+                        if (targetFilterPlayer.match(player, input.getPlayerId(), input.getSource(), game)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "that targets a " + targetFilterPermanent.getMessage() + " or " + targetFilterPlayer.getMessage();
+    }
+}

--- a/Mage/src/main/java/mage/filter/predicate/mageobject/TargetsPermanentPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/mageobject/TargetsPermanentPredicate.java
@@ -1,6 +1,5 @@
 package mage.filter.predicate.mageobject;
 
-import mage.MageObject;
 import mage.abilities.Mode;
 import mage.filter.FilterPermanent;
 import mage.filter.predicate.ObjectSourcePlayer;
@@ -15,7 +14,7 @@ import java.util.UUID;
 /**
  * @author LoneFox
  */
-public class TargetsPermanentPredicate implements ObjectSourcePlayerPredicate<MageObject> {
+public class TargetsPermanentPredicate implements ObjectSourcePlayerPredicate<StackObject> {
 
     private final FilterPermanent targetFilter;
 
@@ -24,7 +23,7 @@ public class TargetsPermanentPredicate implements ObjectSourcePlayerPredicate<Ma
     }
 
     @Override
-    public boolean apply(ObjectSourcePlayer<MageObject> input, Game game) {
+    public boolean apply(ObjectSourcePlayer<StackObject> input, Game game) {
         StackObject object = game.getStack().getStackObject(input.getObject().getId());
         if (object != null) {
             for (UUID modeId : object.getStackAbility().getModes().getSelectedModes()) {


### PR DESCRIPTION
Following up on https://github.com/magefree/mage/commit/1b88e1eaac195f98aa929018f1e0cd389da451b3#r140416740

I rewrote `TargetsPlayerPredicate` more like `TargetsPermanentPredicate`, rewrote Outwit to use it, and added tests for both Outwit and Ertha Jo.

I still needed the boilerplate `Predicate` for Ertha Jo as `Predicate.or` doesn't work on `ObjectSourcePlayerPredicate<StackObject>`. I'm still not sure why exactly.