### PR TITLE
[REX] Implement Henry Wu, InGen Geneticist

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
+++ b/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
@@ -30,12 +30,6 @@ public final class HenryWuInGenGeneticist extends CardImpl {
         filterYourHumans.add(SubType.HUMAN.getPredicate());
     }
 
-    public static final FilterPermanent filterNonHumans = new FilterCreaturePermanent("non-Human creature");
-
-    static {
-        filterNonHumans.add(Predicates.not(SubType.HUMAN.getPredicate()));
-    }
-
     public HenryWuInGenGeneticist(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{B}{G}{U}");
         
@@ -50,7 +44,7 @@ public final class HenryWuInGenGeneticist extends CardImpl {
                 new ExploitAbility(), Duration.WhileOnBattlefield, filterYourHumans)));
 
         // Whenever a creature you control exploits a non-Human creature, draw a card. If the exploited creature had power 3 or greater, create a Treasure token.
-        this.addAbility(new HenryWuInGenGeneticistTriggeredAbility(filterNonHumans));
+        this.addAbility(new HenryWuInGenGeneticistTriggeredAbility());
     }
 
     private HenryWuInGenGeneticist(final HenryWuInGenGeneticist card) {
@@ -66,18 +60,20 @@ public final class HenryWuInGenGeneticist extends CardImpl {
 // Based on ColonelAutumnTriggeredAbility
 class HenryWuInGenGeneticistTriggeredAbility extends TriggeredAbilityImpl {
 
-    private final FilterPermanent filter;
+    public static final FilterPermanent filterNonHumans = new FilterCreaturePermanent("non-Human creature");
 
-    HenryWuInGenGeneticistTriggeredAbility(FilterPermanent filter) {
+    static {
+        filterNonHumans.add(Predicates.not(SubType.HUMAN.getPredicate()));
+    }
+
+    HenryWuInGenGeneticistTriggeredAbility() {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1));
 //        this.addEffect(new ConditionalOneShotEffect());
-        this.filter = filter;
-        setTriggerPhrase("Whenever a creature you control exploits a " + this.filter.getMessage());
+        setTriggerPhrase("Whenever a creature you control exploits a " + filterNonHumans.getMessage());
     }
 
     private HenryWuInGenGeneticistTriggeredAbility(final HenryWuInGenGeneticistTriggeredAbility ability) {
         super(ability);
-        this.filter = ability.filter;
     }
 
     @Override
@@ -93,7 +89,7 @@ class HenryWuInGenGeneticistTriggeredAbility extends TriggeredAbilityImpl {
         return exploiter != null && exploited != null
                 && exploiter.isCreature(game)
                 && exploiter.isControlledBy(this.getControllerId())
-                && filter.match(exploited, game);
+                && filterNonHumans.match(exploited, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
+++ b/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
@@ -1,0 +1,103 @@
+package mage.cards.h;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.ExploitAbility;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author jimga150
+ */
+public final class HenryWuInGenGeneticist extends CardImpl {
+
+    public static final FilterPermanent filterYourHumans = new FilterCreaturePermanent("Human creatures you control");
+
+    static {
+        filterYourHumans.add(TargetController.YOU.getControllerPredicate());
+        filterYourHumans.add(SubType.HUMAN.getPredicate());
+    }
+
+    public static final FilterPermanent filterNonHumans = new FilterCreaturePermanent("non-Human creature");
+
+    static {
+        filterNonHumans.add(Predicates.not(SubType.HUMAN.getPredicate()));
+    }
+
+    public HenryWuInGenGeneticist(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{B}{G}{U}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SCIENTIST);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(4);
+
+        // Henry Wu, InGen Geneticist and other Human creatures you control have exploit.
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new GainAbilityControlledEffect(
+                new ExploitAbility(), Duration.WhileOnBattlefield, filterYourHumans)));
+
+        // Whenever a creature you control exploits a non-Human creature, draw a card. If the exploited creature had power 3 or greater, create a Treasure token.
+        this.addAbility(new HenryWuInGenGeneticistTriggeredAbility(filterNonHumans));
+    }
+
+    private HenryWuInGenGeneticist(final HenryWuInGenGeneticist card) {
+        super(card);
+    }
+
+    @Override
+    public HenryWuInGenGeneticist copy() {
+        return new HenryWuInGenGeneticist(this);
+    }
+}
+
+// Based on ColonelAutumnTriggeredAbility
+class HenryWuInGenGeneticistTriggeredAbility extends TriggeredAbilityImpl {
+
+    private final FilterPermanent filter;
+
+    HenryWuInGenGeneticistTriggeredAbility(FilterPermanent filter) {
+        super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1));
+//        this.addEffect(new ConditionalOneShotEffect());
+        this.filter = filter;
+        setTriggerPhrase("Whenever a creature you control exploits a " + this.filter.getMessage());
+    }
+
+    private HenryWuInGenGeneticistTriggeredAbility(final HenryWuInGenGeneticistTriggeredAbility ability) {
+        super(ability);
+        this.filter = ability.filter;
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.EXPLOITED_CREATURE;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        Permanent exploiter = game.getPermanentOrLKIBattlefield(event.getSourceId());
+        Permanent exploited = game.getPermanentOrLKIBattlefield(event.getTargetId());
+
+        return exploiter != null && exploited != null
+                && exploiter.isCreature(game)
+                && exploiter.isControlledBy(this.getControllerId())
+                && filter.match(exploited, game);
+    }
+
+    @Override
+    public HenryWuInGenGeneticistTriggeredAbility copy() {
+        return new HenryWuInGenGeneticistTriggeredAbility(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
+++ b/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
@@ -94,7 +94,7 @@ class HenryWuInGenGeneticistTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
 
-        getEffects().setTargetPointer(new FixedTarget(exploited.getId()));
+        getEffects().setTargetPointer(new FixedTarget(exploited.getId(), game));
 
         return exploiter.isCreature(game)
                 && exploiter.isControlledBy(this.getControllerId())
@@ -125,7 +125,7 @@ class HenryWuInGenGeneticistEffect extends CreateTokenEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent exploited = game.getPermanentOrLKIBattlefield(getTargetPointer().getFirst(game, source));
+        Permanent exploited = getTargetPointer().getFirstTargetPermanentOrLKI(game, source);
         if (exploited == null || exploited.getPower().getValue() < 3){
             return false;
         }

--- a/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
+++ b/Mage.Sets/src/mage/cards/h/HenryWuInGenGeneticist.java
@@ -89,7 +89,7 @@ class HenryWuInGenGeneticistTriggeredAbility extends TriggeredAbilityImpl {
         return exploiter != null && exploited != null
                 && exploiter.isCreature(game)
                 && exploiter.isControlledBy(this.getControllerId())
-                && filterNonHumans.match(exploited, game);
+                && filterNonHumans.match(exploited, getControllerId(), this, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/sets/JurassicWorldCollection.java
+++ b/Mage.Sets/src/mage/sets/JurassicWorldCollection.java
@@ -27,6 +27,7 @@ public final class JurassicWorldCollection extends ExpansionSet {
         cards.add(new SetCardInfo("Ellie and Alan, Paleontologists", 10, Rarity.RARE, mage.cards.e.EllieAndAlanPaleontologists.class));
         cards.add(new SetCardInfo("Forest", 25, Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Forest", "25b", Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Henry Wu, InGen Geneticist", 12, Rarity.RARE, mage.cards.h.HenryWuInGenGeneticist.class));
         cards.add(new SetCardInfo("Hunting Velociraptor", 4, Rarity.RARE, mage.cards.h.HuntingVelociraptor.class));
         cards.add(new SetCardInfo("Island", 22, Rarity.LAND, mage.cards.basiclands.Island.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Island", "22b", Rarity.LAND, mage.cards.basiclands.Island.class, FULL_ART_BFZ_VARIOUS));


### PR DESCRIPTION
#11240
I don't see a useful example of how to create a condition that tracks if the triggered ability's event targeted a creature matching the power condition. I'm currently trying to implement this by adding a `ConditionalOneShotEffect`, but maybe there's a better way of doing it?