### PR TITLE
Minor card fixes, Update EachOpponentPermanentTargetsAdjuster

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BlatantThievery.java
+++ b/Mage.Sets/src/mage/cards/b/BlatantThievery.java
@@ -23,7 +23,7 @@ public final class BlatantThievery extends CardImpl {
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.Custom, true)
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of target permanent that player controls"));
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetPermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlatantThievery.java
+++ b/Mage.Sets/src/mage/cards/b/BlatantThievery.java
@@ -23,7 +23,8 @@ public final class BlatantThievery extends CardImpl {
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.Custom, true)
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of target permanent that player controls"));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent()));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetPermanent());
     }
 
     private BlatantThievery(final BlatantThievery card) {

--- a/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
+++ b/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
@@ -46,7 +46,7 @@ public final class BronzebeakForagers extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
-        etbAbility.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        etbAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         etbAbility.addTarget(new TargetNonlandPermanent(0, 1));
         this.addAbility(etbAbility);
 

--- a/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
+++ b/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
@@ -46,7 +46,8 @@ public final class BronzebeakForagers extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
-        etbAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0, 1)));
+        etbAbility.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        etbAbility.addTarget(new TargetNonlandPermanent(0, 1));
         this.addAbility(etbAbility);
 
         // {X}{W}: Put target card with mana value X exiled with Bronzebeak Foragers into its owner's graveyard.

--- a/Mage.Sets/src/mage/cards/d/DecoyGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DecoyGambit.java
@@ -33,7 +33,8 @@ public final class DecoyGambit extends CardImpl {
         // For each opponent, choose up to one target creature that player controls, 
         // then return that creature to its owner's hand unless its controller has you draw a card.
         this.getSpellAbility().addEffect(new DecoyGambitEffect());
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
     }
 
     private DecoyGambit(final DecoyGambit card) {

--- a/Mage.Sets/src/mage/cards/d/DecoyGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DecoyGambit.java
@@ -33,7 +33,7 @@ public final class DecoyGambit extends CardImpl {
         // For each opponent, choose up to one target creature that player controls, 
         // then return that creature to its owner's hand unless its controller has you draw a card.
         this.getSpellAbility().addEffect(new DecoyGambitEffect());
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DesecrateReality.java
+++ b/Mage.Sets/src/mage/cards/d/DesecrateReality.java
@@ -44,7 +44,8 @@ public final class DesecrateReality extends CardImpl {
         this.getSpellAbility().addEffect(new ExileTargetEffect()
             .setTargetPointer(new EachTargetPointer())
             .setText("for each opponent, exile up to one target permanent that player controls with an even mana value."));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0, 1, evenFilter)));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetPermanent(0, 1, evenFilter));
 
         // Adamant -- If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(

--- a/Mage.Sets/src/mage/cards/d/DesecrateReality.java
+++ b/Mage.Sets/src/mage/cards/d/DesecrateReality.java
@@ -44,7 +44,7 @@ public final class DesecrateReality extends CardImpl {
         this.getSpellAbility().addEffect(new ExileTargetEffect()
             .setTargetPointer(new EachTargetPointer())
             .setText("for each opponent, exile up to one target permanent that player controls with an even mana value."));
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetPermanent(0, 1, evenFilter));
 
         // Adamant -- If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.

--- a/Mage.Sets/src/mage/cards/d/DismantlingWave.java
+++ b/Mage.Sets/src/mage/cards/d/DismantlingWave.java
@@ -27,8 +27,8 @@ public final class DismantlingWave extends CardImpl {
         this.getSpellAbility().addEffect(new DestroyTargetEffect()
                 .setTargetPointer(new EachTargetPointer())
                 .setText("For each opponent, destroy up to one target artifact or enchantment that player controls."));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(
-                new TargetPermanent(0, 1, StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT)));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT));
 
         // Cycling {6}{W}{W}
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{6}{W}{W}")));

--- a/Mage.Sets/src/mage/cards/d/DismantlingWave.java
+++ b/Mage.Sets/src/mage/cards/d/DismantlingWave.java
@@ -27,7 +27,7 @@ public final class DismantlingWave extends CardImpl {
         this.getSpellAbility().addEffect(new DestroyTargetEffect()
                 .setTargetPointer(new EachTargetPointer())
                 .setText("For each opponent, destroy up to one target artifact or enchantment that player controls."));
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT));
 
         // Cycling {6}{W}{W}

