### PR TITLE
refactor: Player: LookAtCards --> LookAtCard

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AmarethTheLustrous.java
+++ b/Mage.Sets/src/mage/cards/a/AmarethTheLustrous.java
@@ -81,7 +81,7 @@ class AmarethTheLustrousEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("Top card of library", card, game);
+        player.lookAtCard("Top card of library", card, game);
         Object obj = getValue("permanentEnteringBattlefield");
         Permanent permanent = null;
         if (obj instanceof Permanent) {

--- a/Mage.Sets/src/mage/cards/a/ArchghoulOfThraben.java
+++ b/Mage.Sets/src/mage/cards/a/ArchghoulOfThraben.java
@@ -77,7 +77,7 @@ class ArchghoulOfThrabenEffect extends OneShotEffect {
         if (topCard == null) {
             return false;
         }
-        controller.lookAtCards("Top card of library", topCard, game);
+        controller.lookAtCard("Top card of library", topCard, game);
         if (topCard.hasSubtype(SubType.ZOMBIE, game)) {
             if (controller.chooseUse(Outcome.DrawCard, "Reveal " + topCard.getName() + " and put it into your hand?", source, game)) {
                 controller.revealCards(source, new CardsImpl(topCard), game);

--- a/Mage.Sets/src/mage/cards/b/BucolicRanch.java
+++ b/Mage.Sets/src/mage/cards/b/BucolicRanch.java
@@ -98,7 +98,7 @@ class BucolicRanchEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("Top card of library", card, game);
+        player.lookAtCard("Top card of library", card, game);
         if (filter.match(card, player.getId(), source, game) && player.chooseUse(
                 outcome, "Put " + card.getName() + " into your hand?", source, game
         )) {

--- a/Mage.Sets/src/mage/cards/c/CabarettiAscendancy.java
+++ b/Mage.Sets/src/mage/cards/c/CabarettiAscendancy.java
@@ -68,7 +68,7 @@ class CabarettiAscendencyEffect extends OneShotEffect {
         }
         MageObject sourceObject = source.getSourceObject(game);
         String objectName = sourceObject == null ? "Cabaretti Ascendency" : sourceObject.getIdName();
-        controller.lookAtCards(objectName, card, game);
+        controller.lookAtCard(objectName, card, game);
         if ((card.isCreature(game) || card.isPlaneswalker(game)) && controller.chooseUse(
                 Outcome.DrawCard, "Reveal " + card.getIdName() + " and put it in your hand?", source, game)) {
             controller.revealCards(source, new CardsImpl(card), game);

--- a/Mage.Sets/src/mage/cards/d/DryadGreenseeker.java
+++ b/Mage.Sets/src/mage/cards/d/DryadGreenseeker.java
@@ -74,7 +74,7 @@ class DryadGreenseekerEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards(null, card, game);
+        player.lookAtCard(null, card, game);
         if (!card.isLand(game)) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/f/FrostAugur.java
+++ b/Mage.Sets/src/mage/cards/f/FrostAugur.java
@@ -73,7 +73,7 @@ class FrostAugurEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("", card, game);
+        player.lookAtCard("", card, game);
         if (card.isSnow(game) && player.chooseUse(
                 outcome, "Reveal " + card.getName() + " and put it into your hand?", source, game
         )) {

--- a/Mage.Sets/src/mage/cards/k/KaylasMusicBox.java
+++ b/Mage.Sets/src/mage/cards/k/KaylasMusicBox.java
@@ -80,7 +80,7 @@ class KaylasMusicBoxExileEffect extends OneShotEffect {
         }
 
         card.setFaceDown(true, game);
-        controller.lookAtCards(null, card, game);
+        controller.lookAtCard(null, card, game);
 
         if (controller.moveCardsToExile(card, source, game, true, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source))) {
             card.setFaceDown(true, game);

--- a/Mage.Sets/src/mage/cards/k/KenessosPriestOfThassa.java
+++ b/Mage.Sets/src/mage/cards/k/KenessosPriestOfThassa.java
@@ -126,7 +126,7 @@ class KenessosPriestOfThassaActivatedEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards(null, card, game);
+        player.lookAtCard(null, card, game);
         if (filter.match(card, game) && player.chooseUse(outcome, "Put " + card.getName() + " onto the battlefield?", source, game)) {
             return player.moveCards(card, Zone.BATTLEFIELD, source, game);
         }

--- a/Mage.Sets/src/mage/cards/l/LanternOfRevealing.java
+++ b/Mage.Sets/src/mage/cards/l/LanternOfRevealing.java
@@ -72,7 +72,7 @@ class LanternOfRevealingEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("Top card of library", card, game);
+        player.lookAtCard("Top card of library", card, game);
         if (card.isLand(game) && player.chooseUse(
                 outcome, "Put " + card.getName() + " onto the battlefield tapped?", source, game
         )) {

--- a/Mage.Sets/src/mage/cards/m/MedomaisProphecy.java
+++ b/Mage.Sets/src/mage/cards/m/MedomaisProphecy.java
@@ -144,7 +144,7 @@ class MedomaisProphecyLookEffect extends OneShotEffect {
                 .getPlayersInRange(source.getControllerId(), game)
                 .stream()
                 .map(game::getPlayer)
-                .forEachOrdered(player -> controller.lookAtCards(
+                .forEachOrdered(player -> controller.lookAtCard(
                         sourceObject.getIdName() + " " + player.getName(), player.getLibrary().getFromTop(game), game
                 ));
         return true;

--- a/Mage.Sets/src/mage/cards/o/OmnathLocusOfAll.java
+++ b/Mage.Sets/src/mage/cards/o/OmnathLocusOfAll.java
@@ -107,7 +107,7 @@ class OmnathLocusOfAllCardEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards(null, card, game);
+        player.lookAtCard(null, card, game);
         if (card.getManaCost()
                 .stream()
                 .map(ManaCost::getMana)

--- a/Mage.Sets/src/mage/cards/p/Parcelbeast.java
+++ b/Mage.Sets/src/mage/cards/p/Parcelbeast.java
@@ -79,7 +79,7 @@ class ParcelbeastEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("", card, game);
+        player.lookAtCard("", card, game);
         if (card.isLand(game) && player.chooseUse(
                 outcome, "Put " + card.getName() + " onto the battlefield?",
                 "(otherwise put it into your hand", "To battlefield",

--- a/Mage.Sets/src/mage/cards/q/QuestForUlasTemple.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForUlasTemple.java
@@ -93,7 +93,7 @@ class QuestForUlasTempleEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        controller.lookAtCards("Top of library", card, game);
+        controller.lookAtCard("Top of library", card, game);
         if (!card.isCreature(game) || !controller.chooseUse(
                 Outcome.DrawCard, "Reveal the top card of your library?", source, game
         )) {

--- a/Mage.Sets/src/mage/cards/r/RisenReef.java
+++ b/Mage.Sets/src/mage/cards/r/RisenReef.java
@@ -75,7 +75,7 @@ class RisenReefEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("", card, game);
+        player.lookAtCard("", card, game);
         if (card.isLand(game) && player.chooseUse(
                 outcome, "Put " + card.getName() + " onto the battlefield tapped?",
                 "(otherwise put it into your hand", "To battlefield",

--- a/Mage.Sets/src/mage/cards/r/RulikMonsWarrenChief.java
+++ b/Mage.Sets/src/mage/cards/r/RulikMonsWarrenChief.java
@@ -74,7 +74,7 @@ class RulikMonsWarrenChiefEffect extends OneShotEffect {
         boolean landToPlay = false;
         Card card = controller.getLibrary().getFromTop(game);
         if (card != null) {
-            controller.lookAtCards("Top card of your library", card, game);
+            controller.lookAtCard("Top card of your library", card, game);
             landToPlay = card.isLand(game) && controller.chooseUse(outcome, "Put " + card.getName() + " into play tapped?", source, game)
                     && controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
         }

--- a/Mage.Sets/src/mage/cards/r/RunoStromkirk.java
+++ b/Mage.Sets/src/mage/cards/r/RunoStromkirk.java
@@ -88,7 +88,7 @@ class RunoStromkirkEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards(null, card, game);
+        player.lookAtCard(null, card, game);
         if (!player.chooseUse(outcome, "Reveal " + card.getName() + '?', source, game)) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/SarinthSteelseeker.java
+++ b/Mage.Sets/src/mage/cards/s/SarinthSteelseeker.java
@@ -72,7 +72,7 @@ class SarinthSteelseekerEffect extends OneShotEffect {
         if (topCard == null) {
             return false;
         }
-        controller.lookAtCards("Top card of library", topCard, game);
+        controller.lookAtCard("Top card of library", topCard, game);
         if (topCard.isLand(game) && controller.chooseUse(Outcome.DrawCard, "Reveal " + topCard.getLogName() + " and put it into your hand?", source, game)) {
             controller.revealCards(source, new CardsImpl(topCard), game);
             controller.moveCards(topCard, Zone.HAND, source, game);

--- a/Mage.Sets/src/mage/cards/t/TheBiblioplex.java
+++ b/Mage.Sets/src/mage/cards/t/TheBiblioplex.java
@@ -92,7 +92,7 @@ class TheBiblioplexEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("Top of library", card, game);
+        player.lookAtCard("Top of library", card, game);
         if (card.isInstantOrSorcery(game) && player.chooseUse(
                 Outcome.DrawCard, "Reveal that card and put it into your hand?", source, game
         )) {

--- a/Mage.Sets/src/mage/cards/u/UginTheIneffable.java
+++ b/Mage.Sets/src/mage/cards/u/UginTheIneffable.java
@@ -115,7 +115,7 @@ class UginTheIneffableEffect extends OneShotEffect {
         UUID exileZoneId = CardUtil.getExileZoneId(game, source.getSourceId(), source.getSourceObjectZoneChangeCounter());
         if (player.moveCardsToExile(card, source, game, false, exileZoneId, sourceObject.getIdName() + " (" + player.getName() + ")")) {
             card.turnFaceDown(source, game, source.getControllerId());
-            player.lookAtCards(player.getName() + " - " + card.getIdName() + " - " + CardUtil.sdf.format(System.currentTimeMillis()), card, game);
+            player.lookAtCard(player.getName() + " - " + card.getIdName() + " - " + CardUtil.sdf.format(System.currentTimeMillis()), card, game);
         }
 
         // create token

--- a/Mage.Sets/src/mage/cards/x/XanatharGuildKingpin.java
+++ b/Mage.Sets/src/mage/cards/x/XanatharGuildKingpin.java
@@ -130,7 +130,7 @@ class XanatharLookAtTopCardOfLibraryEffect extends ContinuousEffectImpl {
         if (topCard == null) {
             return false;
         }
-        controller.lookAtCards("Top card of " + opponent.getName() + "'s library", topCard, game);
+        controller.lookAtCard("Top card of " + opponent.getName() + "'s library", topCard, game);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/z/ZiatorasEnvoy.java
+++ b/Mage.Sets/src/mage/cards/z/ZiatorasEnvoy.java
@@ -81,7 +81,7 @@ class ZiatorasEnvoyEffect extends OneShotEffect {
         if (card == null) {
             return false;
         }
-        player.lookAtCards("Top of your library", card, game);
+        player.lookAtCard("Top of your library", card, game);
         Cards cards = new CardsImpl(card);
         // TODO: factor this out and reuse for other cards
         if (player.canPlayLand()) {

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3281,8 +3281,8 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public void lookAtCards(String name, Card card, Game game) {
-        computerPlayer.lookAtCards(name, card, game);
+    public void lookAtCard(String name, Card card, Game game) {
+        computerPlayer.lookAtCard(name, card, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/LookAtTopCardOfLibraryAnyTimeEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/LookAtTopCardOfLibraryAnyTimeEffect.java
@@ -45,7 +45,7 @@ public class LookAtTopCardOfLibraryAnyTimeEffect extends ContinuousEffectImpl {
         if (topCard == null) {
             return false;
         }
-        controller.lookAtCards("Top card of your library", topCard, game);
+        controller.lookAtCard("Top card of your library", topCard, game);
         return true;
     }
 

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -616,7 +616,7 @@ public interface Player extends MageItem, Copyable<Player> {
      */
     void revealCards(Ability source, String name, Cards cards, Game game, boolean postToLog);
 
-    void lookAtCards(String name, Card card, Game game);
+    void lookAtCard(String name, Card card, Game game);
 
     void lookAtCards(String name, Cards cards, Game game);
 

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1871,7 +1871,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     }
 
     @Override
-    public void lookAtCards(String titleSuffix, Card card, Game game) {
+    public void lookAtCard(String titleSuffix, Card card, Game game) {
         game.getState().getLookedAt(this.playerId).add(titleSuffix, card);
         game.fireUpdatePlayersEvent();
     }


### PR DESCRIPTION
This PR affects the interface `mage.players.Player`, along with its implementers and users.

The current naming does not correspond with actual usage. There are two methods with the same name (albeit with different signatures) that do two different things. This is misleading.

- On the one hand, the method `void lookAtCards(String name, Card card, Game game)`
  only looks at *one* card (see signature).

- On the other hand, the method `void lookAtCards(String name, Cards cards, Game game)`
  looks at *many* cards (see signature).

This PR fixes that problem.
- Now, the method that only looks at *one* card is renamed to `lookAtCard`.