### PR TITLE
refactor: clean up static filters for sacrifice targets

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbueloAncestralEcho.java
+++ b/Mage.Sets/src/mage/cards/a/AbueloAncestralEcho.java
@@ -41,7 +41,7 @@ public final class AbueloAncestralEcho extends CardImpl {
                 new ExileReturnBattlefieldNextEndStepTargetEffect().withTextThatCard(false),
                 new ManaCostsImpl<>("{1}{W}{U}")
         );
-        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AcolyteOfAclazotz.java
+++ b/Mage.Sets/src/mage/cards/a/AcolyteOfAclazotz.java
@@ -30,7 +30,7 @@ public final class AcolyteOfAclazotz extends CardImpl {
 
         // {T}, Sacrifice another creature or artifact: Each opponent loses 1 life and you gain 1 life.
         Ability ability = new SimpleActivatedAbility(new LoseLifeOpponentsEffect(1), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/AgentOfTheFates.java
+++ b/Mage.Sets/src/mage/cards/a/AgentOfTheFates.java
@@ -29,7 +29,7 @@ public final class AgentOfTheFates extends CardImpl {
         // Deathtouch
         this.addAbility(DeathtouchAbility.getInstance());
         // Heroic - Whenever you cast a spell that targets Agent of the Fates, each opponent sacrifices a creature.
-        this.addAbility(new HeroicAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        this.addAbility(new HeroicAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private AgentOfTheFates(final AgentOfTheFates card) {

--- a/Mage.Sets/src/mage/cards/a/AllegiantGeneralPryde.java
+++ b/Mage.Sets/src/mage/cards/a/AllegiantGeneralPryde.java
@@ -39,7 +39,7 @@ public class AllegiantGeneralPryde extends CardImpl {
         // Trooper creatures you control have "When this creature enters the battlefield, you may sacrifice a creature. If you do, draw two cards and lose 2 life."
         Ability gainedAbility = new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(
                 new DrawCardSourceControllerEffect(2),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
         ).addEffect(new LoseLifeSourceControllerEffect(2).concatBy("and")))
                 .setTriggerPhrase("When this creature enters the battlefield, ");
         this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(gainedAbility, Duration.WhileOnBattlefield, filter)));

--- a/Mage.Sets/src/mage/cards/a/AltarOfBone.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfBone.java
@@ -20,7 +20,7 @@ public final class AltarOfBone extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{G}{W}");
 
         // As an additional cost to cast Altar of Bone, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Search your library for a creature card, reveal that card, and put it into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true));
     }

--- a/Mage.Sets/src/mage/cards/a/AltarOfDementia.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfDementia.java
@@ -28,7 +28,7 @@ public final class AltarOfDementia extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // Sacrifice a creature: Target player puts a number of cards equal to the sacrificed creature's power from the top of their library into their graveyard.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AltarOfDementiaEffect(), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AltarOfDementiaEffect(), new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/a/AltarsReap.java
+++ b/Mage.Sets/src/mage/cards/a/AltarsReap.java
@@ -21,7 +21,7 @@ public final class AltarsReap extends CardImpl {
 
 
         // As an additional cost to cast Altar's Reap, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Draw two cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
     }

--- a/Mage.Sets/src/mage/cards/a/AnchorToReality.java
+++ b/Mage.Sets/src/mage/cards/a/AnchorToReality.java
@@ -31,7 +31,7 @@ public final class AnchorToReality extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{U}{U}");
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Search your library for an Equipment or Vehicle card, put that card onto the battlefield, then shuffle. If it has mana value less than the sacrificed permanent's mana value, scry 2.
         this.getSpellAbility().addEffect(new AnchorToRealityEffect());

--- a/Mage.Sets/src/mage/cards/a/AnimalBoneyard.java
+++ b/Mage.Sets/src/mage/cards/a/AnimalBoneyard.java
@@ -39,7 +39,7 @@ public final class AnimalBoneyard extends CardImpl {
         this.addAbility(ability);
         // Enchanted land has "{T}, Sacrifice a creature: You gain life equal to that creature's toughness."
         Ability gainedAbility = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AnimalBoneyardEffect(), new TapSourceCost());
-        gainedAbility.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        gainedAbility.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         Effect effect = new GainAbilityAttachedEffect(gainedAbility, AttachmentType.AURA, Duration.WhileOnBattlefield,
                 "Enchanted land has \"{T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.\"");
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, effect));

--- a/Mage.Sets/src/mage/cards/a/AphettoAlchemist.java
+++ b/Mage.Sets/src/mage/cards/a/AphettoAlchemist.java
@@ -1,7 +1,5 @@
-
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -14,23 +12,16 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
  * @author fireshoes
  */
 public final class AphettoAlchemist extends CardImpl {
-    
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
 
     public AphettoAlchemist(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{U}");
@@ -41,7 +32,7 @@ public final class AphettoAlchemist extends CardImpl {
 
         // {tap}: Untap target artifact or creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UntapTargetEffect(), new TapSourceCost());
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
         
         // Morph {U}

--- a/Mage.Sets/src/mage/cards/a/ArcticMerfolk.java
+++ b/Mage.Sets/src/mage/cards/a/ArcticMerfolk.java
@@ -30,7 +30,9 @@ public final class ArcticMerfolk extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Kicker—Return a creature you control to its owner's hand. (You may return a creature you control to its owner's hand in addition to any other costs as you cast this spell.)
-        this.addAbility(new KickerAbility(new ReturnToHandChosenControlledPermanentCost(new TargetControlledCreaturePermanent(1,1,StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT,true))));
+        this.addAbility(new KickerAbility(new ReturnToHandChosenControlledPermanentCost(
+                new TargetControlledCreaturePermanent(1, 1, StaticFilters.FILTER_CONTROLLED_CREATURE, true)
+        )));
 
         // If Arctic Merfolk was kicked, it enters the battlefield with a +1/+1 counter on it.
         this.addAbility(new EntersBattlefieldAbility(

--- a/Mage.Sets/src/mage/cards/a/ArmyAnts.java
+++ b/Mage.Sets/src/mage/cards/a/ArmyAnts.java
@@ -33,7 +33,7 @@ public final class ArmyAnts extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new DestroyTargetEffect(),
                 new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         ability.addTarget(new TargetLandPermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/Artillerize.java
+++ b/Mage.Sets/src/mage/cards/a/Artillerize.java
@@ -20,7 +20,7 @@ public final class Artillerize extends CardImpl {
     public Artillerize(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{R}");
 
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
         this.getSpellAbility().addEffect(new DamageTargetEffect(5));
     }

--- a/Mage.Sets/src/mage/cards/a/AshnodsAltar.java
+++ b/Mage.Sets/src/mage/cards/a/AshnodsAltar.java
@@ -24,7 +24,7 @@ public final class AshnodsAltar extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // Sacrifice a creature: Add {C}{C}.
-        SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+        SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
         this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, 
                 new BasicManaEffect(Mana.ColorlessMana(2), CreaturesYouControlCount.instance), 
                 cost));

--- a/Mage.Sets/src/mage/cards/a/Attrition.java
+++ b/Mage.Sets/src/mage/cards/a/Attrition.java
@@ -24,7 +24,7 @@ public final class Attrition extends CardImpl {
 
         //{B}, Sacrifice a creature: Destroy target nonblack creature.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(new DestroyTargetEffect(), new ColoredManaCost(ColoredManaSymbol.B));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent(StaticFilters.FILTER_PERMANENT_CREATURE_NON_BLACK).withChooseHint("to destroy"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/AyaraWidowOfTheRealm.java
+++ b/Mage.Sets/src/mage/cards/a/AyaraWidowOfTheRealm.java
@@ -48,7 +48,7 @@ public final class AyaraWidowOfTheRealm extends CardImpl {
         // {T}, Sacrifice another creature or artifact: Ayara, Widow of the Realm deals X damage to target opponent or battle and you gain X life, where X is the sacrificed permanent's mana value.
         Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(xValue)
                 .setText("{this} deals X damage to target opponent or battle"), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         ability.addEffect(new GainLifeEffect(xValue).setText("and you gain X life, where X is the sacrificed permanent's mana value"));
         ability.addTarget(new TargetPermanentOrPlayer(filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BaronBertramGraywater.java
+++ b/Mage.Sets/src/mage/cards/b/BaronBertramGraywater.java
@@ -48,7 +48,7 @@ public final class BaronBertramGraywater extends CardImpl {
 
         // {1}{B}, Sacrifice another creature or artifact: Draw a card.
         Ability ability = new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BarrageOfExpendables.java
+++ b/Mage.Sets/src/mage/cards/b/BarrageOfExpendables.java
@@ -26,7 +26,7 @@ public final class BarrageOfExpendables extends CardImpl {
 
         // {R}, Sacrifice a creature: Barrage of Expendables deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new ManaCostsImpl<>("{R}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/b/BarrinMasterWizard.java
+++ b/Mage.Sets/src/mage/cards/b/BarrinMasterWizard.java
@@ -32,7 +32,7 @@ public final class BarrinMasterWizard extends CardImpl {
 
         //{2}, Sacrifice a permanent: Return target creature to its owner's hand.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnToHandTargetEffect(), new ManaCostsImpl<>("{2}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BartolomeDelPresidio.java
+++ b/Mage.Sets/src/mage/cards/b/BartolomeDelPresidio.java
@@ -31,7 +31,7 @@ public final class BartolomeDelPresidio extends CardImpl {
         // Sacrifice another creature or artifact: Put a +1/+1 counter on Bartolome del Presidio.
         this.addAbility(new SimpleActivatedAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BayouGroff.java
+++ b/Mage.Sets/src/mage/cards/b/BayouGroff.java
@@ -28,7 +28,7 @@ public final class BayouGroff extends CardImpl {
 
         // As an additional cost to cast this spell, sacrifice a creature or pay {3}.
         this.getSpellAbility().addCost(new OrCost(
-                "sacrifice a creature or pay {3}", new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), new GenericManaCost(3)
+                "sacrifice a creature or pay {3}", new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), new GenericManaCost(3)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BenalishSleeper.java
+++ b/Mage.Sets/src/mage/cards/b/BenalishSleeper.java
@@ -33,7 +33,7 @@ public final class BenalishSleeper extends CardImpl {
 
         // When Benalish Sleeper enters the battlefield, if it was kicked, each player sacrifices a creature.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(new EntersBattlefieldTriggeredAbility(
-                new SacrificeAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE)
         ), KickedCondition.ONCE, "When {this} enters the battlefield, " +
                 "if it was kicked, each player sacrifices a creature."));
     }

--- a/Mage.Sets/src/mage/cards/b/BirthingPod.java
+++ b/Mage.Sets/src/mage/cards/b/BirthingPod.java
@@ -40,7 +40,7 @@ public final class BirthingPod extends CardImpl {
                 Zone.BATTLEFIELD, new BirthingPodEffect(), new ManaCostsImpl<>("{1}{G/P}")
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlackCarriage.java
+++ b/Mage.Sets/src/mage/cards/b/BlackCarriage.java
@@ -39,7 +39,7 @@ public final class BlackCarriage extends CardImpl {
 
         // Sacrifice a creature: Untap Black Carriage. Activate this ability only during your upkeep.
         this.addAbility(new ConditionalActivatedAbility(Zone.BATTLEFIELD,
-                new UntapSourceEffect(), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new UntapSourceEffect(), new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new IsStepCondition(PhaseStep.UPKEEP), "Sacrifice a creature: Untap {this}. Activate only during your upkeep."));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlastingStation.java
+++ b/Mage.Sets/src/mage/cards/b/BlastingStation.java
@@ -28,7 +28,7 @@ public final class BlastingStation extends CardImpl {
 
         // {tap}, Sacrifice a creature: Blasting Station deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/b/BlightedShaman.java
+++ b/Mage.Sets/src/mage/cards/b/BlightedShaman.java
@@ -47,7 +47,7 @@ public final class BlightedShaman extends CardImpl {
 
         // {tap}, Sacrifice a creature: Target creature gets +2/+2 until end of turn.
         ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(2, 2, Duration.EndOfTurn), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BloodDivination.java
+++ b/Mage.Sets/src/mage/cards/b/BloodDivination.java
@@ -19,7 +19,7 @@ public final class BloodDivination extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Draw three cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(3));

--- a/Mage.Sets/src/mage/cards/b/BloodForBones.java
+++ b/Mage.Sets/src/mage/cards/b/BloodForBones.java
@@ -28,7 +28,7 @@ public final class BloodForBones extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Return a creature card from your graveyard to the battlefield, then return another creature card from your graveyard to your hand.
         this.getSpellAbility().addEffect(new BloodForBonesEffect());

--- a/Mage.Sets/src/mage/cards/b/BloodFunnel.java
+++ b/Mage.Sets/src/mage/cards/b/BloodFunnel.java
@@ -35,7 +35,7 @@ public final class BloodFunnel extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SpellsCostReductionControllerEffect(filter, 2)));
 
         // Whenever you cast a noncreature spell, counter that spell unless you sacrifice a creature.
-        Effect effect = new CounterUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        Effect effect = new CounterUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         effect.setText("counter that spell unless you sacrifice a creature");
         this.addAbility(new SpellCastControllerTriggeredAbility(
                 effect,

--- a/Mage.Sets/src/mage/cards/b/BloodRites.java
+++ b/Mage.Sets/src/mage/cards/b/BloodRites.java
@@ -24,7 +24,7 @@ public final class BloodRites extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{R}{R}");
 
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(2), new ManaCostsImpl<>("{1}{R}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BloodboilSorcerer.java
+++ b/Mage.Sets/src/mage/cards/b/BloodboilSorcerer.java
@@ -36,7 +36,7 @@ public final class BloodboilSorcerer extends CardImpl {
 
         // Crown of Madness — {1}{R}, Sacrifice an artifact or creature: Goad target creature.
         Ability ability = new SimpleActivatedAbility(new GoadTargetEffect(), new ManaCostsImpl<>("{1}{R}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability.withFlavorWord("Crown of Madness"));
     }

--- a/Mage.Sets/src/mage/cards/b/BloodflowConnoisseur.java
+++ b/Mage.Sets/src/mage/cards/b/BloodflowConnoisseur.java
@@ -30,7 +30,7 @@ public final class BloodflowConnoisseur extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Sacrifice a creature: Put a +1/+1 counter on Bloodflow Connoisseur.
-        Cost abilityCost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+        Cost abilityCost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
         Ability ability = new SimpleActivatedAbility(
                 Zone.BATTLEFIELD,
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),

--- a/Mage.Sets/src/mage/cards/b/BloodshotCyclops.java
+++ b/Mage.Sets/src/mage/cards/b/BloodshotCyclops.java
@@ -35,7 +35,7 @@ public final class BloodshotCyclops extends CardImpl {
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new DamageTargetEffect(SacrificeCostCreaturesPower.instance).setText("{this} deals damage equal to the sacrificed creature's power to any target"),
                 new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BloodsoakedAltar.java
+++ b/Mage.Sets/src/mage/cards/b/BloodsoakedAltar.java
@@ -31,7 +31,7 @@ public final class BloodsoakedAltar extends CardImpl {
         );
         ability.addCost(new PayLifeCost(2));
         ability.addCost(new DiscardCardCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BloodthroneVampire.java
+++ b/Mage.Sets/src/mage/cards/b/BloodthroneVampire.java
@@ -28,7 +28,7 @@ public final class BloodthroneVampire extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(2, 2, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private BloodthroneVampire(final BloodthroneVampire card) {

--- a/Mage.Sets/src/mage/cards/b/BogElemental.java
+++ b/Mage.Sets/src/mage/cards/b/BogElemental.java
@@ -34,7 +34,7 @@ public final class BogElemental extends CardImpl {
         
         // At the beginning of your upkeep, sacrifice Bog Elemental unless you sacrifice a land.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(Zone.BATTLEFIELD, 
-                new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)),
+                new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_LAND)),
                 TargetController.YOU, 
                 false));
     }

--- a/Mage.Sets/src/mage/cards/b/BoneSplinters.java
+++ b/Mage.Sets/src/mage/cards/b/BoneSplinters.java
@@ -21,7 +21,7 @@ public final class BoneSplinters extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
 
         // As an additional cost to cast Bone Splinters, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Destroy target creature.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent().withChooseHint("to destroy"));
         this.getSpellAbility().addEffect(new DestroyTargetEffect());

--- a/Mage.Sets/src/mage/cards/b/BovineIntervention.java
+++ b/Mage.Sets/src/mage/cards/b/BovineIntervention.java
@@ -5,8 +5,7 @@ import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.game.permanent.token.Ox22Token;
 import mage.target.TargetPermanent;
 
@@ -17,20 +16,11 @@ import java.util.UUID;
  */
 public final class BovineIntervention extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate())
-        );
-    }
-
     public BovineIntervention(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{W}");
 
         // Destroy target artifact or creature. Its controller creates a 2/2 white Ox creature token.
-        this.getSpellAbility().addTarget(new TargetPermanent(filter));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addEffect(new CreateTokenControllerTargetPermanentEffect(new Ox22Token()));
     }

--- a/Mage.Sets/src/mage/cards/b/BraidssFrightfulReturn.java
+++ b/Mage.Sets/src/mage/cards/b/BraidssFrightfulReturn.java
@@ -42,7 +42,7 @@ public final class BraidssFrightfulReturn extends CardImpl {
                 this, SagaChapter.CHAPTER_I,
                 new DoIfCostPaid(
                         new DiscardEachPlayerEffect(TargetController.OPPONENT),
-                        new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                        new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
                 )
         );
 

--- a/Mage.Sets/src/mage/cards/b/BrainGorgers.java
+++ b/Mage.Sets/src/mage/cards/b/BrainGorgers.java
@@ -70,7 +70,7 @@ class BrainGorgersCounterSourceEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         MageObject sourceObject = source.getSourceObject(game);
         if (sourceObject != null) {
-            SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+            SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
             for (UUID playerId : game.getState().getPlayerList(source.getControllerId())) {
                 cost.clearPaid();
                 Player player = game.getPlayer(playerId);

--- a/Mage.Sets/src/mage/cards/b/BraveTheWilds.java
+++ b/Mage.Sets/src/mage/cards/b/BraveTheWilds.java
@@ -69,7 +69,7 @@ enum BraveTheWildsTargetAdjuster implements TargetAdjuster {
     public void adjustTargets(Ability ability, Game game) {
         ability.getTargets().clear();
         if (BargainedCondition.instance.apply(game, ability)) {
-            ability.addTarget(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+            ability.addTarget(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_PERMANENT_LAND));
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BrineShaman.java
+++ b/Mage.Sets/src/mage/cards/b/BrineShaman.java
@@ -34,13 +34,13 @@ public final class BrineShaman extends CardImpl {
 
         // {tap}, Sacrifice a creature: Target creature gets +2/+2 until end of turn.
         Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(2, 2), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 
         // {1}{U}{U}, Sacrifice a creature: Counter target creature spell.
         ability = new SimpleActivatedAbility(new CounterTargetEffect(), new ManaCostsImpl<>("{1}{U}{U}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetSpell(StaticFilters.FILTER_SPELL_CREATURE));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BroadsideBombardiers.java
+++ b/Mage.Sets/src/mage/cards/b/BroadsideBombardiers.java
@@ -41,7 +41,7 @@ public final class BroadsideBombardiers extends CardImpl {
         Ability ability = new BoastAbility(new DamageTargetEffect(
                 new IntPlusDynamicValue(2, SacrificeCostManaValue.PERMANENT))
                 .setText("{this} deals damage equal to 2 plus the sacrificed permanent's mana value to any target."),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT)
         );
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BroodButcher.java
+++ b/Mage.Sets/src/mage/cards/b/BroodButcher.java
@@ -42,7 +42,7 @@ public final class BroodButcher extends CardImpl {
 
         // {B}{G}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(-2, -2, Duration.EndOfTurn), new ManaCostsImpl<>("{B}{G}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/BubblingCauldron.java
+++ b/Mage.Sets/src/mage/cards/b/BubblingCauldron.java
@@ -35,7 +35,7 @@ public final class BubblingCauldron extends CardImpl {
         // {1}, {T}, Sacrifice a creature: You gain 4 life.
         Ability ability1 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(4), new ManaCostsImpl<>("{1}"));
         ability1.addCost(new TapSourceCost());
-        ability1.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability1.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability1);
         // {1}, {T}, Sacrifice a creature named Festering Newt: Each opponent loses 4 life. You gain life equal to the life lost this way.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new LoseLifeOpponentsYouGainLifeLostEffect(4), new ManaCostsImpl<>("{1}"));

--- a/Mage.Sets/src/mage/cards/b/BurntOffering.java
+++ b/Mage.Sets/src/mage/cards/b/BurntOffering.java
@@ -21,7 +21,7 @@ public final class BurntOffering extends CardImpl {
         super(ownerID, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         //As an additional cost to cast Burnt Offering, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         //Add an amount of {B} and/or {R} equal to the sacrificed creature's converted mana cost.
         SacrificeCostManaValue xValue = SacrificeCostManaValue.CREATURE;
         this.getSpellAbility().addEffect(new AddManaInAnyCombinationEffect(

--- a/Mage.Sets/src/mage/cards/b/ButcherOfMalakir.java
+++ b/Mage.Sets/src/mage/cards/b/ButcherOfMalakir.java
@@ -36,7 +36,7 @@ public final class ButcherOfMalakir extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // Whenever Butcher of Malakir or another creature you control dies, each opponent sacrifices a creature.
-        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), false, filter));
+        this.addAbility(new DiesThisOrAnotherCreatureTriggeredAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE), false, filter));
     }
 
     private ButcherOfMalakir(final ButcherOfMalakir card) {

--- a/Mage.Sets/src/mage/cards/b/ByInvitationOnly.java
+++ b/Mage.Sets/src/mage/cards/b/ByInvitationOnly.java
@@ -61,7 +61,7 @@ class ByInvitationOnlyEffect extends OneShotEffect {
                 0, 13, "Choose a number between 0 and 13", game
         );
         return new SacrificeAllEffect(
-                number, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
+                number, StaticFilters.FILTER_PERMANENT_CREATURE
         ).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CabalPatriarch.java
+++ b/Mage.Sets/src/mage/cards/c/CabalPatriarch.java
@@ -35,7 +35,7 @@ public final class CabalPatriarch extends CardImpl {
 
         // {2}{B}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.
         Ability ability1 = new SimpleActivatedAbility(new BoostTargetEffect(-2, -2), new ManaCostsImpl<>("{2}{B}"));
-        ability1.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability1.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability1.addTarget(new TargetCreaturePermanent().withChooseHint("gets -2/-2"));
         this.addAbility(ability1);
 

--- a/Mage.Sets/src/mage/cards/c/CabalTherapist.java
+++ b/Mage.Sets/src/mage/cards/c/CabalTherapist.java
@@ -51,7 +51,7 @@ public final class CabalTherapist extends CardImpl {
         ability.addEffect(new CabalTherapistDiscardEffect());
         ability.addTarget(new TargetPlayer());
         this.addAbility(new BeginningOfPreCombatMainTriggeredAbility(
-                new DoWhenCostPaid(ability, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
+                new DoWhenCostPaid(ability, new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE
                 ), "Sacrifice a creature?"), TargetController.YOU, false
         ));
     }

--- a/Mage.Sets/src/mage/cards/c/CabalTherapy.java
+++ b/Mage.Sets/src/mage/cards/c/CabalTherapy.java
@@ -35,7 +35,7 @@ public final class CabalTherapy extends CardImpl {
         this.getSpellAbility().addEffect(new CabalTherapyEffect());
 
         // Flashback-Sacrifice a creature.
-        this.addAbility(new FlashbackAbility(this, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        this.addAbility(new FlashbackAbility(this, new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private CabalTherapy(final CabalTherapy card) {

--- a/Mage.Sets/src/mage/cards/c/CallForBlood.java
+++ b/Mage.Sets/src/mage/cards/c/CallForBlood.java
@@ -28,7 +28,7 @@ public final class CallForBlood extends CardImpl {
         this.subtype.add(SubType.ARCANE);
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Target creature gets -X/-X until end of turn, where X is the sacrificed creature's power.
         this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/c/Caregiver.java
+++ b/Mage.Sets/src/mage/cards/c/Caregiver.java
@@ -35,7 +35,7 @@ public final class Caregiver extends CardImpl {
 
         // {W}, Sacrifice a creature: Prevent the next 1 damage that would be dealt to any target this turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new PreventDamageToTargetEffect(Duration.EndOfTurn, 1), new ColoredManaCost(ColoredManaSymbol.W));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CarnageAltar.java
+++ b/Mage.Sets/src/mage/cards/c/CarnageAltar.java
@@ -23,7 +23,7 @@ public final class CarnageAltar extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new GenericManaCost(3));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Carrion.java
+++ b/Mage.Sets/src/mage/cards/c/Carrion.java
@@ -22,7 +22,7 @@ public final class Carrion extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}{B}");
 
         // As an additional cost to cast Carrion, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Put X 0/1 black Insect creature tokens onto the battlefield, where X is the sacrificed creature's power.
         this.getSpellAbility().addEffect(new CreateTokenEffect(new CarrionBlackInsectToken(), SacrificeCostCreaturesPower.instance));

--- a/Mage.Sets/src/mage/cards/c/CarrionFeeder.java
+++ b/Mage.Sets/src/mage/cards/c/CarrionFeeder.java
@@ -34,7 +34,7 @@ public final class CarrionFeeder extends CardImpl {
         // Sacrifice a creature: Put a +1/+1 counter on Carrion Feeder.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private CarrionFeeder(final CarrionFeeder card) {

--- a/Mage.Sets/src/mage/cards/c/CateranOverlord.java
+++ b/Mage.Sets/src/mage/cards/c/CateranOverlord.java
@@ -45,7 +45,7 @@ public final class CateranOverlord extends CardImpl {
 
         // Sacrifice a creature: Regenerate Cateran Overlord.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
         // {6}, {T}: Search your library for a Mercenary permanent card with converted mana cost 6 or less and put it onto the battlefield. Then shuffle your library.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter)), new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/c/CephalidScout.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidScout.java
@@ -36,7 +36,7 @@ public final class CephalidScout extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // {2}{U}, Sacrifice a land: Draw a card.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{2}{U}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/Charforger.java
+++ b/Mage.Sets/src/mage/cards/c/Charforger.java
@@ -35,7 +35,7 @@ public class Charforger extends CardImpl {
         //Whenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Charforger.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.OIL.createInstance()), false,
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE, false
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT, false
         ));
 
         //Remove three oil counters from Charforger: Exile the top card of your library. You may play that card this turn.

--- a/Mage.Sets/src/mage/cards/c/ChitteringHarvester.java
+++ b/Mage.Sets/src/mage/cards/c/ChitteringHarvester.java
@@ -29,7 +29,7 @@ public final class ChitteringHarvester extends CardImpl {
 
         // Whenever this creature mutates, each opponent sacrifices a creature.
         this.addAbility(new MutatesSourceTriggeredAbility(
-                new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE)
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChitteringSkitterling.java
+++ b/Mage.Sets/src/mage/cards/c/ChitteringSkitterling.java
@@ -31,7 +31,7 @@ public final class ChitteringSkitterling extends CardImpl {
         // Corrupted -- Sacrifice an artifact or creature: Draw a card. Activate only if an opponent has three or more poison counters and only once each turn.
         this.addAbility(new LimitedTimesPerTurnActivatedAbility(
                 Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE),
                 1, CorruptedCondition.instance
         ).setAbilityWord(AbilityWord.CORRUPTED).addHint(CorruptedCondition.getHint()));
     }

--- a/Mage.Sets/src/mage/cards/c/ChitteringWitch.java
+++ b/Mage.Sets/src/mage/cards/c/ChitteringWitch.java
@@ -44,7 +44,7 @@ public final class ChitteringWitch extends CardImpl {
 
         // {1}{B}, Sacrifice a creature: Target creature gets -2/-2 until end of turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(-2, -2, Duration.EndOfTurn), new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CircleOfDespair.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfDespair.java
@@ -26,7 +26,7 @@ public final class CircleOfDespair extends CardImpl {
         // {1}, Sacrifice a creature: The next time a source of your choice would deal damage to any target this turn, prevent that damage.
         Ability ability = new SimpleActivatedAbility(
                 Zone.BATTLEFIELD, new PreventNextDamageFromChosenSourceToTargetEffect(Duration.EndOfTurn), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/ClawsOfGix.java
+++ b/Mage.Sets/src/mage/cards/c/ClawsOfGix.java
@@ -23,7 +23,7 @@ public final class ClawsOfGix extends CardImpl {
 
         //{1}, Sacrifice a permanent: You gain 1 life.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CollateralDamage.java
+++ b/Mage.Sets/src/mage/cards/c/CollateralDamage.java
@@ -21,7 +21,7 @@ public final class CollateralDamage extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R}");
 
         // As an additional cost to cast Collateral Damge, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Collateral Damage deals 3 damage to any target.
         this.getSpellAbility().addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/c/ComaVeil.java
+++ b/Mage.Sets/src/mage/cards/c/ComaVeil.java
@@ -1,7 +1,5 @@
-
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.DontUntapInControllersUntapStepEnchantedEffect;
@@ -9,12 +7,13 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -22,20 +21,12 @@ import mage.target.TargetPermanent;
  */
 public final class ComaVeil extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
-
     public ComaVeil(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{4}{U}");
         this.subtype.add(SubType.AURA);
 
         // Enchant artifact or creature
-        TargetPermanent auraTarget = new TargetPermanent(filter);
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Detriment));
         EnchantAbility ability = new EnchantAbility(auraTarget);

--- a/Mage.Sets/src/mage/cards/c/CompleatedHuntmaster.java
+++ b/Mage.Sets/src/mage/cards/c/CompleatedHuntmaster.java
@@ -32,7 +32,7 @@ public final class CompleatedHuntmaster extends CardImpl {
         // {1}, {T}, Sacrifice another creature or artifact: Incubate 3.
         Ability ability = new SimpleActivatedAbility(new IncubateEffect(3), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ConfiscationCoup.java
+++ b/Mage.Sets/src/mage/cards/c/ConfiscationCoup.java
@@ -1,7 +1,5 @@
-
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.PayEnergyCost;
@@ -14,13 +12,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
 
 /**
  *
@@ -28,18 +27,12 @@ import mage.target.targetpointer.FixedTarget;
  */
 public final class ConfiscationCoup extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(CardType.CREATURE.getPredicate(), CardType.ARTIFACT.getPredicate()));
-    }
-
     public ConfiscationCoup(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{U}{U}");
 
         // Choose target creature or artifact. You get {E}{E}{E}{E}, then you may pay an amount of {E} equal to that permanent's converted mana cost. If you do, gain control of it.
         this.getSpellAbility().addEffect(new ConfiscationCoupEffect());
-        this.getSpellAbility().addTarget(new TargetPermanent(filter));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
     }
 
     private ConfiscationCoup(final ConfiscationCoup card) {

--- a/Mage.Sets/src/mage/cards/c/Contamination.java
+++ b/Mage.Sets/src/mage/cards/c/Contamination.java
@@ -30,7 +30,7 @@ public final class Contamination extends CardImpl {
 
         // At the beginning of your upkeep, sacrifice Contamination unless you sacrifice a creature.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)), TargetController.YOU, false)
+                new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)), TargetController.YOU, false)
         );
 
         // If a land is tapped for mana, it produces {B} instead of any other type and amount.

--- a/Mage.Sets/src/mage/cards/c/CorpseHarvester.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseHarvester.java
@@ -39,7 +39,7 @@ public final class CorpseHarvester extends CardImpl {
                 new CorpseHarvesterTarget(), true
         ).setText(ruleText), new ManaCostsImpl<>("{1}{B}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorpseTraders.java
+++ b/Mage.Sets/src/mage/cards/c/CorpseTraders.java
@@ -33,7 +33,7 @@ public final class CorpseTraders extends CardImpl {
         // {2}{B}, Sacrifice a creature: Target opponent reveals their hand. You choose a card from it. That player discards that card. Activate this ability only any time you could cast a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardCardYouChooseTargetEffect(), new ManaCostsImpl<>("{2}{B}"));
         ability.addTarget(new TargetOpponent());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CorruptedConviction.java
+++ b/Mage.Sets/src/mage/cards/c/CorruptedConviction.java
@@ -18,7 +18,7 @@ public final class CorruptedConviction extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Draw two cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));

--- a/Mage.Sets/src/mage/cards/c/CorruptedHarvester.java
+++ b/Mage.Sets/src/mage/cards/c/CorruptedHarvester.java
@@ -30,7 +30,7 @@ public final class CorruptedHarvester extends CardImpl {
         this.power = new MageInt(6);
         this.toughness = new MageInt(3);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/c/CostlyPlunder.java
+++ b/Mage.Sets/src/mage/cards/c/CostlyPlunder.java
@@ -18,7 +18,7 @@ public final class CostlyPlunder extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // As an additional cost to cast Costly Plunder, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Draw two cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));

--- a/Mage.Sets/src/mage/cards/c/CropRotation.java
+++ b/Mage.Sets/src/mage/cards/c/CropRotation.java
@@ -23,7 +23,7 @@ public final class CropRotation extends CardImpl {
 
 
         // As an additional cost to cast Crop Rotation, sacrifice a land.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
 
         // Search your library for a land card and put that card onto the battlefield. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false, true));

--- a/Mage.Sets/src/mage/cards/c/CryptLurker.java
+++ b/Mage.Sets/src/mage/cards/c/CryptLurker.java
@@ -33,7 +33,7 @@ public final class CryptLurker extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(
                 new DrawCardSourceControllerEffect(1),
                 new OrCost(
-                        "sacrifice a creature or discard a creature card", new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), new DiscardTargetCost(new TargetCardInHand(StaticFilters.FILTER_CARD_CREATURE_A))
+                        "sacrifice a creature or discard a creature card", new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), new DiscardTargetCost(new TargetCardInHand(StaticFilters.FILTER_CARD_CREATURE_A))
                 )
         )));
     }

--- a/Mage.Sets/src/mage/cards/c/CullingDais.java
+++ b/Mage.Sets/src/mage/cards/c/CullingDais.java
@@ -31,7 +31,7 @@ public final class CullingDais extends CardImpl {
     public CullingDais(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
         ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CullingDaisEffect(), new GenericManaCost(1));
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/c/CullingTheWeak.java
+++ b/Mage.Sets/src/mage/cards/c/CullingTheWeak.java
@@ -21,7 +21,7 @@ public final class CullingTheWeak extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // As an additional cost to cast Culling the Weak, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Add {B}{B}{B}{B}.
         this.getSpellAbility().addEffect(new BasicManaEffect(Mana.BlackMana(4)));

--- a/Mage.Sets/src/mage/cards/c/CultistOfTheAbsolute.java
+++ b/Mage.Sets/src/mage/cards/c/CultistOfTheAbsolute.java
@@ -47,7 +47,7 @@ public final class CultistOfTheAbsolute extends CardImpl {
         ).setText(", \"Ward&mdash;Pay 3 life,\""));
         ability.addEffect(new GainAbilityAllEffect(
                 new BeginningOfUpkeepTriggeredAbility(new SacrificeControllerEffect(
-                        StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, 1, null
+                        StaticFilters.FILTER_PERMANENT_CREATURE, 1, null
                 ), TargetController.YOU, false),
                 Duration.WhileOnBattlefield, StaticFilters.FILTER_CREATURES_OWNED_COMMANDER
         ).setText("and \"At the beginning of your upkeep, sacrifice a creature.\""));

--- a/Mage.Sets/src/mage/cards/d/DaemogothWoeEater.java
+++ b/Mage.Sets/src/mage/cards/d/DaemogothWoeEater.java
@@ -31,7 +31,7 @@ public final class DaemogothWoeEater extends CardImpl {
 
         // At the beginning of your upkeep, sacrifice a creature.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new SacrificeControllerEffect(
-                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, 1, ""
+                StaticFilters.FILTER_PERMANENT_CREATURE, 1, ""
         ), TargetController.YOU, false));
 
         // When you sacrifice Daemogoth Woe-Eater, each opponent discards a card, you draw a card, and you gain 2 life.

--- a/Mage.Sets/src/mage/cards/d/DarkDwellerOracle.java
+++ b/Mage.Sets/src/mage/cards/d/DarkDwellerOracle.java
@@ -33,7 +33,7 @@ public final class DarkDwellerOracle extends CardImpl {
                 new ExileTopXMayPlayUntilEffect(1, Duration.EndOfTurn).withTextOptions("that card", true),
                 new GenericManaCost(1)
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkPrivilege.java
+++ b/Mage.Sets/src/mage/cards/d/DarkPrivilege.java
@@ -46,7 +46,7 @@ public final class DarkPrivilege extends CardImpl {
 
         // Sacrifice a creature: Regenerate enchanted creature.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateAttachedEffect(AttachmentType.AURA),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkTriumph.java
+++ b/Mage.Sets/src/mage/cards/d/DarkTriumph.java
@@ -31,7 +31,7 @@ public final class DarkTriumph extends CardImpl {
 
         // If you control a Swamp, you may sacrifice a creature rather than pay Dark Triumph's mana cost.
         this.addAbility(new AlternativeCostSourceAbility(
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), condition
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), condition
         ));
 
         // Creatures you control get +2/+0 until end of turn.

--- a/Mage.Sets/src/mage/cards/d/DeadlyDispute.java
+++ b/Mage.Sets/src/mage/cards/d/DeadlyDispute.java
@@ -20,7 +20,7 @@ public final class DeadlyDispute extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Draw two cards and create a Treasure token.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));

--- a/Mage.Sets/src/mage/cards/d/DeathBomb.java
+++ b/Mage.Sets/src/mage/cards/d/DeathBomb.java
@@ -21,7 +21,7 @@ public final class DeathBomb extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{B}");
 
         // As an additional cost to cast Death Bomb, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Destroy target nonblack creature. It can't be regenerated. Its controller loses 2 life.
         this.getSpellAbility().addEffect(new DestroyTargetEffect(true));
         this.getSpellAbility().addEffect(new LoseLifeTargetControllerEffect(2));

--- a/Mage.Sets/src/mage/cards/d/DefiantSalvager.java
+++ b/Mage.Sets/src/mage/cards/d/DefiantSalvager.java
@@ -30,7 +30,7 @@ public final class DefiantSalvager extends CardImpl {
         // Sacrifice an artifact or creature: Put a +1/+1 counter on Defiant Salvager. Activate this ability only any time you could cast a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE)
         );
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/d/DemandingDragon.java
+++ b/Mage.Sets/src/mage/cards/d/DemandingDragon.java
@@ -35,7 +35,7 @@ public final class DemandingDragon extends CardImpl {
         // When Demanding Dragon enters the battlefield, it deals 5 damage to target opponent unless that player sacrifices a creature.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DoUnlessTargetPlayerOrTargetsControllerPaysEffect(
                 new DamageTargetEffect(5),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
         ).setText("it deals 5 damage to target opponent unless that player sacrifices a creature"));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/d/DemonOfCatastrophes.java
+++ b/Mage.Sets/src/mage/cards/d/DemonOfCatastrophes.java
@@ -26,7 +26,7 @@ public final class DemonOfCatastrophes extends CardImpl {
         this.toughness = new MageInt(6);
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());

--- a/Mage.Sets/src/mage/cards/d/DemonOfFatesDesign.java
+++ b/Mage.Sets/src/mage/cards/d/DemonOfFatesDesign.java
@@ -25,6 +25,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterEnchantmentPermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
@@ -39,6 +41,11 @@ import java.util.UUID;
  * @author Susucr
  */
 public final class DemonOfFatesDesign extends CardImpl {
+
+    private static final FilterEnchantmentPermanent filter = new FilterEnchantmentPermanent("another enchantment");
+    static {
+        filter.add(AnotherPredicate.instance);
+    }
 
     public DemonOfFatesDesign(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT, CardType.CREATURE}, "{4}{B}{B}");
@@ -72,9 +79,7 @@ public final class DemonOfFatesDesign extends CardImpl {
                 SacrificeCostManaValue.ENCHANTMENT,
                 StaticValue.get(0), Duration.EndOfTurn
         ), new ManaCostsImpl<>("{2}{B}"));
-        ability.addCost(new SacrificeTargetCost(
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_ENCHANTMENT_SHORT_TEXT
-        ));
+        ability.addCost(new SacrificeTargetCost(filter));
         this.addAbility(ability);
     }
 
@@ -133,8 +138,6 @@ enum DemonOfFatesDesignCost implements DynamicCost {
 
 class DemonOfFatesDesignAlternativeCostSourceAbility extends AlternativeCostSourceAbility {
 
-    private MageObjectReference mor;
-
     DemonOfFatesDesignAlternativeCostSourceAbility() {
         super(
                 new CompoundCondition(SourceIsSpellCondition.instance, IsBeingCastFromHandCondition.instance),
@@ -156,7 +159,7 @@ class DemonOfFatesDesignAlternativeCostSourceAbility extends AlternativeCostSour
     protected void doActivate(Game game, Ability ability) {
         super.doActivate(game, ability);
         for (Cost cost : ability.getCosts()) {
-            if (cost != null && cost instanceof DemonOfFatesDesignPayLifeCost) {
+            if (cost instanceof DemonOfFatesDesignPayLifeCost) {
                 ((DemonOfFatesDesignPayLifeCost) cost).setMor(getMor(game));
             }
         }
@@ -219,7 +222,7 @@ class DemonOfFatesDesignWatcher extends Watcher {
             Spell spell = game.getSpell(event.getTargetId());
             if (spell != null) {
                 for (Cost cost : spell.getStackAbility().getCosts()) {
-                    if (cost != null && cost instanceof DemonOfFatesDesignPayLifeCost) {
+                    if (cost instanceof DemonOfFatesDesignPayLifeCost) {
                         usedFrom.add(((DemonOfFatesDesignPayLifeCost) cost).getMor());
                     }
                 }

--- a/Mage.Sets/src/mage/cards/d/DemonOfWailingAgonies.java
+++ b/Mage.Sets/src/mage/cards/d/DemonOfWailingAgonies.java
@@ -33,7 +33,7 @@ public final class DemonOfWailingAgonies extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         
         // Lieutenant - As long as you control your commander, Demon of Wailing Agonies gets +2/+2 and has "Whenever Demon of Wailing Agonies deals combat damage to a player, that player sacrifices a creature."
-        Ability gainedAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new SacrificeEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, 1, "that player"), false, true);
+        Ability gainedAbility = new DealsCombatDamageToAPlayerTriggeredAbility(new SacrificeEffect(StaticFilters.FILTER_PERMANENT_CREATURE, 1, "that player"), false, true);
         ContinuousEffect effect = new GainAbilitySourceEffect(gainedAbility);
         effect.setText("and has \"Whenever {this} deals combat damage to a player, that player sacrifices a creature.\"");
         this.addAbility(new LieutenantAbility(effect));

--- a/Mage.Sets/src/mage/cards/d/DemonmailHauberk.java
+++ b/Mage.Sets/src/mage/cards/d/DemonmailHauberk.java
@@ -31,7 +31,7 @@ public final class DemonmailHauberk extends CardImpl {
         // Equip - Sacrifice a creature.
         this.addAbility(new EquipAbility(
                 Outcome.AddAbility,
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 false));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DevouringStrossus.java
+++ b/Mage.Sets/src/mage/cards/d/DevouringStrossus.java
@@ -44,7 +44,7 @@ public final class DevouringStrossus extends CardImpl {
         this.addAbility(ability);
         // Sacrifice a creature: Regenerate Devouring Strossus.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private DevouringStrossus(final DevouringStrossus card) {

--- a/Mage.Sets/src/mage/cards/d/DevouringSwarm.java
+++ b/Mage.Sets/src/mage/cards/d/DevouringSwarm.java
@@ -29,7 +29,7 @@ public final class DevouringSwarm extends CardImpl {
         this.toughness = new MageInt(1);
         this.addAbility(FlyingAbility.getInstance());
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private DevouringSwarm(final DevouringSwarm card) {

--- a/Mage.Sets/src/mage/cards/d/DiabolicIntent.java
+++ b/Mage.Sets/src/mage/cards/d/DiabolicIntent.java
@@ -21,7 +21,7 @@ public final class DiabolicIntent extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // As an additional cost to cast Diabolic Intent, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Search your library for a card and put that card into your hand. Then shuffle your library.
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(), false, true));

--- a/Mage.Sets/src/mage/cards/d/DiamondValley.java
+++ b/Mage.Sets/src/mage/cards/d/DiamondValley.java
@@ -28,7 +28,7 @@ public final class DiamondValley extends CardImpl {
         Effect effect = new GainLifeEffect(SacrificeCostCreaturesToughness.instance);
         effect.setText("You gain life equal to the sacrificed creature's toughness");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DimirHouseGuard.java
+++ b/Mage.Sets/src/mage/cards/d/DimirHouseGuard.java
@@ -32,7 +32,7 @@ public final class DimirHouseGuard extends CardImpl {
         this.addAbility(FearAbility.getInstance());
         // Sacrifice a creature: Regenerate Dimir House Guard.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
         // Transmute {1}{B}{B}
         this.addAbility(new TransmuteAbility("{1}{B}{B}"));
     }

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfGriselbrand.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfGriselbrand.java
@@ -36,7 +36,7 @@ public final class DiscipleOfGriselbrand extends CardImpl {
 
         // {1}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DiscipleOfGriselbrandEffect(), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DispersingOrb.java
+++ b/Mage.Sets/src/mage/cards/d/DispersingOrb.java
@@ -24,7 +24,7 @@ public final class DispersingOrb extends CardImpl {
 
         // {3}{U}, Sacrifice a permanent: Return target permanent to its owner's hand.
         Ability ability = new SimpleActivatedAbility(new ReturnToHandTargetEffect(), new ManaCostsImpl<>("{3}{U}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT));
         ability.addTarget(new TargetPermanent().withChooseHint("return to hand"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/d/DocksideChef.java
+++ b/Mage.Sets/src/mage/cards/d/DocksideChef.java
@@ -31,7 +31,7 @@ public final class DocksideChef extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{1}{B}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DregRecycler.java
+++ b/Mage.Sets/src/mage/cards/d/DregRecycler.java
@@ -30,7 +30,7 @@ public final class DregRecycler extends CardImpl {
 
         // {T}, Sacrifice an artifact or creature: Each opponent loses 1 life and you gain 1 life.
         Ability ability = new SimpleActivatedAbility(new LoseLifeOpponentsEffect(1), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/d/DroolingGroodion.java
+++ b/Mage.Sets/src/mage/cards/d/DroolingGroodion.java
@@ -32,7 +32,7 @@ public final class DroolingGroodion extends CardImpl {
         // {2}{B}{G}, Sacrifice a creature: Target creature gets +2/+2 until end of turn. Another target creature gets -2/-2 until end of turn.
         Ability ability = new SimpleActivatedAbility(new BoostTargetEffect(2, 2), new ManaCostsImpl<>("{2}{B}{G}"));
         ability.addEffect(new BoostTargetEffect(-2, -2).setTargetPointer(new SecondTargetPointer()));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         TargetCreaturePermanent target = new TargetCreaturePermanent();
         target.setTargetTag(1);

--- a/Mage.Sets/src/mage/cards/d/DrossHopper.java
+++ b/Mage.Sets/src/mage/cards/d/DrossHopper.java
@@ -32,7 +32,7 @@ public final class DrossHopper extends CardImpl {
         this.toughness = new MageInt(1);
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private DrossHopper(final DrossHopper card) {

--- a/Mage.Sets/src/mage/cards/d/DrownedRusalka.java
+++ b/Mage.Sets/src/mage/cards/d/DrownedRusalka.java
@@ -32,7 +32,7 @@ public final class DrownedRusalka extends CardImpl {
 
         // {U}, Sacrifice a creature: Discard a card, then draw a card.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DiscardControllerEffect(1), new ManaCostsImpl<>("{U}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy(", then"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/d/DuskMangler.java
+++ b/Mage.Sets/src/mage/cards/d/DuskMangler.java
@@ -34,7 +34,7 @@ public final class DuskMangler extends CardImpl {
         // As an additional cost to cast this spell, sacrifice a creature, discard a card, or pay 4 life.
         this.getSpellAbility().addCost(new OrCost(
                 "sacrifice a creature, discard a card, or pay 4 life",
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new DiscardCardCost(), new PayLifeCost(4)
         ));
 

--- a/Mage.Sets/src/mage/cards/d/DuskRoseReliquary.java
+++ b/Mage.Sets/src/mage/cards/d/DuskRoseReliquary.java
@@ -24,7 +24,7 @@ public final class DuskRoseReliquary extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{W}");
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Ward {2}
         this.addAbility(new WardAbility(new ManaCostsImpl<>("{2}"), false));

--- a/Mage.Sets/src/mage/cards/d/DwarvenArmory.java
+++ b/Mage.Sets/src/mage/cards/d/DwarvenArmory.java
@@ -33,7 +33,7 @@ public final class DwarvenArmory extends CardImpl {
                 new ManaCostsImpl<>("{2}"),
                 new IsStepCondition(PhaseStep.UPKEEP, false),
                 null);
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/e/EarthCultElemental.java
+++ b/Mage.Sets/src/mage/cards/e/EarthCultElemental.java
@@ -30,7 +30,7 @@ public final class EarthCultElemental extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(effect).withFlavorWord("Siege Monster"));
 
         // 1-9 | Each player sacrifices a permanent.
-        effect.addTableEntry(1, 9, new SacrificeAllEffect(StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT));
+        effect.addTableEntry(1, 9, new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT));
 
         // 10-19 | Each opponent sacrifices a permanent.
         effect.addTableEntry(10, 19, new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT));

--- a/Mage.Sets/src/mage/cards/e/EarthquakeDragon.java
+++ b/Mage.Sets/src/mage/cards/e/EarthquakeDragon.java
@@ -56,7 +56,7 @@ public final class EarthquakeDragon extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), new ManaCostsImpl<>("{2}{G}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EbonPraetor.java
+++ b/Mage.Sets/src/mage/cards/e/EbonPraetor.java
@@ -47,7 +47,7 @@ public final class EbonPraetor extends CardImpl {
 
         // Sacrifice a creature: Remove a -2/-2 counter from Ebon Praetor. If the sacrificed creature was a Thrull, put a +1/+0 counter on Ebon Praetor. Activate this ability only during your upkeep and only once each turn.
         Ability ability = new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new RemoveCounterSourceEffect(CounterType.M2M2.createInstance()),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), 1, new IsStepCondition(PhaseStep.UPKEEP));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), 1, new IsStepCondition(PhaseStep.UPKEEP));
         ability.addEffect(new EbonPraetorEffect());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/e/EldritchEvolution.java
+++ b/Mage.Sets/src/mage/cards/e/EldritchEvolution.java
@@ -33,7 +33,7 @@ public final class EldritchEvolution extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{G}{G}");
 
         // As an additional cost to cast Eldritch Evolution, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Search your library for a creature card with converted mana cost X or less, where X is 2 plus the sacrificed creature's converted mana cost.
         // Put that card onto the battlefield, then shuffle your library. Exile Eldritch Evolution.

--- a/Mage.Sets/src/mage/cards/e/ElvishReclaimer.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishReclaimer.java
@@ -50,7 +50,7 @@ public final class ElvishReclaimer extends CardImpl {
                 new TargetCardInLibrary(StaticFilters.FILTER_CARD_LAND_A), true
         ), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ElvishSkysweeper.java
+++ b/Mage.Sets/src/mage/cards/e/ElvishSkysweeper.java
@@ -42,7 +42,7 @@ public final class ElvishSkysweeper extends CardImpl {
 
         // {4}{G}, Sacrifice a creature: Destroy target creature with flying.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(), new ManaCostsImpl<>("{4}{G}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent(filter));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/e/Encrust.java
+++ b/Mage.Sets/src/mage/cards/e/Encrust.java
@@ -1,7 +1,5 @@
-
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.Effect;
@@ -12,12 +10,13 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -25,21 +24,13 @@ import mage.target.TargetPermanent;
  */
 public final class Encrust extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-        CardType.CREATURE.getPredicate(),
-        CardType.ARTIFACT.getPredicate()));
-    }
-
     public Encrust(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{U}{U}");
         this.subtype.add(SubType.AURA);
 
 
         // Enchant artifact or creature
-        TargetPermanent auraTarget = new TargetPermanent(filter);
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Detriment));
         Ability ability = new EnchantAbility(auraTarget);

--- a/Mage.Sets/src/mage/cards/e/EndemicPlague.java
+++ b/Mage.Sets/src/mage/cards/e/EndemicPlague.java
@@ -29,7 +29,7 @@ public final class EndemicPlague extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{B}");
 
         // As an additional cost to cast Endemic Plague, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Destroy all creatures that share a creature type with the sacrificed creature. They can't be regenerated.
         this.getSpellAbility().addEffect(new EndemicPlagueEffect());

--- a/Mage.Sets/src/mage/cards/e/EradicatorValkyrie.java
+++ b/Mage.Sets/src/mage/cards/e/EradicatorValkyrie.java
@@ -44,7 +44,7 @@ public final class EradicatorValkyrie extends CardImpl {
         Ability ability = new BoastAbility(new SacrificeOpponentsEffect(
                 StaticFilters.FILTER_PERMANENT_CREATURE_OR_PLANESWALKER
         ), "{1}{B}");
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EverythingamajigE.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingamajigE.java
@@ -41,11 +41,11 @@ public final class EverythingamajigE extends CardImpl {
 
         // Zuran Orb
         // Sacrifice a land: You gain 2 life.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(2), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(2), new SacrificeTargetCost(StaticFilters.FILTER_LAND)));
 
         // Ashnod's Altar
         // Sacrifice a creature: Add {C}{C} to your mana pool.
-        SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+        SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
         this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD,
                 new BasicManaEffect(Mana.ColorlessMana(2), CreaturesYouControlCount.instance),
                 cost));

--- a/Mage.Sets/src/mage/cards/e/EvolutionaryLeap.java
+++ b/Mage.Sets/src/mage/cards/e/EvolutionaryLeap.java
@@ -26,7 +26,7 @@ public final class EvolutionaryLeap extends CardImpl {
         Ability ability = new SimpleActivatedAbility(new RevealCardsFromLibraryUntilEffect(
                 StaticFilters.FILTER_CARD_CREATURE, PutCards.HAND, PutCards.BOTTOM_RANDOM
         ), new ManaCostsImpl<>("{G}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/EvolvingDoor.java
+++ b/Mage.Sets/src/mage/cards/e/EvolvingDoor.java
@@ -37,7 +37,7 @@ public final class EvolvingDoor extends CardImpl {
         // {1}, {T}, Sacrifice a creature: Count the colors of the sacrificed creature, then search your library for a creature card that's exactly that many colors plus one. Exile that card, then shuffle. You may cast the exiled card. Activate only as a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(new EvolvingDoorEffect(), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExcavatingAnurid.java
+++ b/Mage.Sets/src/mage/cards/e/ExcavatingAnurid.java
@@ -42,7 +42,7 @@ public final class ExcavatingAnurid extends CardImpl {
         // When Excavating Anurid enters the battlefield, you may sacrifice a land. If you do, draw a card.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(
                 new DrawCardSourceControllerEffect(1),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_LAND)
         )));
 
         // Threshold — As long as seven or more cards are in your graveyard, Excavating Anurid gets +1/+1 and has vigilance.

--- a/Mage.Sets/src/mage/cards/e/ExtractAConfession.java
+++ b/Mage.Sets/src/mage/cards/e/ExtractAConfession.java
@@ -35,7 +35,7 @@ public final class ExtractAConfession extends CardImpl {
         // instead each opponent sacrifices a creature with the greatest power among creatures they control.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new SacrificeOpponentsEffect(filter),
-                new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE),
                 CollectedEvidenceCondition.instance,
                 "each opponent sacrifices a creature. " +
                         "If evidence was collected, instead each opponent " +

--- a/Mage.Sets/src/mage/cards/e/ExtusOriqOverlord.java
+++ b/Mage.Sets/src/mage/cards/e/ExtusOriqOverlord.java
@@ -62,7 +62,7 @@ public final class ExtusOriqOverlord extends ModalDoubleFacedCard {
         // Awaken the Blood Avatar
         // Sorcery
         // As an additional cost to cast this spell, you may sacrifice any number of creatures. This spell costs {2} less to cast for each creature sacrificed this way.
-        Cost cost = new SacrificeXTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, true);
+        Cost cost = new SacrificeXTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE, true);
         cost.setText("As an additional cost to cast this spell, you may sacrifice any number of creatures. " +
                 "This spell costs {2} less to cast for each creature sacrificed this way");
         this.getRightHalfCard().getSpellAbility().addCost(cost);
@@ -71,9 +71,9 @@ public final class ExtusOriqOverlord extends ModalDoubleFacedCard {
         this.getRightHalfCard().addAbility(ability);
 
         // Each opponent sacrifices a creature. Create a 3/6 black and red Avatar creature token with haste and "Whenever this creature attacks, it deals 3 damage to each opponent."
-        this.getRightHalfCard().getSpellAbility().addEffect(new SacrificeOpponentsEffect(
-                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        ));
+        this.getRightHalfCard().getSpellAbility().addEffect(
+                new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE)
+        );
         this.getRightHalfCard().getSpellAbility().addEffect(new CreateTokenEffect(new BloodAvatarToken()));
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExuberantFuseling.java
+++ b/Mage.Sets/src/mage/cards/e/ExuberantFuseling.java
@@ -46,7 +46,7 @@ public class ExuberantFuseling extends CardImpl {
         this.addAbility(new OrTriggeredAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.OIL.createInstance()),
                 new EntersBattlefieldTriggeredAbility(null, false),
                 new PutIntoGraveFromBattlefieldAllTriggeredAbility(null, false,
-                        StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE, false))
+                        StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT, false))
                 .setTriggerPhrase("When {this} enters the battlefield and whenever another creature or artifact you " +
                         "control is put into a graveyard from the battlefield, "));
     }

--- a/Mage.Sets/src/mage/cards/e/EyeOfYawgmoth.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfYawgmoth.java
@@ -36,7 +36,7 @@ public final class EyeOfYawgmoth extends CardImpl {
         // {3}, {T}, Sacrifice a creature: Reveal a number of cards from the top of your library equal to the sacrificed creature's power. Put one into your hand and exile the rest.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new EyeOfYawgmothEffect(), new GenericManaCost(3));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FainTheBroker.java
+++ b/Mage.Sets/src/mage/cards/f/FainTheBroker.java
@@ -42,7 +42,7 @@ public final class FainTheBroker extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance(2)), new TapSourceCost()
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
@@ -40,7 +40,7 @@ public final class FalkenrathAristocrat extends CardImpl {
         // If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Aristocrat.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addEffect(new FalkenrathAristocratEffect());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
@@ -36,7 +36,7 @@ public final class FalkenrathTorturer extends CardImpl {
         // If the sacrificed creature was a Human, put a +1/+1 counter on Falkenrath Torturer.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addEffect(new FalkenrathAristocratEffect());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/FallenAngel.java
+++ b/Mage.Sets/src/mage/cards/f/FallenAngel.java
@@ -33,7 +33,7 @@ public final class FallenAngel extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Sacrifice a creature: Fallen Angel gets +2/+1 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(2, 1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private FallenAngel(final FallenAngel card) {

--- a/Mage.Sets/src/mage/cards/f/FallenIdeal.java
+++ b/Mage.Sets/src/mage/cards/f/FallenIdeal.java
@@ -43,7 +43,7 @@ public final class FallenIdeal extends CardImpl {
         ability.addEffect(new GainAbilityAttachedEffect(
                 new SimpleActivatedAbility(
                         new BoostSourceEffect(2, 1, Duration.EndOfTurn),
-                        new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                        new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
                 ), AttachmentType.AURA, Duration.WhileOnBattlefield
         ).setText("and \"Sacrifice a creature: This creature gets +2/+1 until end of turn.\""));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/FanaticalDevotion.java
+++ b/Mage.Sets/src/mage/cards/f/FanaticalDevotion.java
@@ -26,7 +26,7 @@ public final class FanaticalDevotion extends CardImpl {
         // Sacrifice a creature: Regenerate target creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new RegenerateTargetEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/f/FanaticalOffering.java
+++ b/Mage.Sets/src/mage/cards/f/FanaticalOffering.java
@@ -20,7 +20,7 @@ public final class FanaticalOffering extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Draw two cards and create a Map token.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));

--- a/Mage.Sets/src/mage/cards/f/FieryBombardment.java
+++ b/Mage.Sets/src/mage/cards/f/FieryBombardment.java
@@ -34,7 +34,7 @@ public final class FieryBombardment extends CardImpl {
         // Chroma - {2}, Sacrifice a creature: Fiery Bombardment deals damage to any target equal to the number of red mana symbols in the sacrificed creature's mana cost.
         Effect effect = new FieryBombardmentEffect();
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect, new ManaCostsImpl<>("{2}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         ability.setAbilityWord(AbilityWord.CHROMA);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/FieryConclusion.java
+++ b/Mage.Sets/src/mage/cards/f/FieryConclusion.java
@@ -21,7 +21,7 @@ public final class FieryConclusion extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{R}");
 
         // As an additional cost to cast Fiery Conclusion, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Fiery Conclusion deals 5 damage to target creature.
         this.getSpellAbility().addEffect(new DamageTargetEffect(5));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/f/FiligreeVector.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeVector.java
@@ -49,7 +49,7 @@ public final class FiligreeVector extends CardImpl {
         // {1}, {T}, Sacrifice another artifact: Proliferate.
         ability = new SimpleActivatedAbility(new ProliferateEffect(), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/f/FinalFlourish.java
+++ b/Mage.Sets/src/mage/cards/f/FinalFlourish.java
@@ -24,7 +24,7 @@ public final class FinalFlourish extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // Kicker--Sacrifice an artifact or creature.
-        this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT)));
+        this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE)));
 
         // Target creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -6/-6 until end of turn instead.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(

--- a/Mage.Sets/src/mage/cards/f/FinalStrike.java
+++ b/Mage.Sets/src/mage/cards/f/FinalStrike.java
@@ -23,7 +23,7 @@ public final class FinalStrike extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{B}{B}");
 
         // As an additional cost to cast Final Strike, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Final Strike deals damage to target opponent equal to the sacrificed creature's power.
         Effect effect = new DamageTargetEffect(SacrificeCostCreaturesPower.instance);

--- a/Mage.Sets/src/mage/cards/f/FirebladeArtist.java
+++ b/Mage.Sets/src/mage/cards/f/FirebladeArtist.java
@@ -41,7 +41,7 @@ public final class FirebladeArtist extends CardImpl {
         );
         ability.addTarget(new TargetOpponentOrPlaneswalker());
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new DoWhenCostPaid(ability, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
+                new DoWhenCostPaid(ability, new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE
                 ), "Sacrifice a creature?"), TargetController.YOU, false
         ));
     }

--- a/Mage.Sets/src/mage/cards/f/FleshAllergy.java
+++ b/Mage.Sets/src/mage/cards/f/FleshAllergy.java
@@ -34,7 +34,7 @@ public final class FleshAllergy extends CardImpl {
 
         // As an additional cost to cast Flesh Allergy, sacrifice a creature.
         // Destroy target creature. Its controller loses life equal to the number of creatures that died this turn.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new FleshAllergyEffect());

--- a/Mage.Sets/src/mage/cards/f/FleshEaterImp.java
+++ b/Mage.Sets/src/mage/cards/f/FleshEaterImp.java
@@ -33,7 +33,7 @@ public final class FleshEaterImp extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         this.addAbility(InfectAbility.getInstance());
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private FleshEaterImp(final FleshEaterImp card) {

--- a/Mage.Sets/src/mage/cards/f/Fling.java
+++ b/Mage.Sets/src/mage/cards/f/Fling.java
@@ -24,7 +24,7 @@ public final class Fling extends CardImpl {
 
         Effect effect = new DamageTargetEffect(SacrificeCostCreaturesPower.instance);
         effect.setText("{this} deals damage equal to the sacrificed creature's power to any target");
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
         this.getSpellAbility().addEffect(effect);
     }

--- a/Mage.Sets/src/mage/cards/f/FodderCannon.java
+++ b/Mage.Sets/src/mage/cards/f/FodderCannon.java
@@ -29,7 +29,7 @@ public final class FodderCannon extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(4), new ManaCostsImpl<>("{4}"));
         ability.addTarget(new TargetCreaturePermanent());
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/f/ForgeNeverwinterCharlatan.java
+++ b/Mage.Sets/src/mage/cards/f/ForgeNeverwinterCharlatan.java
@@ -45,7 +45,7 @@ public final class ForgeNeverwinterCharlatan extends CardImpl {
         this.addAbility(new MenaceAbility(false));
 
         // Ward--Sacrifice a creature.
-        this.addAbility(new WardAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), false));
+        this.addAbility(new WardAbility(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), false));
 
         // Forge, Neverwinter Charlatan gets +2/+0 for each Treasure you control.
         this.addAbility(new SimpleStaticAbility(new BoostSourceEffect(

--- a/Mage.Sets/src/mage/cards/f/ForgehammerCenturion.java
+++ b/Mage.Sets/src/mage/cards/f/ForgehammerCenturion.java
@@ -31,7 +31,7 @@ public class ForgehammerCenturion extends CardImpl {
         //counter on Forgehammer Centurion.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.OIL.createInstance()),
-                false, StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE, false
+                false, StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT, false
         ));
 
         //Whenever Forgehammer Centurion attacks, you may remove two oil counters from it. When you do, target creature

--- a/Mage.Sets/src/mage/cards/f/FoundryHelix.java
+++ b/Mage.Sets/src/mage/cards/f/FoundryHelix.java
@@ -27,7 +27,7 @@ public final class FoundryHelix extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{R}{W}");
 
         // As an additional cost to cast this spell, sacrifice a permanent.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT));
 
         // Foundry Helix deals 4 damage to any target. If the sacrificed permanent was an artifact, you gain 4 life.
         this.getSpellAbility().addEffect(new DamageTargetEffect(4));

--- a/Mage.Sets/src/mage/cards/g/GarrukTheVeilCursed.java
+++ b/Mage.Sets/src/mage/cards/g/GarrukTheVeilCursed.java
@@ -51,7 +51,7 @@ public final class GarrukTheVeilCursed extends CardImpl {
                         StaticFilters.FILTER_CARD_CREATURE_A
                 ), true),
                 null,
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 false
         ), -1));
 

--- a/Mage.Sets/src/mage/cards/g/GateToPhyrexia.java
+++ b/Mage.Sets/src/mage/cards/g/GateToPhyrexia.java
@@ -27,7 +27,7 @@ public final class GateToPhyrexia extends CardImpl {
 
         // Sacrifice a creature: Destroy target artifact. Activate this ability only during your upkeep and only once each turn.
         Ability ability = new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 1, new IsStepCondition(PhaseStep.UPKEEP));
         ability.addTarget(new TargetArtifactPermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/g/GhaveGuruOfSpores.java
+++ b/Mage.Sets/src/mage/cards/g/GhaveGuruOfSpores.java
@@ -49,7 +49,7 @@ public final class GhaveGuruOfSpores extends CardImpl {
 
         // {1}, Sacrifice a creature: Put a +1/+1 counter on target creature.
         Ability ability2 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()), new GenericManaCost(1));
-        ability2.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability2.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability2.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability2);
     }

--- a/Mage.Sets/src/mage/cards/g/GhostCouncilOfOrzhova.java
+++ b/Mage.Sets/src/mage/cards/g/GhostCouncilOfOrzhova.java
@@ -45,7 +45,7 @@ public final class GhostCouncilOfOrzhova extends CardImpl {
                 Zone.BATTLEFIELD,
                 new ExileReturnBattlefieldOwnerNextEndStepSourceEffect(),
                 new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GibberingBarricade.java
+++ b/Mage.Sets/src/mage/cards/g/GibberingBarricade.java
@@ -34,7 +34,7 @@ public final class GibberingBarricade extends CardImpl {
 
         // {2}{B}, Sacrifice a creature: You gain 1 life and draw a card.
         Ability ability = new SimpleActivatedAbility(new GainLifeEffect(1), new ManaCostsImpl<>("{2}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy("and"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/g/GlareOfSubdual.java
+++ b/Mage.Sets/src/mage/cards/g/GlareOfSubdual.java
@@ -1,7 +1,5 @@
-
 package mage.cards.g;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapTargetCost;
@@ -10,12 +8,13 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.Predicates;
 import mage.filter.predicate.permanent.TappedPredicate;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetControlledCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -24,13 +23,9 @@ import mage.target.common.TargetControlledCreaturePermanent;
 public final class GlareOfSubdual extends CardImpl {
 
     private static final FilterControlledCreaturePermanent filterCost = new FilterControlledCreaturePermanent("untapped creature you control");
-    private static final FilterPermanent filterTarget = new FilterPermanent("artifact or creature");
 
     static {
         filterCost.add(TappedPredicate.UNTAPPED);
-        filterTarget.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
     }
 
     public GlareOfSubdual(UUID ownerId, CardSetInfo setInfo) {
@@ -39,7 +34,7 @@ public final class GlareOfSubdual extends CardImpl {
 
         // Tap an untapped creature you control: Tap target artifact or creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TapTargetEffect(), new TapTargetCost(new TargetControlledCreaturePermanent(1, 1, filterCost, true)));
-        ability.addTarget(new TargetPermanent(filterTarget));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlorifierOfSuffering.java
+++ b/Mage.Sets/src/mage/cards/g/GlorifierOfSuffering.java
@@ -36,7 +36,7 @@ public final class GlorifierOfSuffering extends CardImpl {
                 false);
         reflexive.addTarget(new TargetCreaturePermanent(0, 2));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(
-                reflexive, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT),
+                reflexive, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT),
                 "Sacrifice another creature or artifact?"
         )));
 

--- a/Mage.Sets/src/mage/cards/g/GnawingZombie.java
+++ b/Mage.Sets/src/mage/cards/g/GnawingZombie.java
@@ -35,7 +35,7 @@ public final class GnawingZombie extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), new ManaCostsImpl<>("{1}{B}"));
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         ability.addTarget(new TargetPlayer());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoblinBombardment.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinBombardment.java
@@ -23,7 +23,7 @@ public final class GoblinBombardment extends CardImpl {
     public GoblinBombardment(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{R}");
 
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/g/GoblinTrenches.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinTrenches.java
@@ -24,7 +24,7 @@ public final class GoblinTrenches extends CardImpl {
 
         // {2}, Sacrifice a land: Create two 1/1 red and white Goblin Soldier creature tokens.
         Ability ability = new SimpleActivatedAbility(new CreateTokenEffect(new GoblinSoldierToken(), 2), new GenericManaCost(2));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GolgariGuildmage.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariGuildmage.java
@@ -32,7 +32,7 @@ public final class GolgariGuildmage extends CardImpl {
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
         Ability ability = new SimpleActivatedAbility(new ReturnFromGraveyardToHandTargetEffect(), new ManaCostsImpl<>("{4}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
         this.addAbility(ability);
         ability = new SimpleActivatedAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()), new ManaCostsImpl<>("{4}{G}"));

--- a/Mage.Sets/src/mage/cards/g/GolgariRotwurm.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariRotwurm.java
@@ -34,7 +34,7 @@ public final class GolgariRotwurm extends CardImpl {
 
         // {B}, Sacrifice a creature: Target player loses 1 life.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), new ColoredManaCost(ColoredManaSymbol.B));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/g/GollumPatientPlotter.java
+++ b/Mage.Sets/src/mage/cards/g/GollumPatientPlotter.java
@@ -39,7 +39,7 @@ public final class GollumPatientPlotter extends CardImpl {
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), new ManaCostsImpl<>("{B}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/Goremand.java
+++ b/Mage.Sets/src/mage/cards/g/Goremand.java
@@ -28,7 +28,7 @@ public final class Goremand extends CardImpl {
         this.toughness = new MageInt(5);
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());

--- a/Mage.Sets/src/mage/cards/g/GraftedButcher.java
+++ b/Mage.Sets/src/mage/cards/g/GraftedButcher.java
@@ -53,7 +53,7 @@ public final class GraftedButcher extends CardImpl {
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 Zone.GRAVEYARD, new ReturnSourceFromGraveyardToBattlefieldEffect(false, false), new ManaCostsImpl<>("{3}{B}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraftedIdentity.java
+++ b/Mage.Sets/src/mage/cards/g/GraftedIdentity.java
@@ -30,7 +30,7 @@ public final class GraftedIdentity extends CardImpl {
         this.subtype.add(SubType.AURA);
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();

--- a/Mage.Sets/src/mage/cards/g/Gravelighter.java
+++ b/Mage.Sets/src/mage/cards/g/Gravelighter.java
@@ -34,7 +34,7 @@ public final class Gravelighter extends CardImpl {
         // When Gravelighter enters the battlefield, draw a card if a creature died this turn. Otherwise, each player sacrifices a creature.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new ConditionalOneShotEffect(
                 new DrawCardSourceControllerEffect(1),
-                new SacrificeAllEffect(1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE),
                 MorbidCondition.instance, "draw a card if a creature died this turn. " +
                 "Otherwise, each player sacrifices a creature"
         )).addHint(MorbidHint.instance));

--- a/Mage.Sets/src/mage/cards/g/GreaterGood.java
+++ b/Mage.Sets/src/mage/cards/g/GreaterGood.java
@@ -29,7 +29,7 @@ public final class GreaterGood extends CardImpl {
         Effect effect = new DrawCardSourceControllerEffect(SacrificeCostCreaturesPower.instance);
         effect.setText("Draw cards equal to the sacrificed creature's power");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, effect,
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         effect = new DiscardControllerEffect(3);
         effect.setText(", then discard three cards");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/g/GrimBackwoods.java
+++ b/Mage.Sets/src/mage/cards/g/GrimBackwoods.java
@@ -30,7 +30,7 @@ public final class GrimBackwoods extends CardImpl {
         // {2}{B}{G}, {tap}, Sacrifice a creature: Draw a card.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{2}{B}{G}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GristTheHungerTide.java
+++ b/Mage.Sets/src/mage/cards/g/GristTheHungerTide.java
@@ -58,7 +58,7 @@ public final class GristTheHungerTide extends CardImpl {
         ability.addTarget(new TargetCreatureOrPlaneswalker());
         this.addAbility(new LoyaltyAbility(new DoWhenCostPaid(
                 ability,
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), "Sacrifice a creature?"
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), "Sacrifice a creature?"
         ), -2));
 
         // −5: Each opponent loses life equal to the number of creature cards in your graveyard.

--- a/Mage.Sets/src/mage/cards/g/GutlessGhoul.java
+++ b/Mage.Sets/src/mage/cards/g/GutlessGhoul.java
@@ -32,7 +32,7 @@ public final class GutlessGhoul extends CardImpl {
 
         // {1}, Sacrifice a creature: You gain 2 life.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(2), new ManaCostsImpl<>("{1}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/Harrow.java
+++ b/Mage.Sets/src/mage/cards/h/Harrow.java
@@ -21,7 +21,7 @@ public final class Harrow extends CardImpl {
         this.color.setGreen(true);        
 
         // As an additional cost to cast Harrow, sacrifice a land.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
 
         // Search your library for up to two basic land cards and put them onto the battlefield. Then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS);

--- a/Mage.Sets/src/mage/cards/h/HellsCaretaker.java
+++ b/Mage.Sets/src/mage/cards/h/HellsCaretaker.java
@@ -35,7 +35,7 @@ public final class HellsCaretaker extends CardImpl {
                 new ReturnFromGraveyardToBattlefieldTargetEffect(),
                 new TapSourceCost(),
                 new IsStepCondition(PhaseStep.UPKEEP));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/h/HelmOfPossession.java
+++ b/Mage.Sets/src/mage/cards/h/HelmOfPossession.java
@@ -37,7 +37,7 @@ public final class HelmOfPossession extends CardImpl {
                 "gain control of target creature for as long as you control {this} and {this} remains tapped"
         ), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/h/HenrikaDomnathi.java
+++ b/Mage.Sets/src/mage/cards/h/HenrikaDomnathi.java
@@ -40,9 +40,7 @@ public final class HenrikaDomnathi extends CardImpl {
 
         // At the beginning of combat on your turn, choose one that hasn't been chosen —
         // • Each player sacrifices a creature.
-        Ability ability = new BeginningOfCombatTriggeredAbility(new SacrificeAllEffect(
-                1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        ), TargetController.YOU, false);
+        Ability ability = new BeginningOfCombatTriggeredAbility(new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE), TargetController.YOU, false);
         ability.setModeTag("each player sacrifice");
         ability.getModes().setLimitUsageByOnce(false);
 

--- a/Mage.Sets/src/mage/cards/h/HewTheEntwood.java
+++ b/Mage.Sets/src/mage/cards/h/HewTheEntwood.java
@@ -16,8 +16,8 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
-import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
+import mage.target.common.TargetSacrifice;
 
 import java.util.UUID;
 
@@ -78,9 +78,7 @@ class HewTheEntwoodEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        TargetPermanent target = new TargetPermanent(
-                0, Integer.MAX_VALUE, StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT, true
-        );
+        TargetSacrifice target = new TargetSacrifice(0, Integer.MAX_VALUE, StaticFilters.FILTER_LAND);
         player.choose(outcome, target, source, game);
         int count = 0;
         for (UUID targetId : target.getTargets()) {

--- a/Mage.Sets/src/mage/cards/h/HiddenStockpile.java
+++ b/Mage.Sets/src/mage/cards/h/HiddenStockpile.java
@@ -38,7 +38,7 @@ public final class HiddenStockpile extends CardImpl {
 
         // {1}, Sacrifice a creature: Scry 1.
         Ability ability = new SimpleActivatedAbility(new ScryEffect(1, false), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HidetsuguDevouringChaos.java
+++ b/Mage.Sets/src/mage/cards/h/HidetsuguDevouringChaos.java
@@ -39,7 +39,7 @@ public final class HidetsuguDevouringChaos extends CardImpl {
 
         // {B}, Sacrifice a creature: Scry 2.
         Ability ability = new SimpleActivatedAbility(new ScryEffect(2), new ManaCostsImpl<>("{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // {2}{R}, {T}: Exile the top card of your library. You may play that card this turn. When you exile a nonland card this way, Hidetsugu, Devouring Chaos deals damage equal to the exiled card's mana value to any target.

--- a/Mage.Sets/src/mage/cards/h/HighMarket.java
+++ b/Mage.Sets/src/mage/cards/h/HighMarket.java
@@ -28,7 +28,7 @@ public final class HighMarket extends CardImpl {
         this.addAbility(new ColorlessManaAbility());
         // {tap}, Sacrifice a creature: You gain 1 life.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HostileHostel.java
+++ b/Mage.Sets/src/mage/cards/h/HostileHostel.java
@@ -39,7 +39,7 @@ public final class HostileHostel extends CardImpl {
         this.addAbility(new TransformAbility());
         Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new HostileHostelEffect(), new ManaCostsImpl<>("{1}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IchorExplosion.java
+++ b/Mage.Sets/src/mage/cards/i/IchorExplosion.java
@@ -25,7 +25,7 @@ public final class IchorExplosion extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{B}{B}");
 
         // As an additional cost to cast Ichor Explosion, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // All creatures get -X/-X until end of turn, where X is the sacrificed creature's power.
         this.getSpellAbility().addEffect(new BoostAllEffect(xValue, xValue, Duration.EndOfTurn));

--- a/Mage.Sets/src/mage/cards/i/ImprovisedClub.java
+++ b/Mage.Sets/src/mage/cards/i/ImprovisedClub.java
@@ -20,7 +20,7 @@ public final class ImprovisedClub extends CardImpl {
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
         this.getSpellAbility().addCost(new SacrificeTargetCost(
-                StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT
+                StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE
         ));
 
         // Improvised Club deals 4 damage to any target.

--- a/Mage.Sets/src/mage/cards/i/IndulgentAristocrat.java
+++ b/Mage.Sets/src/mage/cards/i/IndulgentAristocrat.java
@@ -42,7 +42,7 @@ public final class IndulgentAristocrat extends CardImpl {
 
         // {2}, Sacrifice a creature: Put a +1/+1 counter on each Vampire you control.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersAllEffect(CounterType.P1P1.createInstance(), filter), new GenericManaCost(2));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/IndulgentTormentor.java
+++ b/Mage.Sets/src/mage/cards/i/IndulgentTormentor.java
@@ -74,7 +74,7 @@ class IndulgentTormentorEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player opponent = game.getPlayer(source.getFirstTarget());
         if (opponent != null) {
-            Cost cost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+            Cost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
             if (cost.canPay(source, source, opponent.getId(), game)
                     && opponent.chooseUse(outcome, "Sacrifice a creature to prevent the card draw?", source, game)) {
                 if (cost.pay(source, game, source, opponent.getId(), false, null)) {

--- a/Mage.Sets/src/mage/cards/i/InfernalPlunge.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalPlunge.java
@@ -21,7 +21,7 @@ public final class InfernalPlunge extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R}");
 
         // As an additional cost to cast Infernal Plunge, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Add {R}{R}{R}.
         this.getSpellAbility().addEffect(new BasicManaEffect(Mana.RedMana(3)));
     }

--- a/Mage.Sets/src/mage/cards/i/InnocentBlood.java
+++ b/Mage.Sets/src/mage/cards/i/InnocentBlood.java
@@ -17,9 +17,7 @@ public final class InnocentBlood extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
 
         // Each player sacrifices a creature.
-        this.getSpellAbility().addEffect(new SacrificeAllEffect(
-                1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        ));
+        this.getSpellAbility().addEffect(new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE));
     }
 
     private InnocentBlood(final InnocentBlood card) {

--- a/Mage.Sets/src/mage/cards/i/InvasionOfNewCapenna.java
+++ b/Mage.Sets/src/mage/cards/i/InvasionOfNewCapenna.java
@@ -36,7 +36,7 @@ public final class InvasionOfNewCapenna extends CardImpl {
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(
                 ability,
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE),
                 "Sacrifice and artifact or creature?"
         )));
     }

--- a/Mage.Sets/src/mage/cards/j/JinxedIdol.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedIdol.java
@@ -30,7 +30,7 @@ public final class JinxedIdol extends CardImpl {
 
         // Sacrifice a creature: Target opponent gains control of Jinxed Idol.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TargetPlayerGainControlSourceEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/j/JinxedRing.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedRing.java
@@ -37,7 +37,7 @@ public final class JinxedRing extends CardImpl {
 
         // Sacrifice a creature: Target opponent gains control of Jinxed Ring.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TargetPlayerGainControlSourceEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/j/JunkJet.java
+++ b/Mage.Sets/src/mage/cards/j/JunkJet.java
@@ -42,7 +42,7 @@ public final class JunkJet extends CardImpl {
                 new JunkJetAbility(),
                 new GenericManaCost(3)
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT));
         this.addAbility(ability);
 
         // Equip {1}

--- a/Mage.Sets/src/mage/cards/j/JunkyardGenius.java
+++ b/Mage.Sets/src/mage/cards/j/JunkyardGenius.java
@@ -43,7 +43,7 @@ public final class JunkyardGenius extends CardImpl {
         Ability ability = new SimpleActivatedAbility(new BoostControlledEffect(
                 1, 1, Duration.EndOfTurn, true
         ).setText("until end of turn, other creatures you control get +1/+0"), new ManaCostsImpl<>("{1}{B}{R}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         ability.addEffect(new GainAbilityControlledEffect(
                 new MenaceAbility(), Duration.EndOfTurn,
                 StaticFilters.FILTER_PERMANENT_CREATURES, true

--- a/Mage.Sets/src/mage/cards/k/KardursViciousReturn.java
+++ b/Mage.Sets/src/mage/cards/k/KardursViciousReturn.java
@@ -46,7 +46,7 @@ public final class KardursViciousReturn extends CardImpl {
         );
         ability.addTarget(new TargetAnyTarget());
         sagaAbility.addChapterEffect(this, SagaChapter.CHAPTER_I, new DoWhenCostPaid(
-                ability, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                ability, new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 "Sacrifice a creature?"
         ));
 

--- a/Mage.Sets/src/mage/cards/k/KayasGuile.java
+++ b/Mage.Sets/src/mage/cards/k/KayasGuile.java
@@ -29,9 +29,7 @@ public final class KayasGuile extends CardImpl {
         this.getSpellAbility().getModes().setMaxModes(2);
 
         // • Each opponent sacrifices a creature.
-        this.getSpellAbility().addEffect(new SacrificeOpponentsEffect(
-                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        ));
+        this.getSpellAbility().addEffect(new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // • Exile all cards from each opponent's graveyard.
         this.getSpellAbility().addMode(new Mode(new ExileGraveyardAllPlayersEffect(

--- a/Mage.Sets/src/mage/cards/k/KazuulsFury.java
+++ b/Mage.Sets/src/mage/cards/k/KazuulsFury.java
@@ -32,7 +32,7 @@ public final class KazuulsFury extends ModalDoubleFacedCard {
         // Instant
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getLeftHalfCard().getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getLeftHalfCard().getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Kazuul's Fury deals damage equal to the sacrificed creatures power to any target.
         this.getLeftHalfCard().getSpellAbility().addEffect(new DamageTargetEffect(SacrificeCostCreaturesPower.instance)

--- a/Mage.Sets/src/mage/cards/k/KeldonNecropolis.java
+++ b/Mage.Sets/src/mage/cards/k/KeldonNecropolis.java
@@ -33,7 +33,7 @@ public final class KeldonNecropolis extends CardImpl {
         // {4}{R}, {T}, Sacrifice a creature: Keldon Necropolis deals 2 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(2), new ManaCostsImpl<>("{4}{R}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/k/KelsFightFixer.java
+++ b/Mage.Sets/src/mage/cards/k/KelsFightFixer.java
@@ -49,7 +49,7 @@ public final class KelsFightFixer extends CardImpl {
         Ability ability = new SimpleActivatedAbility(new GainAbilitySourceEffect(
                 IndestructibleAbility.getInstance(), Duration.EndOfTurn
         ), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KillZoneAcrobat.java
+++ b/Mage.Sets/src/mage/cards/k/KillZoneAcrobat.java
@@ -31,7 +31,7 @@ public final class KillZoneAcrobat extends CardImpl {
         // Whenever Kill-Zone Acrobat attacks, you may sacrifice another creature or artifact. If you do, Kill-Zone Acrobat gains flying until end of turn.
         this.addAbility(new AttacksTriggeredAbility(new DoIfCostPaid(
                 new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT)
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KnightsOfRen.java
+++ b/Mage.Sets/src/mage/cards/k/KnightsOfRen.java
@@ -37,12 +37,12 @@ public class KnightsOfRen extends CardImpl {
         //than combat damage this turn, you may have each player sacrifice a creature.
         Ability abilityEnterBattlefield = new ConditionalInterveningIfTriggeredAbility(
                 new EntersBattlefieldTriggeredAbility(
-                        new SacrificeAllEffect(1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), true),
+                        new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE), true),
                 HateCondition.instance,
                 "<i>Hate</i> &mdash; When {this} enters the battlefield, if an opponent lost life from a source other than combat damage this turn, you may have each player sacrifice a creature");
         Ability abilityAttacks = new ConditionalInterveningIfTriggeredAbility(
                 new AttacksTriggeredAbility(
-                        new SacrificeAllEffect(1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), true),
+                        new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE), true),
                 HateCondition.instance,
                 "<i>Hate</i> &mdash; When {this} attacks, if an opponent lost life from a source other than combat damage this turn, you may have each player sacrifice a creature");
         this.addAbility(abilityEnterBattlefield, new LifeLossOtherFromCombatWatcher());

--- a/Mage.Sets/src/mage/cards/k/KrovikanHorror.java
+++ b/Mage.Sets/src/mage/cards/k/KrovikanHorror.java
@@ -45,7 +45,7 @@ public final class KrovikanHorror extends CardImpl {
 
         // {1}, Sacrifice a creature: Krovikan Horror deals 1 damage to any target.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/l/LampadOfDeathsVigil.java
+++ b/Mage.Sets/src/mage/cards/l/LampadOfDeathsVigil.java
@@ -31,7 +31,7 @@ public final class LampadOfDeathsVigil extends CardImpl {
         // {1}, Sacrifice a creature: Each opponent loses 1 life and you gain 1 life.
         Ability ability = new SimpleActivatedAbility(new LoseLifeOpponentsEffect(1), new GenericManaCost(1));
         ability.addEffect(new GainLifeEffect(1).concatBy("and"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LashOfTheBalrog.java
+++ b/Mage.Sets/src/mage/cards/l/LashOfTheBalrog.java
@@ -23,7 +23,7 @@ public final class LashOfTheBalrog extends CardImpl {
         // As an additional cost to cast this spell, sacrifice a creature or pay {4}.
         this.getSpellAbility().addCost(new OrCost(
                 "sacrifice a creature or pay {4}",
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new GenericManaCost(4)
         ));
 

--- a/Mage.Sets/src/mage/cards/l/LaunchParty.java
+++ b/Mage.Sets/src/mage/cards/l/LaunchParty.java
@@ -22,7 +22,7 @@ public final class LaunchParty extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{B}");
 
         // As an additional cost to cast Launch Party, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Destroy target creature. Its controller loses 2 life.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/l/LaurineTheDiversion.java
+++ b/Mage.Sets/src/mage/cards/l/LaurineTheDiversion.java
@@ -40,7 +40,7 @@ public final class LaurineTheDiversion extends CardImpl {
 
         // {2}, Sacrifice an artifact or creature: Goad target creature.
         Ability ability = new SimpleActivatedAbility(new GoadTargetEffect(), new GenericManaCost(2));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/l/LegacyOfTheBeloved.java
+++ b/Mage.Sets/src/mage/cards/l/LegacyOfTheBeloved.java
@@ -33,7 +33,7 @@ public final class LegacyOfTheBeloved extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}{G}");
 
         // As an additional cost to cast Legacy of the Beloved, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Search you library for up to two creatures cards that each have a lower converted mana cost that sacrificied creature's converted mana cost, reveal them and put them onto the battlefield, then shuffle you library.
         this.getSpellAbility().addEffect(new LegacyOfTheBelovedEffect());

--- a/Mage.Sets/src/mage/cards/l/LegionExtruder.java
+++ b/Mage.Sets/src/mage/cards/l/LegionExtruder.java
@@ -33,7 +33,7 @@ public final class LegionExtruder extends CardImpl {
         // {2}, {T}, Sacrifice another artifact: Create a 3/3 colorless Golem artifact creature token.
         ability = new SimpleActivatedAbility(new CreateTokenEffect(new GolemToken()), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LifeChisel.java
+++ b/Mage.Sets/src/mage/cards/l/LifeChisel.java
@@ -31,7 +31,7 @@ public final class LifeChisel extends CardImpl {
         Ability ability = new ConditionalActivatedAbility(
                 Zone.BATTLEFIELD,
                 new LifeChiselEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new IsStepCondition(PhaseStep.UPKEEP)
         );
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/l/LifesLegacy.java
+++ b/Mage.Sets/src/mage/cards/l/LifesLegacy.java
@@ -25,7 +25,7 @@ public final class LifesLegacy extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{G}");
 
         // As an additional cost to cast Life's Legacy, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Draw cards equal to the sacrificed creature's power.
         this.getSpellAbility().addEffect(new LifesLegacyEffect());
 

--- a/Mage.Sets/src/mage/cards/l/LilianasTriumph.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasTriumph.java
@@ -29,9 +29,7 @@ public final class LilianasTriumph extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // Each opponent sacrifices a creature. If you control a Liliana planeswalker, each opponent also discards a card.
-        this.getSpellAbility().addEffect(new SacrificeOpponentsEffect(
-                StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        ));
+        this.getSpellAbility().addEffect(new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new DiscardEachPlayerEffect(
                         StaticValue.get(1), false, TargetController.OPPONENT

--- a/Mage.Sets/src/mage/cards/l/LokhustHeavyDestroyer.java
+++ b/Mage.Sets/src/mage/cards/l/LokhustHeavyDestroyer.java
@@ -30,9 +30,7 @@ public final class LokhustHeavyDestroyer extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Enmitic Exterminator -- When Lokhust Heavy Destroyer enters the battlefield, each plater sacrifices a creature.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeAllEffect(
-                1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        )).withFlavorWord("Enmitic Exterminator"));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE)).withFlavorWord("Enmitic Exterminator"));
 
         // Unearth {5}{B}{B}{B}
         this.addAbility(new UnearthAbility(new ManaCostsImpl<>("{5}{B}{B}{B}")));

--- a/Mage.Sets/src/mage/cards/l/LyzoldaTheBloodWitch.java
+++ b/Mage.Sets/src/mage/cards/l/LyzoldaTheBloodWitch.java
@@ -62,7 +62,7 @@ public final class LyzoldaTheBloodWitch extends CardImpl {
                 new SacrificedWasCondition(blackFilter),
                 "Draw a card if the sacrificed creature was black");
         ability.addEffect(effect);
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
+++ b/Mage.Sets/src/mage/cards/m/MaestrosAscendancy.java
@@ -89,7 +89,7 @@ class MaestrosAscendancyCastEffect extends AsThoughEffectImpl {
         }
         Costs<Cost> newCosts = new CostsImpl<>();
         newCosts.addAll(card.getSpellAbility().getCosts());
-        newCosts.add(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        newCosts.add(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         player.setCastSourceIdWithAlternateMana(
                 card.getId(), card.getManaCost(), newCosts,
                 MageIdentifier.MaestrosAscendencyAlternateCast

--- a/Mage.Sets/src/mage/cards/m/MagmaRift.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaRift.java
@@ -21,7 +21,7 @@ public final class MagmaRift extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{R}");
 
         // As an additional cost to cast Magma Rift, sacrifice a land.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
 
         // Magma Rift deals 5 damage to target creature.
         this.getSpellAbility().addEffect(new DamageTargetEffect(5));

--- a/Mage.Sets/src/mage/cards/m/MakeshiftMunitions.java
+++ b/Mage.Sets/src/mage/cards/m/MakeshiftMunitions.java
@@ -23,7 +23,7 @@ public final class MakeshiftMunitions extends CardImpl {
 
         // {1}, Sacrifice an artifact or creature: Makeshift Munitions deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(1), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MalevolentAwakening.java
+++ b/Mage.Sets/src/mage/cards/m/MalevolentAwakening.java
@@ -35,7 +35,7 @@ public final class MalevolentAwakening extends CardImpl {
         // {1}{B}{B}, Sacrifice a creature: Return target creature card from your graveyard to your hand.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnFromGraveyardToHandTargetEffect(), new ManaCostsImpl<>("{1}{B}{B}"));
         ability.addTarget(new TargetCardInYourGraveyard(filter));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Malfunction.java
+++ b/Mage.Sets/src/mage/cards/m/Malfunction.java
@@ -13,8 +13,7 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -24,21 +23,12 @@ import java.util.UUID;
  */
 public final class Malfunction extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()
-        ));
-    }
-
     public Malfunction(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{U}");
         this.subtype.add(SubType.AURA);
 
         // Enchant artifact or creature.
-        TargetPermanent auraTarget = new TargetPermanent(filter);
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Detriment));
         Ability ability = new EnchantAbility(auraTarget);

--- a/Mage.Sets/src/mage/cards/m/Marjhan.java
+++ b/Mage.Sets/src/mage/cards/m/Marjhan.java
@@ -54,7 +54,7 @@ public final class Marjhan extends CardImpl {
         // {U}{U}, Sacrifice a creature: Untap Marjhan. Activate this ability only during your upkeep.
         Ability ability = new ConditionalActivatedAbility(Zone.BATTLEFIELD,
                 new UntapSourceEffect(), new ManaCostsImpl<>("{U}{U}"), new IsStepCondition(PhaseStep.UPKEEP), null);
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // Marjhan can't attack unless defending player controls an Island.

--- a/Mage.Sets/src/mage/cards/m/MartyredRusalka.java
+++ b/Mage.Sets/src/mage/cards/m/MartyredRusalka.java
@@ -32,7 +32,7 @@ public final class MartyredRusalka extends CardImpl {
 
         // {W}, Sacrifice a creature: Target creature can't attack this turn.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CantAttackTargetEffect(Duration.EndOfTurn), new ManaCostsImpl<>("{W}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/m/MartyrsCause.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrsCause.java
@@ -26,7 +26,7 @@ public final class MartyrsCause extends CardImpl {
 
         // Sacrifice a creature: The next time a source of your choice would deal damage to any target this turn, prevent that damage.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new PreventNextDamageFromChosenSourceToTargetEffect(Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MaskOfTheMimic.java
+++ b/Mage.Sets/src/mage/cards/m/MaskOfTheMimic.java
@@ -37,7 +37,7 @@ public final class MaskOfTheMimic extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{U}");
 
         // As an additional cost to cast Mask of the Mimic, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Search your library for a card with the same name as target nontoken creature and put that card onto the battlefield. Then shuffle your library.
         this.getSpellAbility().addEffect(new MaskOfTheMimicEffect());

--- a/Mage.Sets/src/mage/cards/m/MawOfTheObzedat.java
+++ b/Mage.Sets/src/mage/cards/m/MawOfTheObzedat.java
@@ -26,7 +26,7 @@ public final class MawOfTheObzedat extends CardImpl {
 
         // Sacrifice a creature: Creatures you control get +1/+1 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostControlledEffect(1, 1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
     }
 

--- a/Mage.Sets/src/mage/cards/m/MegatronDestructiveForce.java
+++ b/Mage.Sets/src/mage/cards/m/MegatronDestructiveForce.java
@@ -18,8 +18,8 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
-import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
+import mage.target.common.TargetSacrifice;
 
 import java.util.UUID;
 
@@ -78,8 +78,8 @@ class MegatronDestructiveForceEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        TargetPermanent target = new TargetPermanent(
-            0, 1, StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT, true
+        TargetSacrifice target = new TargetSacrifice(
+            0, 1, StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT
         );
         player.choose(outcome, target, source, game);
         Permanent permanent = game.getPermanent(target.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/m/MelokuTheCloudedMirror.java
+++ b/Mage.Sets/src/mage/cards/m/MelokuTheCloudedMirror.java
@@ -39,7 +39,7 @@ public final class MelokuTheCloudedMirror extends CardImpl {
                 new MelokuTheCloudedMirrorToken(), 1
         ), new GenericManaCost(1));
         ability.addCost(new ReturnToHandChosenControlledPermanentCost(
-                new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)
+                new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_PERMANENT_LAND)
         ));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/Metamorphosis.java
+++ b/Mage.Sets/src/mage/cards/m/Metamorphosis.java
@@ -28,7 +28,7 @@ public final class Metamorphosis extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{G}");
 
         // As an additional cost to cast Metamorphosis, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.getSpellAbility().addEffect(new MetamorphosisEffect());
         // Add X mana of any one color, where X is one plus the sacrificed creature's converted mana cost. Spend this mana only to cast creature spells.
     }

--- a/Mage.Sets/src/mage/cards/m/MindExtraction.java
+++ b/Mage.Sets/src/mage/cards/m/MindExtraction.java
@@ -29,7 +29,7 @@ public final class MindExtraction extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Target player reveals their hand and discards all cards of each of the sacrificed creature’s colors.
         this.getSpellAbility().addEffect(new MindExtractionEffect());

--- a/Mage.Sets/src/mage/cards/m/MindSlash.java
+++ b/Mage.Sets/src/mage/cards/m/MindSlash.java
@@ -27,7 +27,7 @@ public final class MindSlash extends CardImpl {
         // {B}, Sacrifice a creature: Target opponent reveals their hand. You choose a card from it.
         // That player discards that card. Activate this ability only any time you could cast a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardCardYouChooseTargetEffect(), new ManaCostsImpl<>("{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/m/MindSwords.java
+++ b/Mage.Sets/src/mage/cards/m/MindSwords.java
@@ -43,7 +43,7 @@ public final class MindSwords extends CardImpl {
 
         // If you control a Swamp, you may sacrifice a creature rather than pay Mind Swords's mana cost.
         this.addAbility(new AlternativeCostSourceAbility(
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new PermanentsOnTheBattlefieldCondition(filterSwamp), null
         ));
 

--- a/Mage.Sets/src/mage/cards/m/MirenTheMoaningWell.java
+++ b/Mage.Sets/src/mage/cards/m/MirenTheMoaningWell.java
@@ -37,7 +37,7 @@ public final class MirenTheMoaningWell extends CardImpl {
         // {3}, {tap}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new MirenTheMoaningWellEffect(), new GenericManaCost(3));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MishraTamerOfMakFawa.java
+++ b/Mage.Sets/src/mage/cards/m/MishraTamerOfMakFawa.java
@@ -36,7 +36,7 @@ public final class MishraTamerOfMakFawa extends CardImpl {
         // Permanents you control have "Ward--Sacrifice a permanent."
         this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(
                 new WardAbility(new SacrificeTargetCost(
-                        StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT
+                        StaticFilters.FILTER_PERMANENT
                 ), false), Duration.WhileOnBattlefield
         ).withForceQuotes()));
 

--- a/Mage.Sets/src/mage/cards/m/MomentousFall.java
+++ b/Mage.Sets/src/mage/cards/m/MomentousFall.java
@@ -25,7 +25,7 @@ public final class MomentousFall extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{G}{G}");
 
         // As an additional cost to cast Momentous Fall, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // You draw cards equal to the sacrificed creature's power, then you gain life equal to its toughness.
         this.getSpellAbility().addEffect(new MomentousFallEffect());

--- a/Mage.Sets/src/mage/cards/m/MorbidCuriosity.java
+++ b/Mage.Sets/src/mage/cards/m/MorbidCuriosity.java
@@ -20,7 +20,7 @@ public final class MorbidCuriosity extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}{B}");
 
         // As an additional cost to cast Morbid Curiosity, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Draw cards equal to the converted mana cost of the sacrificed permanent.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(

--- a/Mage.Sets/src/mage/cards/m/MorkrutBehemoth.java
+++ b/Mage.Sets/src/mage/cards/m/MorkrutBehemoth.java
@@ -29,7 +29,7 @@ public final class MorkrutBehemoth extends CardImpl {
 
         // As an additional cost to cast this spell, sacrifice a creature or pay {1}{B}.
         this.getSpellAbility().addCost(new OrCost(
-                "sacrifice a creature or pay {1}{B}", new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), new ManaCostsImpl<>("{1}{B}")
+                "sacrifice a creature or pay {1}{B}", new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), new ManaCostsImpl<>("{1}{B}")
         ));
 
         // Menace

--- a/Mage.Sets/src/mage/cards/m/MutualDestruction.java
+++ b/Mage.Sets/src/mage/cards/m/MutualDestruction.java
@@ -47,7 +47,7 @@ public final class MutualDestruction extends CardImpl {
         )).setRuleAtTheTop(true));
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Destroy target creature.
         this.getSpellAbility().addEffect(new DestroyTargetEffect("Destroy target creature"));

--- a/Mage.Sets/src/mage/cards/m/MyrkulsEdict.java
+++ b/Mage.Sets/src/mage/cards/m/MyrkulsEdict.java
@@ -44,7 +44,7 @@ public final class MyrkulsEdict extends CardImpl {
         effect.addTableEntry(1, 9, new MyrkulsEdictEffect());
 
         // 10-19 | Each opponent sacrifices a creature.
-        effect.addTableEntry(10, 19, new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        effect.addTableEntry(10, 19, new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // 20 | Each opponent sacrifices a creature with the greatest power among creatures that player controls.
         effect.addTableEntry(20, 20, new SacrificeOpponentsEffect(filter));

--- a/Mage.Sets/src/mage/cards/n/NahirisLithoforming.java
+++ b/Mage.Sets/src/mage/cards/n/NahirisLithoforming.java
@@ -13,7 +13,7 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
-import mage.target.TargetPermanent;
+import mage.target.common.TargetSacrifice;
 
 import java.util.UUID;
 
@@ -66,12 +66,12 @@ class NahirisLithoformingSacrificeEffect extends OneShotEffect {
             return false;
         }
         int landCount = game.getBattlefield().count(
-                StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT,
+                TargetSacrifice.makeFilter(StaticFilters.FILTER_LAND),
                 source.getControllerId(), source, game
         );
         landCount = Math.min(source.getManaCostsToPay().getX(), landCount);
-        TargetPermanent target = new TargetPermanent(
-                landCount, landCount, StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT, true
+        TargetSacrifice target = new TargetSacrifice(
+                landCount, landCount, StaticFilters.FILTER_LAND
         );
         player.choose(outcome, target, source, game);
         int counter = 0;

--- a/Mage.Sets/src/mage/cards/n/NantukoHusk.java
+++ b/Mage.Sets/src/mage/cards/n/NantukoHusk.java
@@ -31,7 +31,7 @@ public final class NantukoHusk extends CardImpl {
 
         // Sacrifice a creature: Nantuko Husk gets +2/+2 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(2, 2, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private NantukoHusk(final NantukoHusk card) {

--- a/Mage.Sets/src/mage/cards/n/NastyEnd.java
+++ b/Mage.Sets/src/mage/cards/n/NastyEnd.java
@@ -24,7 +24,7 @@ public final class NastyEnd extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Draw two cards. If the sacrificed creature was legendary, draw three cards instead.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(

--- a/Mage.Sets/src/mage/cards/n/Necrosavant.java
+++ b/Mage.Sets/src/mage/cards/n/Necrosavant.java
@@ -39,7 +39,7 @@ public final class Necrosavant extends CardImpl {
                 new IsStepCondition(PhaseStep.UPKEEP),
                 null
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/n/Necrosquito.java
+++ b/Mage.Sets/src/mage/cards/n/Necrosquito.java
@@ -51,7 +51,7 @@ public final class Necrosquito extends CardImpl {
         // Whenever another creature or artifact you control is put into a graveyard from the battlefield, put an oil counter on Necrosquito.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.OIL.createInstance()), false,
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE, false
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT, false
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/n/NecroticHex.java
+++ b/Mage.Sets/src/mage/cards/n/NecroticHex.java
@@ -19,9 +19,7 @@ public final class NecroticHex extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{6}{B}");
 
         // Each player sacrifices six creatures.
-        this.getSpellAbility().addEffect(new SacrificeAllEffect(
-                6, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        ).setText("each player sacrifices six creatures"));
+        this.getSpellAbility().addEffect(new SacrificeAllEffect(6, StaticFilters.FILTER_PERMANENT_CREATURES));
 
         // You create six tapped 2/2 black creature tokens.
         this.getSpellAbility().addEffect(new CreateTokenEffect(

--- a/Mage.Sets/src/mage/cards/n/NefaroxOverlordOfGrixis.java
+++ b/Mage.Sets/src/mage/cards/n/NefaroxOverlordOfGrixis.java
@@ -34,7 +34,7 @@ public final class NefaroxOverlordOfGrixis extends CardImpl {
         this.addAbility(new ExaltedAbility());
         // Whenever Nefarox, Overlord of Grixis attacks alone, defending player sacrifices a creature.
         this.addAbility(new AttacksAloneSourceTriggeredAbility(new SacrificeEffect(
-            StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, 1, "defending player")));
+            StaticFilters.FILTER_PERMANENT_CREATURE, 1, "defending player")));
     }
 
     private NefaroxOverlordOfGrixis(final NefaroxOverlordOfGrixis card) {

--- a/Mage.Sets/src/mage/cards/n/Neoform.java
+++ b/Mage.Sets/src/mage/cards/n/Neoform.java
@@ -34,7 +34,7 @@ public final class Neoform extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{G}{U}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Search your library for a creature card with converted mana cost equal to 1 plus the sacrificed creature's converted mana cost,
         // put that card onto the battlefield with an additional +1/+1 counter on it, then shuffle your library.

--- a/Mage.Sets/src/mage/cards/n/NezumiBoneReader.java
+++ b/Mage.Sets/src/mage/cards/n/NezumiBoneReader.java
@@ -32,7 +32,7 @@ public final class NezumiBoneReader extends CardImpl {
         this.toughness = new MageInt(1);
         // {B}, Sacrifice a creature: Target player discards a card. Activate this ability only any time you could cast a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardTargetEffect(1),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addCost(new ManaCostsImpl<>("{B}"));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/n/NimShambler.java
+++ b/Mage.Sets/src/mage/cards/n/NimShambler.java
@@ -39,7 +39,7 @@ public final class NimShambler extends CardImpl {
         this.toughness = new MageInt(1);
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostSourceEffect(new PermanentsOnBattlefieldCount(filter), StaticValue.get(0), Duration.WhileOnBattlefield)));
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private NimShambler(final NimShambler card) {

--- a/Mage.Sets/src/mage/cards/n/NumbingDose.java
+++ b/Mage.Sets/src/mage/cards/n/NumbingDose.java
@@ -1,7 +1,5 @@
-
 package mage.cards.n;
 
-import java.util.UUID;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.AttachEffect;
@@ -11,17 +9,17 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
 import mage.target.targetpointer.FixedTarget;
+
+import java.util.UUID;
 
 /**
  *
@@ -29,21 +27,13 @@ import mage.target.targetpointer.FixedTarget;
  */
 public final class NumbingDose extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
-
     public NumbingDose(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{3}{U}{U}");
         this.subtype.add(SubType.AURA);
 
 
         // Enchant artifact or creature
-        TargetPermanent auraTarget = new TargetPermanent(filter);
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.Detriment));
         this.addAbility(new EnchantAbility(auraTarget));
@@ -67,7 +57,7 @@ public final class NumbingDose extends CardImpl {
 
 class NumbingDoseTriggeredAbility extends TriggeredAbilityImpl {
 
-    public NumbingDoseTriggeredAbility() {
+    NumbingDoseTriggeredAbility() {
         super(Zone.BATTLEFIELD, new LoseLifeTargetEffect(1), false);
     }
 

--- a/Mage.Sets/src/mage/cards/n/NyxbornBehemoth.java
+++ b/Mage.Sets/src/mage/cards/n/NyxbornBehemoth.java
@@ -18,9 +18,10 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledEnchantmentPermanent;
+import mage.filter.common.FilterEnchantmentPermanent;
 import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 
 import java.util.UUID;
 
@@ -30,9 +31,11 @@ import java.util.UUID;
 public final class NyxbornBehemoth extends CardImpl {
 
     private static final FilterPermanent filter = new FilterControlledEnchantmentPermanent("noncreature enchantments you control");
+    private static final FilterEnchantmentPermanent filterSac = new FilterEnchantmentPermanent("another enchantment");
 
     static {
         filter.add(Predicates.not(CardType.CREATURE.getPredicate()));
+        filterSac.add(AnotherPredicate.instance);
     }
 
     private static final TotalPermanentsManaValue xValue = new TotalPermanentsManaValue(filter);
@@ -60,7 +63,7 @@ public final class NyxbornBehemoth extends CardImpl {
             new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
             new ManaCostsImpl<>("{1}{G}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ENCHANTMENT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(filterSac));
 
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/o/OathOfLiliana.java
+++ b/Mage.Sets/src/mage/cards/o/OathOfLiliana.java
@@ -31,7 +31,7 @@ public final class OathOfLiliana extends CardImpl {
         this.supertype.add(SuperType.LEGENDARY);
 
         // When Oath of Liliana enters the battlefield, each opponent sacrifices a creature.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), false));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE), false));
 
         // At the beginning of each end step, if a planeswalker entered the battlefield under your control this turn, create a 2/2 black Zombie creature token.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(new BeginningOfEndStepTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/o/OboroEnvoy.java
+++ b/Mage.Sets/src/mage/cards/o/OboroEnvoy.java
@@ -44,7 +44,7 @@ public final class OboroEnvoy extends CardImpl {
         Effect effect = new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("Target creature gets -X/-0 until end of turn, where X is the number of cards in your hand");
         Ability ability = new SimpleActivatedAbility(effect, new GenericManaCost(2));
-        ability.addCost(new ReturnToHandChosenControlledPermanentCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
+        ability.addCost(new ReturnToHandChosenControlledPermanentCost(new TargetControlledPermanent(StaticFilters.FILTER_CONTROLLED_PERMANENT_LAND)));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/o/OgreMarauder.java
+++ b/Mage.Sets/src/mage/cards/o/OgreMarauder.java
@@ -73,7 +73,7 @@ class OgreMarauderEffect extends OneShotEffect {
         MageObject sourceObject = game.getObject(source);
         Player defender = game.getPlayer(defendingPlayerId);
         if (defender != null && sourceObject != null) {
-            Cost cost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+            Cost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
             boolean paid = false;
             if (cost.canPay(source, source, defendingPlayerId, game)
                     && defender.chooseUse(Outcome.LoseAbility, "Sacrifice a creature to prevent "

--- a/Mage.Sets/src/mage/cards/o/OldFlitterfang.java
+++ b/Mage.Sets/src/mage/cards/o/OldFlitterfang.java
@@ -46,7 +46,7 @@ public final class OldFlitterfang extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new BoostSourceEffect(2, 2, Duration.EndOfTurn), new ManaCostsImpl<>("{2}{B}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OniPossession.java
+++ b/Mage.Sets/src/mage/cards/o/OniPossession.java
@@ -37,7 +37,7 @@ public final class OniPossession extends CardImpl {
 
         // At the beginning of your upkeep, sacrifice a creature.
         Ability ability2 = new BeginningOfUpkeepTriggeredAbility(
-                new SacrificeControllerEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT, 1, ""), TargetController.YOU, false);
+                new SacrificeControllerEffect(StaticFilters.FILTER_PERMANENT_CREATURE, 1, ""), TargetController.YOU, false);
         this.addAbility(ability2);
         // Enchanted creature gets +3/+3 and has trample.
         Ability staticAbility = new SimpleStaticAbility(new BoostEnchantedEffect(3, 3));

--- a/Mage.Sets/src/mage/cards/o/OrcishBloodpainter.java
+++ b/Mage.Sets/src/mage/cards/o/OrcishBloodpainter.java
@@ -32,7 +32,7 @@ public final class OrcishBloodpainter extends CardImpl {
 
         // {tap}, Sacrifice a creature: Orcish Bloodpainter deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/o/OrochiEggwatcher.java
+++ b/Mage.Sets/src/mage/cards/o/OrochiEggwatcher.java
@@ -79,7 +79,7 @@ class ShidakoBroodmistress extends TokenImpl {
                 Zone.BATTLEFIELD,
                 new BoostTargetEffect(3, 3, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{G}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PacificationArray.java
+++ b/Mage.Sets/src/mage/cards/p/PacificationArray.java
@@ -1,7 +1,5 @@
-
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -11,21 +9,15 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  * @author JRHerlehy
  */
 public final class PacificationArray extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
 
     public PacificationArray(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}");
@@ -33,7 +25,7 @@ public final class PacificationArray extends CardImpl {
         // {2}, {t}: Tap target artifact or creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TapTargetEffect(), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PegasusStampede.java
+++ b/Mage.Sets/src/mage/cards/p/PegasusStampede.java
@@ -22,7 +22,7 @@ public final class PegasusStampede extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{W}");
 
         // Buyback-Sacrifice a land.
-        this.addAbility(new BuybackAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
+        this.addAbility(new BuybackAbility(new SacrificeTargetCost(StaticFilters.FILTER_LAND)));
 
         // Create a 1/1 white Pegasus creature token with flying.
         this.getSpellAbility().addEffect(new CreateTokenEffect(new PegasusToken()));

--- a/Mage.Sets/src/mage/cards/p/PerilousForays.java
+++ b/Mage.Sets/src/mage/cards/p/PerilousForays.java
@@ -42,7 +42,7 @@ public final class PerilousForays extends CardImpl {
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(filter), true),
                 new ManaCostsImpl<>("{1}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianAltar.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianAltar.java
@@ -21,7 +21,7 @@ public final class PhyrexianAltar extends CardImpl {
 
         // Sacrifice a creature: Add one mana of any color.
         this.addAbility(new AnyColorManaAbility(
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 CreaturesYouControlCount.instance,
                 false
         ));

--- a/Mage.Sets/src/mage/cards/p/PhyrexianBroodlings.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianBroodlings.java
@@ -33,7 +33,7 @@ public final class PhyrexianBroodlings extends CardImpl {
 
         // {1}, Sacrifice a creature: Put a +1/+1 counter on Phyrexian Broodlings.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PhyrexianGhoul.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianGhoul.java
@@ -29,7 +29,7 @@ public final class PhyrexianGhoul extends CardImpl {
         this.power = new MageInt(2);
         this.toughness = new MageInt(2);
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(2, 2, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private PhyrexianGhoul(final PhyrexianGhoul card) {

--- a/Mage.Sets/src/mage/cards/p/PhyrexianMetamorph.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianMetamorph.java
@@ -1,6 +1,5 @@
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
@@ -13,24 +12,17 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.util.functions.CopyApplier;
+
+import java.util.UUID;
 
 /**
  *
  * @author Loki
  */
 public final class PhyrexianMetamorph extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
 
     public PhyrexianMetamorph(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{3}{U/P}");
@@ -50,7 +42,7 @@ public final class PhyrexianMetamorph extends CardImpl {
 
         // {U/P} ( can be paid with either {U} or 2 life.)
         // You may have Phyrexian Metamorph enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types.
-        Effect effect = new CopyPermanentEffect(filter, phyrexianMetamorphCopyApplier);
+        Effect effect = new CopyPermanentEffect(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE, phyrexianMetamorphCopyApplier);
         effect.setText("You may have {this} enter the battlefield as a copy of any artifact or creature on the battlefield, except it's an artifact in addition to its other types");
         Ability ability = new SimpleStaticAbility(Zone.ALL, new EntersBattlefieldEffect(effect, "", true));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/p/PhyrexianPlaguelord.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianPlaguelord.java
@@ -43,7 +43,7 @@ public final class PhyrexianPlaguelord extends CardImpl {
         // Sacrifice a creature: Target creature gets -1/-1 until end of turn.
         ability = new SimpleActivatedAbility(Zone.BATTLEFIELD,
                 new BoostTargetEffect(-1, -1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianSoulgorger.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianSoulgorger.java
@@ -29,7 +29,7 @@ public final class PhyrexianSoulgorger extends CardImpl {
 
         // Cumulative upkeep-Sacrifice a creature.
         this.addAbility(new CumulativeUpkeepAbility(
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private PhyrexianSoulgorger(final PhyrexianSoulgorger card) {

--- a/Mage.Sets/src/mage/cards/p/PhyrexianTower.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianTower.java
@@ -31,7 +31,7 @@ public final class PhyrexianTower extends CardImpl {
 
         // {T}, Sacrifice a creature: Add {B}{B}.
         Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, Mana.BlackMana(2), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/p/PhyrexianVault.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianVault.java
@@ -25,7 +25,7 @@ public final class PhyrexianVault extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PlaguedRusalka.java
+++ b/Mage.Sets/src/mage/cards/p/PlaguedRusalka.java
@@ -28,7 +28,7 @@ public final class PlaguedRusalka extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostTargetEffect(-1, -1, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.B));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PlaguemawBeast.java
+++ b/Mage.Sets/src/mage/cards/p/PlaguemawBeast.java
@@ -32,7 +32,7 @@ public final class PlaguemawBeast extends CardImpl {
 
         // {T}, Sacrifice a creature: Proliferate. (You choose any number of permanents and/or players with counters on them, then give each another counter of a kind already there.)
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ProliferateEffect(), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PolarKraken.java
+++ b/Mage.Sets/src/mage/cards/p/PolarKraken.java
@@ -32,7 +32,7 @@ public final class PolarKraken extends CardImpl {
         // Polar Kraken enters the battlefield tapped.
         this.addAbility(new EntersBattlefieldTappedAbility());
         // Cumulative upkeep-Sacrifice a land.
-        this.addAbility(new CumulativeUpkeepAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
+        this.addAbility(new CumulativeUpkeepAbility(new SacrificeTargetCost(StaticFilters.FILTER_LAND)));
     }
 
     private PolarKraken(final PolarKraken card) {

--- a/Mage.Sets/src/mage/cards/p/PowerstoneFracture.java
+++ b/Mage.Sets/src/mage/cards/p/PowerstoneFracture.java
@@ -19,7 +19,7 @@ public final class PowerstoneFracture extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // Destroy target creature or planeswalker.
         this.getSpellAbility().addEffect(new DestroyTargetEffect());

--- a/Mage.Sets/src/mage/cards/p/PrimalGrowth.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalGrowth.java
@@ -23,7 +23,7 @@ public final class PrimalGrowth extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}");
 
         // Kicker-Sacrifice a creature.
-        this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
         // Search your library for a basic land card, put that card onto the battlefield, then shuffle your library.
         // If Primal Growth was kicked, instead search your library for up to two basic land cards, put them onto the battlefield, then shuffle your library.

--- a/Mage.Sets/src/mage/cards/p/PsychicVortex.java
+++ b/Mage.Sets/src/mage/cards/p/PsychicVortex.java
@@ -30,7 +30,7 @@ public final class PsychicVortex extends CardImpl {
 
         // At the beginning of your end step, sacrifice a land and discard your hand.
         Ability ability = new BeginningOfEndStepTriggeredAbility(new SacrificeControllerEffect(
-                StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT, 1, null
+                StaticFilters.FILTER_LAND, 1, null
         ), TargetController.YOU, false);
         ability.addEffect(new DiscardHandControllerEffect().concatBy("and"));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/p/Putrefy.java
+++ b/Mage.Sets/src/mage/cards/p/Putrefy.java
@@ -1,34 +1,25 @@
-
-
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
  * @author Loki
  */
 public final class Putrefy extends CardImpl {
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
 
     public Putrefy (UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{B}{G}");
 
         // Destroy target artifact or creature. It can't be regenerated.
-        this.getSpellAbility().addTarget(new TargetPermanent(filter));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.getSpellAbility().addEffect(new DestroyTargetEffect(true));
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyreOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/p/PyreOfHeroes.java
@@ -40,7 +40,7 @@ public final class PyreOfHeroes extends CardImpl {
                 Zone.BATTLEFIELD, new PyreOfHeroesEffect(), new GenericManaCost(2)
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/p/PyrrhicBlast.java
+++ b/Mage.Sets/src/mage/cards/p/PyrrhicBlast.java
@@ -22,7 +22,7 @@ public final class PyrrhicBlast extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{R}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Pyrrhic Blast deals damage equal to the sacrificed creature's power to any target. Draw a card.
         this.getSpellAbility().addEffect(new DamageTargetEffect(SacrificeCostCreaturesPower.instance)

--- a/Mage.Sets/src/mage/cards/q/QuagmireDruid.java
+++ b/Mage.Sets/src/mage/cards/q/QuagmireDruid.java
@@ -36,7 +36,7 @@ public final class QuagmireDruid extends CardImpl {
         // {G}, {T}, Sacrifice a creature: Destroy target enchantment.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(false), new ColoredManaCost(ColoredManaSymbol.G));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetEnchantmentPermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/r/RakdosRiteknife.java
+++ b/Mage.Sets/src/mage/cards/r/RakdosRiteknife.java
@@ -130,7 +130,7 @@ class RakdosRiteknifeEffect extends ContinuousEffectImpl {
                         .setTargetPointer(new FixedTarget(permanent, game)),
                 new TapSourceCost()
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         return ability;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RankleAndTorbran.java
+++ b/Mage.Sets/src/mage/cards/r/RankleAndTorbran.java
@@ -54,7 +54,7 @@ public final class RankleAndTorbran extends CardImpl {
         ability.getModes().setMaxModes(3);
 
         // * Each player sacrifices a creature.
-        ability.addMode(new Mode(new SacrificeAllEffect(1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        ability.addMode(new Mode(new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
         // * If a source would deal damage to a player or battle this turn, it deals that much damage plus 2 instead.
         ability.addMode(new Mode(new RankleAndTorbranEffect()));

--- a/Mage.Sets/src/mage/cards/r/RankleMasterOfPranks.java
+++ b/Mage.Sets/src/mage/cards/r/RankleMasterOfPranks.java
@@ -49,7 +49,7 @@ public final class RankleMasterOfPranks extends CardImpl {
         ability.addMode(mode);
 
         // • Each player sacrifices a creature.
-        ability.addMode(new Mode(new SacrificeAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        ability.addMode(new Mode(new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
         ability.getModes().setMinModes(0);
         ability.getModes().setMaxModes(3);

--- a/Mage.Sets/src/mage/cards/r/RavenousSquirrel.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousSquirrel.java
@@ -33,7 +33,7 @@ public final class RavenousSquirrel extends CardImpl {
         // Whenever you sacrifice an artifact or creature, put a +1/+1 counter on Ravenous Squirrel.
         this.addAbility(new SacrificePermanentTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
-                StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT
+                StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE
         ));
 
         // {1}{B}{G}, Sacrifice an artifact or creature: You gain 1 life and draw a card.

--- a/Mage.Sets/src/mage/cards/r/RavenousSquirrel.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousSquirrel.java
@@ -39,7 +39,7 @@ public final class RavenousSquirrel extends CardImpl {
         // {1}{B}{G}, Sacrifice an artifact or creature: You gain 1 life and draw a card.
         Ability ability = new SimpleActivatedAbility(new GainLifeEffect(1), new ManaCostsImpl<>("{1}{B}{G}"));
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy("and"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/r/Raze.java
+++ b/Mage.Sets/src/mage/cards/r/Raze.java
@@ -22,7 +22,7 @@ public final class Raze extends CardImpl {
 
 
         // As an additional cost to cast Raze, sacrifice a land.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         // Destroy target land.
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetLandPermanent());

--- a/Mage.Sets/src/mage/cards/r/ReaperOfFlightMoonsilver.java
+++ b/Mage.Sets/src/mage/cards/r/ReaperOfFlightMoonsilver.java
@@ -38,7 +38,7 @@ public final class ReaperOfFlightMoonsilver extends CardImpl {
         // Activate this ability only if there are four or more card types among cards in your graveyard.
         this.addAbility(new ConditionalActivatedAbility(Zone.BATTLEFIELD,
                 new BoostSourceEffect(2, 1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 DeliriumCondition.instance,
                 "<i>Delirium</i> &mdash; Sacrifice another creature: Reaper of Flight Moonsilver gets +2/+1 until end of turn. "
                         + "Activate only if there are four or more card types among cards in your graveyard.")

--- a/Mage.Sets/src/mage/cards/r/RecklessAbandon.java
+++ b/Mage.Sets/src/mage/cards/r/RecklessAbandon.java
@@ -21,7 +21,7 @@ public final class RecklessAbandon extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R}");
 
         // As an additional cost to cast Reckless Abandon, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Reckless Abandon deals 4 damage to any target.
         this.getSpellAbility().addEffect(new DamageTargetEffect(4));

--- a/Mage.Sets/src/mage/cards/r/ReckonersBargain.java
+++ b/Mage.Sets/src/mage/cards/r/ReckonersBargain.java
@@ -27,7 +27,7 @@ public final class ReckonersBargain extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // As an additional cost to cast this spell, sacrifice an artifact or creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
 
         // You gain life equal to the sacrificed permanent's mana value. Draw two cards.
         this.getSpellAbility().addEffect(new GainLifeEffect(

--- a/Mage.Sets/src/mage/cards/r/RecurringNightmare.java
+++ b/Mage.Sets/src/mage/cards/r/RecurringNightmare.java
@@ -27,7 +27,7 @@ public final class RecurringNightmare extends CardImpl {
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 Zone.BATTLEFIELD,
                 new ReturnFromGraveyardToBattlefieldTargetEffect(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
         );
         ability.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
         ability.addCost(new ReturnToHandFromBattlefieldSourceCost());

--- a/Mage.Sets/src/mage/cards/r/RedrockSentinel.java
+++ b/Mage.Sets/src/mage/cards/r/RedrockSentinel.java
@@ -38,7 +38,7 @@ public final class RedrockSentinel extends CardImpl {
                 new DrawCardSourceControllerEffect(1), new GenericManaCost(2)
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         ability.addEffect(new CreateTokenEffect(new TreasureToken()).concatBy("and"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/r/RelicVial.java
+++ b/Mage.Sets/src/mage/cards/r/RelicVial.java
@@ -41,7 +41,7 @@ public final class RelicVial extends CardImpl {
                 new DrawCardSourceControllerEffect(1), new GenericManaCost(2)
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // As long as you control a Cleric, Relic Vial has "Whenever a creature you control dies, each opponent loses 1 life and you gain 1 life."

--- a/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
+++ b/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
@@ -2,7 +2,6 @@ package mage.cards.r;
 
 import mage.abilities.Ability;
 import mage.abilities.DelayedTriggeredAbility;
-import mage.abilities.Mode;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.effects.Effect;
@@ -13,18 +12,15 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreatureCard;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInGraveyard;
 import mage.target.common.TargetCardInYourGraveyard;
-import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
 import mage.filter.StaticFilters;
@@ -145,12 +141,8 @@ class RescueFromTheUnderworldCreateDelayedTriggeredAbilityEffect extends OneShot
 
 class RescueFromTheUnderworldDelayedTriggeredAbility extends DelayedTriggeredAbility {
 
-    public RescueFromTheUnderworldDelayedTriggeredAbility() {
-        this(new RescueFromTheUnderworldReturnEffect(), TargetController.YOU);
-    }
-
-    public RescueFromTheUnderworldDelayedTriggeredAbility(Effect effect, TargetController targetController) {
-        super(effect);
+    RescueFromTheUnderworldDelayedTriggeredAbility() {
+        super(new RescueFromTheUnderworldReturnEffect());
     }
 
     private RescueFromTheUnderworldDelayedTriggeredAbility(final RescueFromTheUnderworldDelayedTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
+++ b/Mage.Sets/src/mage/cards/r/RescueFromTheUnderworld.java
@@ -57,7 +57,7 @@ public final class RescueFromTheUnderworld extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{4}{B}");
 
         // As an additional cost to cast Rescue from the Underworld, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Choose target creature card in your graveyard. Return that card and the sacrificed card to the battlefield under your control at the beginning of your next upkeep. Exile Rescue from the Underworld.
         this.getSpellAbility().addEffect(new RescueFromTheUnderworldTextEffect());

--- a/Mage.Sets/src/mage/cards/r/RiteOfConsumption.java
+++ b/Mage.Sets/src/mage/cards/r/RiteOfConsumption.java
@@ -27,7 +27,7 @@ public final class RiteOfConsumption extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // As an additional cost to cast Rite of Consumption, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Rite of Consumption deals damage equal to the sacrificed creature's power to target player. You gain life equal to the damage dealt this way.
         this.getSpellAbility().addEffect(new RiteOfConsumptionEffect());
         this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());

--- a/Mage.Sets/src/mage/cards/r/RitualOfTheMachine.java
+++ b/Mage.Sets/src/mage/cards/r/RitualOfTheMachine.java
@@ -33,7 +33,7 @@ public final class RitualOfTheMachine extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{B}{B}");
 
         // As an additional cost to cast Ritual of the Machine, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Gain control of target nonartifact, nonblack creature.
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfGame));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));

--- a/Mage.Sets/src/mage/cards/r/RotTideGargantua.java
+++ b/Mage.Sets/src/mage/cards/r/RotTideGargantua.java
@@ -29,7 +29,7 @@ public final class RotTideGargantua extends CardImpl {
         this.addAbility(new ExploitAbility());
 
         // When Rot-Tide Gargantua exploits a creature, each opponent sacrifices a creature.
-        this.addAbility(new ExploitCreatureTriggeredAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        this.addAbility(new ExploitCreatureTriggeredAbility(new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private RotTideGargantua(final RotTideGargantua card) {

--- a/Mage.Sets/src/mage/cards/r/RumblingRockslide.java
+++ b/Mage.Sets/src/mage/cards/r/RumblingRockslide.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public final class RumblingRockslide extends CardImpl {
 
     private static final DynamicValue xValue
-            = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT);
+            = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_CONTROLLED_PERMANENT_LAND);
 
     public RumblingRockslide(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{R}");

--- a/Mage.Sets/src/mage/cards/r/RuthlessDisposal.java
+++ b/Mage.Sets/src/mage/cards/r/RuthlessDisposal.java
@@ -24,7 +24,7 @@ public final class RuthlessDisposal extends CardImpl {
         // As an additional cost to cast Ruthless Disposal, discard a card and sacrifice a creature.
         this.getSpellAbility().addCost(new CompositeCost(
                 new DiscardCardCost(),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 "discard a card and sacrifice a creature"
         ));
 

--- a/Mage.Sets/src/mage/cards/r/RuthlessKnave.java
+++ b/Mage.Sets/src/mage/cards/r/RuthlessKnave.java
@@ -42,7 +42,7 @@ public final class RuthlessKnave extends CardImpl {
 
         // {2}{B}, Sacrifice a creature: Create two colorless Treasure artifact tokens with "{T}, Sacrifice this artifact: Add one mana of any color."
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenEffect(new TreasureToken(), 2), new ManaCostsImpl<>("{2}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // Sacrifice three Treasures: Draw a card.

--- a/Mage.Sets/src/mage/cards/s/Sacrifice.java
+++ b/Mage.Sets/src/mage/cards/s/Sacrifice.java
@@ -21,7 +21,7 @@ public final class Sacrifice extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // As an additional cost to cast Sacrifice, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Add an amount of {B} equal to the sacrificed creature's converted mana cost.
         this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.BlackMana(1), SacrificeCostManaValue.CREATURE,
                 "add an amount of {B} equal to the sacrificed creature's mana value"));

--- a/Mage.Sets/src/mage/cards/s/SadisticHypnotist.java
+++ b/Mage.Sets/src/mage/cards/s/SadisticHypnotist.java
@@ -32,7 +32,7 @@ public final class SadisticHypnotist extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Sacrifice a creature: Target player discards two cards. Activate this ability only any time you could cast a sorcery.
-        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardTargetEffect(2), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        Ability ability = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new DiscardTargetEffect(2), new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SaheeliTheSunsBrilliance.java
+++ b/Mage.Sets/src/mage/cards/s/SaheeliTheSunsBrilliance.java
@@ -37,7 +37,7 @@ public final class SaheeliTheSunsBrilliance extends CardImpl {
         // {U}{R}, {T}: Create a token that's a copy of another target creature or artifact you control, except it's an artifact in addition to its other types. It gains haste. Sacrifice it at the beginning of the next end step.
         Ability ability = new SimpleActivatedAbility(new SaheeliTheSunsBrillianceEffect(), new ManaCostsImpl<>("{U}{R}"));
         ability.addCost(new TapSourceCost());
-        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SanguinePraetor.java
+++ b/Mage.Sets/src/mage/cards/s/SanguinePraetor.java
@@ -36,7 +36,7 @@ public final class SanguinePraetor extends CardImpl {
 
         // {B}, Sacrifice a creature: Destroy each creature with the same converted mana cost as the sacrificed creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SanguinePraetorEffect(), new ManaCostsImpl<>("{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/s/Scapegoat.java
+++ b/Mage.Sets/src/mage/cards/s/Scapegoat.java
@@ -22,7 +22,7 @@ public final class Scapegoat extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{W}");
 
         // As an additional cost to cast Scapegoat, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Return any number of target creatures you control to their owner's hand.
         Effect effect = new ReturnToHandTargetEffect();

--- a/Mage.Sets/src/mage/cards/s/ScarlandThrinax.java
+++ b/Mage.Sets/src/mage/cards/s/ScarlandThrinax.java
@@ -34,7 +34,7 @@ public final class ScarlandThrinax extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 Zone.BATTLEFIELD,
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ScorchedRusalka.java
+++ b/Mage.Sets/src/mage/cards/s/ScorchedRusalka.java
@@ -31,7 +31,7 @@ public final class ScorchedRusalka extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(1), new ColoredManaCost(ColoredManaSymbol.R));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetPlayerOrPlaneswalker());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/ScytheTiger.java
+++ b/Mage.Sets/src/mage/cards/s/ScytheTiger.java
@@ -31,7 +31,7 @@ public final class ScytheTiger extends CardImpl {
         this.addAbility(ShroudAbility.getInstance());
 
         // When Scythe Tiger enters the battlefield, sacrifice it unless you sacrifice a land.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)).setText("sacrifice it unless you sacrifice a land")));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeSourceUnlessPaysEffect(new SacrificeTargetCost(StaticFilters.FILTER_LAND)).setText("sacrifice it unless you sacrifice a land")));
     }
 
     private ScytheTiger(final ScytheTiger card) {

--- a/Mage.Sets/src/mage/cards/s/SeismicMonstrosaur.java
+++ b/Mage.Sets/src/mage/cards/s/SeismicMonstrosaur.java
@@ -33,7 +33,7 @@ public final class SeismicMonstrosaur extends CardImpl {
 
         // {2}{R}, Sacrifice a land: Draw a card.
         Ability ability = new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{2}{R}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
 
         // Mountaincycling {2}

--- a/Mage.Sets/src/mage/cards/s/SeraphOfNewPhyrexia.java
+++ b/Mage.Sets/src/mage/cards/s/SeraphOfNewPhyrexia.java
@@ -37,7 +37,7 @@ public final class SeraphOfNewPhyrexia extends CardImpl {
         // Whenever Seraph of New Phyrexia attacks, you may sacrifice another creature or artifact. If you do, Seraph of New Phyrexia gets +2/+1 until end of turn.
         this.addAbility(new AttacksTriggeredAbility(new DoIfCostPaid(
                 new BoostSourceEffect(2, 1, Duration.EndOfTurn),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT)
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SeveredStrands.java
+++ b/Mage.Sets/src/mage/cards/s/SeveredStrands.java
@@ -22,7 +22,7 @@ public final class SeveredStrands extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // You gain life equal to the sacrificed creature's toughness. Destroy target creature an opponent controls.
         this.getSpellAbility().addEffect(new GainLifeEffect(

--- a/Mage.Sets/src/mage/cards/s/ShardVolley.java
+++ b/Mage.Sets/src/mage/cards/s/ShardVolley.java
@@ -22,7 +22,7 @@ public final class ShardVolley extends CardImpl {
 
 
         // As an additional cost to cast Shard Volley, sacrifice a land.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
 
         // Shard Volley deals 3 damage to any target.
         this.getSpellAbility().addEffect(new DamageTargetEffect(3));

--- a/Mage.Sets/src/mage/cards/s/ShattergangBrothers.java
+++ b/Mage.Sets/src/mage/cards/s/ShattergangBrothers.java
@@ -42,7 +42,7 @@ public final class ShattergangBrothers extends CardImpl {
 
         // {2}{B}, Sacrifice a creature: Each other player sacrifices a creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), new ManaCostsImpl<>("{2}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
         // {2}{R}, Sacrifice an artifact: Each other player sacrifices an artifact.
         FilterControlledPermanent filter = new FilterControlledArtifactPermanent("an artifact");

--- a/Mage.Sets/src/mage/cards/s/ShattergangBrothers.java
+++ b/Mage.Sets/src/mage/cards/s/ShattergangBrothers.java
@@ -1,8 +1,5 @@
-
 package mage.cards.s;
 
-import java.util.Objects;
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -11,19 +8,17 @@ import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Outcome;
-import mage.constants.SuperType;
-import mage.constants.Zone;
+import mage.constants.*;
+import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledArtifactPermanent;
-import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
-import mage.target.common.TargetControlledCreaturePermanent;
-import mage.target.common.TargetControlledPermanent;
+import mage.target.common.TargetSacrifice;
+import mage.util.CardUtil;
+
+import java.util.Objects;
+import java.util.UUID;
 
 /**
  *
@@ -41,19 +36,16 @@ public final class ShattergangBrothers extends CardImpl {
         this.toughness = new MageInt(3);
 
         // {2}{B}, Sacrifice a creature: Each other player sacrifices a creature.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), new ManaCostsImpl<>("{2}{B}"));
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(StaticFilters.FILTER_PERMANENT_CREATURE), new ManaCostsImpl<>("{2}{B}"));
         ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
         // {2}{R}, Sacrifice an artifact: Each other player sacrifices an artifact.
-        FilterControlledPermanent filter = new FilterControlledArtifactPermanent("an artifact");
-        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(filter), new ManaCostsImpl<>("{2}{R}"));
-        ability.addCost(new SacrificeTargetCost(filter));
+        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(StaticFilters.FILTER_PERMANENT_ARTIFACT), new ManaCostsImpl<>("{2}{R}"));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT));
         this.addAbility(ability);
         // {2}{G}, Sacrifice an enchantment: Each other player sacrifices an enchantment.
-        filter = new FilterControlledPermanent("an enchantment");
-        filter.add(CardType.ENCHANTMENT.getPredicate());
-        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(filter), new ManaCostsImpl<>("{2}{G}"));
-        ability.addCost(new SacrificeTargetCost(filter));
+        ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ShattergangBrothersEffect(StaticFilters.FILTER_PERMANENT_ENCHANTMENT), new ManaCostsImpl<>("{2}{G}"));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ENCHANTMENT));
         this.addAbility(ability);
     }
 
@@ -69,12 +61,12 @@ public final class ShattergangBrothers extends CardImpl {
 
 class ShattergangBrothersEffect extends OneShotEffect {
 
-    private FilterControlledPermanent filter;
+    private final FilterPermanent filter;
 
-    public ShattergangBrothersEffect(FilterControlledPermanent filter) {
+    ShattergangBrothersEffect(FilterPermanent filter) {
         super(Outcome.Sacrifice);
         this.filter = filter;
-        this.staticText = "Each other player sacrifices " + filter.getMessage();
+        this.staticText = "Each other player sacrifices " + CardUtil.addArticle(filter.getMessage());
     }
 
     private ShattergangBrothersEffect(final ShattergangBrothersEffect effect) {
@@ -95,8 +87,7 @@ class ShattergangBrothersEffect extends OneShotEffect {
                 if (!Objects.equals(playerId, source.getControllerId())) {
                     Player player = game.getPlayer(playerId);
                     if (player != null) {
-                        TargetControlledPermanent target = new TargetControlledPermanent(filter);
-                        target.withNotTarget(true);
+                        TargetSacrifice target = new TargetSacrifice(filter);
                         if (target.canChoose(playerId, source, game)
                                 && player.chooseTarget(outcome, target, source, game)) {
                             Permanent permanent = game.getPermanent(target.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/s/ShivanHarvest.java
+++ b/Mage.Sets/src/mage/cards/s/ShivanHarvest.java
@@ -26,7 +26,7 @@ public final class ShivanHarvest extends CardImpl {
 
         // {1}{R}, Sacrifice a creature: Destroy target nonbasic land.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(), new ManaCostsImpl<>("{1}{R}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetNonBasicLandPermanent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/ShrapnelSlinger.java
+++ b/Mage.Sets/src/mage/cards/s/ShrapnelSlinger.java
@@ -33,7 +33,7 @@ public final class ShrapnelSlinger extends CardImpl {
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_ARTIFACT));
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(
                 ability,
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 "Sacrifice a creature?"
         )));
     }

--- a/Mage.Sets/src/mage/cards/s/SithEvoker.java
+++ b/Mage.Sets/src/mage/cards/s/SithEvoker.java
@@ -44,7 +44,7 @@ public final class SithEvoker extends CardImpl {
         // {T}, {B}, Sacrifice a creature: You gain life equal to that creature's power or toughness.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new SithEvokerEffect(), new ManaCostsImpl<>("{B}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SkeletalKathari.java
+++ b/Mage.Sets/src/mage/cards/s/SkeletalKathari.java
@@ -33,7 +33,7 @@ public final class SkeletalKathari extends CardImpl {
 
         this.addAbility(FlyingAbility.getInstance());
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkirsdagCultist.java
+++ b/Mage.Sets/src/mage/cards/s/SkirsdagCultist.java
@@ -34,7 +34,7 @@ public final class SkirsdagCultist extends CardImpl {
         // {R}, {T}, Sacrifice a creature: Skirsdag Cultist deals 2 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(2), new ManaCostsImpl<>("{R}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SkullCatapult.java
+++ b/Mage.Sets/src/mage/cards/s/SkullCatapult.java
@@ -28,7 +28,7 @@ public final class SkullCatapult extends CardImpl {
         // {1}, {tap}, Sacrifice a creature: Skull Catapult deals 2 damage to any target.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageTargetEffect(2), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/Skulltap.java
+++ b/Mage.Sets/src/mage/cards/s/Skulltap.java
@@ -20,7 +20,7 @@ public final class Skulltap extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{B}");
 
         // As an additional cost to cast Skulltap, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         // Draw two cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));
     }

--- a/Mage.Sets/src/mage/cards/s/SloppityBilepiper.java
+++ b/Mage.Sets/src/mage/cards/s/SloppityBilepiper.java
@@ -34,7 +34,7 @@ public final class SloppityBilepiper extends CardImpl {
                 new NextSpellCastHasAbilityEffect(new CascadeAbility(), StaticFilters.FILTER_CARD_CREATURE),
                 new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability.withFlavorWord("Jolly Gutpipes"));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SoulreaperOfMogis.java
+++ b/Mage.Sets/src/mage/cards/s/SoulreaperOfMogis.java
@@ -32,7 +32,7 @@ public final class SoulreaperOfMogis extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{2}{B}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpawningPit.java
+++ b/Mage.Sets/src/mage/cards/s/SpawningPit.java
@@ -27,7 +27,7 @@ public final class SpawningPit extends CardImpl {
     public SpawningPit(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.CHARGE.createInstance()),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new CreateTokenEffect(new SpawningPitToken()), new GenericManaCost(1));
         ability.addCost(new RemoveCountersSourceCost(CounterType.CHARGE.createInstance(2)));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SpittingSpider.java
+++ b/Mage.Sets/src/mage/cards/s/SpittingSpider.java
@@ -38,7 +38,7 @@ public final class SpittingSpider extends CardImpl {
         // Reach
         this.addAbility(ReachAbility.getInstance());
         // Sacrifice a land: Spitting Spider deals 1 damage to each creature with flying.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageAllEffect(1, filter), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new DamageAllEffect(1, filter), new SacrificeTargetCost(StaticFilters.FILTER_LAND)));
     }
 
     private SpittingSpider(final SpittingSpider card) {

--- a/Mage.Sets/src/mage/cards/s/SpontaneousCombustion.java
+++ b/Mage.Sets/src/mage/cards/s/SpontaneousCombustion.java
@@ -20,7 +20,7 @@ public final class SpontaneousCombustion extends CardImpl {
     public SpontaneousCombustion(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}{R}");
 
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.getSpellAbility().addEffect(new DamageAllEffect(3, new FilterCreaturePermanent()));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpringbloomDruid.java
+++ b/Mage.Sets/src/mage/cards/s/SpringbloomDruid.java
@@ -35,7 +35,7 @@ public final class SpringbloomDruid extends CardImpl {
                 ), true
                 ).setText("search your library for up to two basic land cards, " +
                         "put them onto the battlefield tapped, then shuffle"
-                ), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)
+                ), new SacrificeTargetCost(StaticFilters.FILTER_LAND)
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SproutingGoblin.java
+++ b/Mage.Sets/src/mage/cards/s/SproutingGoblin.java
@@ -61,7 +61,7 @@ public final class SproutingGoblin extends CardImpl {
         // {R}, {T}, Sacrifice a land: Draw a card.
         Ability ability = new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{R}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StarkeOfRath.java
+++ b/Mage.Sets/src/mage/cards/s/StarkeOfRath.java
@@ -1,7 +1,5 @@
-
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -12,27 +10,20 @@ import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.UUID;
+
 /**
  *
  * @author LevelX2
  */
 public final class StarkeOfRath extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
-    }
 
     public StarkeOfRath(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{R}{R}");
@@ -44,7 +35,7 @@ public final class StarkeOfRath extends CardImpl {
 
         // {tap}: Destroy target artifact or creature. That permanent's controller gains control of Starke of Rath.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new StarkeOfRathEffect(), new TapSourceCost());
-        ability.addTarget(new TargetPermanent(filter));
+        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/s/StartFinish.java
+++ b/Mage.Sets/src/mage/cards/s/StartFinish.java
@@ -36,7 +36,7 @@ public final class StartFinish extends SplitCard {
         // Aftermath
         // As an additional cost to cast Finish, sacrifice a creature. Destroy target creature.
         getRightHalfCard().addAbility(new AftermathAbility().setRuleAtTheTop(true));
-        getRightHalfCard().getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        getRightHalfCard().getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         getRightHalfCard().getSpellAbility().addTarget(new TargetCreaturePermanent(new FilterCreaturePermanent("creature (to destoy)")));
         getRightHalfCard().getSpellAbility().addEffect(new DestroyTargetEffect("Destroy target creature"));
     }

--- a/Mage.Sets/src/mage/cards/s/StarvedRusalka.java
+++ b/Mage.Sets/src/mage/cards/s/StarvedRusalka.java
@@ -30,7 +30,7 @@ public final class StarvedRusalka extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), new ColoredManaCost(ColoredManaSymbol.G));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/StolenIdentity.java
+++ b/Mage.Sets/src/mage/cards/s/StolenIdentity.java
@@ -1,15 +1,14 @@
-
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.abilities.effects.common.CipherEffect;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -17,18 +16,12 @@ import mage.target.TargetPermanent;
  */
 public final class StolenIdentity extends CardImpl {
 
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(CardType.ARTIFACT.getPredicate(), CardType.CREATURE.getPredicate()));
-    }
-
     public StolenIdentity(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{4}{U}{U}");
 
         // Create a token that's a copy of target artifact or creature.
         this.getSpellAbility().addEffect(new CreateTokenCopyTargetEffect());
-        this.getSpellAbility().addTarget(new TargetPermanent(filter));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         // Cipher
         this.getSpellAbility().addEffect(new CipherEffect());
     }

--- a/Mage.Sets/src/mage/cards/s/StormclawRager.java
+++ b/Mage.Sets/src/mage/cards/s/StormclawRager.java
@@ -33,7 +33,7 @@ public final class StormclawRager extends CardImpl {
         Ability ability = new ActivateAsSorceryActivatedAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()), new GenericManaCost(1)
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy("and"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/StrongholdAssassin.java
+++ b/Mage.Sets/src/mage/cards/s/StrongholdAssassin.java
@@ -34,7 +34,7 @@ public final class StrongholdAssassin extends CardImpl {
 
         // {tap}, Sacrifice a creature: Destroy target nonblack creature.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DestroyTargetEffect(), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         Target target = new TargetCreaturePermanent(StaticFilters.FILTER_PERMANENT_CREATURE_NON_BLACK);
         ability.addTarget(target);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SwashbucklersWhip.java
+++ b/Mage.Sets/src/mage/cards/s/SwashbucklersWhip.java
@@ -15,8 +15,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.AttachmentType;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -25,15 +24,6 @@ import java.util.UUID;
  * @author Susucr
  */
 public final class SwashbucklersWhip extends CardImpl {
-
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-
-    static {
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()
-        ));
-    }
 
     public SwashbucklersWhip(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}");
@@ -50,7 +40,7 @@ public final class SwashbucklersWhip extends CardImpl {
                 new GenericManaCost(2)
         );
         tapAbility.addCost(new TapSourceCost());
-        tapAbility.addTarget(new TargetPermanent(filter));
+        tapAbility.addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         ability.addEffect(new GainAbilityAttachedEffect(tapAbility, AttachmentType.EQUIPMENT)
                 .setText(", \"{2}, {T}: Tap target artifact or creature,\""));
 

--- a/Mage.Sets/src/mage/cards/t/TeferiTimebender.java
+++ b/Mage.Sets/src/mage/cards/t/TeferiTimebender.java
@@ -1,7 +1,5 @@
-
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.GainLifeEffect;
@@ -12,9 +10,10 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -30,17 +29,13 @@ public final class TeferiTimebender extends CardImpl {
         this.setStartingLoyalty(5);
 
         // +2: Untap up to one target artifact or creature.
-        FilterPermanent filter = new FilterPermanent("artifact or creature");
-        filter.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()));
         LoyaltyAbility ability = new LoyaltyAbility(new UntapTargetEffect(), +2);
-        ability.addTarget(new TargetPermanent(0, 1, filter, false));
+        ability.addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE, false));
         this.addAbility(ability);
 
         // -3: You gain 2 life and draw two cards.
         ability = new LoyaltyAbility(new GainLifeEffect(2), -3);
-        ability.addEffect(new DrawCardSourceControllerEffect(2).setText("and draw two cards"));
+        ability.addEffect(new DrawCardSourceControllerEffect(2).concatBy("and"));
         this.addAbility(ability);
 
         // -9: Take an extra turn after this one.

--- a/Mage.Sets/src/mage/cards/t/TeferisCurse.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisCurse.java
@@ -1,7 +1,5 @@
-
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.AttachEffect;
@@ -11,30 +9,23 @@ import mage.abilities.keyword.PhasingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
-import mage.filter.predicate.Predicates;
+import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
  * @author fireshoes
  */
 public final class TeferisCurse extends CardImpl {
-    
-    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
-    
-    static {
-        filter.add(Predicates.or(
-        CardType.CREATURE.getPredicate(),
-        CardType.ARTIFACT.getPredicate()));
-    }
 
     public TeferisCurse(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{U}");
         this.subtype.add(SubType.AURA);
 
         // Enchant artifact or creature
-        TargetPermanent auraTarget = new TargetPermanent(filter);
+        TargetPermanent auraTarget = new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE);
         this.getSpellAbility().addTarget(auraTarget);
         this.getSpellAbility().addEffect(new AttachEffect(Outcome.AddAbility));
         Ability ability = new EnchantAbility(auraTarget);

--- a/Mage.Sets/src/mage/cards/t/TempleOfAclazotz.java
+++ b/Mage.Sets/src/mage/cards/t/TempleOfAclazotz.java
@@ -37,7 +37,7 @@ public final class TempleOfAclazotz extends CardImpl {
 
         // {T}, Sacrifice a creature: You gain life equal to the sacrificed creature's toughness.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new TempleOfAclazotzEffect(), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TendThePests.java
+++ b/Mage.Sets/src/mage/cards/t/TendThePests.java
@@ -21,7 +21,7 @@ public final class TendThePests extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}{G}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Create X 1/1 black and green Pest creature tokens with "When this creature dies, you gain 1 life," where X is the sacrificed creature's power.
         this.getSpellAbility().addEffect(new CreateTokenEffect(

--- a/Mage.Sets/src/mage/cards/t/TendrilsOfDespair.java
+++ b/Mage.Sets/src/mage/cards/t/TendrilsOfDespair.java
@@ -21,7 +21,7 @@ public final class TendrilsOfDespair extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
 
         // As an additional cost to cast Tendrils of Despair, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Target opponent discards two cards.
         this.getSpellAbility().addTarget(new TargetOpponent());

--- a/Mage.Sets/src/mage/cards/t/ThallidSoothsayer.java
+++ b/Mage.Sets/src/mage/cards/t/ThallidSoothsayer.java
@@ -30,7 +30,7 @@ public final class ThallidSoothsayer extends CardImpl {
 
         // {2}, Sacrifice a creature: Draw a card.
         SimpleActivatedAbility ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new GenericManaCost(2));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheGoldenThrone.java
+++ b/Mage.Sets/src/mage/cards/t/TheGoldenThrone.java
@@ -33,7 +33,7 @@ public final class TheGoldenThrone extends CardImpl {
 
         // A Thousand Souls Die Every Day -- {T}, Sacrifice a creature: Add three mana in any combination of colors.
         Ability ability = new SimpleManaAbility(Zone.BATTLEFIELD, new AddManaInAnyCombinationEffect(3), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability.withFlavorWord("A Thousand Souls Die Every Day"));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheHuntsmansRedemption.java
+++ b/Mage.Sets/src/mage/cards/t/TheHuntsmansRedemption.java
@@ -57,7 +57,7 @@ public final class TheHuntsmansRedemption extends CardImpl {
                 this, SagaChapter.CHAPTER_II,
                 new DoIfCostPaid(
                         new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true),
-                        new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                        new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
                 )
         );
 

--- a/Mage.Sets/src/mage/cards/t/TheLongReachOfNight.java
+++ b/Mage.Sets/src/mage/cards/t/TheLongReachOfNight.java
@@ -32,7 +32,7 @@ public final class TheLongReachOfNight extends CardImpl {
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_I, SagaChapter.CHAPTER_II,
                 new SacrificeOpponentsUnlessPayEffect(
-                        new DiscardCardCost(), StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
+                        new DiscardCardCost(), StaticFilters.FILTER_PERMANENT_CREATURE
                 )
         );
 

--- a/Mage.Sets/src/mage/cards/t/TheloniteDruid.java
+++ b/Mage.Sets/src/mage/cards/t/TheloniteDruid.java
@@ -48,7 +48,7 @@ public final class TheloniteDruid extends CardImpl {
                 effect,
                 new ManaCostsImpl<>("{1}{G}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TheloniteDruid.java
+++ b/Mage.Sets/src/mage/cards/t/TheloniteDruid.java
@@ -1,7 +1,5 @@
-
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -15,9 +13,9 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
-import mage.game.permanent.token.TokenImpl;
 import mage.game.permanent.token.custom.CreatureToken;
-import mage.target.common.TargetControlledCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -59,22 +57,5 @@ public final class TheloniteDruid extends CardImpl {
     @Override
     public TheloniteDruid copy() {
         return new TheloniteDruid(this);
-    }
-}
-
-class TheloniteDruidLandToken extends TokenImpl {
-
-    public TheloniteDruidLandToken() {
-        super("", "2/3 creatures");
-        cardType.add(CardType.CREATURE);
-        power = new MageInt(2);
-        toughness = new MageInt(3);
-    }
-    private TheloniteDruidLandToken(final TheloniteDruidLandToken token) {
-        super(token);
-    }
-
-    public TheloniteDruidLandToken copy() {
-        return new TheloniteDruidLandToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/Thermopod.java
+++ b/Mage.Sets/src/mage/cards/t/Thermopod.java
@@ -40,7 +40,7 @@ public final class Thermopod extends CardImpl {
                 HasteAbility.getInstance(), Duration.EndOfTurn), new ManaCostsImpl<>("{S}")));
         // Sacrifice a creature: Add {R}.
         this.addAbility(new SimpleManaAbility(Zone.BATTLEFIELD, new BasicManaEffect(Mana.RedMana(1), CreaturesYouControlCount.instance),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private Thermopod(final Thermopod card) {

--- a/Mage.Sets/src/mage/cards/t/ThoughtpickerWitch.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtpickerWitch.java
@@ -42,7 +42,7 @@ public final class ThoughtpickerWitch extends CardImpl {
 
         // {1}, Sacrifice a creature: Look at the top two cards of target opponent's library, then exile one of them.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ThoughtpickerWitchEffect(), new GenericManaCost(1));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/t/Thraxodemon.java
+++ b/Mage.Sets/src/mage/cards/t/Thraxodemon.java
@@ -30,7 +30,7 @@ public final class Thraxodemon extends CardImpl {
         // {3}, {T}, Sacrifice another creature or artifact: Draw a card.
         Ability ability = new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new GenericManaCost(3));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/ThreefoldThunderhulk.java
+++ b/Mage.Sets/src/mage/cards/t/ThreefoldThunderhulk.java
@@ -53,7 +53,7 @@ public final class ThreefoldThunderhulk extends CardImpl {
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
                 new GenericManaCost(2)
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/Thud.java
+++ b/Mage.Sets/src/mage/cards/t/Thud.java
@@ -21,7 +21,7 @@ public final class Thud extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Thud deals damage equal to the sacrificed creature's power to any target.
         this.getSpellAbility().addEffect(new DamageTargetEffect(SacrificeCostCreaturesPower.instance)

--- a/Mage.Sets/src/mage/cards/t/TitanHunter.java
+++ b/Mage.Sets/src/mage/cards/t/TitanHunter.java
@@ -50,7 +50,7 @@ public final class TitanHunter extends CardImpl {
 
         // {1}{B}, Sacrifice a creature: You gain 4 life.
         Ability ability = new SimpleActivatedAbility(new GainLifeEffect(4), new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TithingBlade.java
+++ b/Mage.Sets/src/mage/cards/t/TithingBlade.java
@@ -21,7 +21,7 @@ public final class TithingBlade extends CardImpl {
 
         // When Tithing Blade enters the battlefield, each opponent sacrifices a creature.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
-                new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE)
         ));
 
         // Craft with creature {4}{B}

--- a/Mage.Sets/src/mage/cards/t/TombTyrant.java
+++ b/Mage.Sets/src/mage/cards/t/TombTyrant.java
@@ -66,7 +66,7 @@ public final class TombTyrant extends CardImpl {
                 new ManaCostsImpl<>("{2}{B}"), condition
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability.addHint(MyTurnHint.instance).addHint(hint));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TorgaarFamineIncarnate.java
+++ b/Mage.Sets/src/mage/cards/t/TorgaarFamineIncarnate.java
@@ -34,7 +34,7 @@ public final class TorgaarFamineIncarnate extends CardImpl {
         this.toughness = new MageInt(6);
 
         // As an additional cost to cast this spell, you may sacrifice any number of creatures.
-        Cost cost = new SacrificeXTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+        Cost cost = new SacrificeXTargetCost(StaticFilters.FILTER_PERMANENT_CREATURES);
         cost.setText("As an additional cost to cast this spell, you may sacrifice any number of creatures");
         this.getSpellAbility().addCost(cost);
         // This spell costs {2} less to cast for each creature sacrificed this way.

--- a/Mage.Sets/src/mage/cards/t/TormentedThoughts.java
+++ b/Mage.Sets/src/mage/cards/t/TormentedThoughts.java
@@ -27,7 +27,7 @@ public final class TormentedThoughts extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{B}");
 
         // As an additional cost to cast Tormented Thoughts, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Target player discards a number of cards equal to the sacrificed creature's power.
         this.getSpellAbility().addEffect(new TormentedThoughtsDiscardEffect());

--- a/Mage.Sets/src/mage/cards/t/TradingPost.java
+++ b/Mage.Sets/src/mage/cards/t/TradingPost.java
@@ -48,7 +48,7 @@ public final class TradingPost extends CardImpl {
         Ability ability3 = new SimpleActivatedAbility(Zone.BATTLEFIELD, new ReturnFromGraveyardToHandTargetEffect(), new GenericManaCost(1));
         ability3.addTarget(new TargetCardInGraveyard(StaticFilters.FILTER_CARD_ARTIFACT_FROM_YOUR_GRAVEYARD));
         ability3.addCost(new TapSourceCost());
-        ability3.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability3.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability3);
 
         // {1}, {T}, Sacrifice an artifact: Draw a card.

--- a/Mage.Sets/src/mage/cards/t/TransmograntAltar.java
+++ b/Mage.Sets/src/mage/cards/t/TransmograntAltar.java
@@ -31,7 +31,7 @@ public final class TransmograntAltar extends CardImpl {
                 Zone.BATTLEFIELD, Mana.ColorlessMana(3), new ManaCostsImpl<>("{B}")
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
         // {2}, {T}, Sacrifice a creature: Create a 3/3 colorless Zombie artifact creature token. Activate only as a sorcery.
@@ -39,7 +39,7 @@ public final class TransmograntAltar extends CardImpl {
                 new CreateTokenEffect(new AshnodZombieToken()), new GenericManaCost(2)
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TymaretTheMurderKing.java
+++ b/Mage.Sets/src/mage/cards/t/TymaretTheMurderKing.java
@@ -42,7 +42,7 @@ public final class TymaretTheMurderKing extends CardImpl {
         this.addAbility(ability);
         // {1}{B}, Sacrifice a creature: Return Tymaret from your graveyard to your hand.
         ability = new SimpleActivatedAbility(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/t/TyrantsChoice.java
+++ b/Mage.Sets/src/mage/cards/t/TyrantsChoice.java
@@ -72,7 +72,7 @@ class TyrantsChoiceEffect extends OneShotEffect {
         int deathCount = vote.getVoteCount(true);
         int tortureCount = vote.getVoteCount(false);
         if (deathCount > tortureCount) {
-            return new SacrificeOpponentsEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT).apply(game, source);
+            return new SacrificeOpponentsEffect(StaticFilters.FILTER_PERMANENT_CREATURE).apply(game, source);
         } else {
             return new LoseLifeOpponentsEffect(4).apply(game, source);
         }

--- a/Mage.Sets/src/mage/cards/u/UndercityEliminator.java
+++ b/Mage.Sets/src/mage/cards/u/UndercityEliminator.java
@@ -32,7 +32,7 @@ public final class UndercityEliminator extends CardImpl {
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(new ExileTargetEffect(), false);
         ability.addTarget(new TargetOpponentsCreaturePermanent());
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DoWhenCostPaid(
-                ability, new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT),
+                ability, new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE),
                 "Sacrifice an artifact or creature?"
         )));
     }

--- a/Mage.Sets/src/mage/cards/u/UndercityInformer.java
+++ b/Mage.Sets/src/mage/cards/u/UndercityInformer.java
@@ -38,7 +38,7 @@ public final class UndercityInformer extends CardImpl {
 
         //{1}, Sacrifice a creature: Target player reveals the top card of their library until they reveal a land card, then puts those cards into their graveyard.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new UndercityInformerEffect(), new ManaCostsImpl<>("{1}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/u/UurgSpawnOfTurg.java
+++ b/Mage.Sets/src/mage/cards/u/UurgSpawnOfTurg.java
@@ -45,7 +45,7 @@ public final class UurgSpawnOfTurg extends CardImpl {
 
         // {B}{G}, Sacrifice a land: You gain 2 life.
         Ability ability = new SimpleActivatedAbility(new GainLifeEffect(2), new ManaCostsImpl<>("{B}{G}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VampiricRites.java
+++ b/Mage.Sets/src/mage/cards/v/VampiricRites.java
@@ -27,7 +27,7 @@ public final class VampiricRites extends CardImpl {
 
         // {1}{B}, Sacrifice a creature: You gain 1 life and draw a card.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(1), new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         Effect effect = new DrawCardSourceControllerEffect(1);
         effect.setText("and draw a card");
         ability.addEffect(effect);

--- a/Mage.Sets/src/mage/cards/v/VanguardOfTheRose.java
+++ b/Mage.Sets/src/mage/cards/v/VanguardOfTheRose.java
@@ -35,7 +35,7 @@ public final class VanguardOfTheRose extends CardImpl {
                 new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
                 new ManaCostsImpl<>("{1}")
         );
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         ability.addEffect(new TapSourceEffect().setText("tap it"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/v/VatOfRebirth.java
+++ b/Mage.Sets/src/mage/cards/v/VatOfRebirth.java
@@ -13,6 +13,9 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.target.common.TargetCardInYourGraveyard;
 
 import java.util.UUID;
@@ -22,13 +25,22 @@ import java.util.UUID;
  */
 public final class VatOfRebirth extends CardImpl {
 
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("another artifact or creature you control");
+    static {
+        filter.add(AnotherPredicate.instance);
+        filter.add(Predicates.or(
+                CardType.ARTIFACT.getPredicate(),
+                CardType.CREATURE.getPredicate()
+        ));
+    }
+
     public VatOfRebirth(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{B}");
 
         // Whenever another artifact or creature you control is put into a graveyard from the battlefield, put an oil counter on Vat of Rebirth.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.OIL.createInstance()), false,
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE, false
+                filter, false
         ));
 
         // {2}{B}, {T}, Remove four oil counters from Vat of Rebirth: Return target creature card from your graveyard to the battlefield. Activate only as a sorcery.

--- a/Mage.Sets/src/mage/cards/v/VeinRipper.java
+++ b/Mage.Sets/src/mage/cards/v/VeinRipper.java
@@ -34,7 +34,7 @@ public final class VeinRipper extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Ward--Sacrifice a creature.
-        this.addAbility(new WardAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT), false));
+        this.addAbility(new WardAbility(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), false));
 
         // Whenever a creature dies, target opponent loses 2 life and you gain 2 life.
         Ability ability = new DiesCreatureTriggeredAbility(new LoseLifeTargetEffect(2), false);

--- a/Mage.Sets/src/mage/cards/v/ViciousOffering.java
+++ b/Mage.Sets/src/mage/cards/v/ViciousOffering.java
@@ -26,7 +26,7 @@ public final class ViciousOffering extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // Kicker—Sacrifice a creature.
-        this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+        this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
 
         // Target creature gets -2/-2 until end of turn. If this spell was kicked, that creature gets -5/-5 until end of turn instead.
         this.getSpellAbility().addEffect(new ConditionalContinuousEffect(new BoostTargetEffect(-5, -5, Duration.EndOfTurn),

--- a/Mage.Sets/src/mage/cards/v/Victimize.java
+++ b/Mage.Sets/src/mage/cards/v/Victimize.java
@@ -62,7 +62,7 @@ class VictimizeEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
-            SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT);
+            SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
             if (cost.pay(source, game, source, source.getControllerId(), false, null)) {
                 game.getState().processAction(game); // To end effects of the sacrificed creature
                 controller.moveCards(new CardsImpl(getTargetPointer().getTargets(game, source)).getCards(game),

--- a/Mage.Sets/src/mage/cards/v/VillageRites.java
+++ b/Mage.Sets/src/mage/cards/v/VillageRites.java
@@ -19,7 +19,7 @@ public final class VillageRites extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{B}");
 
         // As an additional cost to cast this spell, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // Draw two cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(2));

--- a/Mage.Sets/src/mage/cards/v/VisceraSeer.java
+++ b/Mage.Sets/src/mage/cards/v/VisceraSeer.java
@@ -29,7 +29,7 @@ public final class VisceraSeer extends CardImpl {
         this.toughness = new MageInt(1);
         // Sacrifice a creature: Scry 1. (To scry 1, look at the top card of your library, then you may put that card on the bottom of your library.)
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new ScryEffect(1),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)));
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private VisceraSeer(final VisceraSeer card) {

--- a/Mage.Sets/src/mage/cards/v/VisceridDrone.java
+++ b/Mage.Sets/src/mage/cards/v/VisceridDrone.java
@@ -50,7 +50,7 @@ public final class VisceridDrone extends CardImpl {
         // {tap}, Sacrifice a creature and a Swamp: Destroy target nonartifact creature. It can't be regenerated.
         Ability ability = new SimpleActivatedAbility(new DestroyTargetEffect(true), new TapSourceCost());
         ability.addCost(new CompositeCost(
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new SacrificeTargetCost(filter2),
                 "Sacrifice a creature and a Swamp"
         ));
@@ -60,7 +60,7 @@ public final class VisceridDrone extends CardImpl {
         // {tap}, Sacrifice a creature and a snow Swamp: Destroy target creature. It can't be regenerated.
         ability = new SimpleActivatedAbility(new DestroyTargetEffect(true), new TapSourceCost());
         ability.addCost(new CompositeCost(
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT),
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE),
                 new SacrificeTargetCost(filter3),
                 "Sacrifice a creature and a snow Swamp"
         ));

--- a/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
+++ b/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
@@ -51,7 +51,7 @@ public final class VishKalBloodArbiter extends CardImpl {
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(), SacrificeCostCreaturesPower.instance, true
                 ).setText("put X +1/+1 counters on {this}, where X is the sacrificed creature's power"),
-                new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT)
+                new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
         ));
 
         // Remove all +1/+1 counters from Vish Kal: Target creature gets -1/-1 until end of turn for each +1/+1 counter removed this way.

--- a/Mage.Sets/src/mage/cards/v/VitosInquisitor.java
+++ b/Mage.Sets/src/mage/cards/v/VitosInquisitor.java
@@ -36,7 +36,7 @@ public final class VitosInquisitor extends CardImpl {
                 new ManaCostsImpl<>("{B}"));
         ability.addEffect(new GainAbilitySourceEffect(new MenaceAbility(false), Duration.EndOfTurn)
                 .setText("It gains menace until end of turn"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT));
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/v/Vivisection.java
+++ b/Mage.Sets/src/mage/cards/v/Vivisection.java
@@ -20,7 +20,7 @@ public final class Vivisection extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}");
 
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(3));
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
     }
 
     private Vivisection(final Vivisection card) {

--- a/Mage.Sets/src/mage/cards/w/WakeOfVultures.java
+++ b/Mage.Sets/src/mage/cards/w/WakeOfVultures.java
@@ -33,7 +33,7 @@ public final class WakeOfVultures extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // {1}{B}, Sacrifice a creature: Regenerate Wake of Vultures.
         Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new RegenerateSourceEffect(), new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WarehouseThief.java
+++ b/Mage.Sets/src/mage/cards/w/WarehouseThief.java
@@ -34,7 +34,7 @@ public final class WarehouseThief extends CardImpl {
                 new ExileTopXMayPlayUntilEffect(1, Duration.UntilEndOfYourNextTurn), new GenericManaCost(2)
         );
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WastelandRaider.java
+++ b/Mage.Sets/src/mage/cards/w/WastelandRaider.java
@@ -30,9 +30,7 @@ public final class WastelandRaider extends CardImpl {
         this.addAbility(new SquadAbility(new ManaCostsImpl<>("{2}")));
 
         // When Wasteland Raider enters the battlefield, each player sacrifices a creature.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeAllEffect(
-                1, StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT
-        )));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SacrificeAllEffect(StaticFilters.FILTER_PERMANENT_CREATURE)));
     }
 
     private WastelandRaider(final WastelandRaider card) {

--- a/Mage.Sets/src/mage/cards/w/WeaponizeTheMonsters.java
+++ b/Mage.Sets/src/mage/cards/w/WeaponizeTheMonsters.java
@@ -24,7 +24,7 @@ public final class WeaponizeTheMonsters extends CardImpl {
 
         // {2}, Sacrifice a creature: Weaponize the Monsters deals 2 damage to any target.
         Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(2), new GenericManaCost(2));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addTarget(new TargetAnyTarget());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/w/WickedReward.java
+++ b/Mage.Sets/src/mage/cards/w/WickedReward.java
@@ -17,7 +17,7 @@ public final class WickedReward extends CardImpl {
         super(cardId, cardSetInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         //As an additional cost to cast Wicked Reward, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         //Target creature gets +4/+2 until end of turn.
         this.getSpellAbility().addEffect(new BoostTargetEffect(4, 2, Duration.EndOfTurn));

--- a/Mage.Sets/src/mage/cards/w/WitchsCauldron.java
+++ b/Mage.Sets/src/mage/cards/w/WitchsCauldron.java
@@ -26,7 +26,7 @@ public final class WitchsCauldron extends CardImpl {
         // {1}{B}, {T}, Sacrifice a creature: You gain 1 life and draw a card.
         Ability ability = new SimpleActivatedAbility(new GainLifeEffect(1), new ManaCostsImpl<>("{1}{B}"));
         ability.addCost(new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy("and"));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/w/WitchsOven.java
+++ b/Mage.Sets/src/mage/cards/w/WitchsOven.java
@@ -31,7 +31,7 @@ public final class WitchsOven extends CardImpl {
 
         // {T}, Sacrifice a creature: Create a Food token. If the sacrificed creature's toughness was 4 or greater, create two Food tokens instead.
         Ability ability = new SimpleActivatedAbility(new WitchsOvenEffect(), new TapSourceCost());
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorldBreaker.java
+++ b/Mage.Sets/src/mage/cards/w/WorldBreaker.java
@@ -57,7 +57,7 @@ public final class WorldBreaker extends CardImpl {
         
         // {2}{C}, Sacrifice a land: Return World Breaker from your graveyard to your hand.
         ability = new SimpleActivatedAbility(Zone.GRAVEYARD, new ReturnSourceFromGraveyardToHandEffect(), new ManaCostsImpl<>("{2}{C}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_LAND));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WorthyCause.java
+++ b/Mage.Sets/src/mage/cards/w/WorthyCause.java
@@ -26,7 +26,7 @@ public final class WorthyCause extends CardImpl {
         this.addAbility(new BuybackAbility("{2}"));
 
         // As an additional cost to cast Worthy Cause, sacrifice a creature.
-        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
 
         // You gain life equal to the sacrificed creature's toughness.
         Effect effect = new GainLifeEffect(SacrificeCostCreaturesToughness.instance);

--- a/Mage.Sets/src/mage/cards/y/YumaProudProtector.java
+++ b/Mage.Sets/src/mage/cards/y/YumaProudProtector.java
@@ -52,7 +52,7 @@ public final class YumaProudProtector extends CardImpl {
 
         // Whenever Yuma, Proud Protector enters the battlefield or attacks, you may sacrifice a land. If you do, draw a card.
         this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(
-                new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT))
+                new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new SacrificeTargetCost(StaticFilters.FILTER_LAND))
         ));
 
         // Whenever a Desert card is put into your graveyard from anywhere, create a 4/2 green Plant Warrior creature token with reach.

--- a/Mage.Sets/src/mage/cards/z/ZoyowaLavaTongue.java
+++ b/Mage.Sets/src/mage/cards/z/ZoyowaLavaTongue.java
@@ -93,7 +93,7 @@ class ZoyowaLavaTongueEffect extends OneShotEffect {
             Cost cost = new OrCost(
                     "discard a card or sacrifice a permanent?",
                     new DiscardCardCost(),
-                    new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_SHORT_TEXT)
+                    new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT)
             );
 
             boolean choseToPay = cost.canPay(source, source, id, game)

--- a/Mage.Sets/src/mage/cards/z/ZuranOrb.java
+++ b/Mage.Sets/src/mage/cards/z/ZuranOrb.java
@@ -22,7 +22,7 @@ public final class ZuranOrb extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{0}");
 
         // Sacrifice a land: You gain 2 life.
-        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(2), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_LAND_SHORT_TEXT)));
+        this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new GainLifeEffect(2), new SacrificeTargetCost(StaticFilters.FILTER_LAND)));
     }
 
     private ZuranOrb(final ZuranOrb card) {

--- a/Mage/src/main/java/mage/abilities/costs/common/SacrificeXTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/SacrificeXTargetCost.java
@@ -14,7 +14,7 @@ import mage.target.common.TargetSacrifice;
  */
 public class SacrificeXTargetCost extends VariableCostImpl implements SacrificeCost {
 
-    protected final FilterPermanent filter;
+    private final FilterPermanent filter;
     private final int minValue;
 
     public SacrificeXTargetCost(FilterPermanent filter) {
@@ -29,7 +29,7 @@ public class SacrificeXTargetCost extends VariableCostImpl implements SacrificeC
         super(useAsAdditionalCost ? VariableCostType.ADDITIONAL : VariableCostType.NORMAL,
                 filter.getMessage() + " to sacrifice");
         this.text = (useAsAdditionalCost ? "as an additional cost to cast this spell, sacrifice " : "Sacrifice ") + xText + ' ' + filter.getMessage();
-        this.filter = filter;
+        this.filter = TargetSacrifice.makeFilter(filter);
         this.minValue = minValue;
     }
 

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -429,16 +429,6 @@ public final class StaticFilters {
         FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT = new FilterControlledPermanent("artifact or creature");
-
-    static {
-        FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()
-        ));
-        FILTER_CONTROLLED_ARTIFACT_OR_CREATURE_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterControlledPermanent FILTER_CONTROLLED_ARTIFACT_OR_OTHER_CREATURE = new FilterControlledPermanent("another creature or an artifact");
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -455,17 +455,6 @@ public final class StaticFilters {
         FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT = new FilterControlledPermanent("another creature or artifact");
-
-    static {
-        FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT.add(AnotherPredicate.instance);
-        FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT.add(Predicates.or(
-                CardType.ARTIFACT.getPredicate(),
-                CardType.CREATURE.getPredicate()
-        ));
-        FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterControlledPermanent FILTER_CONTROLLED_PERMANENT_ENCHANTMENT = new FilterControlledEnchantmentPermanent();
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -488,14 +488,6 @@ public final class StaticFilters {
         FILTER_CONTROLLED_PERMANENT_AN_ENCHANTMENT.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_ENCHANTMENT_SHORT_TEXT = new FilterControlledPermanent("another enchantment");
-
-    static {
-        FILTER_CONTROLLED_ANOTHER_ENCHANTMENT_SHORT_TEXT.add(AnotherPredicate.instance);
-        FILTER_CONTROLLED_ANOTHER_ENCHANTMENT_SHORT_TEXT.add(CardType.ENCHANTMENT.getPredicate());
-        FILTER_CONTROLLED_ANOTHER_ENCHANTMENT_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterControlledPermanent FILTER_CONTROLLED_PERMANENT_LAND = new FilterControlledLandPermanent();
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -401,12 +401,6 @@ public final class StaticFilters {
         FILTER_CONTROLLED_PERMANENTS.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_PERMANENT_SHORT_TEXT = new FilterControlledPermanent("permanent");
-
-    static {
-        FILTER_CONTROLLED_PERMANENT_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterControlledPermanent FILTER_CONTROLLED_PERMANENT_ARTIFACT = new FilterControlledArtifactPermanent();
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -454,14 +454,6 @@ public final class StaticFilters {
         FILTER_CONTROLLED_ANOTHER_ARTIFACT.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT = new FilterControlledPermanent("another artifact");
-
-    static {
-        FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT.add(AnotherPredicate.instance);
-        FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT.add(CardType.ARTIFACT.getPredicate());
-        FILTER_CONTROLLED_ANOTHER_ARTIFACT_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE = new FilterControlledPermanent("another creature or artifact you control");
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -633,13 +633,6 @@ public final class StaticFilters {
         FILTER_CONTROLLED_CREATURE.setLockedFilter(true);
     }
 
-    // Used for sacrifice targets that don't need the "you control" text
-    public static final FilterControlledCreaturePermanent FILTER_CONTROLLED_CREATURE_SHORT_TEXT = new FilterControlledCreaturePermanent("a creature");
-
-    static {
-        FILTER_CONTROLLED_CREATURE_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterControlledCreaturePermanent FILTER_CONTROLLED_CREATURES = new FilterControlledCreaturePermanent("creatures you control");
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -728,13 +728,6 @@ public final class StaticFilters {
         FILTER_LANDS_NONBASIC.setLockedFilter(true);
     }
 
-    // Used for sacrifice targets that don't need the "you control" text
-    public static final FilterControlledLandPermanent FILTER_CONTROLLED_LAND_SHORT_TEXT = new FilterControlledLandPermanent("a land");
-
-    static {
-        FILTER_CONTROLLED_LAND_SHORT_TEXT.setLockedFilter(true);
-    }
-
     public static final FilterCreaturePermanent FILTER_PERMANENT_CREATURE = new FilterCreaturePermanent();
 
     static {

--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -444,15 +444,15 @@ public final class StaticFilters {
         FILTER_CONTROLLED_ANOTHER_ARTIFACT.setLockedFilter(true);
     }
 
-    public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE = new FilterControlledPermanent("another creature or artifact you control");
+    public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT = new FilterControlledPermanent("another creature or artifact you control");
 
     static {
-        FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE.add(AnotherPredicate.instance);
-        FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE.add(Predicates.or(
+        FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT.add(AnotherPredicate.instance);
+        FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT.add(Predicates.or(
                 CardType.ARTIFACT.getPredicate(),
                 CardType.CREATURE.getPredicate()
         ));
-        FILTER_CONTROLLED_ANOTHER_ARTIFACT_OR_CREATURE.setLockedFilter(true);
+        FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT.setLockedFilter(true);
     }
 
     public static final FilterControlledPermanent FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT_SHORT_TEXT = new FilterControlledPermanent("another creature or artifact");

--- a/Mage/src/main/java/mage/game/command/emblems/ObNixilisOfTheBlackOathEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/ObNixilisOfTheBlackOathEmblem.java
@@ -27,7 +27,7 @@ public final class ObNixilisOfTheBlackOathEmblem extends Emblem {
         Effect effect = new GainLifeEffect(xValue);
         effect.setText("You gain X life");
         Ability ability = new SimpleActivatedAbility(Zone.COMMAND, effect, new ManaCostsImpl<>("{1}{B}"));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_CREATURE_SHORT_TEXT));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
         effect = new DrawCardSourceControllerEffect(xValue);
         effect.setText("and draw X cards, where X is the sacrificed creature's power");
         ability.addEffect(effect);


### PR DESCRIPTION
With the rework from #11587 , the "short text" filters are no longer required.

In the process I caught a few more custom implementations that needed to use `TargetSacrifice` and fixed them.

Confirmed that all text generation is as expected after this batch of changes.