--- a/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
+++ b/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
@@ -25,7 +25,8 @@ public final class ElminstersSimulacrum extends CardImpl {
 
         // For each opponent, you create a token that's a copy of up to one target creature that player controls.
         this.getSpellAbility().addEffect(new ElminstersSimulacrumAdjusterEffect());
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
     }
 
     private ElminstersSimulacrum(final ElminstersSimulacrum card) {

--- a/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
+++ b/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
@@ -25,7 +25,7 @@ public final class ElminstersSimulacrum extends CardImpl {
 
         // For each opponent, you create a token that's a copy of up to one target creature that player controls.
         this.getSpellAbility().addEffect(new ElminstersSimulacrumAdjusterEffect());
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnigmaThief.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaThief.java
@@ -39,7 +39,7 @@ public final class EnigmaThief extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new ReturnToHandTargetEffect()
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"));
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetNonlandPermanent(0,1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/e/EnigmaThief.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaThief.java
@@ -39,7 +39,8 @@ public final class EnigmaThief extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new ReturnToHandTargetEffect()
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0,1)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetNonlandPermanent(0,1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraspOfFate.java
+++ b/Mage.Sets/src/mage/cards/g/GraspOfFate.java
@@ -25,7 +25,7 @@ public final class GraspOfFate extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetNonlandPermanent(0,1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/g/GraspOfFate.java
+++ b/Mage.Sets/src/mage/cards/g/GraspOfFate.java
@@ -25,7 +25,8 @@ public final class GraspOfFate extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0,1)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetNonlandPermanent(0,1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
+++ b/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
@@ -1,6 +1,7 @@
 package mage.cards.h;
 
 import mage.MageInt;
+import mage.abilities.Ability;
 import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.abilities.keyword.MyriadAbility;
@@ -31,11 +32,14 @@ public final class HammersOfMoradin extends CardImpl {
         this.addAbility(new MyriadAbility());
 
         // Whenever Hammers of Moradin attacks, for each opponent, tap up to one target creature that player controls.
-        this.addAbility(new AttacksTriggeredAbility(
+        Ability ability = new AttacksTriggeredAbility(
                 new TapTargetEffect()
                         .setTargetPointer(new EachTargetPointer())
                         .setText("for each opponent, tap up to one target creature that player controls")
-        ).setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1))));
+        );
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetCreaturePermanent(0,1));
+        this.addAbility(ability);
     }
 
     private HammersOfMoradin(final HammersOfMoradin card) {

--- a/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
+++ b/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
@@ -37,7 +37,7 @@ public final class HammersOfMoradin extends CardImpl {
                         .setTargetPointer(new EachTargetPointer())
                         .setText("for each opponent, tap up to one target creature that player controls")
         );
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
+++ b/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
@@ -57,7 +57,8 @@ public final class InTheDarknessBindThem extends CardImpl {
                     ability.addEffect(new TheRingTemptsYouEffect());
 
                     ability.getEffects().setTargetPointer(new EachTargetPointer());
-                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+                    ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+                    ability.addTarget(new TargetCreaturePermanent(0,1));
                 }
         );
 

--- a/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
+++ b/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
@@ -57,7 +57,7 @@ public final class InTheDarknessBindThem extends CardImpl {
                     ability.addEffect(new TheRingTemptsYouEffect());
 
                     ability.getEffects().setTargetPointer(new EachTargetPointer());
-                    ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
                     ability.addTarget(new TargetCreaturePermanent(0,1));
                 }
         );

--- a/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
+++ b/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
@@ -42,7 +42,8 @@ public final class JuvenileMistDragon extends CardImpl {
                         .setTargetPointer(new EachTargetPointer())
                         .setText("Each of those creatures doesn't untap during its controller's next untap step")
         );
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability.withFlavorWord("Confounding Clouds"));
     }
 

--- a/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
+++ b/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
@@ -42,7 +42,7 @@ public final class JuvenileMistDragon extends CardImpl {
                         .setTargetPointer(new EachTargetPointer())
                         .setText("Each of those creatures doesn't untap during its controller's next untap step")
         );
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability.withFlavorWord("Confounding Clouds"));
     }

