### PR TITLE
fix and test Zirda's Companion legality

### DIFF
--- a/Mage.Sets/src/mage/cards/z/ZirdaTheDawnwaker.java
+++ b/Mage.Sets/src/mage/cards/z/ZirdaTheDawnwaker.java
@@ -2,8 +2,7 @@ package mage.cards.z;
 
 import mage.MageInt;
 import mage.MageObject;
-import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
+import mage.abilities.*;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -79,7 +78,11 @@ enum ZirdaTheDawnwakerCompanionCondition implements CompanionCondition {
                 .allMatch(card -> card
                         .getAbilities()
                         .stream()
-                        .anyMatch(ActivatedAbility.class::isInstance)
+                        .anyMatch(ability -> // This may be imperfect? Not sure everything is excluded correctly.
+                                ability instanceof ActivatedAbility &&
+                                        !(ability instanceof SpellAbility) &&
+                                        !(ability instanceof PlayLandAbility) &&
+                                        !(ability instanceof SpecialAction))
                 );
     }
 }

--- a/Mage.Sets/src/mage/cards/z/ZirdaTheDawnwaker.java
+++ b/Mage.Sets/src/mage/cards/z/ZirdaTheDawnwaker.java
@@ -78,11 +78,9 @@ enum ZirdaTheDawnwakerCompanionCondition implements CompanionCondition {
                 .allMatch(card -> card
                         .getAbilities()
                         .stream()
-                        .anyMatch(ability -> // This may be imperfect? Not sure everything is excluded correctly.
-                                ability instanceof ActivatedAbility &&
-                                        !(ability instanceof SpellAbility) &&
-                                        !(ability instanceof PlayLandAbility) &&
-                                        !(ability instanceof SpecialAction))
+                        .anyMatch(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
+                                || ability.getAbilityType() == AbilityType.MANA
+                                || ability.getAbilityType() == AbilityType.LOYALTY)
                 );
     }
 }

--- a/Mage.Tests/Companion_ZirdaInvalid.dck
+++ b/Mage.Tests/Companion_ZirdaInvalid.dck
@@ -1,0 +1,20 @@
+NAME:Invalid Zirda Invalid
+
+4 [MRD:278] Ancient Den
+4 [UMA:236] Ancient Tomb
+4 [2XM:232] Basalt Monolith
+1 [CLU:231] Boros Garrison
+4 [CLU:220] Boros Signet
+4 [LCI:269] Cavern of Souls
+4 [EXO:143] City of Traitors
+4 [C21:292] Great Furnace
+4 [ULG:126] Grim Monolith
+4 [VIS:149] Magma Mine
+4 [STH:138] Mox Diamond
+4 [SOM:179] Mox Opal
+4 [FUT:42] Pact of Negation
+2 [ICE:213] Pyroblast
+1 [ELD:171] Questing Beast
+4 [5DN:156] Staff of Domination
+4 [AER:181] Walking Ballista
+SB: 1 [IKO:233] Zirda, the Dawnwaker

--- a/Mage.Tests/Companion_ZirdaValid.dck
+++ b/Mage.Tests/Companion_ZirdaValid.dck
@@ -1,0 +1,20 @@
+NAME:Valid Zirda Deck
+
+4 [MRD:278] Ancient Den
+4 [UMA:236] Ancient Tomb
+4 [2XM:232] Basalt Monolith
+1 [CLU:231] Boros Garrison
+4 [CLU:220] Boros Signet
+4 [LCI:269] Cavern of Souls
+4 [EXO:143] City of Traitors
+4 [C21:292] Great Furnace
+4 [ULG:126] Grim Monolith
+4 [VIS:149] Magma Mine
+4 [STH:138] Mox Diamond
+4 [SOM:179] Mox Opal
+4 [FUT:42] Pact of Negation
+1 [OTJ:277] Plains
+2 [ICE:213] Pyroblast
+4 [5DN:156] Staff of Domination
+4 [AER:181] Walking Ballista
+SB: 1 [IKO:233] Zirda, the Dawnwaker

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/iko/ZirdaTheDawnwakerCompanionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/iko/ZirdaTheDawnwakerCompanionTest.java
@@ -1,0 +1,55 @@
+package org.mage.test.cards.single.iko;
+
+import mage.constants.MultiplayerAttackOption;
+import mage.constants.PhaseStep;
+import mage.constants.RangeOfInfluence;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.GameException;
+import mage.game.TwoPlayerDuel;
+import mage.game.mulligan.MulliganType;
+import org.junit.Test;
+import org.mage.test.serverside.base.impl.CardTestPlayerAPIImpl;
+
+import java.io.FileNotFoundException;
+
+/**
+ * @author TheElk801
+ */
+public class ZirdaTheDawnwakerCompanionTest extends CardTestPlayerAPIImpl {
+
+    private static final String zirda = "Zirda, the Dawnwaker";
+
+    public ZirdaTheDawnwakerCompanionTest() {
+        deckNameA = "Companion_ZirdaValid.dck";
+        deckNameB = "Companion_ZirdaInvalid.dck";
+    }
+
+    @Override
+    protected Game createNewGameAndPlayers() throws GameException, FileNotFoundException {
+        Game game = new TwoPlayerDuel(MultiplayerAttackOption.LEFT, RangeOfInfluence.ONE, MulliganType.GAME_DEFAULT.getMulligan(0), 60, 20, 7);
+
+        playerA = createPlayer(game, "PlayerA", deckNameA);
+        playerB = createPlayer(game, "PlayerB", deckNameB);
+        return game;
+    }
+
+    @Test
+    public void testCompanionAbility() {
+        setChoice(playerA, true); // choice to companion Zirda
+        // playerB does not make a choice.
+
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 3);
+
+        checkPlayableAbility("Valid Zirda Deck", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Companion", true);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Companion");
+        checkPlayableAbility("Invalid Zirda Deck", 2, PhaseStep.PRECOMBAT_MAIN, playerB, "Companion", false);
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, zirda, 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/CompanionAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CompanionAbility.java
@@ -6,8 +6,10 @@ import mage.abilities.effects.keyword.CompanionEffect;
 import mage.cards.Card;
 import mage.constants.TimingRule;
 import mage.constants.Zone;
+import mage.game.Game;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Allows card to be companion
@@ -47,5 +49,14 @@ public class CompanionAbility extends SpecialAction {
 
     public final String getLegalRule() {
         return companionCondition.getRule();
+    }
+
+    @Override
+    public ActivationStatus canActivate(UUID playerId, Game game) {
+        // Check that the card is actually a companion.
+        Card card = game.getState().getCompanion().getCard(getSourceId(), game);
+        return card != null
+                ? super.canActivate(playerId, game)
+                : ActivationStatus.getFalse();
     }
 }


### PR DESCRIPTION
Zirda's check for valid deck to be Companion was broken.

This is better than before, and now there's a test for it.
Did I exclude all the ActivatedAbility that are not really ones?
Do we have that check elsewhere in another shape I could reuse?

fix #11346