### PR TITLE
Fix DestroyPlaneswalkerWhenDamagedTriggeredAbility

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/DestroyPlaneswalkerWhenDamagedTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/damage/DestroyPlaneswalkerWhenDamagedTest.java
@@ -1,0 +1,37 @@
+package org.mage.test.cards.triggers.damage;
+
+import mage.abilities.common.DestroyPlaneswalkerWhenDamagedTriggeredAbility;
+import mage.constants.CardType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ *
+ * @author jimga150
+ */
+public class DestroyPlaneswalkerWhenDamagedTest extends CardTestPlayerBase {
+
+    @Test
+    public void nullFilterTest() {
+        addCustomCardWithAbility("nullFilterDPwD", playerA, new DestroyPlaneswalkerWhenDamagedTriggeredAbility(), null, CardType.CREATURE, "", Zone.BATTLEFIELD);
+
+        addCard(Zone.BATTLEFIELD, playerB, "Phyrexian Walker", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Chandra, Acolyte of Flame");
+
+        attack(1, playerA, "nullFilterDPwD", "Chandra, Acolyte of Flame");
+        block(1, playerB, "Phyrexian Walker", "nullFilterDPwD");
+
+        attack(3, playerA, "nullFilterDPwD", "Chandra, Acolyte of Flame");
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertPowerToughness(playerA, "nullFilterDPwD", 1, 1);
+        assertPermanentCount(playerB, "Phyrexian Walker", 1);
+        assertGraveyardCount(playerB, "Chandra, Acolyte of Flame", 1);
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/common/DestroyPlaneswalkerWhenDamagedTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DestroyPlaneswalkerWhenDamagedTriggeredAbility.java
@@ -40,13 +40,17 @@ public class DestroyPlaneswalkerWhenDamagedTriggeredAbility extends TriggeredAbi
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        Permanent permanent = getSourcePermanentIfItStillExists(game);
-        if (permanent == null) {
+        Permanent sourcePermanent = getSourcePermanentIfItStillExists(game);
+        if (sourcePermanent == null) {
             return false;
         }
-        boolean applies = filter != null ?
-                permanent.isPlaneswalker(game) && filter.match(permanent, game) : event.getSourceId().equals(getSourceId());
-        if (applies) {
+        Permanent damagedPermanent = game.getPermanent(event.getTargetId());
+        if (damagedPermanent == null) {
+            return false;
+        }
+        boolean targetsPlaneswalker = damagedPermanent.isPlaneswalker(game);
+        boolean filterMatch = filter != null ? filter.match(sourcePermanent, game) : event.getSourceId().equals(getSourceId());
+        if (targetsPlaneswalker && filterMatch) {
             Effect effect = new DestroyTargetEffect();
             effect.setTargetPointer(new FixedTarget(event.getTargetId(), game));
             this.getEffects().clear();


### PR DESCRIPTION
Currently the logic for determining when to destroy a damage permanent under the influence of `DestroyPlaneswalkerWhenDamagedTriggeredAbility` is miswritten. In the case where the filter is null, the ability is supposed to give the source permanent deathouch to planeswalkers, but instead it gives unconditional deathtouch.