--- a/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
+++ b/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
@@ -40,7 +40,8 @@ public final class LuminatePrimordial extends CardImpl {
         // When Luminate Primordial enters the battlefield, for each opponent, exile up to one target creature
         // that player controls and that player gains life equal to its power.
         Ability ability = new EntersBattlefieldTriggeredAbility(new LuminatePrimordialEffect(), false);
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
+++ b/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
@@ -40,7 +40,7 @@ public final class LuminatePrimordial extends CardImpl {
         // When Luminate Primordial enters the battlefield, for each opponent, exile up to one target creature
         // that player controls and that player gains life equal to its power.
         Ability ability = new EntersBattlefieldTriggeredAbility(new LuminatePrimordialEffect(), false);
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MassMutiny.java
+++ b/Mage.Sets/src/mage/cards/m/MassMutiny.java
@@ -31,7 +31,8 @@ public final class MassMutiny extends CardImpl {
 
         // For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.
         this.getSpellAbility().addEffect(new MassMutinyEffect());
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
     }
 
     private MassMutiny(final MassMutiny card) {

--- a/Mage.Sets/src/mage/cards/m/MassMutiny.java
+++ b/Mage.Sets/src/mage/cards/m/MassMutiny.java
@@ -31,7 +31,7 @@ public final class MassMutiny extends CardImpl {
 
         // For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.
         this.getSpellAbility().addEffect(new MassMutinyEffect());
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
@@ -41,7 +41,8 @@ public final class MoltenPrimordial extends CardImpl {
 
         // When Molten Primordial enters the battlefield, for each opponent, take control of up to one target creature that player controls until end of turn. Untap those creatures. They have haste until end of turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(new MoltenPrimordialEffect(), false);
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
@@ -41,7 +41,7 @@ public final class MoltenPrimordial extends CardImpl {
 
         // When Molten Primordial enters the battlefield, for each opponent, take control of up to one target creature that player controls until end of turn. Untap those creatures. They have haste until end of turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(new MoltenPrimordialEffect(), false);
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetCreaturePermanent(0,1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SinisterConcierge.java
+++ b/Mage.Sets/src/mage/cards/s/SinisterConcierge.java
@@ -84,8 +84,7 @@ class SinisterConciergeEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         Card card = game.getCard(source.getSourceId());
-        Permanent targetCreature = game.getPermanent(this.getTargetPointer().getFirst(game, source));
-        if (controller == null || card == null || targetCreature == null) {
+        if (controller == null || card == null) {
             return false;
         }
 
@@ -97,6 +96,11 @@ class SinisterConciergeEffect extends OneShotEffect {
             if (sourceCardShouldGetSuspend && !card.getAbilities(game).containsClass(SuspendAbility.class)) {
                 game.addEffect(new GainSuspendEffect(new MageObjectReference(card, game)), source);
             }
+        }
+
+        Permanent targetCreature = game.getPermanent(this.getTargetPointer().getFirst(game, source));
+        if (targetCreature == null){
+            return false;
         }
 
         // Exile, put time counters, and give suspend for target

--- a/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
+++ b/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
@@ -42,7 +42,8 @@ public final class SontaranGeneral extends CardImpl {
                 .setText("for each opponent, goad up to one target creature that player controls."));
         ability.addEffect(new CantBlockTargetEffect(Duration.EndOfTurn)
                 .setText("Those creatures can't block this turn."));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0, 1)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetCreaturePermanent(0, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
+++ b/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
@@ -42,7 +42,7 @@ public final class SontaranGeneral extends CardImpl {
                 .setText("for each opponent, goad up to one target creature that player controls."));
         ability.addEffect(new CantBlockTargetEffect(Duration.EndOfTurn)
                 .setText("Those creatures can't block this turn."));
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetCreaturePermanent(0, 1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
@@ -46,7 +46,7 @@ public final class SylvanPrimordial extends CardImpl {
 
         // When Sylvan Primordial enters the battlefield, for each opponent, destroy target noncreature permanent that player controls. For each permanent destroyed this way, search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new EntersBattlefieldTriggeredAbility(new SylvanPrimordialEffect(), false);
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
@@ -46,7 +46,8 @@ public final class SylvanPrimordial extends CardImpl {
 
         // When Sylvan Primordial enters the battlefield, for each opponent, destroy target noncreature permanent that player controls. For each permanent destroyed this way, search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new EntersBattlefieldTriggeredAbility(new SylvanPrimordialEffect(), false);
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(filter)));
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
+++ b/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
@@ -31,7 +31,7 @@ public final class TemptedByTheOriq extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of up to one target creature " +
                         "or planeswalker that player controls with mana value 3 or less"));
-        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         this.getSpellAbility().addTarget(new TargetPermanent(0, 1, filter));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
+++ b/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
@@ -31,7 +31,8 @@ public final class TemptedByTheOriq extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of up to one target creature " +
                         "or planeswalker that player controls with mana value 3 or less"));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0, 1, filter)));
+        this.getSpellAbility().setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        this.getSpellAbility().addTarget(new TargetPermanent(0, 1, filter));
     }
 
     private TemptedByTheOriq(final TemptedByTheOriq card) {

--- a/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
+++ b/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
@@ -51,7 +51,8 @@ public final class TheBalrogOfMoria extends CardImpl {
                 .setText("for each opponent, exile up to one target creature that player controls."),
             false
         );
-        reflexiveAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreaturePermanent(0,1)));
+        reflexiveAbility.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        reflexiveAbility.addTarget(new TargetCreaturePermanent(0,1));
 
         this.addAbility(new DiesSourceTriggeredAbility(
             new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
+++ b/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
@@ -51,7 +51,7 @@ public final class TheBalrogOfMoria extends CardImpl {
                 .setText("for each opponent, exile up to one target creature that player controls."),
             false
         );
-        reflexiveAbility.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        reflexiveAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         reflexiveAbility.addTarget(new TargetCreaturePermanent(0,1));
 
         this.addAbility(new DiesSourceTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/t/TheHorusHeresy.java
+++ b/Mage.Sets/src/mage/cards/t/TheHorusHeresy.java
@@ -57,7 +57,7 @@ public final class TheHorusHeresy extends CardImpl {
         // I -- For each opponent, gain control of up to one target nonlegendary creature that player controls for as long as The Horus Heresy remains on the battlefield.
         sagaAbility.addChapterEffect(this, SagaChapter.CHAPTER_I, ability -> {
             ability.addEffect(new TheHorusHeresyControlEffect());
-            ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+            ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
             ability.addTarget(new TargetPermanent(0, 1, filterNonlegendary));
         });
 

--- a/Mage.Sets/src/mage/cards/t/TheHorusHeresy.java
+++ b/Mage.Sets/src/mage/cards/t/TheHorusHeresy.java
@@ -57,7 +57,8 @@ public final class TheHorusHeresy extends CardImpl {
         // I -- For each opponent, gain control of up to one target nonlegendary creature that player controls for as long as The Horus Heresy remains on the battlefield.
         sagaAbility.addChapterEffect(this, SagaChapter.CHAPTER_I, ability -> {
             ability.addEffect(new TheHorusHeresyControlEffect());
-            ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0, 1, filterNonlegendary)));
+            ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+            ability.addTarget(new TargetPermanent(0, 1, filterNonlegendary));
         });
 
         // II -- Draw a card for each creature you control but don't own.

--- a/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
+++ b/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
@@ -46,7 +46,8 @@ public final class TheTrueScriptures extends CardImpl {
                 ability -> {
                     ability.addEffect(new DestroyTargetEffect().setTargetPointer(new EachTargetPointer())
                             .setText("for each opponent, destroy up to one target creature or planeswalker that player controls"));
-                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetCreatureOrPlaneswalker(0,1)));
+                    ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+                    ability.addTarget(new TargetCreatureOrPlaneswalker(0,1));
                 }
         );
 

