### PR TITLE
Introduce a new layer 0 for transform characteristics

### DIFF
--- a/Mage/src/main/java/mage/abilities/common/SpellTransformedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SpellTransformedAbility.java
@@ -86,7 +86,7 @@ public class SpellTransformedAbility extends SpellAbility {
 class TransformedEffect extends ContinuousEffectImpl {
 
     public TransformedEffect() {
-        super(Duration.WhileOnStack, Layer.CopyEffects_1, SubLayer.CopyEffects_1a, Outcome.BecomeCreature);
+        super(Duration.WhileOnStack, Layer.TransformCharacteristics_0, SubLayer.NA, Outcome.BecomeCreature);
         staticText = "";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -180,6 +180,7 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
         if (AbilityType.STATIC != source.getAbilityType()) {
             if (layer != null) {
                 switch (layer) {
+                    case TransformCharacteristics_0:
                     case CopyEffects_1:
                     case ControlChangingEffects_2:
                     case TextChangingEffects_3:
@@ -189,7 +190,8 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
                     case PTChangingEffects_7:
                         this.affectedObjectsSet = true;
                 }
-            } else if (hasLayer(Layer.CopyEffects_1)
+            } else if (hasLayer(Layer.TransformCharacteristics_0)
+                    || hasLayer(Layer.CopyEffects_1)
                     || hasLayer(Layer.ControlChangingEffects_2)
                     || hasLayer(Layer.TextChangingEffects_3)
                     || hasLayer(Layer.TypeChangingEffects_4)

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -944,7 +944,19 @@ public class ContinuousEffects implements Serializable {
         removeInactiveEffects(game);
         List<ContinuousEffect> activeLayerEffects = getLayeredEffects(game); // main call
 
-        List<ContinuousEffect> layer = filterLayeredEffects(activeLayerEffects, Layer.CopyEffects_1);
+        List<ContinuousEffect> layer = filterLayeredEffects(activeLayerEffects, Layer.TransformCharacteristics_0);
+        for (ContinuousEffect effect : layer) {
+            Set<Ability> abilities = layeredEffects.getAbility(effect.getId());
+            for (Ability ability : abilities) {
+                effect.apply(Layer.TransformCharacteristics_0, SubLayer.NA, ability, game);
+            }
+        }
+        // Reload layerEffect if transform characteristics were applied
+        if (!layer.isEmpty()) {
+            activeLayerEffects = getLayeredEffects(game, "layer_0");
+        }
+
+        layer = filterLayeredEffects(activeLayerEffects, Layer.CopyEffects_1);
         for (ContinuousEffect effect : layer) {
             Set<Ability> abilities = layeredEffects.getAbility(effect.getId());
             for (Ability ability : abilities) {

--- a/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/TransformAbility.java
@@ -142,7 +142,7 @@ public class TransformAbility extends SimpleStaticAbility {
 class TransformEffect extends ContinuousEffectImpl {
 
     TransformEffect() {
-        super(Duration.WhileOnBattlefield, Layer.CopyEffects_1, SubLayer.CopyEffects_1a, Outcome.BecomeCreature);
+        super(Duration.WhileOnBattlefield, Layer.TransformCharacteristics_0, SubLayer.NA, Outcome.BecomeCreature);
         staticText = "";
     }
 

--- a/Mage/src/main/java/mage/constants/Layer.java
+++ b/Mage/src/main/java/mage/constants/Layer.java
@@ -5,6 +5,7 @@ package mage.constants;
  * @author North
  */
 public enum Layer {
+    TransformCharacteristics_0,
     CopyEffects_1,
     ControlChangingEffects_2,
     TextChangingEffects_3,


### PR DESCRIPTION
Fixes #11683 

As discussed in the issue above and #11677, this introduces a new layer 0 for transform characteristics. This is done so that the effect of a transformed permanent can be applied before any effects in layer 1 (copy effects).