### PR TITLE
Fix Dragon Cultist

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DragonCultist.java
+++ b/Mage.Sets/src/mage/cards/d/DragonCultist.java
@@ -77,9 +77,10 @@ class DragonCultistWatcher extends Watcher {
 
     @Override
     public void watch(GameEvent event, Game game) {
-        if (event instanceof DamagedEvent) {
+        if (event.getType() == GameEvent.EventType.DAMAGED_PERMANENT || event.getType() == GameEvent.EventType.DAMAGED_PLAYER) {
+            Integer amount = event.getAmount();
             map.computeIfAbsent(game.getControllerId(event.getSourceId()), x -> new HashMap<>())
-                    .compute(new MageObjectReference(event.getSourceId(), game), CardUtil::setOrIncrementValue);
+                    .compute(new MageObjectReference(event.getSourceId(), game), (k, v) -> (v == null) ? amount : v + amount);
         }
     }
 


### PR DESCRIPTION
Reported in #12147 
Looks like the watcher was incrementing the tracked damage by 1 instead of using the damage amount. Also i switched the watcher to look for specific event types instead of checking inheritance since the latter causes double damage-counting.