--- a/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
+++ b/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
@@ -46,7 +46,7 @@ public final class TheTrueScriptures extends CardImpl {
                 ability -> {
                     ability.addEffect(new DestroyTargetEffect().setTargetPointer(new EachTargetPointer())
                             .setText("for each opponent, destroy up to one target creature or planeswalker that player controls"));
-                    ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
                     ability.addTarget(new TargetCreatureOrPlaneswalker(0,1));
                 }
         );

--- a/Mage.Sets/src/mage/cards/t/TolarianContempt.java
+++ b/Mage.Sets/src/mage/cards/t/TolarianContempt.java
@@ -46,9 +46,10 @@ public final class TolarianContempt extends CardImpl {
         ));
 
         // At the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.
-        this.addAbility(new BeginningOfEndStepTriggeredAbility(
-                new TolarianContemptEffect(), TargetController.YOU, false
-        ).setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0,1, filterRejection))));
+        Ability ability = new BeginningOfEndStepTriggeredAbility(new TolarianContemptEffect(), TargetController.YOU, false);
+        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.addTarget(new TargetPermanent(0,1, filterRejection));
+        this.addAbility(ability);
     }
 
     private TolarianContempt(final TolarianContempt card) {

--- a/Mage.Sets/src/mage/cards/t/TolarianContempt.java
+++ b/Mage.Sets/src/mage/cards/t/TolarianContempt.java
@@ -47,7 +47,7 @@ public final class TolarianContempt extends CardImpl {
 
         // At the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.
         Ability ability = new BeginningOfEndStepTriggeredAbility(new TolarianContemptEffect(), TargetController.YOU, false);
-        ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability.addTarget(new TargetPermanent(0,1, filterRejection));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
+++ b/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
@@ -56,7 +56,7 @@ public final class VronosMaskedInquisitor extends CardImpl {
         // −2: For each opponent, return up to one target nonland permanent that player controls to its owner's hand.
         LoyaltyAbility ability2 = new LoyaltyAbility(new ReturnToHandTargetEffect().setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"), -2);
-        ability2.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability2.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
         ability2.addTarget(new TargetNonlandPermanent(0,1));
         this.addAbility(ability2);
 

--- a/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
+++ b/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
@@ -56,7 +56,8 @@ public final class VronosMaskedInquisitor extends CardImpl {
         // −2: For each opponent, return up to one target nonland permanent that player controls to its owner's hand.
         LoyaltyAbility ability2 = new LoyaltyAbility(new ReturnToHandTargetEffect().setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"), -2);
-        ability2.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetNonlandPermanent(0,1)));
+        ability2.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+        ability2.addTarget(new TargetNonlandPermanent(0,1));
         this.addAbility(ability2);
 
         // −7: Target artifact you control becomes a 9/9 Construct artifact creature and gains vigilance, indestructible, and "This creature can't be blocked."

--- a/Mage.Sets/src/mage/cards/w/WelcomeTo.java
+++ b/Mage.Sets/src/mage/cards/w/WelcomeTo.java
@@ -63,7 +63,7 @@ public final class WelcomeTo extends CardImpl {
                     ).setText("For each opponent, up to one target noncreature artifact they control becomes " +
                               "a 0/4 Wall artifact creature with defender for as long as you control this Saga."));
             ability.getEffects().setTargetPointer(new EachTargetPointer());
-            ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+            ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
             ability.addTarget(new TargetPermanent(0, 1, filterNoncreatureArtifact));
         });
 

--- a/Mage.Sets/src/mage/cards/w/WelcomeTo.java
+++ b/Mage.Sets/src/mage/cards/w/WelcomeTo.java
@@ -63,7 +63,8 @@ public final class WelcomeTo extends CardImpl {
                     ).setText("For each opponent, up to one target noncreature artifact they control becomes " +
                               "a 0/4 Wall artifact creature with defender for as long as you control this Saga."));
             ability.getEffects().setTargetPointer(new EachTargetPointer());
