### PR TITLE
Fix Saga DFC rendering

### DIFF
--- a/Mage.Common/src/main/java/mage/view/CardView.java
+++ b/Mage.Common/src/main/java/mage/view/CardView.java
@@ -486,6 +486,9 @@ public class CardView extends SimpleCardView {
                 if (!permanent.getControllerId().equals(permanent.getOwnerId())) {
                     controlledByOwner = false;
                 }
+                if (permanent.isTransformed()) {
+                    transformed = true;
+                }
             }
         } else {
             if (card.isCopy()) {
@@ -631,10 +634,10 @@ public class CardView extends SimpleCardView {
             }
 
             // Cases, classes and sagas have portrait art
-            if (card.getSubtype().contains(SubType.CASE) ||
-                    card.getSubtype().contains(SubType.CLASS)) {
+            if (card.getSubtype(game).contains(SubType.CASE) ||
+                    card.getSubtype(game).contains(SubType.CLASS)) {
                 artRect = ArtRect.FULL_LENGTH_LEFT;
-            } else if (card.getSubtype().contains(SubType.SAGA)) {
+            } else if (card.getSubtype(game).contains(SubType.SAGA)) {
                 artRect = ArtRect.FULL_LENGTH_RIGHT;
             }
 


### PR DESCRIPTION
Rendering of the card when the second face is being shown now works as expected.

In addition to the frame now being correct for the non-Saga side, the day/night button now shows the correct state and the "dark" frame shows correctly. This seems to have been an existing issue with all transform cards that exile and return transformed.

Fixes #12129