### PR TITLE
Clean play|cast difference.

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AminatousAugury.java
+++ b/Mage.Sets/src/mage/cards/a/AminatousAugury.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author credman0
  */
 public class AminatousAugury extends CardImpl {
@@ -129,7 +128,7 @@ class AminatousAuguryEffect extends OneShotEffect {
 class AminatousAuguryCastFromExileEffect extends AsThoughEffectImpl {
 
     AminatousAuguryCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.PlayForFree);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.PlayForFree);
         staticText = "Cast this card without paying its mana cost";
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArvinoxTheMindFlail.java
+++ b/Mage.Sets/src/mage/cards/a/ArvinoxTheMindFlail.java
@@ -119,7 +119,7 @@ class ArvinoxTheMindFlailExileEffect extends OneShotEffect {
 class ArvinoxTheMindFlailCastFromExileEffect extends AsThoughEffectImpl {
 
     ArvinoxTheMindFlailCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
     }
 
     private ArvinoxTheMindFlailCastFromExileEffect(final ArvinoxTheMindFlailCastFromExileEffect effect) {

--- a/Mage.Sets/src/mage/cards/a/AssembleThePlayers.java
+++ b/Mage.Sets/src/mage/cards/a/AssembleThePlayers.java
@@ -56,7 +56,7 @@ public final class AssembleThePlayers extends CardImpl {
 class AssembleThePlayersPlayTopEffect extends AsThoughEffectImpl {
 
     AssembleThePlayersPlayTopEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "Once each turn, you may cast a creature spell with power 2 or less from the top of your library";
     }
 

--- a/Mage.Sets/src/mage/cards/a/AuthorOfShadows.java
+++ b/Mage.Sets/src/mage/cards/a/AuthorOfShadows.java
@@ -100,7 +100,7 @@ class AuthorOfShadowsEffect extends OneShotEffect {
         ExileZone exileZone = game.getExile().createZone(exileZoneId, exileZoneName);
         game.getExile().moveToAnotherZone(card, game, exileZone);
 
-        CardUtil.makeCardPlayable(game, source, card, Duration.Custom, true);
+        CardUtil.makeCardPlayable(game, source, card, true, Duration.Custom, true);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BosiumStrip.java
+++ b/Mage.Sets/src/mage/cards/b/BosiumStrip.java
@@ -1,7 +1,6 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -12,11 +11,7 @@ import mage.abilities.keyword.FlashbackAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -24,8 +19,9 @@ import mage.game.events.ZoneChangeEvent;
 import mage.players.Player;
 import mage.watchers.common.CastFromGraveyardWatcher;
 
+import java.util.UUID;
+
 /**
- *
  * @author spjspj & L_J
  */
 public final class BosiumStrip extends CardImpl {
@@ -53,7 +49,7 @@ public final class BosiumStrip extends CardImpl {
 class BosiumStripCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     BosiumStripCastFromGraveyardEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "Until end of turn, if the top card of your graveyard is an instant or sorcery card, you may cast that card";
     }
 

--- a/Mage.Sets/src/mage/cards/b/BrainstealerDragon.java
+++ b/Mage.Sets/src/mage/cards/b/BrainstealerDragon.java
@@ -98,7 +98,7 @@ class BrainstealerDragonExileEffect extends OneShotEffect {
         player.moveCards(cards, Zone.EXILED, source, game);
         for (Card card : cards.getCards(game)) {
             CardUtil.makeCardPlayable(
-                    game, source, card, Duration.Custom, true,
+                    game, source, card, false, Duration.Custom, true,
                     source.getControllerId(), null
             );
         }

--- a/Mage.Sets/src/mage/cards/b/BreechesBrazenPlunderer.java
+++ b/Mage.Sets/src/mage/cards/b/BreechesBrazenPlunderer.java
@@ -143,7 +143,7 @@ class BreechesBrazenPlundererEffect extends OneShotEffect {
             return false;
         }
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CaseOfTheBurningMasks.java
+++ b/Mage.Sets/src/mage/cards/c/CaseOfTheBurningMasks.java
@@ -1,12 +1,5 @@
 package mage.cards.c;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.common.CaseAbility;
@@ -18,17 +11,8 @@ import mage.abilities.decorator.ConditionalActivatedAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.hint.common.CaseSolvedHint;
-import mage.cards.Card;
-import mage.cards.Cards;
-import mage.cards.CardsImpl;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.WatcherScope;
-import mage.constants.Zone;
+import mage.cards.*;
+import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
@@ -38,6 +22,8 @@ import mage.target.common.TargetCardInExile;
 import mage.target.common.TargetOpponentsCreaturePermanent;
 import mage.util.CardUtil;
 import mage.watchers.Watcher;
+
+import java.util.*;
 
 /**
  * Case of the Burning Masks {1}{R}{R}
@@ -64,7 +50,7 @@ public final class CaseOfTheBurningMasks extends CardImpl {
                 new SacrificeSourceCost().setText("sacrifice this Case"), SolvedSourceCondition.SOLVED);
 
         this.addAbility(new CaseAbility(initialAbility, CaseOfTheBurningMasksCondition.instance, solvedAbility)
-                .addHint(new CaseOfTheBurningMasksHint()),
+                        .addHint(new CaseOfTheBurningMasksHint()),
                 new CaseOfTheBurningMasksWatcher());
     }
 
@@ -189,7 +175,7 @@ class CaseOfTheBurningMasksEffect extends OneShotEffect {
                 card = game.getCard(target.getFirstTarget());
         }
         if (card != null) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CavesOfChaosAdventurer.java
+++ b/Mage.Sets/src/mage/cards/c/CavesOfChaosAdventurer.java
@@ -90,7 +90,7 @@ class CavesOfChaosAdventurerEffect extends OneShotEffect {
                     Zone.EXILED, TargetController.YOU, Duration.EndOfTurn, true
             ).setTargetPointer(new FixedTarget(card, game)), source);
         } else {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/CemeteryIlluminator.java
+++ b/Mage.Sets/src/mage/cards/c/CemeteryIlluminator.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author weirddan455
  */
 public final class CemeteryIlluminator extends CardImpl {
@@ -53,7 +52,7 @@ public final class CemeteryIlluminator extends CardImpl {
 
         // Once each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with Cemetery Illuminator.
         this.addAbility(new SimpleStaticAbility(new CemeteryIlluminatorPlayTopEffect())
-                .setIdentifier(MageIdentifier.OnceEachTurnCastWatcher)
+                        .setIdentifier(MageIdentifier.OnceEachTurnCastWatcher)
                         .addHint(OnceEachTurnCastWatcher.getHint()),
                 new OnceEachTurnCastWatcher());
     }
@@ -106,7 +105,7 @@ class CemeteryIlluminatorExileEffect extends OneShotEffect {
 class CemeteryIlluminatorPlayTopEffect extends AsThoughEffectImpl {
 
     CemeteryIlluminatorPlayTopEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "Once each turn, you may cast a spell from the top of your library if it shares a card type with a card exiled with {this}";
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
+++ b/Mage.Sets/src/mage/cards/c/ChainerNightmareAdept.java
@@ -64,7 +64,7 @@ public final class ChainerNightmareAdept extends CardImpl {
 class ChainerNightmareAdeptContinuousEffect extends AsThoughEffectImpl {
 
     ChainerNightmareAdeptContinuousEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "you may cast a creature spell from your graveyard this turn";
     }
 
@@ -95,6 +95,7 @@ class ChainerNightmareAdeptContinuousEffect extends AsThoughEffectImpl {
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         throw new IllegalArgumentException("Wrong code usage: can't call applies method on empty affectedAbility");
     }
+
     @Override
     public boolean applies(UUID objectId, Ability affectedAbility, Ability source, Game game, UUID playerId) {
         ChainerNightmareAdeptWatcher watcher = game.getState().getWatcher(ChainerNightmareAdeptWatcher.class);

--- a/Mage.Sets/src/mage/cards/c/ChandraHopesBeacon.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraHopesBeacon.java
@@ -108,7 +108,7 @@ class ChandraHopesBeaconPlayEffect extends AsThoughEffectImpl {
     private final Set<MageObjectReference> morSet = new HashSet<>();
 
     ChandraHopesBeaconPlayEffect(Cards cards, Game game) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.UntilEndOfYourNextTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.UntilEndOfYourNextTurn, Outcome.Benefit);
         cards.stream()
                 .map(uuid -> new MageObjectReference(uuid, game))
                 .forEach(morSet::add);

--- a/Mage.Sets/src/mage/cards/c/ChandraLegacyOfFire.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraLegacyOfFire.java
@@ -142,7 +142,7 @@ class ChandraLegacyOfFireExileEffect extends OneShotEffect {
         Cards cards = new CardsImpl(player.getLibrary().getTopCards(game, count));
         player.moveCards(cards, Zone.EXILED, source, game);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
+++ b/Mage.Sets/src/mage/cards/c/ChissGoriaForgeTyrant.java
@@ -27,7 +27,7 @@ import java.util.*;
  * @author Xanderhall, xenohedron
  */
 public final class ChissGoriaForgeTyrant extends CardImpl {
-    
+
     public ChissGoriaForgeTyrant(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}{R}{R}{R}");
         this.supertype.add(SuperType.LEGENDARY);
@@ -105,7 +105,7 @@ class ChissGoriaForgeTyrantCanPlayEffect extends AsThoughEffectImpl {
     private final Set<MageObjectReference> morSet = new HashSet<>();
 
     ChissGoriaForgeTyrantCanPlayEffect(Set<MageObjectReference> morSet) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         this.morSet.addAll(morSet);
     }
 
@@ -131,10 +131,10 @@ class ChissGoriaForgeTyrantCanPlayEffect extends AsThoughEffectImpl {
         }
         UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId);
         Card card = game.getCard(objectIdToCast);
-        
+
         return (card != null && card.isArtifact(game)
-            && morSet.stream().anyMatch(mor -> mor.refersTo(objectIdToCast, game))
-            && ChissGoriaForgeTyrantWatcher.checkRef(source, morSet, game));
+                && morSet.stream().anyMatch(mor -> mor.refersTo(objectIdToCast, game))
+                && ChissGoriaForgeTyrantWatcher.checkRef(source, morSet, game));
     }
 }
 
@@ -159,10 +159,10 @@ class ChissGoriaForgeTyrantAffinityEffect extends ContinuousEffectImpl {
 
     @Override
     public boolean apply(Game game, Ability source) {
-         if (!ChissGoriaForgeTyrantWatcher.checkRef(source, morSet, game)) {
-             discard();
-             return false;
-         }
+        if (!ChissGoriaForgeTyrantWatcher.checkRef(source, morSet, game)) {
+            discard();
+            return false;
+        }
 
         for (Card card : game.getExile().getAllCardsByRange(game, source.getControllerId())) {
             if (morSet.contains(new MageObjectReference(card, game)) && card.isArtifact(game)) {

--- a/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
+++ b/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
@@ -28,14 +28,13 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author htrajan
  */
 public final class ConspiracyTheorist extends CardImpl {
 
     public ConspiracyTheorist(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{R}");
-        
+
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.SHAMAN);
         this.power = new MageInt(2);
@@ -43,7 +42,7 @@ public final class ConspiracyTheorist extends CardImpl {
 
         // Whenever Conspiracy Theorist attacks, you may pay {1} and discard a card. If you do, draw a card.
         this.addAbility(new AttacksTriggeredAbility(new DoIfCostPaid(new DrawCardSourceControllerEffect(1),
-            new CompositeCost(new ManaCostsImpl<>("{1}"), new DiscardCardCost(), "pay {1} and discard a card"))
+                new CompositeCost(new ManaCostsImpl<>("{1}"), new DiscardCardCost(), "pay {1} and discard a card"))
                 .setText("you may pay {1} and discard a card. If you do, draw a card"), false));
 
         // Whenever you discard one or more nonland cards, you may exile one of them from your graveyard. If you do, you may cast it this turn.
@@ -121,13 +120,13 @@ class ConspiracyTheoristEffect extends OneShotEffect {
             CardsImpl cards = new CardsImpl(discardedCards);
             TargetCard target = new TargetCard(Zone.GRAVEYARD, new FilterCard("card to exile"));
             boolean validTarget = cards.stream()
-                .anyMatch(card -> target.canTarget(card, game));
+                    .anyMatch(card -> target.canTarget(card, game));
             if (validTarget && controller.chooseUse(Outcome.Benefit, "Exile a card?", source, game)) {
                 if (controller.choose(Outcome.Benefit, cards, target, source, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);
                     if (card != null && controller.moveCards(card, Zone.EXILED, source, game)) {
                         // you may cast it this turn
-                        CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+                        CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, false);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/c/CourtOfLocthwain.java
+++ b/Mage.Sets/src/mage/cards/c/CourtOfLocthwain.java
@@ -107,7 +107,7 @@ class CourtOfLocthwainFirstEffect extends OneShotEffect {
 
         if (game.getState().getZone(card.getId()) == Zone.EXILED) {
             CardUtil.makeCardPlayable(
-                    game, source, card, Duration.EndOfGame,
+                    game, source, card, false, Duration.EndOfGame,
                     true, controller.getId(), null
             );
         }
@@ -160,7 +160,7 @@ class CourtOfLocthwainCastForFreeEffect extends AsThoughEffectImpl {
     private final MageObjectReference mor;
 
     public CourtOfLocthwainCastForFreeEffect(MageObjectReference mor) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         this.mor = mor;
     }
 

--- a/Mage.Sets/src/mage/cards/c/CovetousUrge.java
+++ b/Mage.Sets/src/mage/cards/c/CovetousUrge.java
@@ -91,7 +91,7 @@ class CovetousUrgeEffect extends OneShotEffect {
         if (card.getSpellAbility() == null) {
             return true;
         }
-        CardUtil.makeCardPlayable(game, source, card, Duration.Custom, true);
+        CardUtil.makeCardPlayable(game, source, card, true, Duration.Custom, true);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CunningRhetoric.java
+++ b/Mage.Sets/src/mage/cards/c/CunningRhetoric.java
@@ -115,7 +115,7 @@ class CunningRhetoricEffect extends OneShotEffect {
 
         UUID exileZoneId = CardUtil.getExileZoneId(game, sourceObject.getId(), sourceObject.getZoneChangeCounter(game));
         opponent.moveCardsToExile(card, source, game, true, exileZoneId, sourceObject.getIdName());
-        CardUtil.makeCardPlayable(game, source, card, Duration.Custom, true);
+        CardUtil.makeCardPlayable(game, source, card, false, Duration.Custom, true);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CurseOfHospitality.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfHospitality.java
@@ -160,7 +160,7 @@ class CurseOfHospitalityEffect extends OneShotEffect {
         if (player == null) {
             return true;
         }
-        CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true, player.getId(), null);
+        CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, true, player.getId(), null);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DaxosOfMeletis.java
+++ b/Mage.Sets/src/mage/cards/d/DaxosOfMeletis.java
@@ -90,7 +90,7 @@ class DaxosOfMeletisEffect extends OneShotEffect {
                     if (card.getSpellAbility() != null) {
                         // allow to cast the card
                         // and you may spend mana as though it were mana of any color to cast it
-                        CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+                        CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
                     }
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/d/DeadMansChest.java
+++ b/Mage.Sets/src/mage/cards/d/DeadMansChest.java
@@ -108,7 +108,7 @@ class DeadMansChestEffect extends OneShotEffect {
 class DeadMansChestCastFromExileEffect extends AsThoughEffectImpl {
 
     DeadMansChestCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "You may cast nonland cards from among them as long as they remain exiled";
     }
 

--- a/Mage.Sets/src/mage/cards/d/DecadentDragon.java
+++ b/Mage.Sets/src/mage/cards/d/DecadentDragon.java
@@ -107,7 +107,7 @@ class ExpensiveTasteEffect extends OneShotEffect {
                 }
                 exileZones.add(exileZoneId);
                 // allow to cast the card
-                CardUtil.makeCardPlayable(game, source, card, Duration.EndOfGame, false, controller.getId(), null);
+                CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfGame, false, controller.getId(), null);
                 // For as long as that card remains exiled, you may look at it
                 ContinuousEffect effect = new MayLookAtTargetCardEffect(controller.getId());
                 effect.setTargetPointer(new FixedTarget(card.getId(), game));

--- a/Mage.Sets/src/mage/cards/d/Demilich.java
+++ b/Mage.Sets/src/mage/cards/d/Demilich.java
@@ -29,7 +29,6 @@ import mage.watchers.common.SpellsCastWatcher;
 import java.util.UUID;
 
 /**
- *
  * @author weirddan455
  */
 public final class Demilich extends CardImpl {
@@ -98,7 +97,7 @@ enum DemilichValue implements DynamicValue {
 class DemilichPlayEffect extends AsThoughEffectImpl {
 
     DemilichPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         this.staticText = "You may cast {this} from your graveyard by exiling four instant and/or sorcery cards from your graveyard in addition to paying its other costs";
     }
 

--- a/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicEmbrace.java
@@ -72,7 +72,7 @@ public final class DemonicEmbrace extends CardImpl {
 class DemonicEmbracePlayEffect extends AsThoughEffectImpl {
 
     DemonicEmbracePlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard by paying 3 life and discarding a card in addition to paying its other costs";
     }
 

--- a/Mage.Sets/src/mage/cards/d/DireFleetDaredevil.java
+++ b/Mage.Sets/src/mage/cards/d/DireFleetDaredevil.java
@@ -92,7 +92,7 @@ class DireFleetDaredevilEffect extends OneShotEffect {
             Card card = game.getCard(targetCard.getId());
             if (card != null) {
                 // you may play and spend any mana
-                CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+                CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
                 // exile from graveyard
                 ContinuousEffect effect = new ThatSpellGraveyardExileReplacementEffect(false);
                 effect.setTargetPointer(new FixedTarget(card, game));

--- a/Mage.Sets/src/mage/cards/d/DraugrNecromancer.java
+++ b/Mage.Sets/src/mage/cards/d/DraugrNecromancer.java
@@ -102,7 +102,7 @@ class DraugrNecromancerReplacementEffect extends ReplacementEffectImpl {
 class DraugrNecromancerCastFromExileEffect extends AsThoughEffectImpl {
 
     DraugrNecromancerCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "You may cast spells from among cards in exile your opponents own with ice counters on them";
     }
 

--- a/Mage.Sets/src/mage/cards/e/EbondeathDracolich.java
+++ b/Mage.Sets/src/mage/cards/e/EbondeathDracolich.java
@@ -1,17 +1,16 @@
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.AsThoughEffectImpl;
-import mage.cards.Card;
-import mage.constants.*;
 import mage.abilities.keyword.FlashAbility;
 import mage.abilities.keyword.FlyingAbility;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.*;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.NamePredicate;
@@ -20,8 +19,9 @@ import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.watchers.Watcher;
 
+import java.util.UUID;
+
 /**
- *
  * @author weirddan455
  */
 public final class EbondeathDracolich extends CardImpl {
@@ -61,7 +61,7 @@ public final class EbondeathDracolich extends CardImpl {
 class EbondeathDracolichEffect extends AsThoughEffectImpl {
 
     EbondeathDracolichEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         this.staticText = "You may cast {this} from your graveyard if a creature not named Ebondeath, Dracolich died this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/e/EcstaticBeauty.java
+++ b/Mage.Sets/src/mage/cards/e/EcstaticBeauty.java
@@ -68,7 +68,7 @@ class EcstaticBeautyEffect extends OneShotEffect {
         Cards cards = new CardsImpl(player.getLibrary().getTopCards(game, 3));
         player.moveCards(cards, Zone.EXILED, source, game);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
             if (card.getAbilities(game).containsClass(SuspendAbility.class)) {
                 card.addCounters(CounterType.TIME.createInstance(4), source, game);
             }

--- a/Mage.Sets/src/mage/cards/e/ElderBrain.java
+++ b/Mage.Sets/src/mage/cards/e/ElderBrain.java
@@ -106,7 +106,7 @@ class ElderBrainEffect extends OneShotEffect {
         player.drawCards(cards.size(), source, game);
         for (Card card : cards.getCards(game)) {
             CardUtil.makeCardPlayable(
-                    game, source, card, Duration.Custom,
+                    game, source, card, false, Duration.Custom,
                     true, controller.getId(), null
             );
         }

--- a/Mage.Sets/src/mage/cards/e/ElkinBottle.java
+++ b/Mage.Sets/src/mage/cards/e/ElkinBottle.java
@@ -19,7 +19,6 @@ import mage.util.CardUtil;
 import java.util.UUID;
 
 /**
- *
  * @author L_J
  */
 public final class ElkinBottle extends CardImpl {
@@ -66,7 +65,7 @@ class ElkinBottleExileEffect extends OneShotEffect {
             Card card = controller.getLibrary().getFromTop(game);
             if (card != null) {
                 controller.moveCardsToExile(card, source, game, true, source.getSourceId(), CardUtil.createObjectRealtedWindowTitle(source, game, null));
-                CardUtil.makeCardPlayable(game, source, card, Duration.UntilYourNextUpkeepStep, false);
+                CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilYourNextUpkeepStep, false);
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/e/EmryLurkerOfTheLoch.java
+++ b/Mage.Sets/src/mage/cards/e/EmryLurkerOfTheLoch.java
@@ -63,7 +63,7 @@ public final class EmryLurkerOfTheLoch extends CardImpl {
 class EmryLurkerOfTheLochPlayEffect extends AsThoughEffectImpl {
 
     EmryLurkerOfTheLochPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "Choose target artifact card in your graveyard. You may cast that card this turn.";
     }
 

--- a/Mage.Sets/src/mage/cards/e/EruthTormentedProphet.java
+++ b/Mage.Sets/src/mage/cards/e/EruthTormentedProphet.java
@@ -70,7 +70,7 @@ class EruthTormentedProphetEffect extends ReplacementEffectImpl {
         Set<Card> cards = player.getLibrary().getTopCards(game, 2);
         player.moveCards(cards, Zone.EXILED, source, game);
         for (Card card : cards) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EternalScourge.java
+++ b/Mage.Sets/src/mage/cards/e/EternalScourge.java
@@ -16,7 +16,6 @@ import mage.game.Game;
 import java.util.UUID;
 
 /**
- *
  * @author fireshoes
  */
 public final class EternalScourge extends CardImpl {
@@ -49,7 +48,7 @@ public final class EternalScourge extends CardImpl {
 class EternalScourgePlayEffect extends AsThoughEffectImpl {
 
     EternalScourgePlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from exile";
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExtraordinaryJourney.java
+++ b/Mage.Sets/src/mage/cards/e/ExtraordinaryJourney.java
@@ -34,14 +34,13 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- *
  * @author Susucr
  */
 public final class ExtraordinaryJourney extends CardImpl {
 
     public ExtraordinaryJourney(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{X}{X}{U}{U}");
-        
+
 
         // When Extraordinary Journey enters the battlefield, exile up to X target creatures. For each of those cards, its owner may play it for as long as it remains exiled.
         Ability ability = new EntersBattlefieldTriggeredAbility(new ExtraordinaryJourneyEffect());
@@ -100,7 +99,7 @@ class ExtraordinaryJourneyEffect extends OneShotEffect {
 
         // exile up to X target creatures.
         Effect effect = new ExileTargetEffect().setTargetPointer(new FixedTargets(permanents, game));
-        if(!effect.apply(game, source)) {
+        if (!effect.apply(game, source)) {
             return false;
         }
         game.getState().applyEffects(game);
@@ -127,11 +126,11 @@ class ExtraordinaryJourneyEffect extends OneShotEffect {
             );
 
             ExileZone zone = game.getState().getExile().createZone(exileZoneId, exileZoneName);
-            for(Card card : cards) {
+            for (Card card : cards) {
                 if (card.getOwnerId().equals(owner.getId())) {
                     game.getExile().moveToAnotherZone(card, game, zone);
                     CardUtil.makeCardPlayable(
-                            game, source, card, Duration.Custom,
+                            game, source, card, false, Duration.Custom,
                             false, card.getOwnerId(), null
                     );
                 }
@@ -147,7 +146,7 @@ class ExtraordinaryJourneyTriggeredAbility extends TriggeredAbilityImpl {
     ExtraordinaryJourneyTriggeredAbility() {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1, "you"), false);
         setTriggerPhrase("Whenever one or more nontoken creatures enter the battlefield, "
-            + "if one or more of them entered from exile or was cast from exile, ");
+                + "if one or more of them entered from exile or was cast from exile, ");
         setTriggersOnceEachTurn(true);
     }
 
@@ -168,25 +167,25 @@ class ExtraordinaryJourneyTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         EntersTheBattlefieldEvent zEvent = (EntersTheBattlefieldEvent) event;
-        if(zEvent == null){
+        if (zEvent == null) {
             return false;
         }
 
         Permanent permanent = zEvent.getTarget();
-        if(permanent == null || !permanent.isCreature(game)) {
+        if (permanent == null || !permanent.isCreature(game)) {
             return false;
         }
 
         Zone fromZone = zEvent.getFromZone();
-        if(fromZone == Zone.EXILED) {
+        if (fromZone == Zone.EXILED) {
             // Directly from exile
             return true;
         }
 
-        if(fromZone == Zone.STACK) {
+        if (fromZone == Zone.STACK) {
             // Get spell in the stack.
             Spell spell = game.getSpellOrLKIStack(permanent.getId());
-            if(spell != null && spell.getFromZone() == Zone.EXILED) {
+            if (spell != null && spell.getFromZone() == Zone.EXILED) {
                 // Creature was cast from exile
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/f/FalcoSparaPactweaver.java
+++ b/Mage.Sets/src/mage/cards/f/FalcoSparaPactweaver.java
@@ -49,7 +49,7 @@ public final class FalcoSparaPactweaver extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.SHIELD.createInstance(1)),
                 "with a shield counter on it. <i>(If it would be dealt damage "
-                + "or destroyed, remove a shield counter from it instead.)</i>"
+                        + "or destroyed, remove a shield counter from it instead.)</i>"
         ));
 
         // You may look at the top card of your library any time.
@@ -75,7 +75,7 @@ public final class FalcoSparaPactweaver extends CardImpl {
 class FalcoSparaPactweaverEffect extends AsThoughEffectImpl {
 
     FalcoSparaPactweaverEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.AIDontUseIt);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.AIDontUseIt);
         staticText = "you may cast spells from the top of your library by removing "
                 + "a counter from a creature you control in addition to paying their other costs";
     }

--- a/Mage.Sets/src/mage/cards/f/FeldonRonomExcavator.java
+++ b/Mage.Sets/src/mage/cards/f/FeldonRonomExcavator.java
@@ -92,7 +92,7 @@ class FeldonRonomExcavatorEffect extends OneShotEffect {
                 card = game.getCard(target.getFirstTarget());
         }
         if (card != null) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.UntilEndOfYourNextTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilEndOfYourNextTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/f/FeralEncounter.java
+++ b/Mage.Sets/src/mage/cards/f/FeralEncounter.java
@@ -72,7 +72,7 @@ class FeralEncounterEffect extends LookLibraryAndPickControllerEffect {
         boolean result = putPickedCards.moveCards(player, pickedCards, source, game);
         pickedCards.retainZone(Zone.EXILED, game);
         for (Card card : pickedCards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, false);
         }
         result |= putLookedCards.moveCards(player, otherCards, source, game);
         return result;

--- a/Mage.Sets/src/mage/cards/f/FiendOfTheShadows.java
+++ b/Mage.Sets/src/mage/cards/f/FiendOfTheShadows.java
@@ -16,7 +16,6 @@ import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
-import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetDiscard;
 import mage.util.CardUtil;
 
@@ -89,7 +88,7 @@ class FiendOfTheShadowsEffect extends OneShotEffect {
                 card, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source),
                 source, game, Zone.HAND, true
         );
-        CardUtil.makeCardPlayable(game, source, card, Duration.Custom, false);
+        CardUtil.makeCardPlayable(game, source, card, false, Duration.Custom, false);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FiresOfMountDoom.java
+++ b/Mage.Sets/src/mage/cards/f/FiresOfMountDoom.java
@@ -25,23 +25,22 @@ import mage.util.CardUtil;
 import java.util.UUID;
 
 /**
- *
  * @author Susucr
  */
 public final class FiresOfMountDoom extends CardImpl {
 
     public FiresOfMountDoom(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{R}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
 
         // When Fires of Mount Doom enters the battlefield, it deals 2 damage to target creature
         // an opponent controls. Destroy all Equipment attached to that creature.
         TriggeredAbility trigger = new EntersBattlefieldTriggeredAbility(new DamageTargetEffect(2));
         trigger.addEffect(
-            new DestroyAllAttachedToTargetEffect(
-                StaticFilters.FILTER_PERMANENT_EQUIPMENT,
-                "that creature")
+                new DestroyAllAttachedToTargetEffect(
+                        StaticFilters.FILTER_PERMANENT_EQUIPMENT,
+                        "that creature")
         );
         trigger.addTarget(new TargetOpponentsCreaturePermanent());
         this.addAbility(trigger);
@@ -49,9 +48,9 @@ public final class FiresOfMountDoom extends CardImpl {
         // {2}{R}: Exile the top card of your library. You may play that card this turn.
         // When you play a card this way, Fires of Mount Doom deals 2 damage to each player.
         this.addAbility(new SimpleActivatedAbility(
-            Zone.BATTLEFIELD,
-            new FiresOfMountDoomEffect(),
-            new ManaCostsImpl<>("{2}{R}")));
+                Zone.BATTLEFIELD,
+                new FiresOfMountDoomEffect(),
+                new ManaCostsImpl<>("{2}{R}")));
     }
 
     private FiresOfMountDoom(final FiresOfMountDoom card) {
@@ -69,7 +68,7 @@ class FiresOfMountDoomEffect extends OneShotEffect {
     FiresOfMountDoomEffect() {
         super(Outcome.Benefit);
         this.staticText = "exile the top card of your library. You may play that card this turn. " +
-            "When you play a card this way, Fires of Mount Doom deals 2 damage to each player";
+                "When you play a card this way, Fires of Mount Doom deals 2 damage to each player";
     }
 
     private FiresOfMountDoomEffect(final FiresOfMountDoomEffect effect) {
@@ -85,7 +84,7 @@ class FiresOfMountDoomEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = game.getObject(source);
-        if(controller == null || sourceObject == null){
+        if (controller == null || sourceObject == null) {
             return false;
         }
 
@@ -95,7 +94,7 @@ class FiresOfMountDoomEffect extends OneShotEffect {
         }
 
         controller.moveCardsToExile(card, source, game, true, source.getSourceId(), sourceObject.getIdName());
-        CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+        CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         game.addDelayedTriggeredAbility(new FiresOfMountDoomDelayedTriggeredAbility(card.getId()), source);
         return true;
     }
@@ -129,7 +128,7 @@ class FiresOfMountDoomDelayedTriggeredAbility extends DelayedTriggeredAbility {
     public boolean checkEventType(GameEvent event, Game game) {
         GameEvent.EventType type = event.getType();
         return type == GameEvent.EventType.PLAY_LAND
-            || type == GameEvent.EventType.SPELL_CAST;
+                || type == GameEvent.EventType.SPELL_CAST;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/g/GalesRedirection.java
+++ b/Mage.Sets/src/mage/cards/g/GalesRedirection.java
@@ -86,10 +86,10 @@ class GalesRedirectionEffect extends RollDieWithResultTableEffect {
         }
         if (result >= 15) {
             game.addEffect(new PlayFromNotOwnHandZoneTargetEffect(
-                    Zone.EXILED, TargetController.YOU, Duration.Custom, true
+                    Zone.EXILED, TargetController.YOU, Duration.Custom, true, true
             ).setTargetPointer(new FixedTarget(card, game)), source);
         } else if (result >= 1) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.Custom, true);
+            CardUtil.makeCardPlayable(game, source, card, true, Duration.Custom, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseTheCosmos.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author jeffwadsworth
  */
 public class GlimpseTheCosmos extends CardImpl {
@@ -66,7 +65,7 @@ public class GlimpseTheCosmos extends CardImpl {
 class GlimpseTheCosmosPlayEffect extends AsThoughEffectImpl {
 
     GlimpseTheCosmosPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "As long as you control a Giant, you may cast {this} from your graveyard by paying {U} rather than paying its mana cost";
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinResearcher.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinResearcher.java
@@ -74,7 +74,7 @@ class GoblinResearcherEffect extends OneShotEffect {
         }
         player.moveCards(card, Zone.EXILED, source, game);
         CardUtil.makeCardPlayable(
-                game, source, card, Duration.Custom, false,
+                game, source, card, false, Duration.Custom, false,
                 source.getControllerId(), GoblinResearcherCondition.instance
         );
         return true;

--- a/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
+++ b/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
@@ -4,25 +4,18 @@ import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
-import mage.abilities.effects.AsThoughEffectImpl;
-import mage.abilities.effects.AsThoughManaEffect;
-import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.ExileFaceDownYouMayCastAsLongAsExiledEffect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.asthought.MayLookAtTargetCardEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.cards.*;
 import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.game.Game;
-import mage.players.ManaPoolItem;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetOpponent;
 import mage.target.targetpointer.FixedTarget;
-import mage.util.CardUtil;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -61,8 +54,6 @@ public final class GontiLordOfLuxury extends CardImpl {
 
 class GontiLordOfLuxuryEffect extends OneShotEffect {
 
-    private static final String VALUE_PREFIX = "ExileZones";
-
     public GontiLordOfLuxuryEffect() {
         super(Outcome.Benefit);
         this.staticText = "look at the top four cards of target opponent's library, exile one of them face down, then put the rest on the bottom of that library in a random order. You may look at and cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any type to cast that spell";
@@ -90,126 +81,14 @@ class GontiLordOfLuxuryEffect extends OneShotEffect {
         TargetCard target = new TargetCard(Zone.LIBRARY, new FilterCard("card to exile"));
         controller.choose(outcome, topCards, target, source, game);
         Card card = game.getCard(target.getFirstTarget());
-        if (card == null) {
-            controller.putCardsOnBottomOfLibrary(topCards, game, source, false);
-            return true;
+        if (card != null) {
+            new ExileFaceDownYouMayCastAsLongAsExiledEffect(true, CastManaAdjustment.AS_THOUGH_ANY_MANA_TYPE)
+                    .setTargetPointer(new FixedTarget(card, game))
+                    .apply(game, source);
         }
-        topCards.remove(card);
-        // move card to exile
-        UUID exileZoneId = CardUtil.getExileZoneId(game, source.getSourceId(), source.getSourceObjectZoneChangeCounter());
-        card.setFaceDown(true, game);
-        if (controller.moveCardsToExile(card, source, game, false, exileZoneId, sourceObject.getIdName())) {
-            card.setFaceDown(true, game);
-            Set<UUID> exileZones = (Set<UUID>) game.getState().getValue(VALUE_PREFIX + source.getSourceId().toString());
-            if (exileZones == null) {
-                exileZones = new HashSet<>();
-                game.getState().setValue(VALUE_PREFIX + source.getSourceId().toString(), exileZones);
-            }
-            exileZones.add(exileZoneId);
-            // allow to cast the card
-            ContinuousEffect effect = new GontiLordOfLuxuryCastFromExileEffect();
-            effect.setTargetPointer(new FixedTarget(card.getId(), game));
-            game.addEffect(effect, source);
-            // and you may spend mana as though it were mana of any color to cast it
-            effect = new GontiLordOfLuxurySpendAnyManaEffect();
-            effect.setTargetPointer(new FixedTarget(card.getId(), game));
-            game.addEffect(effect, source);
-            // For as long as that card remains exiled, you may look at it
-            effect = new MayLookAtTargetCardEffect(controller.getId());
-            effect.setTargetPointer(new FixedTarget(card.getId(), game));
-            game.addEffect(effect, source);
-        }
+        topCards.retainZone(Zone.LIBRARY, game);
         // then put the rest on the bottom of that library in a random order
         controller.putCardsOnBottomOfLibrary(topCards, game, source, false);
         return true;
-    }
-}
-
-class GontiLordOfLuxuryCastFromExileEffect extends AsThoughEffectImpl {
-
-    GontiLordOfLuxuryCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
-        staticText = "You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell";
-    }
-
-    private GontiLordOfLuxuryCastFromExileEffect(final GontiLordOfLuxuryCastFromExileEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
-    public GontiLordOfLuxuryCastFromExileEffect copy() {
-        return new GontiLordOfLuxuryCastFromExileEffect(this);
-    }
-
-    @Override
-    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        UUID targetId = getTargetPointer().getFirst(game, source);
-        if (targetId == null) {
-            this.discard(); // card is no longer in the origin zone, effect can be discarded
-            return false;
-        }
-        Card theCard = game.getCard(objectId);
-        if (theCard == null || theCard.isLand(game)) {
-            return false;
-        }
-        objectId = theCard.getMainCard().getId(); // for split cards
-
-        if (objectId.equals(targetId)
-                && affectedControllerId.equals(source.getControllerId())) {
-            Card card = game.getCard(objectId);
-            // TODO: Allow to cast Zoetic Cavern face down
-            return card != null;
-        }
-        return false;
-    }
-}
-
-class GontiLordOfLuxurySpendAnyManaEffect extends AsThoughEffectImpl implements AsThoughManaEffect {
-
-    public GontiLordOfLuxurySpendAnyManaEffect() {
-        super(AsThoughEffectType.SPEND_OTHER_MANA, Duration.Custom, Outcome.Benefit);
-        staticText = "you may spend mana as though it were mana of any color to cast it";
-    }
-
-    private GontiLordOfLuxurySpendAnyManaEffect(final GontiLordOfLuxurySpendAnyManaEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return true;
-    }
-
-    @Override
-    public GontiLordOfLuxurySpendAnyManaEffect copy() {
-        return new GontiLordOfLuxurySpendAnyManaEffect(this);
-    }
-
-    @Override
-    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        Card theCard = game.getCard(objectId);
-        if (theCard == null) {
-            return false;
-        }
-        objectId = theCard.getMainCard().getId(); // for split cards
-        if (objectId.equals(((FixedTarget) getTargetPointer()).getTarget())
-                && game.getState().getZoneChangeCounter(objectId) <= ((FixedTarget) getTargetPointer()).getZoneChangeCounter() + 1) {
-            // if the card moved from exile to spell the zone change counter is increased by 1 (effect must applies before and on stack, use isCheckPlayableMode?)
-            return source.isControlledBy(affectedControllerId);
-        } else if (((FixedTarget) getTargetPointer()).getTarget().equals(objectId)) {
-            // object has moved zone so effect can be discarded
-            this.discard();
-        }
-        return false;
-    }
-
-    @Override
-    public ManaType getAsThoughManaType(ManaType manaType, ManaPoolItem mana, UUID affectedControllerId, Ability source, Game game) {
-        return mana.getFirstAvailable();
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
+++ b/Mage.Sets/src/mage/cards/g/GontiLordOfLuxury.java
@@ -4,7 +4,7 @@ import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
-import mage.abilities.effects.ExileFaceDownYouMayCastAsLongAsExiledEffect;
+import mage.abilities.effects.ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.cards.*;
@@ -82,7 +82,7 @@ class GontiLordOfLuxuryEffect extends OneShotEffect {
         controller.choose(outcome, topCards, target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {
-            new ExileFaceDownYouMayCastAsLongAsExiledEffect(true, CastManaAdjustment.AS_THOUGH_ANY_MANA_TYPE)
+            new ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect(true, CastManaAdjustment.AS_THOUGH_ANY_MANA_TYPE)
                     .setTargetPointer(new FixedTarget(card, game))
                     .apply(game, source);
         }

--- a/Mage.Sets/src/mage/cards/g/Gravecrawler.java
+++ b/Mage.Sets/src/mage/cards/g/Gravecrawler.java
@@ -1,7 +1,6 @@
 
 package mage.cards.g;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.CantBlockAbility;
@@ -14,14 +13,15 @@ import mage.constants.*;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward
  */
 public final class Gravecrawler extends CardImpl {
 
     public Gravecrawler(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{B}");
         this.subtype.add(SubType.ZOMBIE);
 
         this.power = new MageInt(2);
@@ -54,7 +54,7 @@ class GravecrawlerPlayEffect extends AsThoughEffectImpl {
     }
 
     public GravecrawlerPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard as long as you control a Zombie";
     }
 

--- a/Mage.Sets/src/mage/cards/g/GrenzoHavocRaiser.java
+++ b/Mage.Sets/src/mage/cards/g/GrenzoHavocRaiser.java
@@ -152,7 +152,7 @@ class GrenzoHavocRaiserEffect extends OneShotEffect {
                     if (card.getSpellAbility() != null) {
                         // allow to cast the card
                         // and you may spend mana as though it were mana of any color to cast it
-                        CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+                        CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
                     }
                 }
                 return true;

--- a/Mage.Sets/src/mage/cards/g/GrinningTotem.java
+++ b/Mage.Sets/src/mage/cards/g/GrinningTotem.java
@@ -83,7 +83,7 @@ class GrinningTotemSearchAndExileEffect extends OneShotEffect {
         if (card != null) {
             UUID exileZoneId = CardUtil.getCardExileZoneId(game, source);
             you.moveCardsToExile(card, source, game, true, exileZoneId, CardUtil.getSourceName(game, source));
-            CardUtil.makeCardPlayable(game, source, card, Duration.UntilYourNextUpkeepStep, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilYourNextUpkeepStep, false);
             game.addDelayedTriggeredAbility(new GrinningTotemDelayedTriggeredAbility(exileZoneId), source);
         }
         targetOpponent.shuffleLibrary(source, game);

--- a/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
+++ b/Mage.Sets/src/mage/cards/h/HaakonStromgaldScourge.java
@@ -2,7 +2,6 @@
 
 package mage.cards.h;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DiesSourceTriggeredAbility;
@@ -17,14 +16,15 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 
+import java.util.UUID;
+
 /**
- *
  * @author Mainiack11
  */
 public final class HaakonStromgaldScourge extends CardImpl {
 
     public HaakonStromgaldScourge(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{B}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{B}{B}");
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.ZOMBIE);
         this.subtype.add(SubType.KNIGHT);
@@ -59,7 +59,7 @@ public final class HaakonStromgaldScourge extends CardImpl {
 class HaakonStromgaldScourgePlayEffect extends AsThoughEffectImpl {
 
     HaakonStromgaldScourgePlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard";
     }
 
@@ -103,12 +103,12 @@ class HaakonStromgaldScourgePlayEffect2 extends ContinuousRuleModifyingEffectImp
     public HaakonStromgaldScourgePlayEffect2 copy() {
         return new HaakonStromgaldScourgePlayEffect2(this);
     }
-    
+
     @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.CAST_SPELL;
     }
-    
+
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         Card card = game.getCard(event.getSourceId());
@@ -122,8 +122,8 @@ class HaakonStromgaldScourgePlayEffect2 extends ContinuousRuleModifyingEffectImp
 
 class HaakonPlayKnightsFromGraveyardEffect extends AsThoughEffectImpl {
 
-    public HaakonPlayKnightsFromGraveyardEffect () {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+    public HaakonPlayKnightsFromGraveyardEffect() {
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "As long as {this} is on the battlefield, you may cast Knight spells from your graveyard";
     }
 
@@ -142,7 +142,7 @@ class HaakonPlayKnightsFromGraveyardEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {       
+    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         if (affectedControllerId.equals(source.getControllerId())) {
             Card knightToCast = game.getCard(objectId);
             return knightToCast != null

--- a/Mage.Sets/src/mage/cards/h/HavengulLich.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulLich.java
@@ -1,6 +1,5 @@
 package mage.cards.h;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.ActivatedAbility;
@@ -13,14 +12,7 @@ import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
-import mage.constants.SubType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.common.FilterCreatureCard;
 import mage.game.Game;
@@ -28,8 +20,9 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCardInGraveyard;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward
  */
 public final class HavengulLich extends CardImpl {
@@ -66,7 +59,7 @@ public final class HavengulLich extends CardImpl {
 class HavengulLichPlayEffect extends AsThoughEffectImpl {
 
     HavengulLichPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "You may cast target creature card in a graveyard this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/h/HeadlinerScarlett.java
+++ b/Mage.Sets/src/mage/cards/h/HeadlinerScarlett.java
@@ -124,7 +124,7 @@ class HeadlinerScarlettExileEffect extends OneShotEffect {
         controller.moveCardsToExile(card, source, game, false, exileId, exileName);
         if (game.getState().getZone(card.getId()) == Zone.EXILED) {
             card.setFaceDown(true, game);
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
             ContinuousEffect effect = new HeadlinerScarlettLookEffect(controller.getId());
             effect.setTargetPointer(new FixedTarget(card, game));
             game.addEffect(effect, source);

--- a/Mage.Sets/src/mage/cards/h/HeartlessConscription.java
+++ b/Mage.Sets/src/mage/cards/h/HeartlessConscription.java
@@ -77,7 +77,7 @@ class HeartlessConscriptionEffect extends OneShotEffect {
         game.getState().processAction(game);
         cards.retainZone(Zone.EXILED, game);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfGame, true);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfGame, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/h/HedonistsTrove.java
+++ b/Mage.Sets/src/mage/cards/h/HedonistsTrove.java
@@ -123,7 +123,7 @@ class HedonistsTrovePlayLandEffect extends AsThoughEffectImpl {
 class HedonistsTroveCastNonlandCardsEffect extends AsThoughEffectImpl {
 
     HedonistsTroveCastNonlandCardsEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "You may cast spells from among cards exiled with {this}. "
                 + "You can't cast more than one spell this way each turn.";
     }

--- a/Mage.Sets/src/mage/cards/h/Helbrute.java
+++ b/Mage.Sets/src/mage/cards/h/Helbrute.java
@@ -62,7 +62,7 @@ class HelbruteEffect extends AsThoughEffectImpl {
     }
 
     public HelbruteEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         this.staticText = "you may cast {this} from your graveyard by exiling another " +
                 "creature card from your graveyard in addition to paying its other costs.";
     }

--- a/Mage.Sets/src/mage/cards/h/HoardingBroodlord.java
+++ b/Mage.Sets/src/mage/cards/h/HoardingBroodlord.java
@@ -95,7 +95,7 @@ class HoardingBroodlordEffect extends OneShotEffect {
         if (card != null) {
             player.moveCards(card, Zone.EXILED, source, game);
             card.setFaceDown(true, game);
-            CardUtil.makeCardPlayable(game, source, card, Duration.Custom, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.Custom, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/h/HostageTaker.java
+++ b/Mage.Sets/src/mage/cards/h/HostageTaker.java
@@ -91,7 +91,7 @@ class HostageTakerExileEffect extends OneShotEffect {
         UUID exileId = CardUtil.getCardExileZoneId(game, source);
         controller.moveCardToExileWithInfo(card, exileId, permanent.getIdName(), source, game, Zone.BATTLEFIELD, true);
         // allow to cast the card and you may spend mana as though it were mana of any color to cast it
-        CardUtil.makeCardPlayable(game, source, card, Duration.Custom, true);
+        CardUtil.makeCardPlayable(game, source, card, true, Duration.Custom, true);
         game.addDelayedTriggeredAbility(new OnLeaveReturnExiledAbility(), source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/i/IceCauldron.java
+++ b/Mage.Sets/src/mage/cards/i/IceCauldron.java
@@ -117,7 +117,7 @@ class IceCauldronExileEffect extends OneShotEffect {
 class IceCauldronCastFromExileEffect extends AsThoughEffectImpl {
 
     IceCauldronCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "You may cast that card for as long as it remains exiled";
     }
 

--- a/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
+++ b/Mage.Sets/src/mage/cards/i/IdolOfEndurance.java
@@ -159,7 +159,7 @@ class IdolOfEnduranceLeaveEffect extends OneShotEffect {
 class IdolOfEnduranceCastFromExileEffect extends AsThoughEffectImpl {
 
     IdolOfEnduranceCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "until end of turn, you may cast a creature spell from among cards exiled with {this} without paying its mana cost";
     }
 

--- a/Mage.Sets/src/mage/cards/i/IntellectDevourer.java
+++ b/Mage.Sets/src/mage/cards/i/IntellectDevourer.java
@@ -68,10 +68,14 @@ class IntellectDevourerExileEffect extends OneShotEffect {
         this.staticText = "each opponent exiles a card from their hand until {this} leaves the battlefield";
     }
 
-    private IntellectDevourerExileEffect(final IntellectDevourerExileEffect effect) {super(effect);}
+    private IntellectDevourerExileEffect(final IntellectDevourerExileEffect effect) {
+        super(effect);
+    }
 
     @Override
-    public IntellectDevourerExileEffect copy() {return new IntellectDevourerExileEffect(this);}
+    public IntellectDevourerExileEffect copy() {
+        return new IntellectDevourerExileEffect(this);
+    }
 
     @Override
     public boolean apply(Game game, Ability source) {
@@ -105,7 +109,7 @@ class IntellectDevourerExileEffect extends OneShotEffect {
         // Exile all chosen cards at the same time
         Player controller = game.getPlayer(source.getControllerId());
         MageObject sourceObject = source.getSourceObject(game);
-        if (controller == null|| sourceObject == null) {
+        if (controller == null || sourceObject == null) {
             return false;
         }
         UUID exileZoneId = CardUtil.getExileZoneId(game, sourceObject.getId(), sourceObject.getZoneChangeCounter(game));
@@ -120,7 +124,7 @@ class IntellectDevourerExileEffect extends OneShotEffect {
             opponent.moveCardsToExile(opponentCardsToExile.getCards(game), source, game, false, exileZoneId, sourceObject.getIdName());
             Card thisCard = opponentCardsToExile.getCards(game).iterator().next();
             game.getState().setValue(thisCard.getId().toString() + game.getState().getZoneChangeCounter(thisCard.getId()), exileZoneId);
-            CardUtil.makeCardPlayable(game, source, thisCard, Duration.Custom, true, source.getControllerId(), null);
+            CardUtil.makeCardPlayable(game, source, thisCard, false, Duration.Custom, true, source.getControllerId(), null);
             applied = true;
         }
 
@@ -136,10 +140,14 @@ class IntellectDevourerReturnCardsAbility extends DelayedTriggeredAbility {
         this.setRuleVisible(false);
     }
 
-    private IntellectDevourerReturnCardsAbility(final IntellectDevourerReturnCardsAbility ability) {super(ability);}
+    private IntellectDevourerReturnCardsAbility(final IntellectDevourerReturnCardsAbility ability) {
+        super(ability);
+    }
 
     @Override
-    public IntellectDevourerReturnCardsAbility copy() {return new IntellectDevourerReturnCardsAbility(this);}
+    public IntellectDevourerReturnCardsAbility copy() {
+        return new IntellectDevourerReturnCardsAbility(this);
+    }
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
@@ -165,10 +173,14 @@ class IntellectDevourerReturnExiledCardEffect extends OneShotEffect {
         this.staticText = "Return exiled cards to their owners' hands";
     }
 
-    private IntellectDevourerReturnExiledCardEffect(final IntellectDevourerReturnExiledCardEffect effect) {super(effect);}
+    private IntellectDevourerReturnExiledCardEffect(final IntellectDevourerReturnExiledCardEffect effect) {
+        super(effect);
+    }
 
     @Override
-    public IntellectDevourerReturnExiledCardEffect copy() {return new IntellectDevourerReturnExiledCardEffect(this);}
+    public IntellectDevourerReturnExiledCardEffect copy() {
+        return new IntellectDevourerReturnExiledCardEffect(this);
+    }
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/i/IntrepidPaleontologist.java
+++ b/Mage.Sets/src/mage/cards/i/IntrepidPaleontologist.java
@@ -29,7 +29,6 @@ import mage.watchers.Watcher;
 import java.util.UUID;
 
 /**
- *
  * @author notgreat
  */
 public final class IntrepidPaleontologist extends CardImpl {
@@ -70,7 +69,7 @@ public final class IntrepidPaleontologist extends CardImpl {
 class IntrepidPaleontologistPlayEffect extends AsThoughEffectImpl {
 
     IntrepidPaleontologistPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "You may cast Dinosaur creature spells from among cards you own exiled with {this}. If you cast a spell this way, that creature enters the battlefield with a finality counter on it.";
     }
 
@@ -94,7 +93,7 @@ class IntrepidPaleontologistPlayEffect extends AsThoughEffectImpl {
             Card card = game.getCard(objectId);
             MageObject sourceObject = game.getObject(source);
             if (card != null && sourceObject != null && affectedAbility instanceof SpellAbility) {
-                Card characteristics = ((SpellAbility)affectedAbility).getCharacteristics(game);
+                Card characteristics = ((SpellAbility) affectedAbility).getCharacteristics(game);
                 if (card.getOwnerId().equals(playerId) && characteristics.isCreature(game) && characteristics.hasSubtype(SubType.DINOSAUR, game)) {
                     UUID exileId = CardUtil.getExileZoneId(game, source.getSourceId(), sourceObject.getZoneChangeCounter(game));
                     ExileZone exileZone = game.getState().getExile().getExileZone(exileId);

--- a/Mage.Sets/src/mage/cards/i/InvasionOfKaldheim.java
+++ b/Mage.Sets/src/mage/cards/i/InvasionOfKaldheim.java
@@ -68,7 +68,7 @@ class InvasionOfKaldheimEffect extends OneShotEffect {
         player.moveCards(cards, Zone.EXILED, source, game);
         player.drawCards(cards.size(), source, game);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.UntilEndOfYourNextTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilEndOfYourNextTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/j/JayaFieryNegotiator.java
+++ b/Mage.Sets/src/mage/cards/j/JayaFieryNegotiator.java
@@ -108,7 +108,7 @@ class JayaFieryNegotiatorExileEffect extends OneShotEffect {
             player.moveCardsToExile(exileCards, source, game, true, CardUtil.getExileZoneId(game, source), "Jaya, Fiery Negotiator");
         }
         if (card != null) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/j/JohannApprenticeSorcerer.java
+++ b/Mage.Sets/src/mage/cards/j/JohannApprenticeSorcerer.java
@@ -58,7 +58,7 @@ public final class JohannApprenticeSorcerer extends CardImpl {
 class JohannApprenticeSorcererPlayTopEffect extends AsThoughEffectImpl {
 
     JohannApprenticeSorcererPlayTopEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "Once each turn, you may cast an instant or sorcery spell from the top of your library";
     }
 

--- a/Mage.Sets/src/mage/cards/k/KaylasMusicBox.java
+++ b/Mage.Sets/src/mage/cards/k/KaylasMusicBox.java
@@ -1,12 +1,5 @@
 package mage.cards.k;
 
-import java.util.UUID;
-import mage.constants.SuperType;
-import mage.game.ExileZone;
-import mage.game.Game;
-import mage.players.Player;
-import mage.target.targetpointer.FixedTarget;
-import mage.util.CardUtil;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -18,20 +11,23 @@ import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
+import mage.constants.*;
+import mage.game.ExileZone;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
+
+import java.util.UUID;
 
 /**
- *
  * @author Xanderhall
  */
 public final class KaylasMusicBox extends CardImpl {
 
     public KaylasMusicBox(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
 
         // {W}, {T}: Look at the top card of your library, then exile it face down.
@@ -163,7 +159,7 @@ class KaylasMusicBoxPlayFromExileEffect extends AsThoughEffectImpl {
         if (exileZone == null || !exileZone.contains(sourceId)) {
             return false;
         }
-        CardUtil.makeCardPlayable(game, source, exileZone.get(sourceId, game), Duration.EndOfTurn, false);
+        CardUtil.makeCardPlayable(game, source, exileZone.get(sourceId, game), false, Duration.EndOfTurn, false);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
+++ b/Mage.Sets/src/mage/cards/k/KessDissidentMage.java
@@ -60,7 +60,7 @@ public final class KessDissidentMage extends CardImpl {
 class KessDissidentMageCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     KessDissidentMageCastFromGraveyardEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "During each of your turns, you may cast an instant or sorcery card from your graveyard";
     }
 

--- a/Mage.Sets/src/mage/cards/k/KingNarfisBetrayal.java
+++ b/Mage.Sets/src/mage/cards/k/KingNarfisBetrayal.java
@@ -22,7 +22,6 @@ import mage.util.CardUtil;
 import java.util.UUID;
 
 /**
- *
  * @author varaghar
  */
 public final class KingNarfisBetrayal extends CardImpl {
@@ -146,7 +145,7 @@ class KingNarfisBetrayalSecondEffect extends OneShotEffect {
         ExileZone exileZone = game.getExile().getExileZone(CardUtil.getCardExileZoneId(game, source));
         if (exileZone != null) {
             for (Card card : exileZone.getCards(game)) {
-                CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+                CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
             }
         }
 

--- a/Mage.Sets/src/mage/cards/k/KorvoldAndTheNobleThief.java
+++ b/Mage.Sets/src/mage/cards/k/KorvoldAndTheNobleThief.java
@@ -96,7 +96,7 @@ class KorvoldAndTheNobleThiefEffect extends OneShotEffect {
         cards.retainZone(Zone.EXILED, game);
 
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/k/KotoseTheSilentSpider.java
+++ b/Mage.Sets/src/mage/cards/k/KotoseTheSilentSpider.java
@@ -129,7 +129,7 @@ class KotoseTheSilentSpiderEffect extends OneShotEffect {
         KotoseTheSilentSpiderWatcher.addCards(source, cardSet, game);
         for (Card exiledCard : cardSet) {
             CardUtil.makeCardPlayable(
-                    game, source, exiledCard, Duration.WhileControlled, true,
+                    game, source, exiledCard, false, Duration.WhileControlled, true,
                     null, new KotoseTheSilentSpiderCondition(exiledCard, game)
             );
         }

--- a/Mage.Sets/src/mage/cards/l/LaughingJasperFlint.java
+++ b/Mage.Sets/src/mage/cards/l/LaughingJasperFlint.java
@@ -112,7 +112,7 @@ class LaughingJasperFlintEffect extends OneShotEffect {
         }
         controller.moveCards(cards, Zone.EXILED, source, game);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+            CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LidlessGaze.java
+++ b/Mage.Sets/src/mage/cards/l/LidlessGaze.java
@@ -83,7 +83,7 @@ class LidlessGazeEffect extends OneShotEffect {
 
         cards.retainZone(Zone.EXILED, game);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn,
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn,
                     true, controller.getId(), null);
         }
 

--- a/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaUntouchedByDeath.java
@@ -95,7 +95,7 @@ class LilianaUntouchedByDeathEffect extends OneShotEffect {
 class LilianaUntouchedByDeathGraveyardEffect extends AsThoughEffectImpl {
 
     LilianaUntouchedByDeathGraveyardEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "You may cast Zombie cards from your graveyard this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/l/LukkaCoppercoatOutcast.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaCoppercoatOutcast.java
@@ -96,7 +96,7 @@ class LukkaCoppercoatOutcastCastEffect extends AsThoughEffectImpl {
     private static final FilterPermanent filter = new FilterPlaneswalkerPermanent(SubType.LUKKA);
 
     LukkaCoppercoatOutcastCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         this.staticText = "You may cast this card from exile as long as you control a Lukka planeswalker.";
     }
 

--- a/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
+++ b/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
@@ -52,7 +52,7 @@ public final class MaestrosAscendancy extends CardImpl {
 class MaestrosAscendancyCastEffect extends AsThoughEffectImpl {
 
     MaestrosAscendancyCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.AIDontUseIt);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.AIDontUseIt);
         staticText = "once during each of your turns, you may cast an instant or sorcery spell " +
                 "from your graveyard by sacrificing a creature in addition to paying its other costs.";
     }

--- a/Mage.Sets/src/mage/cards/m/MarangRiverProwler.java
+++ b/Mage.Sets/src/mage/cards/m/MarangRiverProwler.java
@@ -1,7 +1,6 @@
 
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
@@ -13,25 +12,21 @@ import mage.abilities.effects.common.combat.CantBlockSourceEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.game.Game;
 
+import java.util.UUID;
+
 /**
- *
  * @author emerald000
  */
 public final class MarangRiverProwler extends CardImpl {
 
     public MarangRiverProwler(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.ROGUE);
         this.power = new MageInt(2);
@@ -43,7 +38,7 @@ public final class MarangRiverProwler extends CardImpl {
         effect.setText("and can't be blocked");
         ability.addEffect(effect);
         this.addAbility(ability);
-        
+
         // You may cast Marang River Prowler from your graveyard as long as you control a black or green permanent.
         this.addAbility(new SimpleStaticAbility(Zone.GRAVEYARD, new MarangRiverProwlerCastEffect()));
     }
@@ -59,14 +54,15 @@ public final class MarangRiverProwler extends CardImpl {
 }
 
 class MarangRiverProwlerCastEffect extends AsThoughEffectImpl {
-    
+
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("a black or green permanent");
+
     static {
         filter.add(Predicates.or(new ColorPredicate(ObjectColor.BLACK), new ColorPredicate(ObjectColor.GREEN)));
     }
 
     MarangRiverProwlerCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard as long as you control a black or green permanent";
     }
 
@@ -88,7 +84,7 @@ class MarangRiverProwlerCastEffect extends AsThoughEffectImpl {
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         if (sourceId.equals(source.getSourceId())) {
             Card card = game.getCard(source.getSourceId());
-            if (card != null 
+            if (card != null
                     && card.isOwnedBy(affectedControllerId)
                     && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD
                     && game.getBattlefield().count(filter, source.getControllerId(), source, game) > 0) {

--- a/Mage.Sets/src/mage/cards/m/MarchOfRecklessJoy.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfRecklessJoy.java
@@ -90,7 +90,7 @@ class MarchOfRecklessJoyEffect extends OneShotEffect {
         );
         for (Card card : cards) {
             CardUtil.makeCardPlayable(
-                    game, source, card, Duration.UntilEndOfYourNextTurn,
+                    game, source, card, false, Duration.UntilEndOfYourNextTurn,
                     false, null, MarchOfRecklessJoyCondition.instance
             );
         }

--- a/Mage.Sets/src/mage/cards/m/MeTheImmortal.java
+++ b/Mage.Sets/src/mage/cards/m/MeTheImmortal.java
@@ -1,7 +1,5 @@
 package mage.cards.m;
 
-import java.util.UUID;
-
 import mage.MageIdentifier;
 import mage.MageInt;
 import mage.abilities.Ability;
@@ -17,9 +15,9 @@ import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.counter.AddCounterChoiceSourceEffect;
-import mage.constants.*;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.*;
 import mage.counters.Counter;
 import mage.counters.CounterType;
 import mage.counters.Counters;
@@ -30,15 +28,16 @@ import mage.game.events.ZoneChangeEvent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 
+import java.util.UUID;
+
 /**
- *
  * @author Skiwkr
  */
 public final class MeTheImmortal extends CardImpl {
 
     public MeTheImmortal(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{U}{R}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.ROGUE);
@@ -139,7 +138,7 @@ class MeTheImmortalEffect extends ReplacementEffectImpl {
 class MeTheImmortalCastEffect extends AsThoughEffectImpl {
 
     MeTheImmortalCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         this.staticText = "you may cast {this} from your graveyard " +
                 "by discarding two cards in addition to paying its other costs";
     }

--- a/Mage.Sets/src/mage/cards/m/MeetingOfTheFive.java
+++ b/Mage.Sets/src/mage/cards/m/MeetingOfTheFive.java
@@ -85,7 +85,7 @@ class MeetingOfTheFiveExileEffect extends OneShotEffect {
 class MeetingOfTheFiveCastEffect extends CanPlayCardControllerEffect {
 
     MeetingOfTheFiveCastEffect(Game game, Card card) {
-        super(game, card.getId(), card.getZoneChangeCounter(game), Duration.EndOfTurn);
+        super(game, card.getId(), card.getZoneChangeCounter(game), true, Duration.EndOfTurn);
     }
 
     private MeetingOfTheFiveCastEffect(final MeetingOfTheFiveCastEffect effect) {

--- a/Mage.Sets/src/mage/cards/m/MemoryVessel.java
+++ b/Mage.Sets/src/mage/cards/m/MemoryVessel.java
@@ -74,7 +74,7 @@ class MemoryVesselExileEffect extends OneShotEffect {
             player.moveCards(cards, Zone.EXILED, source, game);
             for (Card card : cards) {
                 CardUtil.makeCardPlayable(
-                        game, source, card, Duration.UntilYourNextTurn,
+                        game, source, card, false, Duration.UntilYourNextTurn,
                         false, playerId, null
                 );
             }

--- a/Mage.Sets/src/mage/cards/m/MezzioMugger.java
+++ b/Mage.Sets/src/mage/cards/m/MezzioMugger.java
@@ -85,7 +85,7 @@ class MezzioMuggerEffect extends OneShotEffect {
         }
         player.moveCards(cards, Zone.EXILED, source, game);
         for (Card card : cards) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/m/MishrasResearchDesk.java
+++ b/Mage.Sets/src/mage/cards/m/MishrasResearchDesk.java
@@ -92,7 +92,7 @@ class MishrasResearchDeskEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        CardUtil.makeCardPlayable(game, source, card, Duration.UntilEndOfYourNextTurn, false);
+        CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilEndOfYourNextTurn, false);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MisthollowGriffin.java
+++ b/Mage.Sets/src/mage/cards/m/MisthollowGriffin.java
@@ -1,7 +1,6 @@
 
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
@@ -10,16 +9,12 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
  */
 public final class MisthollowGriffin extends CardImpl {
@@ -50,7 +45,7 @@ public final class MisthollowGriffin extends CardImpl {
 class MisthollowGriffinPlayEffect extends AsThoughEffectImpl {
 
     MisthollowGriffinPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from exile";
     }
 

--- a/Mage.Sets/src/mage/cards/m/MnemonicBetrayal.java
+++ b/Mage.Sets/src/mage/cards/m/MnemonicBetrayal.java
@@ -91,7 +91,7 @@ class MnemonicBetrayalExileEffect extends OneShotEffect {
             if (card.isLand(game)) {
                 continue;
             }
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+            CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
         }
         cards.retainZone(Zone.EXILED, game);
         game.addDelayedTriggeredAbility(new MnemonicBetrayalDelayedTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/m/MonkClass.java
+++ b/Mage.Sets/src/mage/cards/m/MonkClass.java
@@ -125,7 +125,7 @@ class MonkClassEffect extends OneShotEffect {
 class MonkClassCastEffect extends AsThoughEffectImpl {
 
     MonkClassCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "you may cast this card from exile as long as you've cast another spell this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/n/NahirisWarcrafting.java
+++ b/Mage.Sets/src/mage/cards/n/NahirisWarcrafting.java
@@ -91,7 +91,7 @@ class NahirisWarcraftingEffect extends OneShotEffect {
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {
             player.moveCards(card, Zone.EXILED, source, game);
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         cards.retainZone(Zone.LIBRARY, game);
         player.putCardsOnBottomOfLibrary(cards, game, source, false);

--- a/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetEnlightenedMaster.java
@@ -1,7 +1,5 @@
 package mage.cards.n;
 
-import java.util.Set;
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
@@ -19,8 +17,10 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class NarsetEnlightenedMaster extends CardImpl {
@@ -94,7 +94,7 @@ class NarsetEnlightenedMasterExileEffect extends OneShotEffect {
 class NarsetEnlightenedMasterCastFromExileEffect extends AsThoughEffectImpl {
 
     NarsetEnlightenedMasterCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "Until end of turn, you may cast noncreature cards exiled with {this} this turn without paying their mana costs";
     }
 

--- a/Mage.Sets/src/mage/cards/n/NashiMoonSagesScion.java
+++ b/Mage.Sets/src/mage/cards/n/NashiMoonSagesScion.java
@@ -167,7 +167,7 @@ class NashiMoonSagesScionWatcher extends Watcher {
 class NashiMoonSagesScionPlayEffect extends CanPlayCardControllerEffect {
 
     NashiMoonSagesScionPlayEffect(Game game, Card card) {
-        super(game, card.getMainCard().getId(), card.getZoneChangeCounter(game), Duration.EndOfTurn);
+        super(game, card.getMainCard().getId(), card.getZoneChangeCounter(game), false, Duration.EndOfTurn);
     }
 
     private NashiMoonSagesScionPlayEffect(final NashiMoonSagesScionPlayEffect effect) {

--- a/Mage.Sets/src/mage/cards/n/NeyaliSunsVanguard.java
+++ b/Mage.Sets/src/mage/cards/n/NeyaliSunsVanguard.java
@@ -134,7 +134,7 @@ class NeyaliSunsVanguardEffect extends OneShotEffect {
         }
         player.moveCardsToExile(card, source, game, true, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source));
         CardUtil.makeCardPlayable(
-                game, source, card, Duration.Custom, false,
+                game, source, card, false, Duration.Custom, false,
                 source.getControllerId(), NeyaliSunsVanguardWatcher::checkPlayer
         );
         return true;

--- a/Mage.Sets/src/mage/cards/n/NivixAerieOfTheFiremind.java
+++ b/Mage.Sets/src/mage/cards/n/NivixAerieOfTheFiremind.java
@@ -1,7 +1,6 @@
 
 package mage.cards.n;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -13,19 +12,16 @@ import mage.abilities.mana.ColorlessManaAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.players.Library;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author emerald000
  */
 public final class NivixAerieOfTheFiremind extends CardImpl {
@@ -92,7 +88,7 @@ class NivixAerieOfTheFiremindEffect extends OneShotEffect {
 class NivixAerieOfTheFiremindCanCastEffect extends AsThoughEffectImpl {
 
     NivixAerieOfTheFiremindCanCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.UntilYourNextTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.UntilYourNextTurn, Outcome.Benefit);
         staticText = "Until your next turn, you may cast that card";
     }
 

--- a/Mage.Sets/src/mage/cards/o/OathswornVampire.java
+++ b/Mage.Sets/src/mage/cards/o/OathswornVampire.java
@@ -50,7 +50,7 @@ public final class OathswornVampire extends CardImpl {
 class OathswornVampirePlayEffect extends AsThoughEffectImpl {
 
     OathswornVampirePlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard if you gained life this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/o/OneWithTheMultiverse.java
+++ b/Mage.Sets/src/mage/cards/o/OneWithTheMultiverse.java
@@ -77,7 +77,7 @@ enum OneWithTheMultiverseCondition implements Condition {
 class OneWithTheMultiverseEffect extends AsThoughEffectImpl {
 
     OneWithTheMultiverseEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.PlayForFree);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.PlayForFree);
         staticText = "once during each of your turns, you may cast a spell from your hand " +
                 "or the top of your library without paying its mana cost.";
     }

--- a/Mage.Sets/src/mage/cards/o/OppositionAgent.java
+++ b/Mage.Sets/src/mage/cards/o/OppositionAgent.java
@@ -13,6 +13,7 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.LibrarySearchedEvent;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.util.CardUtil;
 
@@ -20,7 +21,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import mage.game.permanent.Permanent;
 
 /**
  * @author JayDi85
@@ -104,7 +104,7 @@ class OppositionAgentReplacementEffect extends ReplacementEffectImpl {
         // You may play those cards for as long as they remain exiled, and you may spend mana as though it were mana of any color to cast them
         for (Card card : cardsToExile) {
             // the source ability is tied to the effect so we need to keep it active to work correctly
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfGame, true);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfGame, true);
         }
 
         // return false all the time

--- a/Mage.Sets/src/mage/cards/o/OutrageousRobbery.java
+++ b/Mage.Sets/src/mage/cards/o/OutrageousRobbery.java
@@ -1,8 +1,5 @@
 package mage.cards.o;
 
-import java.util.Set;
-import java.util.UUID;
-
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffect;
@@ -20,8 +17,10 @@ import mage.target.common.TargetOpponent;
 import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
 
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author DominionSpy
  */
 public final class OutrageousRobbery extends CardImpl {
@@ -91,7 +90,7 @@ class OutrageousRobberyEffect extends OneShotEffect {
                 game.addEffect(effect, source);
 
                 CardUtil.makeCardPlayable(
-                        game, source, card, Duration.Custom, true,
+                        game, source, card, false, Duration.Custom, true,
                         source.getControllerId(), null);
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneswalkersMischief.java
@@ -95,7 +95,7 @@ class PlaneswalkersMischiefEffect extends OneShotEffect {
 class PlaneswalkersMischiefCastFromExileEffect extends AsThoughEffectImpl {
 
     PlaneswalkersMischiefCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "You may cast that card without paying its mana cost as long as it remains exiled";
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicIntrusion.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicIntrusion.java
@@ -124,7 +124,7 @@ class PsychicIntrusionExileEffect extends OneShotEffect {
 class PsychicIntrusionCastFromExileEffect extends AsThoughEffectImpl {
 
     PsychicIntrusionCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell";
     }
 

--- a/Mage.Sets/src/mage/cards/p/PsychicTheft.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicTheft.java
@@ -91,7 +91,7 @@ class PsychicTheftEffect extends OneShotEffect {
         }
         controller.moveCardToExileWithInfo(chosenCard, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source), source, game, Zone.HAND, true);
 
-        CardUtil.makeCardPlayable(game, source, chosenCard, Duration.Custom, false);
+        CardUtil.makeCardPlayable(game, source, chosenCard, true, Duration.Custom, false);
 
         game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(
                 new ConditionalOneShotEffect(

--- a/Mage.Sets/src/mage/cards/q/QuintoriusKand.java
+++ b/Mage.Sets/src/mage/cards/q/QuintoriusKand.java
@@ -89,7 +89,7 @@ class QuintoriusKandEffect extends OneShotEffect {
         player.moveCards(cards, Zone.EXILED, source, game);
         player.getManaPool().addMana(Mana.RedMana(cards.size()), game, source);
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
+++ b/Mage.Sets/src/mage/cards/r/RaffinesGuidance.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 public final class RaffinesGuidance extends CardImpl {
 
     public RaffinesGuidance(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{W}");
         this.subtype.add(SubType.AURA);
 
         // Enchant creature
@@ -58,7 +58,7 @@ public final class RaffinesGuidance extends CardImpl {
 class RafinnesGuidancePlayEffect extends AsThoughEffectImpl {
 
     RafinnesGuidancePlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard by paying {2}{W} rather than paying its mana cost.";
     }
 

--- a/Mage.Sets/src/mage/cards/r/RakdosTheMuscle.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosTheMuscle.java
@@ -112,7 +112,7 @@ class RakdosTheMuscleEffect extends OneShotEffect {
         // remove cards that could not be moved to exile
         cards.removeIf(card -> !Zone.EXILED.equals(game.getState().getZone(card.getId())));
         for (Card card : cards) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.UntilYourNextEndStep, true, controller.getId(), null);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilYourNextEndStep, true, controller.getId(), null);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RamirezDePietroPillager.java
+++ b/Mage.Sets/src/mage/cards/r/RamirezDePietroPillager.java
@@ -82,7 +82,7 @@ class RamirezDePietroPillagerEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.EXILED, source, game);
-        CardUtil.makeCardPlayable(game, source, card, Duration.Custom, false, source.getControllerId(), null);
+        CardUtil.makeCardPlayable(game, source, card, true, Duration.Custom, false, source.getControllerId(), null);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
+++ b/Mage.Sets/src/mage/cards/r/RisenExecutioner.java
@@ -1,8 +1,6 @@
 
 package mage.cards.r;
 
-import java.util.UUID;
-
 import mage.MageIdentifier;
 import mage.MageInt;
 import mage.abilities.Ability;
@@ -12,7 +10,6 @@ import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
-import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -21,12 +18,12 @@ import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
-import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2, Susucr
  */
 public final class RisenExecutioner extends CardImpl {
@@ -76,7 +73,7 @@ class RisenExecutionerCastEffect extends AsThoughEffectImpl {
     }
 
     RisenExecutionerCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard if you pay {1} more to cast it for each other creature card in your graveyard";
     }
 
@@ -100,14 +97,14 @@ class RisenExecutionerCastEffect extends AsThoughEffectImpl {
             return false;
         }
         Card card = game.getCard(source.getSourceId());
-        if(card == null
+        if (card == null
                 || !card.isOwnedBy(affectedControllerId)
                 || game.getState().getZone(source.getSourceId()) != Zone.GRAVEYARD) {
             return false;
         }
 
         Player controller = game.getPlayer(source.getControllerId());
-        if(controller == null) {
+        if (controller == null) {
             return false;
         }
         int costIncrease = controller.getGraveyard().count(filter, source.getControllerId(), source, game);

--- a/Mage.Sets/src/mage/cards/r/RoccoStreetChef.java
+++ b/Mage.Sets/src/mage/cards/r/RoccoStreetChef.java
@@ -15,7 +15,6 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.token.FoodToken;
-import mage.game.permanent.token.TreasureToken;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
 import mage.util.CardUtil;
@@ -85,7 +84,7 @@ class RoccoStreetChefEffect extends OneShotEffect {
             }
             player.moveCards(card, Zone.EXILED, source, game);
             CardUtil.makeCardPlayable(
-                    game, source, card, Duration.UntilYourNextEndStep,
+                    game, source, card, false, Duration.UntilYourNextEndStep,
                     false, playerId, null
             );
         }

--- a/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
+++ b/Mage.Sets/src/mage/cards/r/RonaDiscipleOfGix.java
@@ -1,7 +1,6 @@
 
 package mage.cards.r;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
@@ -16,21 +15,16 @@ import mage.abilities.effects.common.ExileTargetEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.common.FilterHistoricCard;
 import mage.game.ExileZone;
 import mage.game.Game;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class RonaDiscipleOfGix extends CardImpl {
@@ -79,7 +73,7 @@ public final class RonaDiscipleOfGix extends CardImpl {
 class RonaDiscipleOfGixPlayNonLandEffect extends AsThoughEffectImpl {
 
     RonaDiscipleOfGixPlayNonLandEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         staticText = "You may cast nonland cards exiled with {this}";
     }
 

--- a/Mage.Sets/src/mage/cards/r/RonaSheoldredsFaithful.java
+++ b/Mage.Sets/src/mage/cards/r/RonaSheoldredsFaithful.java
@@ -60,7 +60,7 @@ public final class RonaSheoldredsFaithful extends CardImpl {
 class RonaSheoldredsFaithfulEffect extends AsThoughEffectImpl {
 
     RonaSheoldredsFaithfulEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         this.staticText = "you may cast {this} from your graveyard " +
                 "by discarding two cards in addition to paying its other costs";
     }

--- a/Mage.Sets/src/mage/cards/r/RundveltHordemaster.java
+++ b/Mage.Sets/src/mage/cards/r/RundveltHordemaster.java
@@ -85,7 +85,7 @@ class RundveltHordemasterEffect extends OneShotEffect {
         }
         player.moveCards(card, Zone.EXILED, source, game);
         if (card.isCreature(game) && card.hasSubtype(SubType.GOBLIN, game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.UntilEndOfYourNextTurn, false);
+            CardUtil.makeCardPlayable(game, source, card, true, Duration.UntilEndOfYourNextTurn, false);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/ScourgeOfNelToth.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfNelToth.java
@@ -18,18 +18,16 @@ import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class ScourgeOfNelToth extends CardImpl {
 
     public ScourgeOfNelToth(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{B}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{B}{B}");
         this.subtype.add(SubType.ZOMBIE);
         this.subtype.add(SubType.DRAGON);
         this.power = new MageInt(6);
@@ -55,7 +53,7 @@ public final class ScourgeOfNelToth extends CardImpl {
 class ScourgeOfNelTothPlayEffect extends AsThoughEffectImpl {
 
     ScourgeOfNelTothPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard by paying {B}{B} and sacrificing two creatures rather than paying its mana cost";
     }
 

--- a/Mage.Sets/src/mage/cards/s/SerpentsSoulJar.java
+++ b/Mage.Sets/src/mage/cards/s/SerpentsSoulJar.java
@@ -93,7 +93,7 @@ class SerpentsSoulJarExileEffect extends OneShotEffect {
 class SerpentsSoulJarCastFromExileEffect extends AsThoughEffectImpl {
 
     SerpentsSoulJarCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "until end of turn, you may cast a creature spell from among cards exiled with {this}";
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShadowOfTheEnemy.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowOfTheEnemy.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author Susucr
  */
 public final class ShadowOfTheEnemy extends CardImpl {
@@ -52,8 +51,8 @@ class ShadowOfTheEnemyEffect extends OneShotEffect {
     ShadowOfTheEnemyEffect() {
         super(Outcome.Detriment);
         staticText = "Exile all creature cards from target player's graveyard. " +
-            "You may cast spells from among those cards for as long as " +
-            "they remain exiled, and mana of any type can be spent to cast them.";
+                "You may cast spells from among those cards for as long as " +
+                "they remain exiled, and mana of any type can be spent to cast them.";
     }
 
     private ShadowOfTheEnemyEffect(final ShadowOfTheEnemyEffect effect) {
@@ -70,16 +69,16 @@ class ShadowOfTheEnemyEffect extends OneShotEffect {
         Player player = game.getPlayer(source.getControllerId());
         MageObject sourceObject = source.getSourceObject(game);
         Player targetPlayer = game.getPlayer(source.getFirstTarget());
-        if(player == null || targetPlayer == null || sourceObject == null){
+        if (player == null || targetPlayer == null || sourceObject == null) {
             return false;
         }
 
         Set<Card> cards =
-            targetPlayer
-                .getGraveyard()
-                .getCards(StaticFilters.FILTER_CARD_CREATURE, game);
+                targetPlayer
+                        .getGraveyard()
+                        .getCards(StaticFilters.FILTER_CARD_CREATURE, game);
 
-        if(cards.isEmpty()){
+        if (cards.isEmpty()) {
             return true;
         }
 
@@ -101,7 +100,7 @@ class ShadowOfTheEnemyEffect extends OneShotEffect {
 class ShadowOfTheEnemyCastFromExileEffect extends AsThoughEffectImpl {
 
     ShadowOfTheEnemyCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "You may cast spells from among them as long as they remain exiled";
     }
 
@@ -133,7 +132,7 @@ class ShadowOfTheEnemyCastFromExileEffect extends AsThoughEffectImpl {
         objectId = theCard.getMainCard().getId(); // for split cards
 
         if (objectId.equals(cardId)
-            && affectedControllerId.equals(source.getControllerId())) {
+                && affectedControllerId.equals(source.getControllerId())) {
             Card card = game.getCard(objectId);
             return card != null;
         }
@@ -166,7 +165,7 @@ class ShadowOfTheEnemySpendManaEffect extends AsThoughEffectImpl implements AsTh
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
         objectId = CardUtil.getMainCardId(game, objectId); // for split cards
         if (objectId.equals(((FixedTarget) getTargetPointer()).getTarget())
-            && game.getState().getZoneChangeCounter(objectId) <= ((FixedTarget) getTargetPointer()).getZoneChangeCounter() + 1) {
+                && game.getState().getZoneChangeCounter(objectId) <= ((FixedTarget) getTargetPointer()).getZoneChangeCounter() + 1) {
             // if the card moved from exile to spell the zone change counter is increased by 1
             // (effect must applies before and on stack, use isCheckPlayableMode?)
             return source.isControlledBy(affectedControllerId);

--- a/Mage.Sets/src/mage/cards/s/SilasRennSeekerAdept.java
+++ b/Mage.Sets/src/mage/cards/s/SilasRennSeekerAdept.java
@@ -1,7 +1,6 @@
 
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
@@ -16,8 +15,9 @@ import mage.filter.common.FilterArtifactCard;
 import mage.game.Game;
 import mage.target.common.TargetCardInYourGraveyard;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class SilasRennSeekerAdept extends CardImpl {
@@ -56,7 +56,7 @@ public final class SilasRennSeekerAdept extends CardImpl {
 class SilasRennSeekerAdeptPlayEffect extends AsThoughEffectImpl {
 
     SilasRennSeekerAdeptPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "choose target artifact card in your graveyard. You may cast that card this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/s/SiphonInsight.java
+++ b/Mage.Sets/src/mage/cards/s/SiphonInsight.java
@@ -122,7 +122,7 @@ class SiphonInsightEffect extends OneShotEffect {
 class SiphonInsightCastFromExileEffect extends AsThoughEffectImpl {
 
     SiphonInsightCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "You may cast that card for as long as it remains exiled, and you may spend mana as though it were mana of any color to cast that spell";
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkyclaveShade.java
+++ b/Mage.Sets/src/mage/cards/s/SkyclaveShade.java
@@ -76,7 +76,7 @@ enum SkyclaveShadeCondition implements Condition {
 class SkyclaveShadeEffect extends AsThoughEffectImpl {
 
     SkyclaveShadeEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
     }
 
     private SkyclaveShadeEffect(final SkyclaveShadeEffect effect) {

--- a/Mage.Sets/src/mage/cards/s/SqueeDubiousMonarch.java
+++ b/Mage.Sets/src/mage/cards/s/SqueeDubiousMonarch.java
@@ -71,7 +71,7 @@ class SqueeDubiousMonarchEffect extends AsThoughEffectImpl {
     }
 
     public SqueeDubiousMonarchEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         this.staticText = "you may cast {this} from your graveyard by paying {3}{R} and exiling " +
                 "four other cards from your graveyard rather than paying its mana cost";
     }

--- a/Mage.Sets/src/mage/cards/s/SqueeTheImmortal.java
+++ b/Mage.Sets/src/mage/cards/s/SqueeTheImmortal.java
@@ -1,25 +1,19 @@
 
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.cards.Card;
-import mage.constants.SubType;
-import mage.constants.SuperType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public final class SqueeTheImmortal extends CardImpl {
@@ -49,7 +43,7 @@ public final class SqueeTheImmortal extends CardImpl {
 class SqueePlayEffect extends AsThoughEffectImpl {
 
     SqueePlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard or from exile";
     }
 

--- a/Mage.Sets/src/mage/cards/s/StolenStrategy.java
+++ b/Mage.Sets/src/mage/cards/s/StolenStrategy.java
@@ -78,7 +78,7 @@ class StolenStrategyEffect extends OneShotEffect {
                 if (!card.isLand(game) && card.getSpellAbility() != null) {
                     // allow to cast the card
                     // and you may spend mana as though it were mana of any color to cast it
-                    CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+                    CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/t/TavernBrawler.java
+++ b/Mage.Sets/src/mage/cards/t/TavernBrawler.java
@@ -75,7 +75,7 @@ class TavernBrawlerEffect extends OneShotEffect {
         }
         player.moveCards(card, Zone.EXILED, source, game);
         game.addEffect(new BoostSourceEffect(card.getManaValue(), 0, Duration.EndOfTurn), source);
-        CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, false);
+        CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfTurn, false);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TemporalAperture.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalAperture.java
@@ -1,6 +1,5 @@
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -8,21 +7,14 @@ import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.cards.Cards;
-import mage.cards.CardsImpl;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.cards.*;
+import mage.constants.*;
 import mage.game.Game;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
  */
 public final class TemporalAperture extends CardImpl {
@@ -90,7 +82,7 @@ class TemporalApertureTopCardCastEffect extends AsThoughEffectImpl {
     private final Card card;
 
     public TemporalApertureTopCardCastEffect(Card card) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         this.card = card;
         staticText = "Until end of turn, for as long as that card is on top "
                 + "of your library, you may cast it without paying its mana costs";

--- a/Mage.Sets/src/mage/cards/t/TenaciousUnderdog.java
+++ b/Mage.Sets/src/mage/cards/t/TenaciousUnderdog.java
@@ -48,7 +48,7 @@ public final class TenaciousUnderdog extends CardImpl {
 class TenaciousUnderdogEffect extends AsThoughEffectImpl {
 
     TenaciousUnderdogEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.PutCreatureInPlay);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.PutCreatureInPlay);
         staticText = "You may cast {this} from your graveyard using its blitz ability";
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGreatWork.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatWork.java
@@ -103,7 +103,7 @@ class TheGreatWorkEffect extends OneShotEffect {
 class TheGreatWorkCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     TheGreatWorkCastFromGraveyardEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "until end of turn, you may cast instant and sorcery spells from any graveyard";
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheIndomitable.java
+++ b/Mage.Sets/src/mage/cards/t/TheIndomitable.java
@@ -1,7 +1,5 @@
 package mage.cards.t;
 
-import java.util.UUID;
-
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DealsDamageToAPlayerAllTriggeredAbility;
@@ -13,19 +11,14 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SetTargetPointer;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.permanent.TappedPredicate;
 import mage.game.Game;
+
+import java.util.UUID;
 
 /**
  * @author jam736
@@ -33,7 +26,7 @@ import mage.game.Game;
 public final class TheIndomitable extends CardImpl {
 
     public TheIndomitable(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{2}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}{U}{U}");
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.VEHICLE);
         this.power = new MageInt(6);
@@ -67,18 +60,19 @@ public final class TheIndomitable extends CardImpl {
 }
 
 class TheIndomitableCastEffect extends AsThoughEffectImpl {
-    
+
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("three or more tapped pirates and/or vehicles");
+
     static {
         filter.add(TappedPredicate.TAPPED);
         filter.add(Predicates.or(
-            SubType.PIRATE.getPredicate(),
-            SubType.VEHICLE.getPredicate()
+                SubType.PIRATE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
         ));
     }
 
     TheIndomitableCastEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard as long as you control three or more tapped Pirates and/or Vehicles.";
     }
 
@@ -100,7 +94,7 @@ class TheIndomitableCastEffect extends AsThoughEffectImpl {
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         if (sourceId.equals(source.getSourceId())) {
             Card card = game.getCard(source.getSourceId());
-            if (card != null 
+            if (card != null
                     && card.isOwnedBy(affectedControllerId)
                     && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD
                     && game.getBattlefield().count(filter, source.getControllerId(), source, game) >= 3) {

--- a/Mage.Sets/src/mage/cards/t/TheTombOfAclazotz.java
+++ b/Mage.Sets/src/mage/cards/t/TheTombOfAclazotz.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- *
  * @author jeffwadsworth
  */
 public class TheTombOfAclazotz extends CardImpl {
@@ -68,7 +67,7 @@ public class TheTombOfAclazotz extends CardImpl {
 class TheTombOfAclazotzEffect extends AsThoughEffectImpl {
 
     TheTombOfAclazotzEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "You may cast a creature spell from your graveyard this turn. If you do, it enters the battlefield with a finality counter on it and is a Vampire in addition to its other types. <i>(If a creature with a finality counter on it would die, exile it instead.)</i>";
     }
 
@@ -134,15 +133,15 @@ class TheTombOfAclazotzWatcher extends Watcher {
             Card card = target.getCard();
             if (card != null) {
                 game.getState().addEffect(new AddCounterEnteringCreatureEffect(new MageObjectReference(target.getCard(), game),
-                        CounterType.FINALITY.createInstance(), Outcome.Neutral),
+                                CounterType.FINALITY.createInstance(), Outcome.Neutral),
                         target.getSpellAbility());
                 game.getState().addEffect(new AddSubtypeEnteringCreatureEffect(new MageObjectReference(target.getCard(), game), SubType.VAMPIRE, Outcome.Benefit), card.getSpellAbility());
                 // Rule 728.2 we must insure the effect is used (creature is cast successfully) before discarding the play effect
                 UUID playEffectId = this.getPlayFromAnywhereEffect();
                 if (playEffectId != null
-                        && game.getContinuousEffects().getApplicableAsThoughEffects(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, game).listIterator().next().getId().equals(playEffectId)) {
+                        && game.getContinuousEffects().getApplicableAsThoughEffects(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, game).listIterator().next().getId().equals(playEffectId)) {
                     // discard the play effect
-                    game.getContinuousEffects().getApplicableAsThoughEffects(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, game).listIterator().next().discard();
+                    game.getContinuousEffects().getApplicableAsThoughEffects(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, game).listIterator().next().discard();
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/t/ThiefOfSanity.java
+++ b/Mage.Sets/src/mage/cards/t/ThiefOfSanity.java
@@ -126,7 +126,7 @@ class ThiefOfSanityCastFromExileEffect extends AsThoughEffectImpl {
     private final UUID authorizedPlayerId;
 
     public ThiefOfSanityCastFromExileEffect(UUID authorizedPlayerId) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         this.authorizedPlayerId = authorizedPlayerId;
         staticText = "For as long as that card remains exiled, you may cast it";
     }

--- a/Mage.Sets/src/mage/cards/t/TobiasBeckett.java
+++ b/Mage.Sets/src/mage/cards/t/TobiasBeckett.java
@@ -83,7 +83,7 @@ class TobiasBeckettEffect extends OneShotEffect {
                         if (card.getSpellAbility() != null) {
                             // allow to cast the card
                             // and you may spend mana as though it were mana of any color to cast it
-                            CardUtil.makeCardPlayable(game, source, card, Duration.Custom, true);
+                            CardUtil.makeCardPlayable(game, source, card, true, Duration.Custom, true);
                         }
                     }
                     return true;

--- a/Mage.Sets/src/mage/cards/u/UrabraskHereticPraetor.java
+++ b/Mage.Sets/src/mage/cards/u/UrabraskHereticPraetor.java
@@ -89,7 +89,7 @@ class UrabraskHereticPraetorEffect extends ReplacementEffectImpl {
         if (card != null) {
             player.moveCards(card, Zone.EXILED, source, game);
             CardUtil.makeCardPlayable(
-                    game, source, card, Duration.EndOfTurn,
+                    game, source, card, false, Duration.EndOfTurn,
                     false, player.getId(), null
             );
         }

--- a/Mage.Sets/src/mage/cards/u/UvildaDeanOfPerfection.java
+++ b/Mage.Sets/src/mage/cards/u/UvildaDeanOfPerfection.java
@@ -296,7 +296,7 @@ class NassariDeanOfExpressionEffect extends OneShotEffect {
             return false;
         }
         for (Card card : cards.getCards(game)) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.EndOfTurn, true);
+            CardUtil.makeCardPlayable(game, source, card, true, Duration.EndOfTurn, true);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
+++ b/Mage.Sets/src/mage/cards/v/VancesBlastingCannons.java
@@ -1,8 +1,6 @@
 
 package mage.cards.v;
 
-import java.util.UUID;
-
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
@@ -14,19 +12,15 @@ import mage.abilities.keyword.TransformAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SuperType;
-import mage.constants.TargetController;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
 import mage.watchers.common.CastSpellLastTurnWatcher;
+
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -97,7 +91,7 @@ class VancesBlastingCannonsExileEffect extends OneShotEffect {
 class CastFromNonHandZoneTargetEffect extends AsThoughEffectImpl {
 
     CastFromNonHandZoneTargetEffect(Duration duration) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, duration, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, duration, Outcome.Benefit);
         staticText = "If it's a nonland card, you may cast that card this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/v/VivienChampionOfTheWilds.java
+++ b/Mage.Sets/src/mage/cards/v/VivienChampionOfTheWilds.java
@@ -173,7 +173,7 @@ class VivienChampionOfTheWildsCastFromExileEffect extends AsThoughEffectImpl {
     private final UUID authorizedPlayerId;
 
     VivienChampionOfTheWildsCastFromExileEffect(UUID authorizedPlayerId) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         this.authorizedPlayerId = authorizedPlayerId;
     }
 

--- a/Mage.Sets/src/mage/cards/w/WhispersteelDagger.java
+++ b/Mage.Sets/src/mage/cards/w/WhispersteelDagger.java
@@ -4,6 +4,7 @@ import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.common.DealsDamageToAPlayerAttachedTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.AsThoughManaEffect;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
@@ -15,14 +16,13 @@ import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.ManaPoolItem;
+import mage.target.common.TargetControlledCreaturePermanent;
 import mage.util.CardUtil;
 import mage.watchers.Watcher;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import mage.abilities.costs.mana.GenericManaCost;
-import mage.target.common.TargetControlledCreaturePermanent;
 
 /**
  * @author TheElk801
@@ -62,7 +62,7 @@ public final class WhispersteelDagger extends CardImpl {
 class WhispersteelDaggerCastFromExileEffect extends AsThoughEffectImpl {
 
     WhispersteelDaggerCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfTurn, Outcome.Benefit);
         staticText = "you may cast a creature spell from that player's graveyard this turn";
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
+++ b/Mage.Sets/src/mage/cards/w/WorldheartPhoenix.java
@@ -22,13 +22,12 @@ import mage.watchers.Watcher;
 import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class WorldheartPhoenix extends CardImpl {
 
     public WorldheartPhoenix(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{3}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}");
         this.subtype.add(SubType.PHOENIX);
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
@@ -58,7 +57,7 @@ public final class WorldheartPhoenix extends CardImpl {
 class WorldheartPhoenixPlayEffect extends AsThoughEffectImpl {
 
     WorldheartPhoenixPlayEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast {this} from your graveyard by paying {W}{U}{B}{R}{G} rather than paying its mana cost. " +
                 "If you do, it enters the battlefield with two +1/+1 counters on it";
     }

--- a/Mage.Sets/src/mage/cards/x/XandersPact.java
+++ b/Mage.Sets/src/mage/cards/x/XandersPact.java
@@ -97,7 +97,7 @@ class XandersPactExileEffect extends OneShotEffect {
 class XandersPactCastEffect extends CanPlayCardControllerEffect {
 
     XandersPactCastEffect(Game game, Card card) {
-        super(game, card.getMainCard().getId(), card.getZoneChangeCounter(game), Duration.EndOfTurn);
+        super(game, card.getMainCard().getId(), card.getZoneChangeCounter(game), true, Duration.EndOfTurn);
     }
 
     private XandersPactCastEffect(final XandersPactCastEffect effect) {

--- a/Mage.Sets/src/mage/cards/y/YouFindSomePrisoners.java
+++ b/Mage.Sets/src/mage/cards/y/YouFindSomePrisoners.java
@@ -81,7 +81,7 @@ class YouFindSomePrisonersEffect extends OneShotEffect {
         player.choose(Outcome.PlayForFree, cards, target, source, game);
         Card card = cards.get(target.getFirstTarget(), game);
         if (card != null) {
-            CardUtil.makeCardPlayable(game, source, card, Duration.UntilEndOfYourNextTurn, true);
+            CardUtil.makeCardPlayable(game, source, card, false, Duration.UntilEndOfYourNextTurn, true);
         }
         return true;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/control/GontiLordOfLuxuryEffectTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/control/GontiLordOfLuxuryEffectTest.java
@@ -1,13 +1,13 @@
 
 package org.mage.test.cards.control;
 
+import mage.constants.EmptyNames;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- *
  * @author LevelX2
  */
 public class GontiLordOfLuxuryEffectTest extends CardTestPlayerBase {
@@ -197,5 +197,34 @@ public class GontiLordOfLuxuryEffectTest extends CardTestPlayerBase {
 
         assertHandCount(playerB, "Ob Nixilis Reignited", 0);
         assertPermanentCount(playerB, "Ob Nixilis Reignited", 1);
+    }
+
+    @Test
+    public void test_ZoeticCavern_CanMorphButNotPlay() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 7);
+        // Deathtouch
+        // When Gonti, Lord of Luxury enters the battlefield, look at the top four cards of target opponent's library, exile one of them face down,
+        // then put the rest on the bottom of that library in a random order. For as long as that card remains exiled,
+        // you may look at it, you may cast it, and you may spend mana as though it were mana of any type to cast it.
+        addCard(Zone.HAND, playerA, "Gonti, Lord of Luxury", 1); // Creature 2/3 {2}{B}{B}
+        addCard(Zone.HAND, playerA, "Mountain", 1); // just to have a positive check on checkPlayableAbility for a land.
+
+        // Land with Morph {3}
+        addCard(Zone.LIBRARY, playerB, "Zoetic Cavern");
+        skipInitShuffling();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gonti, Lord of Luxury");
+        addTarget(playerA, playerB); // target for Gonti's trigger
+        setChoice(playerA, "Zoetic Cavern");
+        checkPlayableAbility("could play Mountain from hand", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Play Mountain", true);
+        checkPlayableAbility("cannot play Zoetic Cavern from exile", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Play Zoetic", false);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Zoetic Cavern using Morph");
+
+        setStopAt(4, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, EmptyNames.FACE_DOWN_CREATURE.toString(), 1);
     }
 }

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -118,7 +118,9 @@ public class SpellAbility extends ActivatedAbilityImpl {
             }
 
             // play from not own hand
-            Set<ApprovingObject> approvingObjects = game.getContinuousEffects().asThough(getSourceId(), AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, this, playerId, game);
+            Set<ApprovingObject> approvingObjects = new HashSet<>();
+            approvingObjects.addAll(game.getContinuousEffects().asThough(getSourceId(), AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, this, playerId, game));
+            approvingObjects.addAll(game.getContinuousEffects().asThough(getSourceId(), AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, this, playerId, game));
             if (approvingObjects.isEmpty() && getSpellAbilityType().equals(SpellAbilityType.ADVENTURE_SPELL)) {
                 // allowed to cast adventures from non-hand?
                 approvingObjects = game.getContinuousEffects().asThough(getSourceId(), AsThoughEffectType.CAST_ADVENTURE_FROM_NOT_OWN_HAND_ZONE, this, playerId, game);

--- a/Mage/src/main/java/mage/abilities/common/CastFromGraveyardOnceEachTurnAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/CastFromGraveyardOnceEachTurnAbility.java
@@ -48,7 +48,7 @@ class CastFromGraveyardOnceEffect extends AsThoughEffectImpl {
     private final FilterCard filter;
 
     CastFromGraveyardOnceEffect(FilterCard filter) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.WhileOnBattlefield, Outcome.Benefit);
         this.filter = filter;
         this.staticText = "Once during each of your turns, you may cast " + filter.getMessage()
                 + (filter.getMessage().contains("from your graveyard") ? "" : " from your graveyard");

--- a/Mage/src/main/java/mage/abilities/common/GiveManaAbilityAndCastSourceAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/GiveManaAbilityAndCastSourceAbility.java
@@ -3,7 +3,6 @@ package mage.abilities.common;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.ActivatedAbilityImpl;
-import mage.abilities.Mode;
 import mage.abilities.costs.common.ExileSourceFromHandCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.ContinuousEffectImpl;
@@ -68,7 +67,7 @@ class CastExiledFromHandCardEffect extends OneShotEffect {
                 .map(MageObjectReference.class::cast)
                 .map(mor -> mor.getCard(game))
                 .ifPresent(card -> CardUtil.makeCardPlayable(
-                        game, source, card, Duration.Custom, false
+                        game, source, card, true, Duration.Custom, false
                 ));
         return true;
     }
@@ -83,12 +82,12 @@ class GainManaAbilitiesWhileExiledEffect extends ContinuousEffectImpl {
         this.colors = colors;
         this.staticText =
                 "target land gains \"{T}: Add " +
-                CardUtil.concatWithOr(
-                        Arrays.stream(colors.split(""))
-                                .map(s -> '{' + s + '}')
-                                .collect(Collectors.toList())
-                ) +
-                "\" until {this} is cast from exile";
+                        CardUtil.concatWithOr(
+                                Arrays.stream(colors.split(""))
+                                        .map(s -> '{' + s + '}')
+                                        .collect(Collectors.toList())
+                        ) +
+                        "\" until {this} is cast from exile";
     }
 
     private GainManaAbilitiesWhileExiledEffect(final GainManaAbilitiesWhileExiledEffect effect) {

--- a/Mage/src/main/java/mage/abilities/common/MayCastFromGraveyardSourceAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/MayCastFromGraveyardSourceAbility.java
@@ -34,7 +34,7 @@ public class MayCastFromGraveyardSourceAbility extends StaticAbility {
 class MayCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     MayCastFromGraveyardEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.PutCreatureInPlay);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.PutCreatureInPlay);
         staticText = "you may cast {this} from your graveyard";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/ExileFaceDownYouMayCastAsLongAsExiledEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/ExileFaceDownYouMayCastAsLongAsExiledEffect.java
@@ -1,0 +1,102 @@
+package mage.abilities.effects;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.effects.common.asthought.MayLookAtTargetCardEffect;
+import mage.cards.Card;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
+import mage.constants.CastManaAdjustment;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * This exiles the target card or cards.
+ * Each can be looked at by the source's controller.
+ * For each card exiled this way, that player may play|cast that card as long as it stays exiled. (+ mana adjustement)
+ * e.g. [[Gonti, Lord of Luxury]]
+ *
+ * @author Susucr
+ */
+public class ExileFaceDownYouMayCastAsLongAsExiledEffect extends OneShotEffect {
+
+    private final boolean castNotPlay;
+    private final CastManaAdjustment manaAdjustment;
+
+    public ExileFaceDownYouMayCastAsLongAsExiledEffect(boolean castNotPlay, CastManaAdjustment manaAdjustment) {
+        super(Outcome.Exile);
+        switch (manaAdjustment) {
+            case NONE:
+            case AS_THOUGH_ANY_MANA_TYPE:
+            case AS_THOUGH_ANY_MANA_COLOR:
+                this.manaAdjustment = manaAdjustment;
+                break;
+            case WITHOUT_PAYING_MANA_COST: // TODO when needed
+            default:
+                throw new IllegalArgumentException("Wrong code usage, manaAdjustment is not yet supported: " + manaAdjustment);
+        }
+        this.castNotPlay = castNotPlay;
+    }
+
+    private ExileFaceDownYouMayCastAsLongAsExiledEffect(final ExileFaceDownYouMayCastAsLongAsExiledEffect effect) {
+        super(effect);
+        this.manaAdjustment = effect.manaAdjustment;
+        this.castNotPlay = effect.castNotPlay;
+    }
+
+    @Override
+    public ExileFaceDownYouMayCastAsLongAsExiledEffect copy() {
+        return new ExileFaceDownYouMayCastAsLongAsExiledEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Cards cards = new CardsImpl(getTargetPointer()
+                .getTargets(game, source)
+                .stream()
+                .map(game::getCard)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList())
+        );
+        if (controller == null || cards.isEmpty()) {
+            return false;
+        }
+        // move card to exile
+        UUID exileZoneId = CardUtil.getExileZoneId(game, source.getSourceId(), source.getSourceObjectZoneChangeCounter());
+        MageObject sourceObject = source.getSourceObject(game);
+        String exileName = sourceObject == null ? "" : sourceObject.getIdName();
+        for (Card card : cards.getCards(game)) {
+            card.setFaceDown(true, game);
+            if (controller.moveCardsToExile(card, source, game, false, exileZoneId, exileName)) {
+                card.setFaceDown(true, game);
+                switch (manaAdjustment) {
+                    case NONE:
+                        CardUtil.makeCardPlayable(game, source, card, castNotPlay, Duration.Custom, false, controller.getId(), null);
+                        break;
+                    case AS_THOUGH_ANY_MANA_TYPE:
+                    case AS_THOUGH_ANY_MANA_COLOR:
+                        // TODO: untangle why there is a confusion between the two.
+                        CardUtil.makeCardPlayable(game, source, card, castNotPlay, Duration.Custom, true, controller.getId(), null);
+                        break;
+                    case WITHOUT_PAYING_MANA_COST: // TODO.
+                    default:
+                        throw new IllegalArgumentException("Wrong code usage, manaAdjustment is not yet supported: " + manaAdjustment);
+                }
+                // For as long as that card remains exiled, you may look at it
+                ContinuousEffect effect = new MayLookAtTargetCardEffect(controller.getId());
+                effect.setTargetPointer(new FixedTarget(card.getId(), game));
+                game.addEffect(effect, source);
+            }
+        }
+        return true;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/ExileFaceDownYouMayCastAsLongAsExiledEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/ExileFaceDownYouMayCastAsLongAsExiledEffect.java
@@ -28,10 +28,10 @@ import java.util.stream.Collectors;
  */
 public class ExileFaceDownYouMayCastAsLongAsExiledEffect extends OneShotEffect {
 
-    private final boolean castNotPlay;
+    private final boolean useCastSpellOnly;
     private final CastManaAdjustment manaAdjustment;
 
-    public ExileFaceDownYouMayCastAsLongAsExiledEffect(boolean castNotPlay, CastManaAdjustment manaAdjustment) {
+    public ExileFaceDownYouMayCastAsLongAsExiledEffect(boolean useCastSpellOnly, CastManaAdjustment manaAdjustment) {
         super(Outcome.Exile);
         switch (manaAdjustment) {
             case NONE:
@@ -43,13 +43,13 @@ public class ExileFaceDownYouMayCastAsLongAsExiledEffect extends OneShotEffect {
             default:
                 throw new IllegalArgumentException("Wrong code usage, manaAdjustment is not yet supported: " + manaAdjustment);
         }
-        this.castNotPlay = castNotPlay;
+        this.useCastSpellOnly = useCastSpellOnly;
     }
 
     private ExileFaceDownYouMayCastAsLongAsExiledEffect(final ExileFaceDownYouMayCastAsLongAsExiledEffect effect) {
         super(effect);
         this.manaAdjustment = effect.manaAdjustment;
-        this.castNotPlay = effect.castNotPlay;
+        this.useCastSpellOnly = effect.useCastSpellOnly;
     }
 
     @Override
@@ -80,12 +80,12 @@ public class ExileFaceDownYouMayCastAsLongAsExiledEffect extends OneShotEffect {
                 card.setFaceDown(true, game);
                 switch (manaAdjustment) {
                     case NONE:
-                        CardUtil.makeCardPlayable(game, source, card, castNotPlay, Duration.Custom, false, controller.getId(), null);
+                        CardUtil.makeCardPlayable(game, source, card, useCastSpellOnly, Duration.Custom, false, controller.getId(), null);
                         break;
                     case AS_THOUGH_ANY_MANA_TYPE:
                     case AS_THOUGH_ANY_MANA_COLOR:
                         // TODO: untangle why there is a confusion between the two.
-                        CardUtil.makeCardPlayable(game, source, card, castNotPlay, Duration.Custom, true, controller.getId(), null);
+                        CardUtil.makeCardPlayable(game, source, card, useCastSpellOnly, Duration.Custom, true, controller.getId(), null);
                         break;
                     case WITHOUT_PAYING_MANA_COST: // TODO.
                     default:

--- a/Mage/src/main/java/mage/abilities/effects/ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect.java
@@ -26,12 +26,12 @@ import java.util.stream.Collectors;
  *
  * @author Susucr
  */
-public class ExileFaceDownYouMayCastAsLongAsExiledEffect extends OneShotEffect {
+public class ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect extends OneShotEffect {
 
     private final boolean useCastSpellOnly;
     private final CastManaAdjustment manaAdjustment;
 
-    public ExileFaceDownYouMayCastAsLongAsExiledEffect(boolean useCastSpellOnly, CastManaAdjustment manaAdjustment) {
+    public ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect(boolean useCastSpellOnly, CastManaAdjustment manaAdjustment) {
         super(Outcome.Exile);
         switch (manaAdjustment) {
             case NONE:
@@ -46,15 +46,15 @@ public class ExileFaceDownYouMayCastAsLongAsExiledEffect extends OneShotEffect {
         this.useCastSpellOnly = useCastSpellOnly;
     }
 
-    private ExileFaceDownYouMayCastAsLongAsExiledEffect(final ExileFaceDownYouMayCastAsLongAsExiledEffect effect) {
+    private ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect(final ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect effect) {
         super(effect);
         this.manaAdjustment = effect.manaAdjustment;
         this.useCastSpellOnly = effect.useCastSpellOnly;
     }
 
     @Override
-    public ExileFaceDownYouMayCastAsLongAsExiledEffect copy() {
-        return new ExileFaceDownYouMayCastAsLongAsExiledEffect(this);
+    public ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect copy() {
+        return new ExileFaceDownYouMayPlayAsLongAsExiledTargetEffect(this);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileAdventureSpellEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileAdventureSpellEffect.java
@@ -72,7 +72,7 @@ public class ExileAdventureSpellEffect extends OneShotEffect implements MageSing
 class AdventureCastFromExileEffect extends AsThoughEffectImpl {
 
     public AdventureCastFromExileEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.Custom, Outcome.Benefit);
         staticText = "Then exile this card. You may cast the creature later from exile.";
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/MayCastTargetCardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/MayCastTargetCardEffect.java
@@ -120,7 +120,7 @@ public class MayCastTargetCardEffect extends OneShotEffect {
             game.getState().setValue("PlayFromNotOwnHandZone" + card.getId(), null);
         } else {
             // TODO: support (and add tests!) for the non-NONE manaAdjustment
-            CardUtil.makeCardPlayable(game, source, card, duration, false);
+            CardUtil.makeCardPlayable(game, source, card, true, duration, false);
         }
         if (thenExile) {
             ContinuousEffect effect = new ThatSpellGraveyardExileReplacementEffect(true);

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/CanPlayCardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/CanPlayCardControllerEffect.java
@@ -27,13 +27,13 @@ public class CanPlayCardControllerEffect extends AsThoughEffectImpl {
     protected final UUID playerId;
     protected final Condition condition;
 
-    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, boolean castNotPlay, Duration duration) {
-        this(game, cardId, cardZCC, castNotPlay, duration, null, null);
+    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, boolean useCastSpellOnly, Duration duration) {
+        this(game, cardId, cardZCC, useCastSpellOnly, duration, null, null);
     }
 
-    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, boolean castNotPlay, Duration duration, UUID playerId, Condition condition) {
-        super(castNotPlay ? AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE : AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, duration, Outcome.Benefit);
-        this.staticText = castNotPlay ? "You may cast this card" : "You may play this card";
+    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, boolean useCastSpellOnly, Duration duration, UUID playerId, Condition condition) {
+        super(useCastSpellOnly ? AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE : AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, duration, Outcome.Benefit);
+        this.staticText = useCastSpellOnly ? "You may cast this card" : "You may play this card";
         this.mor = new MageObjectReference(cardId, cardZCC, game);
         this.playerId = playerId;
         this.condition = condition;

--- a/Mage/src/main/java/mage/abilities/effects/common/asthought/CanPlayCardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/asthought/CanPlayCardControllerEffect.java
@@ -27,13 +27,13 @@ public class CanPlayCardControllerEffect extends AsThoughEffectImpl {
     protected final UUID playerId;
     protected final Condition condition;
 
-    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, Duration duration) {
-        this(game, cardId, cardZCC, duration, null, null);
+    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, boolean castNotPlay, Duration duration) {
+        this(game, cardId, cardZCC, castNotPlay, duration, null, null);
     }
 
-    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, Duration duration, UUID playerId, Condition condition) {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, duration, Outcome.Benefit);
-        this.staticText = "You may play those card";
+    public CanPlayCardControllerEffect(Game game, UUID cardId, int cardZCC, boolean castNotPlay, Duration duration, UUID playerId, Condition condition) {
+        super(castNotPlay ? AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE : AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, duration, Outcome.Benefit);
+        this.staticText = castNotPlay ? "You may cast this card" : "You may play this card";
         this.mor = new MageObjectReference(cardId, cardZCC, game);
         this.playerId = playerId;
         this.condition = condition;
@@ -57,18 +57,18 @@ public class CanPlayCardControllerEffect extends AsThoughEffectImpl {
     }
 
     @Override
-    public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
+    public boolean applies(UUID objectId, Ability ability, UUID affectedControllerId, Game game) {
         if (mor.getCard(game) == null) {
             discard();
             return false;
         }
 
-        if (condition != null && !condition.apply(game, source)) {
+        if (condition != null && !condition.apply(game, ability)) {
             return false;
         }
 
-        UUID objectIdToCast = CardUtil.getMainCardId(game, sourceId); // affected to all card's parts
+        UUID objectIdToCast = CardUtil.getMainCardId(game, objectId); // affected to all card's parts
         return mor.refersTo(objectIdToCast, game)
-                && (playerId == null ? source.isControlledBy(affectedControllerId) : playerId.equals(affectedControllerId));
+                && (playerId == null ? ability.isControlledBy(affectedControllerId) : playerId.equals(affectedControllerId));
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/AftermathAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/AftermathAbility.java
@@ -55,7 +55,7 @@ public class AftermathAbility extends SimpleStaticAbility {
 class AftermathCastFromGraveyard extends AsThoughEffectImpl {
 
     public AftermathCastFromGraveyard() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
     }
 
     protected AftermathCastFromGraveyard(final AftermathCastFromGraveyard effect) {

--- a/Mage/src/main/java/mage/constants/AsThoughEffectType.java
+++ b/Mage/src/main/java/mage/constants/AsThoughEffectType.java
@@ -35,7 +35,8 @@ public enum AsThoughEffectType {
     // 3. Target must points to mainCard, but checking goes for every card's parts and characteristics from objectId (split, adventure)
     // 4. You must implement/override an applies method with "Ability affectedAbility" (e.g. check multiple play/cast abilities from all card's parts)
     // TODO: search all PLAY_FROM_NOT_OWN_HAND_ZONE and CAST_AS_INSTANT effects and add support of mainCard and objectId
-    PLAY_FROM_NOT_OWN_HAND_ZONE(true, true),
+    PLAY_FROM_NOT_OWN_HAND_ZONE(true, true), // for play lands & cast spells
+    CAST_FROM_NOT_OWN_HAND_ZONE(true, true), // for cast spells
     CAST_ADVENTURE_FROM_NOT_OWN_HAND_ZONE(true, true),
     CAST_AS_INSTANT(true, true),
     //

--- a/Mage/src/main/java/mage/game/command/emblems/JayaBallardEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/JayaBallardEmblem.java
@@ -46,7 +46,7 @@ public final class JayaBallardEmblem extends Emblem {
 class JayaBallardCastFromGraveyardEffect extends AsThoughEffectImpl {
 
     JayaBallardCastFromGraveyardEffect() {
-        super(AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.Benefit);
         staticText = "You may cast instant and sorcery spells from your graveyard";
     }
 

--- a/Mage/src/main/java/mage/game/command/emblems/TibaltCosmicImpostorEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/TibaltCosmicImpostorEmblem.java
@@ -80,7 +80,7 @@ class TibaltCosmicImpostorPlayFromExileEffect extends AsThoughEffectImpl {
         if (exileZone.contains(mainCardId)
                 && affectedControllerId.equals(source.getControllerId())
                 && game.getState().getZone(mainCardId).equals(Zone.EXILED)) {
-            CardUtil.makeCardPlayable(game, source, cardInExile, Duration.Custom, true);
+            CardUtil.makeCardPlayable(game, source, cardInExile, false, Duration.Custom, true);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3987,9 +3987,14 @@ public abstract class PlayerImpl implements Player, Serializable {
 
             Set<ApprovingObject> approvingObjects;
             if ((isPlaySpell || isPlayLand) && (fromZone != Zone.BATTLEFIELD)) {
-                // play hand from non hand zone (except battlefield - you can't play already played permanents)
-                approvingObjects = game.getContinuousEffects().asThough(object.getId(),
-                        AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, ability, this.getId(), game);
+                // play card from non hand zone (except battlefield - you can't play already played permanents)
+                approvingObjects = new HashSet<>();
+                approvingObjects.addAll(game.getContinuousEffects().asThough(object.getId(),
+                        AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE, ability, this.getId(), game));
+                if (isPlaySpell) {
+                    approvingObjects.addAll(game.getContinuousEffects().asThough(object.getId(),
+                            AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, ability, this.getId(), game));
+                }
 
                 if (approvingObjects.isEmpty() && isPlaySpell
                         && ((SpellAbility) ability).getSpellAbilityType().equals(SpellAbilityType.ADVENTURE_SPELL)) {

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1282,8 +1282,8 @@ public final class CardUtil {
     }
 
     // TODO: use CastManaAdjustment instead of boolean anyColor
-    public static void makeCardPlayable(Game game, Ability source, Card card, boolean castNotPlay, Duration duration, boolean anyColor) {
-        makeCardPlayable(game, source, card, castNotPlay, duration, anyColor, null, null);
+    public static void makeCardPlayable(Game game, Ability source, Card card, boolean useCastSpellOnly, Duration duration, boolean anyColor) {
+        makeCardPlayable(game, source, card, useCastSpellOnly, duration, anyColor, null, null);
     }
 
     /**
@@ -1299,14 +1299,14 @@ public final class CardUtil {
      * @param condition can be null
      */
     // TODO: use CastManaAdjustment instead of boolean anyColor
-    public static void makeCardPlayable(Game game, Ability source, Card card, boolean castNotPlay, Duration duration, boolean anyColor, UUID playerId, Condition condition) {
+    public static void makeCardPlayable(Game game, Ability source, Card card, boolean useCastSpellOnly, Duration duration, boolean anyColor, UUID playerId, Condition condition) {
         // Effect can be used for cards in zones and permanents on battlefield
         // PermanentCard's ZCC is static, but we need updated ZCC from the card (after moved to another zone)
         // So there is a workaround to get actual card's ZCC
         // Example: Hostage Taker
         UUID objectId = card.getMainCard().getId();
         int zcc = game.getState().getZoneChangeCounter(objectId);
-        game.addEffect(new CanPlayCardControllerEffect(game, objectId, zcc, castNotPlay, duration, playerId, condition), source);
+        game.addEffect(new CanPlayCardControllerEffect(game, objectId, zcc, useCastSpellOnly, duration, playerId, condition), source);
         if (anyColor) {
             game.addEffect(new YouMaySpendManaAsAnyColorToCastTargetEffect(duration, playerId, condition).setTargetPointer(new FixedTarget(objectId, zcc)), source);
         }

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1282,8 +1282,8 @@ public final class CardUtil {
     }
 
     // TODO: use CastManaAdjustment instead of boolean anyColor
-    public static void makeCardPlayable(Game game, Ability source, Card card, Duration duration, boolean anyColor) {
-        makeCardPlayable(game, source, card, duration, anyColor, null, null);
+    public static void makeCardPlayable(Game game, Ability source, Card card, boolean castNotPlay, Duration duration, boolean anyColor) {
+        makeCardPlayable(game, source, card, castNotPlay, duration, anyColor, null, null);
     }
 
     /**
@@ -1299,14 +1299,14 @@ public final class CardUtil {
      * @param condition can be null
      */
     // TODO: use CastManaAdjustment instead of boolean anyColor
-    public static void makeCardPlayable(Game game, Ability source, Card card, Duration duration, boolean anyColor, UUID playerId, Condition condition) {
+    public static void makeCardPlayable(Game game, Ability source, Card card, boolean castNotPlay, Duration duration, boolean anyColor, UUID playerId, Condition condition) {
         // Effect can be used for cards in zones and permanents on battlefield
         // PermanentCard's ZCC is static, but we need updated ZCC from the card (after moved to another zone)
         // So there is a workaround to get actual card's ZCC
         // Example: Hostage Taker
         UUID objectId = card.getMainCard().getId();
         int zcc = game.getState().getZoneChangeCounter(objectId);
-        game.addEffect(new CanPlayCardControllerEffect(game, objectId, zcc, duration, playerId, condition), source);
+        game.addEffect(new CanPlayCardControllerEffect(game, objectId, zcc, castNotPlay, duration, playerId, condition), source);
         if (anyColor) {
             game.addEffect(new YouMaySpendManaAsAnyColorToCastTargetEffect(duration, playerId, condition).setTargetPointer(new FixedTarget(objectId, zcc)), source);
         }


### PR DESCRIPTION
This PR accomplishes two main things:

1. Separate the "you may cast" from `AsThoughEffectType.PLAY_FROM_NOT_OWN_HAND_ZONE` into `AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE`.
   - The play ones stay the same, they allow `PlayLandAbility` and `SpellAbility`.
   - The cast ones still allow `SpellAbility`, but no longer `PlayLandAbility`
   - This notably solves the usual bug with Zoetic Cavern, and MDFC with lands on the back
   - I did carefully look at all `PLAY_FROM_NOT_OWN_HAND_ZONE` in the code base to replace the right ones with `CAST_FROM_NOT_OWN_HAND_ZONE`.
2. Add a `boolean castNotPlay` to the `CardUtil.makePlayable` methods. That ends up being used in `CanPlayCardControllerEffect` to differentiate cast from play.
   - Again, slowly looked at each caller to separate the "you may play" from "you may cast". Most were for play, but there were a dozen or so that actually were for allowing cast.

In addition, [[Gonti, Lord of Luxury]] has been rewritten to use a new common effect `ExileFaceDownYouMayCastAsLongAsExiledEffect`, which itself use `makePlayable` so benefit from the above changes.
I checked with an unit test that all of this solves the [[Zoetic Cavern]] issue with Gonti, which allow cast so you can morph the Cavern, but are not allowed to play it as land.

I plan to have more cards use the new Effect (including a few new cards from OTC, but also existing ones), and consolidate further in the future the various play/cast effects. But to keep review job easier, this is all for this one.