-            ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(new TargetPermanent(0, 1, filterNoncreatureArtifact)));
+            ability.setTargetAdjuster(EachOpponentPermanentTargetsAdjuster.instance);
+            ability.addTarget(new TargetPermanent(0, 1, filterNoncreatureArtifact));
         });
 
         // II -- Create a 3/3 green Dinosaur creature token with trample. It gains haste until end of turn.

--- a/Mage.Sets/src/mage/cards/w/WreckAndRebuild.java
+++ b/Mage.Sets/src/mage/cards/w/WreckAndRebuild.java
@@ -75,7 +75,7 @@ class WreckAndRebuildEffect extends OneShotEffect {
             return false;
         }
         TargetCard targetCard = new TargetCardInYourGraveyard(
-                0, 1, StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD, true
+                0, 1, StaticFilters.FILTER_CARD_LAND_A, true
         );
         player.choose(outcome, targetCard, source, game);
         Card card = game.getCard(targetCard.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/w/WreckAndRebuild.java
+++ b/Mage.Sets/src/mage/cards/w/WreckAndRebuild.java
@@ -75,7 +75,7 @@ class WreckAndRebuildEffect extends OneShotEffect {
             return false;
         }
         TargetCard targetCard = new TargetCardInYourGraveyard(
-                0, 1, StaticFilters.FILTER_CARD_LAND_A, true
+                0, 1, StaticFilters.FILTER_CARD_LAND, true
         );
         player.choose(outcome, targetCard, source, game);
         Card card = game.getCard(targetCard.getFirstTarget());

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -11,36 +11,31 @@ import mage.target.TargetPermanent;
 import java.util.UUID;
 
 /**
- *
  * @author notgreat
  */
-public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
-    private final TargetPermanent blueprintTarget;
+public enum EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
+    instance;
 
     /**
      * Duplicates the permanent target for each opponent.
      * Filtering of permanent's controllers will be handled inside, so
      * do not pass a blueprint target with a controller restriction filter/predicate.
-     *
-     * @param blueprintTarget The target to be duplicated per opponent
      */
-    public EachOpponentPermanentTargetsAdjuster(TargetPermanent blueprintTarget) {
-        this.blueprintTarget = blueprintTarget.copy(); //Defensively copy the blueprint to ensure immutability
-    }
 
     @Override
     public void adjustTargets(Ability ability, Game game) {
+        TargetPermanent oldTargetPermanent = (TargetPermanent) ability.getTargets().get(0);
         ability.getTargets().clear();
         for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
             Player opponent = game.getPlayer(opponentId);
             if (opponent == null) {
                 continue;
             }
-            TargetPermanent newTarget = blueprintTarget.copy();
+            TargetPermanent newTarget = oldTargetPermanent.copy();
             Filter<Permanent> filter = newTarget.getFilter();
             filter.add(new ControllerIdPredicate(opponentId));
             if (newTarget.canChoose(ability.getControllerId(), ability, game)) {
-                filter.setMessage(filter.getMessage()+" controlled by " + opponent.getLogName());
+                filter.setMessage(filter.getMessage() + " controlled by " + opponent.getLogName());
                 ability.addTarget(newTarget);
             }
         }

--- a/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/EachOpponentPermanentTargetsAdjuster.java
@@ -13,25 +13,28 @@ import java.util.UUID;
 /**
  * @author notgreat
  */
-public enum EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
-    instance;
-
+public class EachOpponentPermanentTargetsAdjuster implements TargetAdjuster {
+    private TargetPermanent blueprintTarget = null;
     /**
      * Duplicates the permanent target for each opponent.
      * Filtering of permanent's controllers will be handled inside, so
      * do not pass a blueprint target with a controller restriction filter/predicate.
      */
+    public EachOpponentPermanentTargetsAdjuster() {
+    }
 
     @Override
     public void adjustTargets(Ability ability, Game game) {
-        TargetPermanent oldTargetPermanent = (TargetPermanent) ability.getTargets().get(0);
+        if (blueprintTarget == null) {
+            blueprintTarget = (TargetPermanent) ability.getTargets().get(0).copy();
+        }
         ability.getTargets().clear();
         for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
             Player opponent = game.getPlayer(opponentId);
             if (opponent == null) {
                 continue;
             }
-            TargetPermanent newTarget = oldTargetPermanent.copy();
+            TargetPermanent newTarget = blueprintTarget.copy();
             Filter<Permanent> filter = newTarget.getFilter();
             filter.add(new ControllerIdPredicate(opponentId));
             if (newTarget.canChoose(ability.getControllerId(), ability, game)) {


### PR DESCRIPTION
When I made `EachOpponentPermanentTargetsAdjuster` I tried to keep the effects identical to the current implementations. However, those implementations were in fact bugged in some situations, namely when as a result of a "At the beginning" trigger which sets the target pointer if the ability doesn't have one.

By making the TargetAdjuster actually adjust a pre-existing target (as the other TargetAdjusters do), I can fix that bug. It also allows me to make it an `instance` like the other adjusters. My apologies for not realizing that in the initial implementation!

Also included are two small card fixes.