### PR TITLE
support meld image download

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -96,6 +96,7 @@ public enum ScryfallImageSource implements CardImageSource {
         }
 
         // double faced cards (modal double faces cards too)
+        // meld cards are excluded.
         if (card.isSecondSide()) {
             // back face - must be prepared before
             logger.warn("Can't find back face info in prepared list "

--- a/Mage/src/main/java/mage/cards/repository/CardCriteria.java
+++ b/Mage/src/main/java/mage/cards/repository/CardCriteria.java
@@ -32,7 +32,7 @@ public class CardCriteria {
     private Boolean variousArt;
     private Boolean doubleFaced;
     private Boolean modalDoubleFaced;
-    private boolean nightCard;
+    private Boolean nightCard;
     private boolean black;
     private boolean blue;
     private boolean green;
@@ -114,7 +114,7 @@ public class CardCriteria {
         return this;
     }
 
-    public CardCriteria nightCard(boolean nightCard) {
+    public CardCriteria nightCard(Boolean nightCard) {
         this.nightCard = nightCard;
         return this;
     }
@@ -217,9 +217,14 @@ public class CardCriteria {
         optimize();
 
         Where where = qb.where();
-        where.eq("nightCard", nightCard);
+
+        int clausesCount = 0;
+        if (nightCard != null) {
+            where.eq("nightCard", nightCard);
+            clausesCount++;
+        }
         where.eq("splitCardHalf", false);
-        int clausesCount = 2;
+        clausesCount++;
         if (nameContains != null) {
             where.like("name", new SelectArg('%' + nameContains + '%'));
             clausesCount++;

--- a/Mage/src/main/java/mage/cards/repository/CardInfo.java
+++ b/Mage/src/main/java/mage/cards/repository/CardInfo.java
@@ -100,6 +100,8 @@ public class CardInfo {
     @DatabaseField(indexName = "nightCard_index")
     protected boolean nightCard;
     @DatabaseField
+    protected boolean meldCard;
+    @DatabaseField
     protected String flipCardName;
     @DatabaseField
     protected String secondSideName;
@@ -149,6 +151,7 @@ public class CardInfo {
 
         this.doubleFaced = card.isTransformable() && card.getSecondCardFace() != null;
         this.nightCard = card.isNightCard();
+        this.meldCard = card instanceof MeldCard;
         Card secondSide = card.getSecondCardFace();
         if (secondSide != null) {
             this.secondSideName = secondSide.getName();
@@ -456,6 +459,10 @@ public class CardInfo {
 
     public boolean isNightCard() {
         return nightCard;
+    }
+
+    public boolean isMeldCard() {
+        return meldCard;
     }
 
     public String getSecondSideName() {


### PR DESCRIPTION
Meld cards are expected to be downloaded as unique cards in the set. This makes sense as 2 front cards have the meld as back face. So it is better to have the 3 of them separate.

However, due to them being set as night cards, they are usually excluded together with other back faces.

This PR adds support for the filtering in `CardCriteria`, allowing to list (and download) the following images:

![image](https://github.com/magefree/mage/assets/34709007/378b7eed-0673-4f8c-b55d-4cc1f2ab2724)

Fix #11778
