### PR TITLE
cleanup AbilityType for easier check that an ability is an activated ability

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeImage.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeImage.java
@@ -280,9 +280,9 @@ public class CardPanelRenderModeImage extends CardPanel {
 
         // Ability icon
         if (newGameCard.isAbility()) {
-            if (newGameCard.getAbilityType() == AbilityType.TRIGGERED) {
+            if (newGameCard.getAbilityType() == AbilityType.TRIGGERED_NONMANA) {
                 setTypeIcon(ImageManagerImpl.instance.getTriggeredAbilityImage(), "Triggered Ability");
-            } else if (newGameCard.getAbilityType() == AbilityType.ACTIVATED_NONMANA_NONLOYALTY) {
+            } else if (newGameCard.getAbilityType() == AbilityType.ACTIVATED_NONMANA) {
                 setTypeIcon(ImageManagerImpl.instance.getActivatedAbilityImage(), "Activated Ability");
             }
         }

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeImage.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeImage.java
@@ -282,7 +282,7 @@ public class CardPanelRenderModeImage extends CardPanel {
         if (newGameCard.isAbility()) {
             if (newGameCard.getAbilityType() == AbilityType.TRIGGERED) {
                 setTypeIcon(ImageManagerImpl.instance.getTriggeredAbilityImage(), "Triggered Ability");
-            } else if (newGameCard.getAbilityType() == AbilityType.ACTIVATED) {
+            } else if (newGameCard.getAbilityType() == AbilityType.ACTIVATED_NONMANA_NONLOYALTY) {
                 setTypeIcon(ImageManagerImpl.instance.getActivatedAbilityImage(), "Activated Ability");
             }
         }

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
@@ -425,9 +425,9 @@ public abstract class CardRenderer {
     // Get a string representing the type line
     protected String getCardTypeLine() {
         if (cardView.isAbility()) {
-            if (cardView.getAbilityType() == AbilityType.TRIGGERED) {
+            if (cardView.getAbilityType() == AbilityType.TRIGGERED_NONMANA) {
                 return "Triggered Ability";
-            } else if (cardView.getAbilityType() == AbilityType.ACTIVATED_NONMANA_NONLOYALTY) {
+            } else if (cardView.getAbilityType() == AbilityType.ACTIVATED_NONMANA) {
                 return "Activated Ability";
             } else if (cardView.getAbilityType() == null) {
                 // TODO: Triggered abilities waiting to be put onto the stack have abilityType = null. Figure out why

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRenderer.java
@@ -427,7 +427,7 @@ public abstract class CardRenderer {
         if (cardView.isAbility()) {
             if (cardView.getAbilityType() == AbilityType.TRIGGERED) {
                 return "Triggered Ability";
-            } else if (cardView.getAbilityType() == AbilityType.ACTIVATED) {
+            } else if (cardView.getAbilityType() == AbilityType.ACTIVATED_NONMANA_NONLOYALTY) {
                 return "Activated Ability";
             } else if (cardView.getAbilityType() == null) {
                 // TODO: Triggered abilities waiting to be put onto the stack have abilityType = null. Figure out why

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ComputerPlayer6.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ComputerPlayer6.java
@@ -12,7 +12,6 @@ import mage.abilities.keyword.*;
 import mage.cards.Card;
 import mage.cards.Cards;
 import mage.choices.Choice;
-import mage.constants.AbilityType;
 import mage.constants.Outcome;
 import mage.constants.RangeOfInfluence;
 import mage.counters.CounterType;
@@ -1082,7 +1081,7 @@ public class ComputerPlayer6 extends ComputerPlayer {
 
     private boolean checkForRepeatedAction(Game sim, SimulationNode2 node, Ability action, UUID playerId) {
         // pass or casting two times a spell multiple times on hand is ok
-        if (action instanceof PassAbility || action instanceof SpellAbility || action.getAbilityType() == AbilityType.MANA) {
+        if (action instanceof PassAbility || action instanceof SpellAbility || action.isManaAbility()) {
             return false;
         }
         int newVal = GameStateEvaluator2.evaluate(playerId, sim).getTotalScore();

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
@@ -11,7 +11,6 @@ import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.effects.Effect;
 import mage.cards.Card;
-import mage.constants.AbilityType;
 import mage.game.Game;
 import mage.game.combat.Combat;
 import mage.game.events.GameEvent;
@@ -100,7 +99,7 @@ public final class SimulatedPlayer2 extends ComputerPlayer {
         List<ActivatedAbility> playables = game.getPlayer(playerId).getPlayable(game, isSimulatedPlayer);
         playables = filterAbilities(game, playables, suggested);
         for (ActivatedAbility ability : playables) {
-            if (ability.getAbilityType() == AbilityType.MANA) {
+            if (ability.isManaAbility()) {
                 continue;
             }
             List<Ability> options = game.getPlayer(playerId).getPlayableOptions(ability, game);

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -117,7 +117,7 @@ public class ComputerPlayer extends PlayerImpl {
         if (hand.size() < 6
                 || isTestsMode() // ignore mulligan in tests
                 || game.getClass().getName().contains("Momir") // ignore mulligan in Momir games
-                ) {
+        ) {
             return false;
         }
         Set<Card> lands = hand.getCards(new FilterLandCard(), game);
@@ -1498,7 +1498,7 @@ public class ComputerPlayer extends PlayerImpl {
         // TODO: wtf?! change to player.getPlayable
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents(playerId)) {
             for (ActivatedAbility ability : permanent.getAbilities().getActivatedAbilities(Zone.BATTLEFIELD)) {
-                if (!(ability instanceof ActivatedManaAbilityImpl) && ability.canActivate(playerId, game).canActivate()) {
+                if (!ability.isManaActivatedAbility() && ability.canActivate(playerId, game).canActivate()) {
                     if (ability instanceof EquipAbility && permanent.getAttachedTo() != null) {
                         continue;
                     }
@@ -2220,7 +2220,7 @@ public class ComputerPlayer extends PlayerImpl {
 
     @Override
     public List<Integer> getMultiAmountWithIndividualConstraints(Outcome outcome, List<MultiAmountMessage> messages,
-            int min, int max, MultiAmountType type, Game game) {
+                                                                 int min, int max, MultiAmountType type, Game game) {
         log.debug("getMultiAmount");
 
         int needCount = messages.size();
@@ -2767,7 +2767,7 @@ public class ComputerPlayer extends PlayerImpl {
     }
 
     protected void findBestPermanentTargets(Outcome outcome, UUID abilityControllerId, UUID sourceId, Ability source, FilterPermanent filter, Game game, Target target,
-            List<Permanent> goodList, List<Permanent> badList, List<Permanent> allList) {
+                                            List<Permanent> goodList, List<Permanent> badList, List<Permanent> allList) {
         // searching for most valuable/powerfull permanents
         goodList.clear();
         badList.clear();

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2364,7 +2364,7 @@ public class HumanPlayer extends PlayerImpl {
         }
         if (userData.isUseFirstManaAbility() && object instanceof Permanent && object.isLand(game)) {
             ActivatedAbility ability = abilities.values().iterator().next();
-            if (ability instanceof ActivatedManaAbilityImpl) {
+            if (ability.isActivatedAbility() && ability.isManaAbility()) {
                 activateAbility(ability, game);
                 return;
             }
@@ -2426,7 +2426,7 @@ public class HumanPlayer extends PlayerImpl {
             }
 
             // hide on mana activate and show all other
-            return ability instanceof ActivatedManaAbilityImpl;
+            return ability.isManaActivatedAbility();
         }
         return true;
     }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2619,7 +2619,7 @@ public class HumanPlayer extends PlayerImpl {
             }
 
             // triggered abilities can't be skipped by cancel or wrong answer
-            if (source.getAbilityType() != AbilityType.TRIGGERED) {
+            if (!source.isTriggeredAbility()) {
                 done = true;
             }
         }
@@ -2787,7 +2787,9 @@ public class HumanPlayer extends PlayerImpl {
                 holdingPriority = false;
                 break;
             case TOGGLE_RECORD_MACRO:
-                if (true) return; // TODO: macro unsupported in current version
+                if (true) {
+                    return; // TODO: macro unsupported in current version
+                }
                 if (recordingMacro) {
                     logger.debug("Finished Recording Macro");
                     activatingMacro = true;

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -18,6 +18,8 @@ import mage.cards.decks.Deck;
 import mage.choices.Choice;
 import mage.choices.ChoiceImpl;
 import mage.constants.*;
+import static mage.constants.PlayerAction.REQUEST_AUTO_ANSWER_RESET_ALL;
+import static mage.constants.PlayerAction.TRIGGER_AUTO_ORDER_RESET_ALL;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterAttackingCreature;
 import mage.filter.common.FilterBlockingCreature;
@@ -54,9 +56,6 @@ import java.util.List;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
-
-import static mage.constants.PlayerAction.REQUEST_AUTO_ANSWER_RESET_ALL;
-import static mage.constants.PlayerAction.TRIGGER_AUTO_ORDER_RESET_ALL;
 
 /**
  * Human: server side logic to exchange game data between server app and another player's app
@@ -1165,7 +1164,7 @@ public class HumanPlayer extends PlayerImpl {
                     return false;
                 }
                 if (controllingPlayer.getUserData().isPassPriorityActivation()
-                        && getJustActivatedType() == AbilityType.ACTIVATED) {
+                        && getJustActivatedType().isNonManaActivatedAbility()) {
                     setJustActivatedType(null);
                     pass(game);
                     return false;

--- a/Mage.Sets/src/mage/cards/a/Abeyance.java
+++ b/Mage.Sets/src/mage/cards/a/Abeyance.java
@@ -4,7 +4,6 @@ import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -93,8 +92,7 @@ class AbeyanceEffect extends ContinuousRuleModifyingEffectImpl {
         }
         if (event.getType() == GameEvent.EventType.ACTIVATE_ABILITY) {
             Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-            return ability.isPresent()
-                    && !(ability.get() instanceof ActivatedManaAbilityImpl);
+            return ability.isPresent() && !ability.get().isManaActivatedAbility();
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/a/AbolethSpawn.java
+++ b/Mage.Sets/src/mage/cards/a/AbolethSpawn.java
@@ -82,7 +82,7 @@ class AbolethSpawnTriggeredAbility extends TriggeredAbilityImpl {
             return false; // only creatures entering under opponent's control
         }
         Ability stackAbility = stackObject.getStackAbility();
-        if (!(stackAbility instanceof TriggeredAbility)) {
+        if (!stackAbility.isTriggeredAbility()) {
             return false;
         }
         GameEvent triggerEvent = ((TriggeredAbility) stackAbility).getTriggerEvent();

--- a/Mage.Sets/src/mage/cards/a/AgathaOfTheVileCauldron.java
+++ b/Mage.Sets/src/mage/cards/a/AgathaOfTheVileCauldron.java
@@ -107,7 +107,7 @@ class AgathaOfTheVileCauldronEffect extends CostModificationEffectImpl {
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         // Activated abilities you control
-        if (abilityToModify.getAbilityType() != AbilityType.ACTIVATED
+        if (!abilityToModify.getAbilityType().isActivatedAbility()
                 || !abilityToModify.isControlledBy(source.getControllerId())) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/a/AgathasSoulCauldron.java
+++ b/Mage.Sets/src/mage/cards/a/AgathasSoulCauldron.java
@@ -1,7 +1,6 @@
 package mage.cards.a;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.delayed.ReflexiveTriggeredAbility;
@@ -132,7 +131,7 @@ class AgathasSoulCauldronAbilityEffect extends ContinuousEffectImpl {
                 .stream()
                 .map(card -> card.getAbilities(game))
                 .flatMap(Collection::stream)
-                .filter(ActivatedAbility.class::isInstance)
+                .filter(Ability::isActivatedAbility)
                 .collect(Collectors.toSet());
         if (abilities.isEmpty()) {
             return false;

--- a/Mage.Sets/src/mage/cards/a/AngelOfJubilation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfJubilation.java
@@ -2,7 +2,6 @@ package mage.cards.a;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
@@ -107,9 +106,7 @@ class AngelOfJubilationSacrificeFilterEffect extends CostModificationEffectImpl 
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-
-        return (abilityToModify.getAbilityType() == AbilityType.ACTIVATED
-                || abilityToModify instanceof SpellAbility)
+        return (abilityToModify.isActivatedAbility() || abilityToModify.getAbilityType() == AbilityType.SPELL)
                 && game.getState().getPlayersInRange(source.getControllerId(), game).contains(abilityToModify.getControllerId());
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnointedPeacekeeper.java
+++ b/Mage.Sets/src/mage/cards/a/AnointedPeacekeeper.java
@@ -1,6 +1,5 @@
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
@@ -9,17 +8,18 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.ChooseACardNameEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.effects.common.cost.SpellsCostIncreasingAllEffect;
-import mage.constants.*;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.predicate.mageobject.ChosenNamePredicate;
 import mage.game.Game;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author weirddan455
  */
 public final class AnointedPeacekeeper extends CardImpl {
@@ -88,7 +88,7 @@ class AnointedPeacekeeperEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() != AbilityType.ACTIVATED) {
+        if (!abilityToModify.getAbilityType().isNonManaActivatedAbility()) {
             return false;
         }
         MageObject activatedSource = game.getObject(abilityToModify.getSourceId());

--- a/Mage.Sets/src/mage/cards/a/AshnodTheUncaring.java
+++ b/Mage.Sets/src/mage/cards/a/AshnodTheUncaring.java
@@ -5,7 +5,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.costs.SacrificeCost;
 import mage.abilities.effects.common.CopyStackObjectEffect;
 import mage.abilities.keyword.DeathtouchAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -77,7 +76,7 @@ class AshnodTheUncaringTriggeredAbility extends TriggeredAbilityImpl {
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
         if (stackAbility == null
-                || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl
+                || stackAbility.getStackAbility().isManaActivatedAbility()
                 || stackAbility
                 .getStackAbility()
                 .getCosts()

--- a/Mage.Sets/src/mage/cards/a/AutomatedArtificer.java
+++ b/Mage.Sets/src/mage/cards/a/AutomatedArtificer.java
@@ -13,6 +13,7 @@ import mage.abilities.mana.builder.ConditionalManaBuilder;
 import mage.abilities.mana.conditional.ManaCondition;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.game.Game;
@@ -76,15 +77,14 @@ class AutomatedArtificerManaCondition extends ManaCondition {
         if (source == null || source.isActivated()) {
             return false;
         }
-        switch (source.getAbilityType()) {
-            case MANA:
-            case ACTIVATED:
-                return true;
-            case SPELL:
-                if (source instanceof SpellAbility) {
-                    MageObject object = game.getObject(source);
-                    return object != null && object.isArtifact(game);
-                }
+        if (source.isActivatedAbility()) {
+            return true;
+        }
+        if (source.getAbilityType() == AbilityType.SPELL) {
+            if (source instanceof SpellAbility) {
+                MageObject object = game.getObject(source);
+                return object != null && object.isArtifact(game);
+            }
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/b/BattlemagesBracers.java
+++ b/Mage.Sets/src/mage/cards/b/BattlemagesBracers.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.abilities.keyword.HasteAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -16,9 +15,9 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.game.stack.StackAbility;
+import mage.target.common.TargetControlledCreaturePermanent;
 
 import java.util.UUID;
-import mage.target.common.TargetControlledCreaturePermanent;
 
 /**
  * @author TheElk801
@@ -79,7 +78,7 @@ class BattlemagesBracersTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         getEffects().setValue("stackObject", stackAbility);

--- a/Mage.Sets/src/mage/cards/b/BiomancersFamiliar.java
+++ b/Mage.Sets/src/mage/cards/b/BiomancersFamiliar.java
@@ -2,7 +2,6 @@ package mage.cards.b;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -73,7 +72,7 @@ class BiomancersFamiliarCostReductionEffect extends CostModificationEffectImpl {
         if (controller == null) {
             return false;
         }
-        int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 2, 1);        
+        int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 2, 1);
         if (reduceMax <= 0) {
             return true;
         }
@@ -84,9 +83,7 @@ class BiomancersFamiliarCostReductionEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() != AbilityType.ACTIVATED
-                && (abilityToModify.getAbilityType() != AbilityType.MANA
-                || !(abilityToModify instanceof ActivatedAbility))) {
+        if (!abilityToModify.getAbilityType().isActivatedAbility()) {
             return false;
         }
         //Activated abilities of creatures you control

--- a/Mage.Sets/src/mage/cards/b/BladegraftAspirant.java
+++ b/Mage.Sets/src/mage/cards/b/BladegraftAspirant.java
@@ -1,31 +1,24 @@
 package mage.cards.b;
 
-import java.util.Set;
-import java.util.UUID;
 import mage.MageInt;
-import mage.constants.SubType;
-import mage.constants.Zone;
-import mage.filter.FilterCard;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
-import mage.util.CardUtil;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.effects.common.cost.SpellsCostReductionControllerEffect;
 import mage.abilities.keyword.MenaceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
-import mage.constants.CardType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
+import mage.constants.*;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.Set;
+import java.util.UUID;
 
 /**
- *
  * @author @stwalsh4118
  */
 public final class BladegraftAspirant extends CardImpl {
@@ -39,7 +32,7 @@ public final class BladegraftAspirant extends CardImpl {
 
     public BladegraftAspirant(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}");
-        
+
         this.subtype.add(SubType.PHYREXIAN);
         this.subtype.add(SubType.WARRIOR);
         this.power = new MageInt(2);
@@ -52,7 +45,7 @@ public final class BladegraftAspirant extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SpellsCostReductionControllerEffect(filter, 1)));
 
         // Activated abilities of Equipment you control that target Bladegraft Aspirant cost {1} less to activate.
-        
+
         this.addAbility(new SimpleStaticAbility(new BladegraftAspirantCostReductionEffect()));
 
     }
@@ -71,7 +64,7 @@ class BladegraftAspirantCostReductionEffect extends CostModificationEffectImpl {
 
     private static final String effectText = "Activated abilities of Equipment you control that target Bladegraft Aspirant cost {1} less to activate.";
 
-            BladegraftAspirantCostReductionEffect() {
+    BladegraftAspirantCostReductionEffect() {
         super(Duration.Custom, Outcome.Benefit, CostModificationType.REDUCE_COST);
         staticText = effectText;
     }
@@ -86,7 +79,7 @@ class BladegraftAspirantCostReductionEffect extends CostModificationEffectImpl {
         if (controller == null) {
             return false;
         }
-        int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 1, 0);        
+        int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 1, 0);
         if (reduceMax <= 0) {
             return true;
         }
@@ -97,15 +90,13 @@ class BladegraftAspirantCostReductionEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() != AbilityType.ACTIVATED
-                && (abilityToModify.getAbilityType() != AbilityType.MANA
-                || !(abilityToModify instanceof ActivatedAbility))) {
+        if (!abilityToModify.getAbilityType().isActivatedAbility()) {
             return false;
         }
 
         Permanent permanent = game.getPermanentOrLKIBattlefield(abilityToModify.getSourceId());
 
-        if(!(permanent != null && permanent.getSubtype(game).contains(SubType.EQUIPMENT) && permanent.isControlledBy(source.getControllerId()))) {
+        if (!(permanent != null && permanent.getSubtype(game).contains(SubType.EQUIPMENT) && permanent.isControlledBy(source.getControllerId()))) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/b/BloodSun.java
+++ b/Mage.Sets/src/mage/cards/b/BloodSun.java
@@ -1,9 +1,6 @@
 
 package mage.cards.b;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -11,20 +8,17 @@ import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class BloodSun extends CardImpl {
@@ -73,9 +67,9 @@ class BloodSunEffect extends ContinuousEffectImpl {
                 switch (layer) {
                     case AbilityAddingRemovingEffects_6:
                         List<Ability> toRemove = new ArrayList<>();
-                        permanent.getAbilities().forEach(a -> {
-                            if (a.getAbilityType() != AbilityType.MANA) {
-                                toRemove.add(a);
+                        permanent.getAbilities().forEach(ability -> {
+                            if (!ability.getAbilityType().isManaAbility()) {
+                                toRemove.add(ability);
                             }
                         });
                         permanent.removeAbilities(toRemove, source.getSourceId(), game);

--- a/Mage.Sets/src/mage/cards/b/BlossomingTortoise.java
+++ b/Mage.Sets/src/mage/cards/b/BlossomingTortoise.java
@@ -2,7 +2,6 @@ package mage.cards.b;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.EntersBattlefieldOrAttacksSourceTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
@@ -25,7 +24,6 @@ import mage.util.CardUtil;
 import java.util.UUID;
 
 /**
- *
  * @author Susucr
  */
 public final class BlossomingTortoise extends CardImpl {
@@ -38,7 +36,7 @@ public final class BlossomingTortoise extends CardImpl {
 
     public BlossomingTortoise(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{G}");
-        
+
         this.subtype.add(SubType.TURTLE);
         this.power = new MageInt(3);
         this.toughness = new MageInt(3);
@@ -121,7 +119,7 @@ class BlossomingTortoiseCostReductionEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (!(abilityToModify instanceof ActivatedAbility)) {
+        if (!abilityToModify.isActivatedAbility()) {
             return false;
         }
         Permanent permanent = abilityToModify.getSourcePermanentIfItStillExists(game);

--- a/Mage.Sets/src/mage/cards/b/BoundInGold.java
+++ b/Mage.Sets/src/mage/cards/b/BoundInGold.java
@@ -1,24 +1,23 @@
 package mage.cards.b;
 
-import java.util.Optional;
-import java.util.UUID;
-
+import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
-import mage.abilities.effects.common.combat.CantAttackBlockAttachedEffect;
-import mage.constants.*;
-import mage.abilities.Ability;
 import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.combat.CantAttackBlockAttachedEffect;
+import mage.abilities.keyword.EnchantAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
-import mage.abilities.keyword.EnchantAbility;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
- *
  * @author weirddan455
  */
 public final class BoundInGold extends CardImpl {
@@ -90,7 +89,7 @@ class BoundInGoldEffect extends ContinuousRuleModifyingEffectImpl {
                 case ACTIVATE_ABILITY:
                     if (enchantment.isAttachedTo(event.getSourceId())) {
                         Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-                        return ability.isPresent() && ability.get().getAbilityType() != AbilityType.MANA;
+                        return ability.isPresent() && ability.get().isNonManaActivatedAbility();
                     }
             }
         }

--- a/Mage.Sets/src/mage/cards/b/BrutalSuppression.java
+++ b/Mage.Sets/src/mage/cards/b/BrutalSuppression.java
@@ -1,29 +1,22 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.AbilityType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.target.common.TargetControlledPermanent;
+
+import java.util.UUID;
 
 /**
- *
  * @author L_J
  */
 public final class BrutalSuppression extends CardImpl {
@@ -48,12 +41,14 @@ public final class BrutalSuppression extends CardImpl {
 class BrutalSuppressionAdditionalCostEffect extends CostModificationEffectImpl {
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("a land");
-    static{
+
+    static {
         filter.add(CardType.LAND.getPredicate());
     }
 
     private static final FilterPermanent filter2 = new FilterPermanent("nontoken Rebels");
-    static{
+
+    static {
         filter2.add(SubType.REBEL.getPredicate());
         filter.add(TokenPredicate.FALSE);
     }
@@ -75,7 +70,7 @@ class BrutalSuppressionAdditionalCostEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED || abilityToModify.getAbilityType() == AbilityType.MANA) {
+        if (abilityToModify.isActivatedAbility()){
             Permanent rebelPermanent = game.getPermanent(abilityToModify.getSourceId());
             if (rebelPermanent != null) {
                 return filter2.match(rebelPermanent, game);

--- a/Mage.Sets/src/mage/cards/b/BurningTreeShaman.java
+++ b/Mage.Sets/src/mage/cards/b/BurningTreeShaman.java
@@ -7,13 +7,11 @@ import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.stack.StackAbility;
 import mage.target.targetpointer.FixedTarget;
 
@@ -68,7 +66,7 @@ class BurningTreeShamanTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility != null && stackAbility.getAbilityType() == AbilityType.ACTIVATED) {
+        if (stackAbility != null && stackAbility.isNonManaActivatedAbility()) {
             for (Effect effect : getEffects()) {
                 effect.setTargetPointer(new FixedTarget(event.getPlayerId()));
             }

--- a/Mage.Sets/src/mage/cards/c/ConvergenceOfDominion.java
+++ b/Mage.Sets/src/mage/cards/c/ConvergenceOfDominion.java
@@ -1,7 +1,6 @@
 package mage.cards.c;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
@@ -76,7 +75,7 @@ class ConvergenceOfDominionEffect extends CostModificationEffectImpl {
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         return ControlYourCommanderCondition.instance.apply(game, source)
-                && abilityToModify instanceof ActivatedAbility
+                && abilityToModify.isActivatedAbility()
                 && game.getState().getZone(abilityToModify.getSourceId()) == Zone.GRAVEYARD;
     }
 

--- a/Mage.Sets/src/mage/cards/c/CrackdownConstruct.java
+++ b/Mage.Sets/src/mage/cards/c/CrackdownConstruct.java
@@ -1,24 +1,23 @@
 
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Duration;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.StackAbility;
 
+import java.util.UUID;
+
 /**
- *
  * @author spjspj
  */
 public final class CrackdownConstruct extends CardImpl {
@@ -71,9 +70,7 @@ class CrackdownConstructTriggeredAbility extends TriggeredAbilityImpl {
             Card source = game.getPermanentOrLKIBattlefield(event.getSourceId());
             if (source != null && (source.isArtifact(game) || source.isCreature(game))) {
                 StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-                if (!(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
-                    return true;
-                }
+                return !stackAbility.getStackAbility().isManaActivatedAbility();
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/c/CrypticTrilobite.java
+++ b/Mage.Sets/src/mage/cards/c/CrypticTrilobite.java
@@ -1,6 +1,5 @@
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.ConditionalMana;
 import mage.MageInt;
 import mage.Mana;
@@ -20,11 +19,12 @@ import mage.abilities.mana.builder.ConditionalManaBuilder;
 import mage.abilities.mana.conditional.ManaCondition;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
 import mage.game.Game;
+
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -94,12 +94,9 @@ class CrypticTrilobiteManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source != null && !source.isActivated()) {
-            // ex: SimpleManaAbility is an ACTIVATED ability, but it is categorized as a MANA ability
-            return source.getAbilityType() == AbilityType.MANA
-                    || source.getAbilityType() == AbilityType.ACTIVATED;
-        }
-        return false;
+        return source != null
+                && !source.isActivated()
+                && source.isActivatedAbility();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CultivatorDrone.java
+++ b/Mage.Sets/src/mage/cards/c/CultivatorDrone.java
@@ -1,13 +1,11 @@
 
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.ConditionalMana;
 import mage.MageInt;
 import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.SpellAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
@@ -24,14 +22,15 @@ import mage.constants.SubType;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class CultivatorDrone extends CardImpl {
 
     public CultivatorDrone(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
         this.subtype.add(SubType.ELDRAZI);
         this.subtype.add(SubType.DRONE);
         this.power = new MageInt(2);
@@ -85,7 +84,7 @@ class CultivatorDroneManaCondition extends ManaCondition implements Condition {
                 return true;
             }
         }
-        if (source instanceof ActivatedAbility && !source.isActivated()) {
+        if (source.isActivatedAbility() && !source.isActivated()) {
             Permanent object = game.getPermanentOrLKIBattlefield(source.getSourceId());
             if (object != null && object.getColor(game).isColorless()) {
                 return true;

--- a/Mage.Sets/src/mage/cards/d/DampingMatrix.java
+++ b/Mage.Sets/src/mage/cards/d/DampingMatrix.java
@@ -5,7 +5,6 @@ import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ReplacementEffectImpl;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -22,13 +21,12 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class DampingMatrix extends CardImpl {
 
     public DampingMatrix(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{3}");
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // Activated abilities of artifacts and creatures can't be activated unless they're mana abilities.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new DampingMatrixEffect()));
@@ -47,6 +45,7 @@ public final class DampingMatrix extends CardImpl {
 class DampingMatrixEffect extends ReplacementEffectImpl {
 
     private static final FilterPermanent filter = new FilterPermanent("artifacts and creatures");
+
     static {
         filter.add(Predicates.or(
                 CardType.ARTIFACT.getPredicate(),
@@ -71,20 +70,18 @@ class DampingMatrixEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         return true;
     }
-    
+
     @Override
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.ACTIVATE_ABILITY;
     }
-    
+
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         MageObject object = game.getObject(event.getSourceId());
-        if (object instanceof Permanent && filter.match((Permanent)object, source.getControllerId(), source, game)) {
+        if (object instanceof Permanent && filter.match((Permanent) object, source.getControllerId(), source, game)) {
             Optional<Ability> ability = object.getAbilities().get(event.getTargetId());
-            if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
-                return true;
-            }
+            return ability.isPresent() && !ability.get().isManaActivatedAbility();
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/d/DarkImpostor.java
+++ b/Mage.Sets/src/mage/cards/d/DarkImpostor.java
@@ -2,7 +2,6 @@ package mage.cards.d;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -109,7 +108,7 @@ class DarkImpostorContinuousEffect extends ContinuousEffectImpl {
         }
         for (Card card : exileZone.getCards(StaticFilters.FILTER_CARD_CREATURE, game)) {
             for (Ability ability : card.getAbilities(game)) {
-                if (ability instanceof ActivatedAbility) {
+                if (ability.isActivatedAbility()) {
                     permanent.addAbility(ability, source.getSourceId(), game, true);
                 }
             }

--- a/Mage.Sets/src/mage/cards/d/DrainPower.java
+++ b/Mage.Sets/src/mage/cards/d/DrainPower.java
@@ -1,10 +1,5 @@
 package mage.cards.d;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.ActivatedAbility;
 import mage.abilities.costs.mana.ManaCost;
@@ -12,7 +7,6 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
@@ -25,8 +19,9 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.TargetPlayer;
 
+import java.util.*;
+
 /**
- *
  * @author L_J
  */
 public final class DrainPower extends CardImpl {
@@ -84,7 +79,7 @@ class DrainPowerEffect extends OneShotEffect {
                         List<ActivatedManaAbilityImpl> manaAbilities = new ArrayList<>();
                         abilitySearch:
                         for (Ability ability : permanent.getAbilities()) {
-                            if (ability instanceof ActivatedAbility && ability.getAbilityType() == AbilityType.MANA) {
+                            if (ability instanceof ActivatedAbility && ability.getAbilityType().isManaAbility()) {
                                 ActivatedManaAbilityImpl manaAbility = (ActivatedManaAbilityImpl) ability;
                                 if (manaAbility.canActivate(targetPlayer.getId(), game).canActivate()) {
                                     // canActivate can't check for mana abilities that require a mana cost, if the payment isn't possible (Cabal Coffers etc)
@@ -126,7 +121,7 @@ class DrainPowerEffect extends OneShotEffect {
                         i++;
                         if (manaAbilitiesMap.get(permanent).size() <= i
                                 || targetPlayer.chooseUse(Outcome.Neutral, "Activate mana ability \"" + manaAbility.getRule() + "\" of " + permanent.getLogName()
-                                        + "? (Choose \"no\" to activate next mana ability)", source, game)) {
+                                + "? (Choose \"no\" to activate next mana ability)", source, game)) {
                             boolean originalCanUndo = manaAbility.isUndoPossible();
                             manaAbility.setUndoPossible(false); // prevents being able to undo Drain Power
                             if (targetPlayer.activateAbility(manaAbility, game)) {

--- a/Mage.Sets/src/mage/cards/d/DrainPower.java
+++ b/Mage.Sets/src/mage/cards/d/DrainPower.java
@@ -1,12 +1,12 @@
 package mage.cards.d;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.costs.mana.ManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
@@ -79,7 +79,7 @@ class DrainPowerEffect extends OneShotEffect {
                         List<ActivatedManaAbilityImpl> manaAbilities = new ArrayList<>();
                         abilitySearch:
                         for (Ability ability : permanent.getAbilities()) {
-                            if (ability instanceof ActivatedAbility && ability.getAbilityType().isManaAbility()) {
+                            if (AbilityType.ACTIVATED_MANA.equals(ability.getAbilityType())) {
                                 ActivatedManaAbilityImpl manaAbility = (ActivatedManaAbilityImpl) ability;
                                 if (manaAbility.canActivate(targetPlayer.getId(), game).canActivate()) {
                                     // canActivate can't check for mana abilities that require a mana cost, if the payment isn't possible (Cabal Coffers etc)

--- a/Mage.Sets/src/mage/cards/d/DranaAndLinvala.java
+++ b/Mage.Sets/src/mage/cards/d/DranaAndLinvala.java
@@ -120,8 +120,7 @@ class DranaAndLinvalaGainAbilitiesEffect extends ContinuousEffectImpl {
                 .map(permanent -> permanent.getAbilities(game))
                 .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
-                .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
-                        || ability.getAbilityType() == AbilityType.MANA)
+                .filter(Ability::isActivatedAbility)
                 .collect(Collectors.toList())) {
             Ability addedAbility = perm.addAbility(ability, source.getSourceId(), game, true);
             if (addedAbility != null) {

--- a/Mage.Sets/src/mage/cards/d/Drought.java
+++ b/Mage.Sets/src/mage/cards/d/Drought.java
@@ -1,6 +1,5 @@
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -10,20 +9,13 @@ import mage.abilities.effects.common.SacrificeSourceUnlessPaysEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
-import mage.constants.CardType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.SubType;
-import mage.constants.TargetController;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
-import mage.target.common.TargetControlledPermanent;
+
+import java.util.UUID;
 
 /**
- *
  * @author L_J
  */
 public final class Drought extends CardImpl {
@@ -81,7 +73,7 @@ class DroughtAdditionalCostEffect extends CostModificationEffectImpl {
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         return (appliesToSpells && abilityToModify.getAbilityType() == AbilityType.SPELL)
-                || (!appliesToSpells && (abilityToModify.getAbilityType() == AbilityType.ACTIVATED || abilityToModify.getAbilityType() == AbilityType.MANA));
+                || (!appliesToSpells && abilityToModify.isActivatedAbility());
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/DynaheirInvokerAdept.java
+++ b/Mage.Sets/src/mage/cards/d/DynaheirInvokerAdept.java
@@ -1,15 +1,6 @@
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.game.stack.StackAbility;
-import mage.watchers.common.ManaPaidSourceWatcher;
 import mage.abilities.Ability;
 import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -19,23 +10,25 @@ import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.common.CopyStackObjectEffect;
 import mage.abilities.effects.common.CreateDelayedTriggeredAbilityEffect;
 import mage.abilities.keyword.HasteAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AsThoughEffectType;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.StackAbility;
+import mage.watchers.common.ManaPaidSourceWatcher;
+
+import java.util.UUID;
 
 /**
- *
  * @author Xanderhall
  */
 public final class DynaheirInvokerAdept extends CardImpl {
 
     public DynaheirInvokerAdept(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}{R}{W}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.WIZARD);
@@ -50,7 +43,7 @@ public final class DynaheirInvokerAdept extends CardImpl {
 
         // {T}: When you next activate an ability that isn't a mana ability this turn by spending four or more mana to activate it, copy that ability. You may choose new targets for the copy.
         this.addAbility(new SimpleActivatedAbility(new CreateDelayedTriggeredAbilityEffect(new DynaheirInvokerAdeptTriggeredAbility()), new TapSourceCost()));
-        
+
     }
 
     private DynaheirInvokerAdept(final DynaheirInvokerAdept card) {
@@ -88,9 +81,9 @@ class DynaheirInvokerAdeptHasteEffect extends AsThoughEffectImpl {
     public boolean applies(UUID sourceId, Ability source, UUID affectedControllerId, Game game) {
         Permanent permanent = game.getPermanent(sourceId);
         return permanent != null
-            && permanent.isCreature(game)
-            && permanent.isControlledBy(source.getControllerId())
-            && !permanent.getId().equals(source.getSourceId());
+                && permanent.isCreature(game)
+                && permanent.isControlledBy(source.getControllerId())
+                && !permanent.getId().equals(source.getSourceId());
     }
 }
 
@@ -121,7 +114,7 @@ class DynaheirInvokerAdeptTriggeredAbility extends DelayedTriggeredAbility {
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
         if (stackAbility == null
-                || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl
+                || stackAbility.getStackAbility().isManaActivatedAbility()
                 || ManaPaidSourceWatcher.getTotalPaid(stackAbility.getId(), game) < 4) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/e/EchoBaseCommando.java
+++ b/Mage.Sets/src/mage/cards/e/EchoBaseCommando.java
@@ -1,10 +1,8 @@
 
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.keyword.ProtectionAbility;
@@ -18,8 +16,9 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author Styxo
  */
 public final class EchoBaseCommando extends CardImpl {
@@ -84,7 +83,7 @@ class EchoBaseCommandoEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED || (abilityToModify.getAbilityType() == AbilityType.MANA && (abilityToModify instanceof ActivatedAbility))) {
+        if (abilityToModify.isActivatedAbility()){
             Permanent permanent = game.getPermanent(abilityToModify.getSourceId());
             if (filter.match(permanent, source.getControllerId(), source, game)) {
                 return true;

--- a/Mage.Sets/src/mage/cards/e/EmbalmersTools.java
+++ b/Mage.Sets/src/mage/cards/e/EmbalmersTools.java
@@ -1,7 +1,6 @@
 package mage.cards.e;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapTargetCost;
@@ -86,8 +85,7 @@ class EmbalmersToolsEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED
-                || (abilityToModify.getAbilityType() == AbilityType.MANA && (abilityToModify instanceof ActivatedAbility))) {
+        if (abilityToModify.isActivatedAbility()){
             // Activated abilities of creatures
             Card card = game.getCard(abilityToModify.getSourceId());
             if (filter.match(card, source.getControllerId(), source, game) && game.getState().getZone(card.getId()) == Zone.GRAVEYARD) {

--- a/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
+++ b/Mage.Sets/src/mage/cards/e/ExperimentKraj.java
@@ -1,10 +1,8 @@
 
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -20,14 +18,15 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class ExperimentKraj extends CardImpl {
 
     public ExperimentKraj(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}{G}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{G}{U}{U}");
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.OOZE);
         this.subtype.add(SubType.MUTANT);
@@ -39,7 +38,7 @@ public final class ExperimentKraj extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new ExperimentKrajEffect()));
 
         // {tap}: Put a +1/+1 counter on target creature.
-        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()),new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersTargetEffect(CounterType.P1P1.createInstance()), new TapSourceCost());
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
     }
@@ -76,9 +75,9 @@ class ExperimentKrajEffect extends ContinuousEffectImpl {
     public boolean apply(Game game, Ability source) {
         Permanent perm = game.getPermanent(source.getSourceId());
         if (perm != null) {
-            for (Permanent creature :game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)){
-                for (Ability ability: creature.getAbilities()) {
-                    if (ability instanceof ActivatedAbility) {
+            for (Permanent creature : game.getState().getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
+                for (Ability ability : creature.getAbilities()) {
+                    if (ability.isActivatedAbility()) {
                         perm.addAbility(ability, source.getSourceId(), game, true);
                     }
                 }

--- a/Mage.Sets/src/mage/cards/f/FaithsFetters.java
+++ b/Mage.Sets/src/mage/cards/f/FaithsFetters.java
@@ -1,8 +1,6 @@
 
 package mage.cards.f;
 
-import java.util.Optional;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -19,6 +17,9 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * @author LevelX2
@@ -83,7 +84,7 @@ class FaithsFettersEffect extends ContinuousRuleModifyingEffectImpl {
         Permanent enchantment = game.getPermanent(source.getSourceId());
         if (enchantment != null && enchantment.isAttachedTo(event.getSourceId())) {
             Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-            if (ability.isPresent() && ability.get().getAbilityType() != AbilityType.MANA) {
+            if (ability.isPresent() && ability.get().isManaAbility()) {
                 return true;
             }
 

--- a/Mage.Sets/src/mage/cards/f/FlamescrollCelebrant.java
+++ b/Mage.Sets/src/mage/cards/f/FlamescrollCelebrant.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.ExileSpellEffect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardSetInfo;
 import mage.cards.ModalDoubleFacedCard;
 import mage.constants.*;
@@ -97,7 +96,7 @@ class FlamescrollCelebrantTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         getEffects().setTargetPointer(new FixedTarget(event.getPlayerId()));

--- a/Mage.Sets/src/mage/cards/f/ForensicGadgeteer.java
+++ b/Mage.Sets/src/mage/cards/f/ForensicGadgeteer.java
@@ -2,7 +2,6 @@ package mage.cards.f;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
@@ -76,9 +75,7 @@ class ForensicGadgeteerEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED
-                || (abilityToModify.getAbilityType() == AbilityType.MANA
-                && (abilityToModify instanceof ActivatedAbility))) {
+        if (abilityToModify.isActivatedAbility()){
             // Activated abilities of artifacts
             Permanent permanent = game.getPermanentOrLKIBattlefield(abilityToModify.getSourceId());
             return permanent != null

--- a/Mage.Sets/src/mage/cards/g/Gloom.java
+++ b/Mage.Sets/src/mage/cards/g/Gloom.java
@@ -66,15 +66,11 @@ class GloomCostIncreaseEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        boolean isWhiteEnchantment = false;
-        boolean isActivated = abilityToModify.getAbilityType() == AbilityType.ACTIVATED;
-        if (isActivated) {
-            MageObject permanent = game.getPermanent(abilityToModify.getSourceId());
-            if (permanent != null) {
-                isWhiteEnchantment = permanent.isEnchantment(game) && permanent.getColor(game).isWhite();
-            }
+        if (!abilityToModify.isActivatedAbility()) {
+            return false;
         }
-        return isActivated && isWhiteEnchantment;
+        MageObject permanent = game.getPermanent(abilityToModify.getSourceId());
+        return permanent != null && permanent.isEnchantment(game) && permanent.getColor(game).isWhite();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/h/HandToHand.java
+++ b/Mage.Sets/src/mage/cards/h/HandToHand.java
@@ -1,27 +1,26 @@
 
 package mage.cards.h;
 
-import java.util.Optional;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 
+import java.util.Optional;
+import java.util.UUID;
+
 /**
- *
  * @author fireshoes
  */
 public final class HandToHand extends CardImpl {
 
     public HandToHand(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{R}");
 
         // During combat, players can't cast instant spells or activate abilities that aren't mana abilities.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new HandToHandEffect()));
@@ -79,9 +78,7 @@ class HandToHandEffect extends ContinuousRuleModifyingEffectImpl {
             }
             if (event.getType() == GameEvent.EventType.ACTIVATE_ABILITY) {
                 Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-                if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
-                    return true;
-                }
+                return ability.isPresent() && !ability.get().isManaActivatedAbility();
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/h/HarshMentor.java
+++ b/Mage.Sets/src/mage/cards/h/HarshMentor.java
@@ -5,7 +5,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -72,7 +71,7 @@ class HarshMentorTriggeredAbility extends TriggeredAbilityImpl {
             Card source = game.getPermanentOrLKIBattlefield(event.getSourceId());
             if (source != null && (source.isArtifact(game) || source.isCreature(game) || source.isLand(game))) {
                 StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-                if (!(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
+                if (!stackAbility.getStackAbility().isManaActivatedAbility()) {
                     for (Effect effect : getEffects()) {
                         effect.setTargetPointer(new FixedTarget(event.getPlayerId()));
                     }

--- a/Mage.Sets/src/mage/cards/h/Heartstone.java
+++ b/Mage.Sets/src/mage/cards/h/Heartstone.java
@@ -1,7 +1,6 @@
 package mage.cards.h;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.cards.CardImpl;
@@ -56,10 +55,10 @@ class HeartstoneEffect extends CostModificationEffectImpl {
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
         Player controller = game.getPlayer(abilityToModify.getControllerId());
         if (controller != null) {
-            int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 1, 1);            
+            int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 1, 1);
             if (reduceMax <= 0) {
                 return true;
-            }            
+            }
             CardUtil.reduceCost(abilityToModify, reduceMax);
             return true;
         }
@@ -68,9 +67,7 @@ class HeartstoneEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED
-                || (abilityToModify.getAbilityType() == AbilityType.MANA
-                && (abilityToModify instanceof ActivatedAbility))) {
+        if (abilityToModify.isActivatedAbility()) {
             // Activated abilities of creatures
             Permanent permanent = game.getPermanentOrLKIBattlefield(abilityToModify.getSourceId());
             return permanent != null && permanent.isCreature(game);

--- a/Mage.Sets/src/mage/cards/i/IllicitMasquerade.java
+++ b/Mage.Sets/src/mage/cards/i/IllicitMasquerade.java
@@ -1,7 +1,5 @@
 package mage.cards.i;
 
-import java.util.UUID;
-
 import mage.MageItem;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbility;
@@ -28,8 +26,9 @@ import mage.game.events.GameEvent;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FirstTargetPointer;
 
+import java.util.UUID;
+
 /**
- *
  * @author DominionSpy
  */
 public final class IllicitMasquerade extends CardImpl {
@@ -107,7 +106,7 @@ enum IllicitMasqueradePredicate implements ObjectSourcePlayerPredicate<MageItem>
     @Override
     public boolean apply(ObjectSourcePlayer<MageItem> input, Game game) {
         Ability ability = input.getSource();
-        if (!(ability instanceof TriggeredAbility)) {
+        if (!ability.isTriggeredAbility()) {
             return true;
         }
         GameEvent event = ((TriggeredAbility) ability).getTriggerEvent();

--- a/Mage.Sets/src/mage/cards/i/IllusionistsBracers.java
+++ b/Mage.Sets/src/mage/cards/i/IllusionistsBracers.java
@@ -4,7 +4,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.CopyStackObjectEffect;
 import mage.abilities.keyword.EquipAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -71,7 +70,7 @@ class IllusionistsBracersTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         this.getEffects().setValue("stackObject", stackAbility);

--- a/Mage.Sets/src/mage/cards/i/ImmolationShaman.java
+++ b/Mage.Sets/src/mage/cards/i/ImmolationShaman.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
 import mage.abilities.keyword.MenaceAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -93,7 +92,7 @@ class ImmolationShamanTriggeredAbility extends TriggeredAbilityImpl {
             Card source = game.getPermanentOrLKIBattlefield(event.getSourceId());
             if (source != null && (source.isArtifact(game) || source.isCreature(game) || source.isLand(game))) {
                 StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-                if (!(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
+                if (!stackAbility.getStackAbility().isManaActivatedAbility()) {
                     for (Effect effect : getEffects()) {
                         effect.setTargetPointer(new FixedTarget(event.getPlayerId()));
                     }

--- a/Mage.Sets/src/mage/cards/i/Imprison.java
+++ b/Mage.Sets/src/mage/cards/i/Imprison.java
@@ -1,21 +1,14 @@
 
 package mage.cards.i;
 
-import java.util.Set;
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.AttacksOrBlocksAttachedTriggeredAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.AttachEffect;
-import mage.abilities.effects.common.CounterTargetEffect;
-import mage.abilities.effects.common.DestroySourceEffect;
-import mage.abilities.effects.common.DoIfCostPaid;
-import mage.abilities.effects.common.RemoveFromCombatTargetEffect;
+import mage.abilities.effects.common.*;
 import mage.abilities.keyword.EnchantAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -29,8 +22,10 @@ import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
 import mage.watchers.common.BlockedByOnlyOneCreatureThisCombatWatcher;
 
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author L_J
  */
 public final class Imprison extends CardImpl {
@@ -38,7 +33,7 @@ public final class Imprison extends CardImpl {
     public Imprison(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{B}");
         this.subtype.add(SubType.AURA);
-        
+
         // Enchant creature
         TargetPermanent auraTarget = new TargetCreaturePermanent();
         this.getSpellAbility().addTarget(auraTarget);
@@ -48,7 +43,7 @@ public final class Imprison extends CardImpl {
 
         // Whenever a player activates an ability of enchanted creature with {T} in its activation cost that isn't a mana ability, you may pay {1}. If you do, counter that ability. If you don't, destroy Imprison.
         this.addAbility(new ImprisonTriggeredAbility());
-        
+
         // Whenever enchanted creature attacks or blocks, you may pay {1}. If you do, tap the creature, remove it from combat, and creatures it was blocking that had become blocked by only that creature this combat become unblocked. If you don't, destroy Imprison.
         this.addAbility(new AttacksOrBlocksAttachedTriggeredAbility(new DoIfCostPaid(new ImprisonUnblockEffect(), new DestroySourceEffect(), new ManaCostsImpl<>("{1}")), AttachmentType.AURA));
     }
@@ -91,7 +86,7 @@ class ImprisonTriggeredAbility extends TriggeredAbilityImpl {
             Permanent enchantedPermanent = game.getPermanentOrLKIBattlefield(enchantment.getAttachedTo());
             if (event.getSourceId().equals(enchantedPermanent.getId())) {
                 StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-                if (!(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
+                if (!stackAbility.getStackAbility().isManaActivatedAbility()) {
                     String abilityText = stackAbility.getRule(true);
                     if (abilityText.contains("{T},") || abilityText.contains("{T}:") || abilityText.contains("{T} or")) {
                         getEffects().get(0).setTargetPointer(new FixedTarget(stackAbility.getId()));
@@ -127,15 +122,15 @@ class ImprisonUnblockEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(enchantment.getAttachedTo());
             if (permanent != null) {
                 if (permanent.isCreature(game)) {
-                    
+
                     // Tap the creature
                     permanent.tap(source, game);
-    
+
                     // Remove it from combat
                     Effect effect = new RemoveFromCombatTargetEffect();
                     effect.setTargetPointer(new FixedTarget(permanent, game));
                     effect.apply(game, source);
-    
+
                     // Make blocked creatures unblocked
                     BlockedByOnlyOneCreatureThisCombatWatcher watcher = game.getState().getWatcher(BlockedByOnlyOneCreatureThisCombatWatcher.class);
                     if (watcher != null) {

--- a/Mage.Sets/src/mage/cards/i/IntercessorsArrest.java
+++ b/Mage.Sets/src/mage/cards/i/IntercessorsArrest.java
@@ -89,7 +89,7 @@ class IntercessorsArrestEffect extends ContinuousRuleModifyingEffectImpl {
             case ACTIVATE_ABILITY:
                 if (enchantment.isAttachedTo(event.getSourceId())) {
                     Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-                    return ability.isPresent() && ability.get().getAbilityType() != AbilityType.MANA;
+                    return ability.isPresent() && ability.get().isNonManaActivatedAbility();
                 }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/i/Interdict.java
+++ b/Mage.Sets/src/mage/cards/i/Interdict.java
@@ -7,7 +7,6 @@ import mage.abilities.effects.RestrictionEffect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
@@ -61,7 +60,7 @@ class InterdictPredicate implements Predicate<StackObject> {
 
     @Override
     public boolean apply(StackObject input, Game game) {
-        if (input instanceof StackAbility && ((StackAbility) input).getAbilityType() == AbilityType.ACTIVATED) {
+        if (input instanceof StackAbility && ((StackAbility) input).isActivatedAbility()){
             MageObject sourceObject = ((StackAbility) input).getSourceObject(game);
             if (sourceObject != null) {
                 return (sourceObject.isArtifact(game)

--- a/Mage.Sets/src/mage/cards/j/JamesWanderingDad.java
+++ b/Mage.Sets/src/mage/cards/j/JamesWanderingDad.java
@@ -14,7 +14,6 @@ import mage.abilities.mana.builder.ConditionalManaBuilder;
 import mage.abilities.mana.conditional.ManaCondition;
 import mage.cards.AdventureCard;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
@@ -90,12 +89,9 @@ class JamesWanderingDadManaCondition extends ManaCondition implements Condition 
 
     @Override
     public boolean apply(Game game, Ability source) {
-        if (source != null && !source.isActivated()) {
-            // ex: SimpleManaAbility is an ACTIVATED ability, but it is categorized as a MANA ability
-            return source.getAbilityType() == AbilityType.MANA
-                    || source.getAbilityType() == AbilityType.ACTIVATED;
-        }
-        return false;
+        return source != null
+                && !source.isActivated()
+                && source.isActivatedAbility();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/k/KopalaWardenOfWaves.java
+++ b/Mage.Sets/src/mage/cards/k/KopalaWardenOfWaves.java
@@ -130,7 +130,7 @@ class KopalaWardenOfWavesCostModificationEffect2 extends CostModificationEffectI
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        return abilityToModify.getAbilityType() == AbilityType.ACTIVATED
+        return abilityToModify.isActivatedAbility()
                 && KopalaWardenOfWaves.isAbilityCompatible(abilityToModify, source, game);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KurkeshOnakkeAncient.java
+++ b/Mage.Sets/src/mage/cards/k/KurkeshOnakkeAncient.java
@@ -5,7 +5,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.CopyStackObjectEffect;
 import mage.abilities.effects.common.DoIfCostPaid;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -78,7 +77,7 @@ class KurkeshOnakkeAncientTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         this.getEffects().setValue("stackObject", stackAbility);

--- a/Mage.Sets/src/mage/cards/l/LeoriSparktouchedHunter.java
+++ b/Mage.Sets/src/mage/cards/l/LeoriSparktouchedHunter.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.CopyStackObjectEffect;
 import mage.abilities.hint.StaticHint;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.VigilanceAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.choices.Choice;
@@ -45,8 +44,8 @@ public final class LeoriSparktouchedHunter extends CardImpl {
 
         // Whenever Leori, Sparktouched Hunter deals combat damage to a player, choose a planeswalker type. Until end of turn, whenever you activate an ability of a planeswalker of that type, copy that ability. You may choose new targets for the copies.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-            new LeoriSparktouchedHunterEffect(),
-            false
+                new LeoriSparktouchedHunterEffect(),
+                false
         ));
     }
 
@@ -66,7 +65,7 @@ class LeoriSparktouchedHunterEffect extends OneShotEffect {
     LeoriSparktouchedHunterEffect() {
         super(Outcome.Benefit);
         this.staticText = "choose a planeswalker type. Until end of turn, whenever you activate an ability " +
-            "of a planeswalker of that type, copy that ability. You may choose new targets for the copies.";
+                "of a planeswalker of that type, copy that ability. You may choose new targets for the copies.";
     }
 
     private LeoriSparktouchedHunterEffect(final LeoriSparktouchedHunterEffect effect) {
@@ -98,8 +97,8 @@ class LeoriSparktouchedHunterEffect extends OneShotEffect {
         game.informPlayers(controller.getLogName() + " has chosen " + subType);
 
         game.addDelayedTriggeredAbility(
-            new LeoriSparktouchedHunterTriggeredAbility(subType),
-            source
+                new LeoriSparktouchedHunterTriggeredAbility(subType),
+                source
         );
 
         return true;
@@ -139,8 +138,7 @@ class LeoriSparktouchedHunterTriggeredAbility extends DelayedTriggeredAbility {
         }
 
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null
-            || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
 
@@ -155,6 +153,6 @@ class LeoriSparktouchedHunterTriggeredAbility extends DelayedTriggeredAbility {
     @Override
     public String getRule() {
         return "Whenever you activate an ability of a planeswalker of the chosen type, copy that ability. " +
-            "You may choose new targets for the copies.";
+                "You may choose new targets for the copies.";
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LocusOfEnlightenment.java
+++ b/Mage.Sets/src/mage/cards/l/LocusOfEnlightenment.java
@@ -6,7 +6,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.CopyStackObjectEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -82,7 +81,7 @@ class LocusOfEnlightenmentEffect extends ContinuousEffectImpl {
         }
         for (Card card : exileZone.getCards(game)) {
             for (Ability ability : card.getAbilities(game)) {
-                if (ability.getAbilityType() == AbilityType.ACTIVATED || ability.getAbilityType() == AbilityType.MANA) {
+                if (ability.isActivatedAbility()) {
                     ActivatedAbility copyAbility = (ActivatedAbility) ability.copy();
                     copyAbility.setMaxActivationsPerTurn(1);
                     permanent.addAbility(copyAbility, source.getSourceId(), game, true);
@@ -120,7 +119,7 @@ class LocusOfEnlightenmentTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.isManaAbility()) {
             return false;
         }
         this.getEffects().setValue("stackObject", stackAbility);

--- a/Mage.Sets/src/mage/cards/m/MagewrightsStone.java
+++ b/Mage.Sets/src/mage/cards/m/MagewrightsStone.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.UntapTargetEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
@@ -64,10 +63,8 @@ class HasAbilityWithTapSymbolPredicate implements Predicate<MageObject> {
         }
 
         for (Ability ability : abilities) {
-            if ((ability.getAbilityType() == AbilityType.ACTIVATED || ability.getAbilityType() == AbilityType.MANA) && !ability.getCosts().isEmpty()) {
-                if (ability.hasTapCost()) {
-                        return true;
-                }
+            if (ability.isActivatedAbility() && ability.hasTapCost()) {
+                return true;
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/m/MagusLuceaKane.java
+++ b/Mage.Sets/src/mage/cards/m/MagusLuceaKane.java
@@ -16,13 +16,12 @@ import mage.constants.*;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.target.common.TargetCreaturePermanent;
-
-import java.util.UUID;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.game.stack.Spell;
 import mage.game.stack.StackAbility;
 import mage.game.stack.StackObject;
+import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -93,7 +92,7 @@ class MagusLuceaKaneTriggeredAbility extends DelayedTriggeredAbility {
         // activated ability
         if (event.getType() == GameEvent.EventType.ACTIVATED_ABILITY) {
             StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-            if (stackAbility != null && !(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
+            if (stackAbility != null && !stackAbility.getStackAbility().isManaActivatedAbility()) {
                 if (stackAbility.getManaCostsToPay().containsX()) {
                     this.getEffects().setValue("stackObject", (StackObject) stackAbility);
                     return true;

--- a/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
+++ b/Mage.Sets/src/mage/cards/m/MairsilThePretender.java
@@ -138,7 +138,7 @@ class MairsilThePretenderGainAbilitiesEffect extends ContinuousEffectImpl {
         for (Card card : game.getExile().getAllCards(game)) {
             if (filter.match(card, game) && Objects.equals(card.getOwnerId(), perm.getControllerId())) {
                 for (Ability ability : card.getAbilities(game)) {
-                    if (ability instanceof ActivatedAbility) {
+                    if (ability.isActivatedAbility()) {
                         ActivatedAbility copyAbility = (ActivatedAbility) ability.copy();
                         copyAbility.setMaxActivationsPerTurn(1);
                         perm.addAbility(copyAbility, source.getSourceId(), game, true);

--- a/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
+++ b/Mage.Sets/src/mage/cards/m/ManascapeRefractor.java
@@ -82,8 +82,7 @@ class ManascapeRefractorGainAbilitiesEffect extends ContinuousEffectImpl {
                 .map(permanent -> permanent.getAbilities(game))
                 .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
-                .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
-                        || ability.getAbilityType() == AbilityType.MANA)
+                .filter(Ability::isActivatedAbility)
                 .collect(Collectors.toList())) {
             // optimization to disallow the adding of duplicate, unnecessary basic mana abilities
             if (!(ability instanceof BasicManaAbility)

--- a/Mage.Sets/src/mage/cards/m/MirranSafehouse.java
+++ b/Mage.Sets/src/mage/cards/m/MirranSafehouse.java
@@ -1,13 +1,6 @@
 package mage.cards.m;
 
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.cards.CardImpl;
@@ -17,6 +10,12 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * @author TheElk801
@@ -70,7 +69,7 @@ class MirranSafehouseEffect extends ContinuousEffectImpl {
                 .flatMap(Collection::stream)
                 .map(card -> card.getAbilities(game))
                 .flatMap(Collection::stream)
-                .filter(ActivatedAbility.class::isInstance)
+                .filter(Ability::isActivatedAbility)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
             permanent.addAbility(ability, source.getSourceId(), game, true);

--- a/Mage.Sets/src/mage/cards/m/MoltenDisaster.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenDisaster.java
@@ -7,7 +7,6 @@ import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.KickerAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -84,9 +83,8 @@ class MoltenDisasterSplitSecondEffect extends ContinuousRuleModifyingEffectImpl 
         }
         if (event.getType() == GameEvent.EventType.ACTIVATE_ABILITY) {
             Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-            if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
-                return KickedCondition.ONCE.apply(game, source);
-            }
+            return ability.isPresent() && !ability.get().isManaActivatedAbility()
+                    && KickedCondition.ONCE.apply(game, source);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/m/MyrWelder.java
+++ b/Mage.Sets/src/mage/cards/m/MyrWelder.java
@@ -1,9 +1,7 @@
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -18,8 +16,9 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCardInGraveyard;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public final class MyrWelder extends CardImpl {
@@ -102,7 +101,7 @@ class MyrWelderContinuousEffect extends ContinuousEffectImpl {
                 Card card = game.getCard(imprintedId);
                 if (card != null) {
                     for (Ability ability : card.getAbilities(game)) {
-                        if (ability instanceof ActivatedAbility) {
+                        if (ability.isActivatedAbility()) {
                             perm.addAbility(ability, source.getId(), game, true);
                         }
                     }

--- a/Mage.Sets/src/mage/cards/n/NecroticOoze.java
+++ b/Mage.Sets/src/mage/cards/n/NecroticOoze.java
@@ -2,7 +2,6 @@ package mage.cards.n;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.cards.CardImpl;
@@ -76,7 +75,7 @@ class NecroticOozeEffect extends ContinuousEffectImpl {
                 .flatMap(Collection::stream)
                 .map(card -> card.getAbilities(game))
                 .flatMap(Collection::stream)
-                .filter(ActivatedAbility.class::isInstance)
+                .filter(Ability::isActivatedAbility)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
             permanent.addAbility(ability, source.getSourceId(), game, true);

--- a/Mage.Sets/src/mage/cards/o/OmenHawker.java
+++ b/Mage.Sets/src/mage/cards/o/OmenHawker.java
@@ -11,7 +11,6 @@ import mage.abilities.mana.builder.ConditionalManaBuilder;
 import mage.abilities.mana.conditional.ManaCondition;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.game.Game;
@@ -74,8 +73,7 @@ class OmenHawkerManaCondition extends ManaCondition implements Condition {
     @Override
     public boolean apply(Game game, Ability source) {
         if (source != null && !source.isActivated()) {
-            return source.getAbilityType() == AbilityType.MANA
-                    || source.getAbilityType() == AbilityType.ACTIVATED;
+            return source.isActivatedAbility();
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/o/OppressiveRays.java
+++ b/Mage.Sets/src/mage/cards/o/OppressiveRays.java
@@ -1,10 +1,7 @@
 
 package mage.cards.o;
 
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
-import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.AttachEffect;
@@ -13,27 +10,22 @@ import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class OppressiveRays extends CardImpl {
 
     public OppressiveRays(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{W}");
         this.subtype.add(SubType.AURA);
 
         // Enchant creature
@@ -80,13 +72,9 @@ class OppressiveRaysCostModificationEffect extends CostModificationEffectImpl {
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         Permanent creature = game.getPermanent(abilityToModify.getSourceId());
-        if (creature != null && creature.getAttachments().contains(source.getSourceId())) {
-            if (abilityToModify instanceof ActivatedAbility
-                    && !(abilityToModify instanceof SpellAbility)) {
-                return true;
-            }
-        }
-        return false;
+        return creature != null
+                && creature.getAttachments().contains(source.getSourceId())
+                && abilityToModify.isActivatedAbility();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingSplendor.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingSplendor.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.keyword.EnchantAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -23,7 +22,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class OverwhelmingSplendor extends CardImpl {
@@ -149,7 +147,7 @@ class OverwhelmingSplendorCantActivateEffect extends ContinuousRuleModifyingEffe
 
         Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
         return ability.isPresent()
-                && !(ability.get() instanceof ActivatedManaAbilityImpl)
+                && !(ability.get().isManaActivatedAbility())
                 && !(ability.get() instanceof LoyaltyAbility);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PatchworkCrawler.java
+++ b/Mage.Sets/src/mage/cards/p/PatchworkCrawler.java
@@ -2,7 +2,6 @@ package mage.cards.p;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -76,7 +75,7 @@ class PatchworkCrawlerEffect extends ContinuousEffectImpl {
         }
         for (Card card : exileZone.getCards(StaticFilters.FILTER_CARD_CREATURE, game)) {
             for (Ability ability : card.getAbilities(game)) {
-                if (ability instanceof ActivatedAbility) {
+                if (ability.isActivatedAbility()) {
                     permanent.addAbility(ability, source.getSourceId(), game, true);
                 }
             }

--- a/Mage.Sets/src/mage/cards/p/PithingNeedle.java
+++ b/Mage.Sets/src/mage/cards/p/PithingNeedle.java
@@ -6,7 +6,6 @@ import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.ChooseACardNameEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -71,12 +70,10 @@ class PithingNeedleEffect extends ContinuousRuleModifyingEffectImpl {
         MageObject object = game.getObject(event.getSourceId());
         String cardName = (String) game.getState().getValue(source.getSourceId().toString() + ChooseACardNameEffect.INFO_KEY);
         Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-        if (ability.isPresent()
-                && object != null) {
-            return game.getState().getPlayersInRange(source.getControllerId(), game).contains(event.getPlayerId()) // controller in range
-                    && !(ability.get() instanceof ActivatedManaAbilityImpl) // not an activated mana ability
-                    && CardUtil.haveSameNames(object, cardName, game);
-        }
-        return false;
+        return ability.isPresent()
+                && object != null
+                && game.getState().getPlayersInRange(source.getControllerId(), game).contains(event.getPlayerId()) // controller in range
+                && !ability.get().isManaActivatedAbility() // not an activated mana ability
+                && CardUtil.haveSameNames(object, cardName, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PowerArtifact.java
+++ b/Mage.Sets/src/mage/cards/p/PowerArtifact.java
@@ -1,8 +1,6 @@
 package mage.cards.p;
 
-import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
@@ -67,10 +65,10 @@ class PowerArtifactCostModificationEffect extends CostModificationEffectImpl {
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
         Player controller = game.getPlayer(abilityToModify.getControllerId());
         if (controller != null) {
-            int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 2, 1);            
+            int reduceMax = CardUtil.calculateActualPossibleGenericManaReduction(abilityToModify.getManaCostsToPay().getMana(), 2, 1);
             if (reduceMax <= 0) {
                 return true;
-            }            
+            }
             CardUtil.reduceCost(abilityToModify, reduceMax);
         }
         return true;
@@ -81,9 +79,7 @@ class PowerArtifactCostModificationEffect extends CostModificationEffectImpl {
         Permanent artifact = game.getPermanentOrLKIBattlefield(abilityToModify.getSourceId());
         if (artifact != null
                 && artifact.getAttachments().contains(source.getSourceId())) {
-            if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED
-                    || (abilityToModify.getAbilityType() == AbilityType.MANA
-                    && (abilityToModify instanceof ActivatedAbility))) {
+            if (abilityToModify.isActivatedAbility()){
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/p/PowerSink.java
+++ b/Mage.Sets/src/mage/cards/p/PowerSink.java
@@ -5,7 +5,6 @@ import mage.abilities.Abilities;
 import mage.abilities.Ability;
 import mage.abilities.costs.Cost;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -87,7 +86,7 @@ class PowerSinkCounterUnlessPaysEffect extends OneShotEffect {
                     for (Permanent land : lands) {
                         Abilities<Ability> landAbilities = land.getAbilities();
                         for (Ability ability : landAbilities) {
-                            if (ability instanceof ActivatedManaAbilityImpl) {
+                            if (ability.isManaActivatedAbility()) {
                                 land.tap(source, game);
                                 break;
                             }

--- a/Mage.Sets/src/mage/cards/r/RavagerWurm.java
+++ b/Mage.Sets/src/mage/cards/r/RavagerWurm.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.FightTargetSourceEffect;
 import mage.abilities.keyword.RiotAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
@@ -78,7 +77,6 @@ enum RavagerWurmPredicate implements Predicate<Permanent> {
                 && input
                 .getAbilities(game)
                 .stream()
-                .map(Ability::getAbilityType)
-                .anyMatch(AbilityType.ACTIVATED::equals);
+                .anyMatch(Ability::isNonManaActivatedAbility);
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RexCyberHound.java
+++ b/Mage.Sets/src/mage/cards/r/RexCyberHound.java
@@ -127,7 +127,7 @@ class RexCyberhoundContinuousEffect extends ContinuousEffectImpl {
         }
         for (Card card : game.getExile().getCards(filter, game)) {
             for (Ability ability : card.getAbilities(game)) {
-                if (ability instanceof ActivatedAbility) {
+                if (ability.isActivatedAbility()) {
                     ActivatedAbility copyAbility = (ActivatedAbility) ability.copy();
                     copyAbility.setMaxActivationsPerTurn(1);
                     perm.addAbility(copyAbility, source.getSourceId(), game, true);

--- a/Mage.Sets/src/mage/cards/r/RingsOfBrighthearth.java
+++ b/Mage.Sets/src/mage/cards/r/RingsOfBrighthearth.java
@@ -4,7 +4,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.CopyStackObjectEffect;
 import mage.abilities.effects.common.DoIfCostPaid;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -63,7 +62,7 @@ class RingsOfBrighthearthTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         this.getEffects().setValue("stackObject", stackAbility);

--- a/Mage.Sets/src/mage/cards/r/RobaranMercenaries.java
+++ b/Mage.Sets/src/mage/cards/r/RobaranMercenaries.java
@@ -79,9 +79,8 @@ class RobaranMercenariesEffect extends ContinuousEffectImpl {
                 .map(permanent -> permanent.getAbilities(game))
                 .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
-                .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
-                        || ability.getAbilityType() == AbilityType.MANA)
-                .collect(Collectors.toList())) {
+                .filter(ability -> ability.isActivatedAbility())
+                .collect(Collectors.toList())){
             // optimization to disallow the adding of duplicate, unnecessary basic mana abilities
             if (!(ability instanceof BasicManaAbility)
                     || perm.getAbilities(game)

--- a/Mage.Sets/src/mage/cards/r/RunicArmasaur.java
+++ b/Mage.Sets/src/mage/cards/r/RunicArmasaur.java
@@ -1,13 +1,11 @@
 package mage.cards.r;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Zone;
@@ -15,8 +13,9 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.StackAbility;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class RunicArmasaur extends CardImpl {
@@ -67,7 +66,7 @@ class RunicArmasaurTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
         if (stackAbility != null
-                && stackAbility.getAbilityType() == AbilityType.ACTIVATED
+                && stackAbility.isNonManaActivatedAbility()
                 && game.getOpponents(this.getControllerId()).contains(stackAbility.getControllerId())
                 && stackAbility.getSourcePermanentOrLKI(game) != null) { // must be a permanent
             MageObject abilitySourceObject = stackAbility.getSourceObject(game);

--- a/Mage.Sets/src/mage/cards/s/SamLoyalAttendant.java
+++ b/Mage.Sets/src/mage/cards/s/SamLoyalAttendant.java
@@ -2,7 +2,6 @@ package mage.cards.s;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.BeginningOfCombatTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.CreateTokenEffect;
@@ -78,7 +77,7 @@ class SamLoyalAttendantEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (!(abilityToModify instanceof ActivatedAbility)) {
+        if (!(abilityToModify.isActivatedAbility())) {
             return false;
         }
         Permanent permanent = abilityToModify.getSourcePermanentIfItStillExists(game);

--- a/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
+++ b/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
@@ -25,12 +25,12 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- *
  * @author Susucr
  */
 public final class SharkeyTyrantOfTheShire extends CardImpl {
 
     private static final FilterPermanent filter = new FilterPermanent("lands your opponents control");
+
     static {
         filter.add(CardType.LAND.getPredicate());
         filter.add(TargetController.OPPONENT.getControllerPredicate());
@@ -38,7 +38,7 @@ public final class SharkeyTyrantOfTheShire extends CardImpl {
 
     public SharkeyTyrantOfTheShire(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{B}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.AVATAR);
         this.subtype.add(SubType.ROGUE);
@@ -98,7 +98,7 @@ class SharkeyTyrantOfTheShireReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         MageObject object = game.getObject(event.getSourceId());
-        if (object instanceof Permanent && filter.match((Permanent)object, source.getControllerId(), source, game)) {
+        if (object instanceof Permanent && filter.match((Permanent) object, source.getControllerId(), source, game)) {
             Optional<Ability> ability = object.getAbilities().get(event.getTargetId());
             if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
                 return true;
@@ -143,7 +143,7 @@ class SharkeyTyrantOfTheShireContinousEffect extends ContinuousEffectImpl {
                 .map(permanent -> permanent.getAbilities(game))
                 .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
-                .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED) // Mana abilities are separated in their own AbilityType.Mana
+                .filter(Ability::isNonManaActivatedAbility)
                 .collect(Collectors.toList())) {
             perm.addAbility(ability, source.getSourceId(), game, true);
         }

--- a/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
+++ b/Mage.Sets/src/mage/cards/s/SharkeyTyrantOfTheShire.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.AsThoughManaEffect;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.ReplacementEffectImpl;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -100,7 +99,7 @@ class SharkeyTyrantOfTheShireReplacementEffect extends ReplacementEffectImpl {
         MageObject object = game.getObject(event.getSourceId());
         if (object instanceof Permanent && filter.match((Permanent) object, source.getControllerId(), source, game)) {
             Optional<Ability> ability = object.getAbilities().get(event.getTargetId());
-            if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
+            if (ability.isPresent() && !ability.get().isManaActivatedAbility()) {
                 return true;
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SoldeviMachinist.java
+++ b/Mage.Sets/src/mage/cards/s/SoldeviMachinist.java
@@ -72,12 +72,8 @@ class ArtifactAbilityManaCondition extends ManaCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        switch (source.getAbilityType()) {
-            case ACTIVATED:
-            case MANA:
-                break;
-            default:
-                return false;
+        if (!source.isActivatedAbility()) {
+            return false;
         }
         MageObject object = game.getObject(source);
         return object != null && object.isArtifact(game) && !source.isActivated();

--- a/Mage.Sets/src/mage/cards/s/SorcerousSpyglass.java
+++ b/Mage.Sets/src/mage/cards/s/SorcerousSpyglass.java
@@ -1,7 +1,5 @@
 package mage.cards.s;
 
-import java.util.Optional;
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
@@ -10,10 +8,16 @@ import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.ChooseACardNameEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.util.CardUtil;
+
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -68,7 +72,7 @@ class SorcerousSpyglassActivationEffect extends ContinuousRuleModifyingEffectImp
         Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
         if (ability.isPresent() && object != null) {
             return game.getState().getPlayersInRange(source.getControllerId(), game).contains(event.getPlayerId()) // controller in range
-                    && ability.get().getAbilityType() != AbilityType.MANA
+                    && !ability.get().isManaAbility()
                     && CardUtil.haveSameNames(object, cardName, game);
         }
         return false;

--- a/Mage.Sets/src/mage/cards/s/StrictProctor.java
+++ b/Mage.Sets/src/mage/cards/s/StrictProctor.java
@@ -70,7 +70,7 @@ class StrictProctorTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         Ability ability = stackObject.getStackAbility();
-        if (!(ability instanceof TriggeredAbility)) {
+        if (!ability.isTriggeredAbility()) {
             return false;
         }
         GameEvent triggerEvent = ((TriggeredAbility) ability).getTriggerEvent();

--- a/Mage.Sets/src/mage/cards/s/SuppressionField.java
+++ b/Mage.Sets/src/mage/cards/s/SuppressionField.java
@@ -1,29 +1,24 @@
 
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
-import mage.constants.CardType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class SuppressionField extends CardImpl {
 
     public SuppressionField(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{1}{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");
 
         // Activated abilities cost {2} more to activate unless they're mana abilities.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new SuppressionFieldCostReductionEffect()));
@@ -58,7 +53,7 @@ class SuppressionFieldCostReductionEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        return abilityToModify.getAbilityType() == AbilityType.ACTIVATED;
+        return abilityToModify.isNonManaActivatedAbility();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
+++ b/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
@@ -80,8 +80,7 @@ class TazriStalwartSurvivorManaAbility extends ActivatedManaAbilityImpl {
                     && permanent
                     .getAbilities(game)
                     .stream()
-                    .filter(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
-                            || ability.getAbilityType() == AbilityType.MANA)
+                    .filter(ability -> ability.isActivatedAbility())
                     .map(Ability::getOriginalId)
                     .anyMatch(abilityId -> !source.getOriginalId().equals(abilityId));
         }
@@ -124,12 +123,8 @@ class TazriStalwartSurvivorManaEffect extends ManaEffect {
 
         @Override
         public boolean apply(Game game, Ability source) {
-            switch (source.getAbilityType()) {
-                case ACTIVATED:
-                case MANA:
-                    break;
-                default:
-                    return false;
+            if (!source.isActivatedAbility()) {
+                return false;
             }
             MageObject object = game.getObject(source);
             return object != null && object.isCreature(game) && !source.isActivated();
@@ -271,8 +266,7 @@ class TazriStalwartSurvivorMillEffect extends OneShotEffect {
                 .getCard(uuid)
                 .getAbilities(game)
                 .stream()
-                .map(Ability::getAbilityType)
-                .noneMatch(AbilityType.ACTIVATED::equals));
+                .noneMatch(Ability::isNonManaActivatedAbility));
         player.moveCards(cards, Zone.HAND, source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TerritoryForge.java
+++ b/Mage.Sets/src/mage/cards/t/TerritoryForge.java
@@ -89,7 +89,7 @@ class TerritoryForgeStaticEffect extends ContinuousEffectImpl {
         }
         for (Card card : exileZone.getCards(game)) {
             for (Ability ability : card.getAbilities(game)) {
-                if (ability.getAbilityType() == AbilityType.ACTIVATED || ability.getAbilityType() == AbilityType.MANA) {
+                if (ability.isActivatedAbility()){
                     ActivatedAbility copyAbility = (ActivatedAbility) ability.copy();
                     permanent.addAbility(copyAbility, source.getSourceId(), game, true);
                 }

--- a/Mage.Sets/src/mage/cards/t/TezzeretBetrayerOfFlesh.java
+++ b/Mage.Sets/src/mage/cards/t/TezzeretBetrayerOfFlesh.java
@@ -1,7 +1,6 @@
 package mage.cards.t;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.DiscardCardCost;
@@ -97,7 +96,7 @@ class TezzeretBetrayerOfFleshReductionEffect extends CostModificationEffectImpl 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         return abilityToModify.isControlledBy(source.getControllerId())
-                && abilityToModify instanceof ActivatedAbility
+                && abilityToModify.isActivatedAbility()
                 && TezzeretBetrayerOfFleshWatcher.checkPlayer(game, abilityToModify);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
+++ b/Mage.Sets/src/mage/cards/t/TheBookOfVileDarkness.java
@@ -2,7 +2,6 @@ package mage.cards.t;
 
 import mage.MageObjectReference;
 import mage.abilities.Ability;
-import mage.abilities.TriggeredAbility;
 import mage.abilities.common.BeginningOfEndStepTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.condition.Condition;
@@ -25,7 +24,6 @@ import mage.game.permanent.token.Token;
 import mage.game.permanent.token.VecnaToken;
 import mage.game.permanent.token.ZombieToken;
 import mage.players.Player;
-import mage.target.TargetPermanent;
 import mage.target.common.TargetSacrifice;
 import mage.watchers.common.PlayerLostLifeWatcher;
 
@@ -187,7 +185,7 @@ class TheBookOfVileDarknessEffect extends OneShotEffect {
                 continue;
             }
             for (Ability ability : card.getAbilities(game)) {
-                if (ability instanceof TriggeredAbility) {
+                if (ability.isTriggeredAbility()) {
                     Ability copyAbility = ability.copy();
                     copyAbility.newId();
                     copyAbility.setControllerId(source.getControllerId());

--- a/Mage.Sets/src/mage/cards/t/TheEnigmaJewel.java
+++ b/Mage.Sets/src/mage/cards/t/TheEnigmaJewel.java
@@ -14,7 +14,6 @@ import mage.abilities.mana.conditional.ManaCondition;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AbilityType;
 import mage.constants.CardType;
 import mage.constants.SuperType;
 import mage.filter.predicate.Predicate;
@@ -66,7 +65,7 @@ enum TheEnigmaJewelPredicate implements Predicate<MageObject> {
                 && input instanceof Card
                 && ((Card) input).getAbilities(game)
                 .stream()
-                .anyMatch(a -> (a.getAbilityType() == AbilityType.ACTIVATED || a.getAbilityType() == AbilityType.MANA));
+                .anyMatch(a -> (a.isActivatedAbility()));
     }
 
 }
@@ -98,8 +97,7 @@ class TheEnigmaJewelManaCondition extends ManaCondition implements Condition {
     @Override
     public boolean apply(Game game, Ability source) {
         if (source != null && !source.isActivated()) {
-            return source.getAbilityType() == AbilityType.MANA
-                    || source.getAbilityType() == AbilityType.ACTIVATED;
+            return source.isActivatedAbility();
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/t/TheMasterMultiplied.java
+++ b/Mage.Sets/src/mage/cards/t/TheMasterMultiplied.java
@@ -2,7 +2,6 @@ package mage.cards.t;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.TriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.ruleModifying.LegendRuleDoesntApplyEffect;
@@ -109,7 +108,7 @@ class TheMasterMultipliedEffect extends ContinuousRuleModifyingEffectImpl {
 
         return controller != null && permanent != null
                 && filter.match(permanent, source.getControllerId(), source, game)
-                && stackAbility instanceof TriggeredAbility
+                && stackAbility.isTriggeredAbility()
                 && source.getControllerId().equals(eventSourceControllerId);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TitheTaker.java
+++ b/Mage.Sets/src/mage/cards/t/TitheTaker.java
@@ -65,7 +65,7 @@ class TitheTakerCostReductionEffect extends CostModificationEffectImpl {
             SpellAbility spellAbility = (SpellAbility) abilityToModify;
             CardUtil.adjustCost(spellAbility, -1);
         }
-        if (abilityToModify.getAbilityType() == AbilityType.ACTIVATED) {
+        if (abilityToModify.isNonManaActivatedAbility()) {
             CardUtil.increaseCost(abilityToModify, 1);
         }
         return true;
@@ -73,14 +73,9 @@ class TitheTakerCostReductionEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (!MyTurnCondition.instance.apply(game, source)) {
-            return false;
-        }
-        if (!(abilityToModify.getAbilityType() == AbilityType.SPELL)
-                && !(abilityToModify.getAbilityType() == AbilityType.ACTIVATED)) {
-            return false;
-        }
-        return game.getOpponents(source.getControllerId()).contains(abilityToModify.getControllerId());
+        return MyTurnCondition.instance.apply(game, source)
+                && (abilityToModify.getAbilityType() == AbilityType.SPELL || abilityToModify.isNonManaActivatedAbility())
+                && game.getOpponents(source.getControllerId()).contains(abilityToModify.getControllerId());
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/t/TrainingGrounds.java
+++ b/Mage.Sets/src/mage/cards/t/TrainingGrounds.java
@@ -1,12 +1,14 @@
 package mage.cards.t;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.CostModificationType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -68,9 +70,7 @@ class TrainingGroundsEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        if (abilityToModify.getAbilityType() != AbilityType.ACTIVATED
-                && (abilityToModify.getAbilityType() != AbilityType.MANA
-                || !(abilityToModify instanceof ActivatedAbility))) {
+        if (!abilityToModify.isActivatedAbility()) {
             return false;
         }
         //Activated abilities of creatures you control

--- a/Mage.Sets/src/mage/cards/t/TrazynTheInfinite.java
+++ b/Mage.Sets/src/mage/cards/t/TrazynTheInfinite.java
@@ -2,7 +2,6 @@ package mage.cards.t;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.keyword.DeathtouchAbility;
@@ -74,7 +73,7 @@ class TrazynTheInfiniteEffect extends ContinuousEffectImpl {
                 .stream()
                 .map(card -> card.getAbilities(game))
                 .flatMap(Collection::stream)
-                .filter(ActivatedAbility.class::isInstance)
+                .filter(Ability::isActivatedAbility)
                 .collect(Collectors.toSet());
         for (Ability ability : abilities) {
             permanent.addAbility(ability, source.getSourceId(), game, true);

--- a/Mage.Sets/src/mage/cards/t/TsabosWeb.java
+++ b/Mage.Sets/src/mage/cards/t/TsabosWeb.java
@@ -1,34 +1,27 @@
 
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
-import mage.abilities.PlayLandAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.constants.PhaseStep;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class TsabosWeb extends CardImpl {
 
     public TsabosWeb(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{2}");
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // When Tsabo's Web enters the battlefield, draw a card.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1), false));
@@ -66,16 +59,14 @@ class TsabosWebPreventUntapEffect extends ContinuousRuleModifyingEffectImpl {
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.UNTAP;
     }
-    
+
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (game.getTurnStepType() == PhaseStep.UNTAP) {
             Permanent permanent = game.getPermanent(event.getTargetId());
             if (permanent != null && permanent.isLand(game)) {
-                for (Ability ability :permanent.getAbilities()) {
-                    if (!(ability instanceof PlayLandAbility)
-                            && !(ability instanceof ActivatedManaAbilityImpl)
-                            && ability instanceof ActivatedAbility) {
+                for (Ability ability : permanent.getAbilities()) {
+                    if (ability.isNonManaActivatedAbility()) {
                         return true;
                     }
                 }

--- a/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
+++ b/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
@@ -5,7 +5,6 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.ReplacementEffectImpl;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -90,7 +89,7 @@ class UnboundFlourishingCopyAbility extends TriggeredAbilityImpl {
     UnboundFlourishingCopyAbility() {
         super(Zone.BATTLEFIELD, new UnboundFlourishingCopyEffect(), false);
         setTriggerPhrase("Whenever you cast an instant or sorcery spell or activate an ability, " +
-                         "if that spell's mana cost or that ability's activation cost contains {X}" );
+                "if that spell's mana cost or that ability's activation cost contains {X}");
     }
 
     private UnboundFlourishingCopyAbility(final UnboundFlourishingCopyAbility ability) {
@@ -117,7 +116,7 @@ class UnboundFlourishingCopyAbility extends TriggeredAbilityImpl {
         // activated ability
         if (event.getType() == GameEvent.EventType.ACTIVATED_ABILITY) {
             StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-            if (stackAbility != null && !(stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl)) {
+            if (stackAbility != null && !stackAbility.getStackAbility().isManaActivatedAbility()) {
                 if (stackAbility.getManaCostsToPay().containsX()) {
                     game.getState().setValue(this.getSourceId() + UnboundFlourishing.needPrefix, stackAbility);
                     return true;

--- a/Mage.Sets/src/mage/cards/v/VerrakWarpedSengir.java
+++ b/Mage.Sets/src/mage/cards/v/VerrakWarpedSengir.java
@@ -8,7 +8,6 @@ import mage.abilities.effects.common.DoIfCostPaid;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.LifelinkAbility;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -84,7 +83,7 @@ class VerrakWarpedSengirTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         int lifePaid = CardUtil.castStream(

--- a/Mage.Sets/src/mage/cards/z/ZirdaTheDawnwaker.java
+++ b/Mage.Sets/src/mage/cards/z/ZirdaTheDawnwaker.java
@@ -78,9 +78,7 @@ enum ZirdaTheDawnwakerCompanionCondition implements CompanionCondition {
                 .allMatch(card -> card
                         .getAbilities()
                         .stream()
-                        .anyMatch(ability -> ability.getAbilityType() == AbilityType.ACTIVATED
-                                || ability.getAbilityType() == AbilityType.MANA
-                                || ability.getAbilityType() == AbilityType.LOYALTY)
+                        .anyMatch(ability -> ability.isActivatedAbility())
                 );
     }
 }
@@ -112,7 +110,7 @@ class ZirdaTheDawnwakerEffect extends CostModificationEffectImpl {
 
     @Override
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
-        return abilityToModify.getAbilityType() == AbilityType.ACTIVATED
+        return abilityToModify.isNonManaActivatedAbility()
                 && abilityToModify.isControlledBy(source.getControllerId());
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/DependentEffectsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/DependentEffectsTest.java
@@ -2,7 +2,6 @@
 package org.mage.test.cards.continuous;
 
 import mage.abilities.Ability;
-import mage.constants.AbilityType;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.game.permanent.Permanent;
@@ -11,7 +10,6 @@ import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- *
  * @author LevelX2
  */
 public class DependentEffectsTest extends CardTestPlayerBase {
@@ -33,9 +31,9 @@ public class DependentEffectsTest extends CardTestPlayerBase {
 
         addCard(Zone.BATTLEFIELD, playerB, "Plains", 2);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Opalescence",true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Opalescence", true);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Enchanted Evening");
-        
+
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -49,12 +47,12 @@ public class DependentEffectsTest extends CardTestPlayerBase {
     /**
      * Opalescence is dependent on Enchanted Evening, so it will be applied
      * after it regardless of timestamp.
-     *
+     * <p>
      * Tokens can also have mana costs, and as a consequence of that, converted
      * mana costs. A token created with Rite of Replication would have the mana
      * cost of the creature it targeted. Most tokens do not have mana costs
      * though.
-     *
+     * <p>
      * Tokens with no mana costs would be 0/0, as you said, and would indeed be
      * put into owner's graveyard next time State Based Actionas are performed.
      * Tokens with mana costs would naturally have whatever power and toughness
@@ -112,7 +110,7 @@ public class DependentEffectsTest extends CardTestPlayerBase {
         Permanent necroticOoze = getPermanent("Necrotic Ooze", playerA);
         int numberOfActivatedAbilities = 0;
         for (Ability ability : necroticOoze.getAbilities(currentGame)) {
-            if (ability.getAbilityType() == AbilityType.ACTIVATED) {
+            if (ability.isActivatedAbility()){
                 numberOfActivatedAbilities++;
             }
         }
@@ -133,7 +131,7 @@ public class DependentEffectsTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Yixlid Jailer", 1); // Creature - {1}{B}
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Yixlid Jailer");
-        
+
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -143,7 +141,7 @@ public class DependentEffectsTest extends CardTestPlayerBase {
         Permanent necroticOoze = getPermanent("Necrotic Ooze", playerA);
         int numberOfActivatedAbilities = 0;
         for (Ability ability : necroticOoze.getAbilities(currentGame)) {
-            if (ability.getAbilityType() == AbilityType.ACTIVATED) {
+            if (ability.isActivatedAbility()){
                 numberOfActivatedAbilities++;
             }
         }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m21/ConspicuousSnoopTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m21/ConspicuousSnoopTest.java
@@ -63,6 +63,6 @@ public class ConspicuousSnoopTest extends CardTestPlayerBase {
         setStrictChooseMode(true);
         execute();
 
-        assertAbilityCount(playerA, "Conspicuous Snoop", ActivatedAbility.class, 3); // (2 X casts + gains flying )
+        assertAbilityCount(playerA, "Conspicuous Snoop", ActivatedAbility.class, 2); // (own cast ability + gains flying )
     }
 }

--- a/Mage/src/main/java/mage/abilities/AbilitiesImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilitiesImpl.java
@@ -5,7 +5,6 @@ import mage.abilities.costs.Cost;
 import mage.abilities.keyword.ProtectionAbility;
 import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.abilities.mana.ManaAbility;
-import mage.constants.AbilityType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.util.ThreadLocalStringBuilder;
@@ -103,6 +102,11 @@ public class AbilitiesImpl<T extends Ability> extends ArrayList<T> implements Ab
         return rules;
     }
 
+    /**
+     * Activated Ability in the engine are broader than in the rules.
+     * Notably SpellAbility & PlayLandAbility are ActivatedAbility,
+     * as they can be activated by a player (the engine meaning).
+     */
     @Override
     public Abilities<ActivatedAbility> getActivatedAbilities(Zone zone) {
         return stream()
@@ -176,7 +180,7 @@ public class AbilitiesImpl<T extends Ability> extends ArrayList<T> implements Ab
     @Override
     public boolean hasPoolDependantAbilities() {
         return stream()
-                .filter(ability -> ability.getAbilityType() == AbilityType.MANA)
+                .filter(Ability::isManaAbility)
                 .map(ManaAbility.class::cast)
                 .anyMatch(ManaAbility::isPoolDependant);
     }

--- a/Mage/src/main/java/mage/abilities/AbilitiesImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilitiesImpl.java
@@ -165,7 +165,7 @@ public class AbilitiesImpl<T extends Ability> extends ArrayList<T> implements Ab
     public Abilities<TriggeredAbility> getTriggeredAbilities(Zone zone) {
         Abilities<TriggeredAbility> zonedAbilities = new AbilitiesImpl<>();
         for (T ability : this) {
-            if (ability instanceof TriggeredAbility && ability.getZone().match(zone)) {
+            if (ability.isTriggeredAbility() && ability.getZone().match(zone)) {
                 zonedAbilities.add((TriggeredAbility) ability);
             } else if (ability instanceof ZoneChangeTriggeredAbility) {
                 ZoneChangeTriggeredAbility zcAbility = (ZoneChangeTriggeredAbility) ability;

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -63,6 +63,21 @@ public interface Ability extends Controllable, Serializable {
     AbilityType getAbilityType();
 
     /**
+     * If this ability is an activated one (loyalty and mana included).
+     */
+    boolean isActivatedAbility();
+
+    /**
+     * If this ability is an activated one, excluding mana (loyalty included).
+     */
+    boolean isNonManaActivatedAbility();
+
+    /**
+     * If this ability is a mana ability, (both triggered and activated can be mana abilities).
+     */
+    boolean isManaAbility();
+
+    /**
      * Sets the id of the controller of this ability.
      *
      * @param controllerId The {@link java.util.UUID} of the controller.

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -78,6 +78,11 @@ public interface Ability extends Controllable, Serializable {
     boolean isNonManaActivatedAbility();
 
     /**
+     * If this ability is a mana activated one.
+     */
+    boolean isManaActivatedAbility();
+
+    /**
      * If this ability is a mana ability, (both triggered and activated can be mana abilities).
      */
     boolean isManaAbility();

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -63,12 +63,17 @@ public interface Ability extends Controllable, Serializable {
     AbilityType getAbilityType();
 
     /**
-     * If this ability is an activated one (loyalty and mana included).
+     * If this ability is an activated one (mana included).
      */
     boolean isActivatedAbility();
 
     /**
-     * If this ability is an activated one, excluding mana (loyalty included).
+     * If this ability is a triggered one (mana included).
+     */
+    boolean isTriggeredAbility();
+
+    /**
+     * If this ability is an activated one, excluding mana.
      */
     boolean isNonManaActivatedAbility();
 

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -379,6 +379,7 @@ public abstract class AbilityImpl implements Ability {
                 Outcome outcome = getEffects().getOutcome(this);
 
                 // only activated abilities can be canceled by human user (not triggered)
+                // Note: ActivatedAbility does include SpellAbility & PlayLandAbility, but those should be able to be canceled too.
                 boolean canCancel = this instanceof ActivatedAbility && controller.isHuman();
                 if (!getTargets().chooseTargets(outcome, this.controllerId, this, noMana, game, canCancel)) {
                     // was canceled during targer selection

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -168,6 +168,11 @@ public abstract class AbilityImpl implements Ability {
     }
 
     @Override
+    public boolean isTriggeredAbility() {
+        return this.abilityType.isTriggeredAbility();
+    }
+
+    @Override
     public boolean isNonManaActivatedAbility() {
         return this.abilityType.isNonManaActivatedAbility();
     }
@@ -366,7 +371,7 @@ public abstract class AbilityImpl implements Ability {
             // and/or zones become the target of a spell trigger at this point; they'll wait to be put on
             // the stack until the spell has finished being cast.)
 
-            if (this.getAbilityType() != AbilityType.TRIGGERED) { // triggered abilities check this already in playerImpl.triggerAbility
+            if (!this.getAbilityType().isTriggeredAbility()) { // triggered abilities check this already in playerImpl.triggerAbility
                 adjustTargets(game);
             }
 

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -178,6 +178,11 @@ public abstract class AbilityImpl implements Ability {
     }
 
     @Override
+    public boolean isManaActivatedAbility() {
+        return this.abilityType.isManaActivatedAbility();
+    }
+
+    @Override
     public boolean isManaAbility() {
         return this.abilityType.isManaAbility();
     }

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -163,6 +163,21 @@ public abstract class AbilityImpl implements Ability {
     }
 
     @Override
+    public boolean isActivatedAbility() {
+        return this.abilityType.isActivatedAbility();
+    }
+
+    @Override
+    public boolean isNonManaActivatedAbility() {
+        return this.abilityType.isNonManaActivatedAbility();
+    }
+
+    @Override
+    public boolean isManaAbility() {
+        return this.abilityType.isManaAbility();
+    }
+
+    @Override
     public boolean resolve(Game game) {
         boolean result = true;
         //20100716 - 117.12
@@ -193,7 +208,7 @@ public abstract class AbilityImpl implements Ability {
                 boolean effectResult = effect.apply(game, this);
                 result &= effectResult;
                 if (logger.isDebugEnabled()) {
-                    if (this.getAbilityType() != AbilityType.MANA) {
+                    if (!this.isManaAbility()) {
                         if (!effectResult) {
                             if (this.getSourceId() != null) {
                                 MageObject mageObject = game.getObject(this.getSourceId());

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -57,7 +57,7 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
     }
 
     protected ActivatedAbilityImpl(Zone zone, Effect effect, Cost cost) {
-        super(AbilityType.ACTIVATED, zone);
+        super(AbilityType.ACTIVATED_NONMANA_NONLOYALTY, zone);
         this.addEffect(effect);
         this.addCost(cost);
     }
@@ -147,8 +147,7 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
 
         if (approvingObjects.isEmpty()) {
             return ActivationStatus.withoutApprovingObject(true);
-        }
-        else {
+        } else {
             return new ActivationStatus(approvingObjects);
         }
     }

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -57,7 +57,7 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
     }
 
     protected ActivatedAbilityImpl(Zone zone, Effect effect, Cost cost) {
-        super(AbilityType.ACTIVATED_NONMANA_NONLOYALTY, zone);
+        super(AbilityType.ACTIVATED_NONMANA, zone);
         this.addEffect(effect);
         this.addCost(cost);
     }

--- a/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbilityImpl.java
@@ -36,7 +36,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
     }
 
     protected TriggeredAbilityImpl(Zone zone, Effect effect, boolean optional) {
-        super(AbilityType.TRIGGERED, zone);
+        super(AbilityType.TRIGGERED_NONMANA, zone);
         setLeavesTheBattlefieldTrigger(false);
         if (effect != null) {
             addEffect(effect);
@@ -265,6 +265,7 @@ public abstract class TriggeredAbilityImpl extends AbilityImpl implements Trigge
 
     /**
      * For use in generating trigger phrases with correct text
+     *
      * @return "When " for an effect that always removes the source from the battlefield, otherwise "Whenever "
      */
     protected final String getWhen() {

--- a/Mage/src/main/java/mage/abilities/common/FinalChapterAbilityResolvesTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/FinalChapterAbilityResolvesTriggeredAbility.java
@@ -54,19 +54,22 @@ public class FinalChapterAbilityResolvesTriggeredAbility extends TriggeredAbilit
         // the ID of the original ability (on the permanent) that the resolving ability
         // came from.
         Optional<Ability> ability_opt = game.getAbility(event.getTargetId(), event.getSourceId());
-        if (!ability_opt.isPresent())
+        if (!ability_opt.isPresent()) {
             return false;
+        }
 
         // Make sure it was a triggered ability (needed for checking if it's a chapter
         // ability)
         Ability ability = ability_opt.get();
-        if (!(ability instanceof TriggeredAbility))
+        if (!(ability.isTriggeredAbility())) {
             return false;
+        }
 
         // Make sure it was a chapter ability
         TriggeredAbility triggeredAbility = (TriggeredAbility) ability;
-        if (!SagaAbility.isChapterAbility(triggeredAbility))
+        if (!SagaAbility.isChapterAbility(triggeredAbility)) {
             return false;
+        }
 
         // There's a chance that the permanent that this abiltiy came from no longer
         // exists, so try and find it on the battlefield or check last known
@@ -75,17 +78,17 @@ public class FinalChapterAbilityResolvesTriggeredAbility extends TriggeredAbilit
         // chapter ability on that permanent.
         Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
         if (permanent == null
-            || !permanent.isControlledBy(getControllerId())
-            || !permanent.hasSubtype(SubType.SAGA, game)) {
+                || !permanent.isControlledBy(getControllerId())
+                || !permanent.hasSubtype(SubType.SAGA, game)) {
             return false;
         }
 
         // Find the max chapter number from that permanent
         int maxChapter = CardUtil
-            .castStream(permanent.getAbilities(game).stream(), SagaAbility.class)
-            .map(SagaAbility::getMaxChapter)
-            .mapToInt(SagaChapter::getNumber)
-            .sum();
+                .castStream(permanent.getAbilities(game).stream(), SagaAbility.class)
+                .map(SagaAbility::getMaxChapter)
+                .mapToInt(SagaChapter::getNumber)
+                .sum();
 
         // Check if the ability was the last one
         if (!SagaAbility.isFinalAbility(triggeredAbility, maxChapter)) {

--- a/Mage/src/main/java/mage/abilities/costs/common/SacrificeAllCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/SacrificeAllCost.java
@@ -47,7 +47,7 @@ public class SacrificeAllCost extends CostImpl implements SacrificeCost {
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
         UUID activator = controllerId;
-        if (ability.getAbilityType() == AbilityType.ACTIVATED || ability.getAbilityType() == AbilityType.SPECIAL_ACTION) {
+        if (ability.getAbilityType().isActivatedAbility() || ability.getAbilityType() == AbilityType.SPECIAL_ACTION) {
             if (((ActivatedAbilityImpl) ability).getActivatorId() != null) {
                 activator = ((ActivatedAbilityImpl) ability).getActivatorId();
             }  // else, Activator not filled?

--- a/Mage/src/main/java/mage/abilities/costs/common/SacrificeTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/SacrificeTargetCost.java
@@ -27,6 +27,7 @@ public class SacrificeTargetCost extends CostImpl implements SacrificeCost {
 
     /**
      * Sacrifice a permanent matching the filter:
+     *
      * @param filter can be generic, will automatically add article and sacrifice predicates
      */
     public SacrificeTargetCost(FilterPermanent filter) {
@@ -35,6 +36,7 @@ public class SacrificeTargetCost extends CostImpl implements SacrificeCost {
 
     /**
      * Sacrifice N permanents matching the filter:
+     *
      * @param filter can be generic, will automatically add sacrifice predicates
      */
     public SacrificeTargetCost(int numToSac, FilterPermanent filter) {
@@ -57,7 +59,7 @@ public class SacrificeTargetCost extends CostImpl implements SacrificeCost {
     @Override
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
         UUID activator = controllerId;
-        if (ability.getAbilityType() == AbilityType.ACTIVATED || ability.getAbilityType() == AbilityType.SPECIAL_ACTION) {
+        if (ability.getAbilityType().isActivatedAbility() || ability.getAbilityType() == AbilityType.SPECIAL_ACTION) {
             activator = ((ActivatedAbilityImpl) ability).getActivatorId();
         }
         // can be cancel by user
@@ -87,7 +89,7 @@ public class SacrificeTargetCost extends CostImpl implements SacrificeCost {
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
         UUID activator = controllerId;
-        if (ability.getAbilityType() == AbilityType.ACTIVATED || ability.getAbilityType() == AbilityType.SPECIAL_ACTION) {
+        if (ability.getAbilityType().isActivatedAbility() || ability.getAbilityType() == AbilityType.SPECIAL_ACTION) {
             if (((ActivatedAbilityImpl) ability).getActivatorId() != null) {
                 activator = ((ActivatedAbilityImpl) ability).getActivatorId();
             }  // else, Activator not filled?

--- a/Mage/src/main/java/mage/abilities/effects/common/GainActivatedAbilitiesOfTopCardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/GainActivatedAbilitiesOfTopCardEffect.java
@@ -1,7 +1,6 @@
 package mage.abilities.effects.common;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.cards.Card;
 import mage.constants.Duration;
@@ -42,7 +41,7 @@ public class GainActivatedAbilitiesOfTopCardEffect extends ContinuousEffectImpl 
                 Permanent permanent = game.getPermanent(source.getSourceId());
                 if (permanent != null) {
                     for (Ability ability : card.getAbilities(game)) {
-                        if (ability instanceof ActivatedAbility) {
+                        if (ability.isActivatedAbility()) {
                             permanent.addAbility(ability, source.getSourceId(), game, true);
                         }
                     }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainControlTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainControlTargetEffect.java
@@ -1,7 +1,6 @@
 package mage.abilities.effects.common.continuous;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.Mode;
 import mage.abilities.condition.Condition;
 import mage.abilities.effects.ContinuousEffectImpl;
@@ -106,7 +105,7 @@ public class GainControlTargetEffect extends ContinuousEffectImpl {
                     controlChanged = true;
                 }
             }
-            if (source instanceof ActivatedAbility
+            if (source.isActivatedAbility()
                     && firstControlChange && !controlChanged) {
                 // If it was not possible to get control of target permanent by the activated ability the first time it took place
                 // the effect failed (e.g. because of Guardian Beast) and must be discarded

--- a/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/TargetsHaveToTargetPermanentIfAbleEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/TargetsHaveToTargetPermanentIfAbleEffect.java
@@ -2,7 +2,6 @@ package mage.abilities.effects.common.ruleModifying;
 
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbility;
 import mage.abilities.SpellAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.constants.Duration;
@@ -86,7 +85,7 @@ public class TargetsHaveToTargetPermanentIfAbleEffect extends ContinuousRuleModi
             }
             Ability stackAbility = stackObject.getStackAbility();
             // Ensure that this ability is activated or a cast spell, because Flag Bearer effects don't require triggered abilities to choose a Standard Bearer
-            if (!(stackAbility instanceof ActivatedAbility) &&
+            if (!(stackAbility.isActivatedAbility()) &&
                     !(stackAbility instanceof SpellAbility)) {
                 return false;
             }

--- a/Mage/src/main/java/mage/abilities/effects/mana/ManaEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/mana/ManaEffect.java
@@ -4,7 +4,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.TriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.constants.AbilityType;
 import mage.constants.ManaType;
 import mage.constants.Outcome;
 import mage.game.Game;
@@ -132,7 +131,7 @@ public abstract class ManaEffect extends OneShotEffect {
      * @param source
      */
     public void checkToFirePossibleEvents(Mana mana, Game game, Ability source) {
-        if (source.getAbilityType() == AbilityType.MANA && source.hasTapCost()) {
+        if (source.getAbilityType().isManaAbility() && source.hasTapCost()) {
             ManaEvent event = new TappedForManaEvent(source.getSourceId(), source, source.getControllerId(), mana, game);
             if (!game.replaceEvent(event)) {
                 game.fireEvent(event);

--- a/Mage/src/main/java/mage/abilities/effects/mana/ManaEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/mana/ManaEffect.java
@@ -2,7 +2,6 @@ package mage.abilities.effects.mana;
 
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.TriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.constants.ManaType;
 import mage.constants.Outcome;
@@ -38,7 +37,7 @@ public abstract class ManaEffect extends OneShotEffect {
             // During calculation of the available mana for a player the "TappedForMana" event is fired to simulate triggered mana production.
             // By checking the inCheckPlayableState these events are handled to give back only the available mana of instead really producing mana
             // So it's important if ManaEffects overwrite the apply method to take care for this.
-            if (source instanceof TriggeredAbility) {
+            if (source.isTriggeredAbility()) {
                 player.addAvailableTriggeredMana(getNetMana(game, source));
             }
             return true; // No need to add mana to pool during checkPlayable   

--- a/Mage/src/main/java/mage/abilities/keyword/SplitSecondAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SplitSecondAbility.java
@@ -3,7 +3,6 @@ package mage.abilities.keyword;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -14,11 +13,11 @@ import java.util.Optional;
 
 /**
  * Split Second
- *
+ * <p>
  * As long as this spell is on the stack, players can't cast other spells or activate abilities that aren't mana abilities.
  */
 
-public class SplitSecondAbility extends SimpleStaticAbility  {
+public class SplitSecondAbility extends SimpleStaticAbility {
 
     public SplitSecondAbility() {
         super(Zone.STACK, new SplitSecondEffect());
@@ -70,7 +69,7 @@ class SplitSecondEffect extends ContinuousRuleModifyingEffectImpl {
         }
         if (event.getType() == GameEvent.EventType.ACTIVATE_ABILITY) {
             Optional<Ability> ability = game.getAbility(event.getTargetId(), event.getSourceId());
-            if (ability.isPresent() && !(ability.get() instanceof ActivatedManaAbilityImpl)) {
+            if (ability.isPresent() && !ability.get().isManaActivatedAbility()) {
                 return true;
             }
         }

--- a/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/mana/ActivatedManaAbilityImpl.java
@@ -22,7 +22,7 @@ public abstract class ActivatedManaAbilityImpl extends ActivatedAbilityImpl impl
     protected boolean poolDependant;
 
     public ActivatedManaAbilityImpl(Zone zone, ManaEffect effect, Cost cost) {
-        super(AbilityType.MANA, zone);
+        super(AbilityType.ACTIVATED_MANA, zone);
         this.usesStack = false;
         this.undoPossible = true;
         if (effect != null) {

--- a/Mage/src/main/java/mage/abilities/mana/TriggeredManaAbility.java
+++ b/Mage/src/main/java/mage/abilities/mana/TriggeredManaAbility.java
@@ -5,6 +5,7 @@ import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.mana.ManaEffect;
 import mage.constants.AbilityType;
+import mage.constants.ManaType;
 import mage.constants.Zone;
 import mage.game.Game;
 
@@ -12,8 +13,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import mage.constants.ManaType;
 
 /**
  * see 20110715 - 605.1b
@@ -32,8 +31,7 @@ public abstract class TriggeredManaAbility extends TriggeredAbilityImpl implemen
     public TriggeredManaAbility(Zone zone, ManaEffect effect, boolean optional) {
         super(zone, effect, optional);
         this.usesStack = false;
-        this.abilityType = AbilityType.MANA;
-
+        this.abilityType = AbilityType.TRIGGERED_MANA;
     }
 
     protected TriggeredManaAbility(final TriggeredManaAbility ability) {

--- a/Mage/src/main/java/mage/constants/AbilityType.java
+++ b/Mage/src/main/java/mage/constants/AbilityType.java
@@ -1,26 +1,31 @@
 package mage.constants;
 
 /**
- * @author North
+ * @author North, Susucr
  */
 public enum AbilityType {
-    PLAY_LAND("Play land", true),
-    MANA("Mana", false),
-    SPELL("Spell", true),
-    ACTIVATED("Activated", false),
-    STATIC("Static", false),
-    TRIGGERED("Triggered", false),
-    EVASION("Evasion", false),
-    LOYALTY("Loyalty", false),
-    SPECIAL_ACTION("Special Action", false),
-    SPECIAL_MANA_PAYMENT("Special Mana Payment", false); // No activated ability and no special action. (e.g. Improvise, Delve)
+    PLAY_LAND("Play land", true, false, false),
+    SPELL("Spell", true, false, false),
+    STATIC("Static", false, false, false),
+    EVASION("Evasion", false, false, false),
+    ACTIVATED_NONMANA_NONLOYALTY("Activated", false, true, false),
+    ACTIVATED_MANA("Mana", false, true, true),
+    ACTIVATED_LOYALTY("Loyalty", false, true, false),
+    TRIGGERED("Triggered", false, false, false),
+    TRIGGERED_MANA("Triggered Mana", false, false, true),
+    SPECIAL_ACTION("Special Action", false, false, false),
+    SPECIAL_MANA_PAYMENT("Special Mana Payment", false, false, false); // No activated ability and no special action. (e.g. Improvise, Delve)
 
     private final String text;
     private final boolean playCardAbility;
+    private final boolean activatedAbility;
+    private final boolean manaAbility;
 
-    AbilityType(String text, boolean playCardAbility) {
+    AbilityType(String text, boolean playCardAbility, boolean activatedAbility, boolean manaAbility) {
         this.text = text;
         this.playCardAbility = playCardAbility;
+        this.activatedAbility = activatedAbility;
+        this.manaAbility = manaAbility;
     }
 
     @Override
@@ -30,5 +35,17 @@ public enum AbilityType {
 
     public boolean isPlayCardAbility() {
         return playCardAbility;
+    }
+
+    public boolean isActivatedAbility() {
+        return activatedAbility;
+    }
+
+    public boolean isNonManaActivatedAbility() {
+        return activatedAbility && !manaAbility;
+    }
+
+    public boolean isManaAbility() {
+        return manaAbility;
     }
 }

--- a/Mage/src/main/java/mage/constants/AbilityType.java
+++ b/Mage/src/main/java/mage/constants/AbilityType.java
@@ -50,6 +50,10 @@ public enum AbilityType {
         return activatedAbility && !manaAbility;
     }
 
+    public boolean isManaActivatedAbility() {
+        return activatedAbility && manaAbility;
+    }
+
     public boolean isManaAbility() {
         return manaAbility;
     }

--- a/Mage/src/main/java/mage/constants/AbilityType.java
+++ b/Mage/src/main/java/mage/constants/AbilityType.java
@@ -4,27 +4,28 @@ package mage.constants;
  * @author North, Susucr
  */
 public enum AbilityType {
-    PLAY_LAND("Play land", true, false, false),
-    SPELL("Spell", true, false, false),
-    STATIC("Static", false, false, false),
-    EVASION("Evasion", false, false, false),
-    ACTIVATED_NONMANA_NONLOYALTY("Activated", false, true, false),
-    ACTIVATED_MANA("Mana", false, true, true),
-    ACTIVATED_LOYALTY("Loyalty", false, true, false),
-    TRIGGERED("Triggered", false, false, false),
-    TRIGGERED_MANA("Triggered Mana", false, false, true),
-    SPECIAL_ACTION("Special Action", false, false, false),
-    SPECIAL_MANA_PAYMENT("Special Mana Payment", false, false, false); // No activated ability and no special action. (e.g. Improvise, Delve)
+    PLAY_LAND("Play land", true, false, false, false),
+    SPELL("Spell", true, false, false, false),
+    STATIC("Static", false, false, false, false),
+    EVASION("Evasion", false, false, false, false),
+    ACTIVATED_NONMANA("Activated", false, true, false, false),
+    ACTIVATED_MANA("Mana", false, true, false, true),
+    TRIGGERED_NONMANA("Triggered", false, false, true, false),
+    TRIGGERED_MANA("Triggered Mana", false, false, true, true),
+    SPECIAL_ACTION("Special Action", false, false, false, false),
+    SPECIAL_MANA_PAYMENT("Special Mana Payment", false, false, false, false); // No activated ability and no special action. (e.g. Improvise, Delve)
 
     private final String text;
     private final boolean playCardAbility;
     private final boolean activatedAbility;
+    private final boolean triggeredAbility;
     private final boolean manaAbility;
 
-    AbilityType(String text, boolean playCardAbility, boolean activatedAbility, boolean manaAbility) {
+    AbilityType(String text, boolean playCardAbility, boolean activatedAbility, boolean triggeredAbility, boolean manaAbility) {
         this.text = text;
         this.playCardAbility = playCardAbility;
         this.activatedAbility = activatedAbility;
+        this.triggeredAbility = triggeredAbility;
         this.manaAbility = manaAbility;
     }
 
@@ -39,6 +40,10 @@ public enum AbilityType {
 
     public boolean isActivatedAbility() {
         return activatedAbility;
+    }
+
+    public boolean isTriggeredAbility() {
+        return triggeredAbility;
     }
 
     public boolean isNonManaActivatedAbility() {

--- a/Mage/src/main/java/mage/filter/common/FilterActivatedOrTriggeredAbility.java
+++ b/Mage/src/main/java/mage/filter/common/FilterActivatedOrTriggeredAbility.java
@@ -3,11 +3,11 @@ package mage.filter.common;
 import mage.abilities.Ability;
 import mage.constants.AbilityType;
 import mage.filter.FilterStackObject;
+import mage.filter.predicate.other.ActivatedOrTriggeredAbilityPredicate;
 import mage.game.Game;
 import mage.game.stack.StackObject;
 
 import java.util.UUID;
-import mage.filter.predicate.other.ActivatedOrTriggeredAbilityPredicate;
 
 /**
  * @author TheElk801
@@ -29,25 +29,25 @@ public class FilterActivatedOrTriggeredAbility extends FilterStackObject {
 
     @Override
     public boolean match(StackObject stackObject, UUID playerId, Ability source, Game game) {
-        
+
         if (!super.match(stackObject, playerId, source, game)
                 || !(stackObject instanceof Ability)) {
             return false;
         }
         Ability ability = (Ability) stackObject;
         return ability.getAbilityType() == AbilityType.TRIGGERED
-                || ability.getAbilityType() == AbilityType.ACTIVATED;
+                || ability.isActivatedAbility();
     }
 
     @Override
     public boolean match(StackObject stackObject, Game game) {
-        
+
         if (!super.match(stackObject, game)
                 || !(stackObject instanceof Ability)) {
             return false;
         }
         Ability ability = (Ability) stackObject;
         return ability.getAbilityType() == AbilityType.TRIGGERED
-                || ability.getAbilityType() == AbilityType.ACTIVATED;
+                || ability.isActivatedAbility();
     }
 }

--- a/Mage/src/main/java/mage/filter/common/FilterActivatedOrTriggeredAbility.java
+++ b/Mage/src/main/java/mage/filter/common/FilterActivatedOrTriggeredAbility.java
@@ -1,7 +1,6 @@
 package mage.filter.common;
 
 import mage.abilities.Ability;
-import mage.constants.AbilityType;
 import mage.filter.FilterStackObject;
 import mage.filter.predicate.other.ActivatedOrTriggeredAbilityPredicate;
 import mage.game.Game;
@@ -35,8 +34,7 @@ public class FilterActivatedOrTriggeredAbility extends FilterStackObject {
             return false;
         }
         Ability ability = (Ability) stackObject;
-        return ability.getAbilityType() == AbilityType.TRIGGERED
-                || ability.isActivatedAbility();
+        return ability.isTriggeredAbility() || ability.isActivatedAbility();
     }
 
     @Override
@@ -47,7 +45,6 @@ public class FilterActivatedOrTriggeredAbility extends FilterStackObject {
             return false;
         }
         Ability ability = (Ability) stackObject;
-        return ability.getAbilityType() == AbilityType.TRIGGERED
-                || ability.isActivatedAbility();
+        return ability.getAbilityType().isTriggeredAbility() || ability.isActivatedAbility();
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/other/ActivatedOrTriggeredAbilityPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/ActivatedOrTriggeredAbilityPredicate.java
@@ -1,7 +1,6 @@
 package mage.filter.predicate.other;
 
 import mage.abilities.Ability;
-import mage.constants.AbilityType;
 import mage.filter.predicate.Predicate;
 import mage.game.Game;
 import mage.game.stack.StackObject;
@@ -18,8 +17,7 @@ public enum ActivatedOrTriggeredAbilityPredicate implements Predicate<StackObjec
             return false;
         }
         Ability ability = ((Ability) input);
-        return ability.getAbilityType() == AbilityType.TRIGGERED
-                || ability.isActivatedAbility();
+        return ability.isTriggeredAbility() || ability.isActivatedAbility();
     }
 
     @Override

--- a/Mage/src/main/java/mage/filter/predicate/other/ActivatedOrTriggeredAbilityPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/other/ActivatedOrTriggeredAbilityPredicate.java
@@ -7,7 +7,6 @@ import mage.game.Game;
 import mage.game.stack.StackObject;
 
 /**
- *
  * @author jeffwadsworth
  */
 public enum ActivatedOrTriggeredAbilityPredicate implements Predicate<StackObject> {
@@ -20,7 +19,7 @@ public enum ActivatedOrTriggeredAbilityPredicate implements Predicate<StackObjec
         }
         Ability ability = ((Ability) input);
         return ability.getAbilityType() == AbilityType.TRIGGERED
-                || ability.getAbilityType() == AbilityType.ACTIVATED;
+                || ability.isActivatedAbility();
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/command/emblems/RowanKenrithEmblem.java
+++ b/Mage/src/main/java/mage/game/command/emblems/RowanKenrithEmblem.java
@@ -2,7 +2,6 @@ package mage.game.command.emblems;
 
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.common.CopyStackObjectEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.command.Emblem;
@@ -56,7 +55,7 @@ class RowanKenrithEmblemTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         StackAbility stackAbility = (StackAbility) game.getStack().getStackObject(event.getSourceId());
-        if (stackAbility == null || stackAbility.getStackAbility() instanceof ActivatedManaAbilityImpl) {
+        if (stackAbility == null || stackAbility.getStackAbility().isManaActivatedAbility()) {
             return false;
         }
         this.getEffects().setValue("stackObject", stackAbility);

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -431,6 +431,21 @@ public class StackAbility extends StackObjectImpl implements Ability {
     }
 
     @Override
+    public boolean isActivatedAbility() {
+        return ability.isActivatedAbility();
+    }
+
+    @Override
+    public boolean isNonManaActivatedAbility() {
+        return ability.isNonManaActivatedAbility();
+    }
+
+    @Override
+    public boolean isManaAbility() {
+        return ability.isManaAbility();
+    }
+
+    @Override
     public boolean isUsesStack() {
         return true;
     }

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -434,7 +434,7 @@ public class StackAbility extends StackObjectImpl implements Ability {
     public boolean isActivatedAbility() {
         return ability.isActivatedAbility();
     }
-    
+
     @Override
     public boolean isTriggeredAbility() {
         return ability.isTriggeredAbility();
@@ -443,6 +443,11 @@ public class StackAbility extends StackObjectImpl implements Ability {
     @Override
     public boolean isNonManaActivatedAbility() {
         return ability.isNonManaActivatedAbility();
+    }
+
+    @Override
+    public boolean isManaActivatedAbility() {
+        return ability.isManaActivatedAbility();
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -434,6 +434,11 @@ public class StackAbility extends StackObjectImpl implements Ability {
     public boolean isActivatedAbility() {
         return ability.isActivatedAbility();
     }
+    
+    @Override
+    public boolean isTriggeredAbility() {
+        return ability.isTriggeredAbility();
+    }
 
     @Override
     public boolean isNonManaActivatedAbility() {

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3580,7 +3580,7 @@ public abstract class PlayerImpl implements Player, Serializable {
      * @return
      */
     protected boolean canPlay(ActivatedAbility ability, ManaOptions availableMana, MageObject sourceObject, Game game) {
-        if (!(ability instanceof ActivatedManaAbilityImpl)) {
+        if (!ability.isManaActivatedAbility()) {
             ActivatedAbility copy = ability.copy(); // Copy is needed because cost reduction effects modify e.g. the mana to activate/cast the ability
             if (!copy.canActivate(playerId, game).canActivate()) {
                 return false;

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1592,7 +1592,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                 case SPECIAL_MANA_PAYMENT:
                     result = specialManaPayment((SpecialAction) ability.copy(), game);
                     break;
-                case MANA:
+                case ACTIVATED_MANA:
                     result = playManaAbility((ActivatedManaAbilityImpl) ability.copy(), game);
                     break;
                 case SPELL:
@@ -1616,9 +1616,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         //if player has taken an action then reset all player passed flags
         justActivatedType = null;
         if (result) {
-            if (isHuman()
-                    && (ability.getAbilityType() == AbilityType.SPELL
-                    || ability.getAbilityType() == AbilityType.ACTIVATED)) {
+            if (isHuman() && (ability.getAbilityType() == AbilityType.SPELL || ability.getAbilityType().isActivatedAbility())) {
                 if (ability.isUsesStack()) { // if the ability does not use the stack (e.g. Suspend) auto pass would go to next phase unintended
                     setJustActivatedType(ability.getAbilityType());
                 }
@@ -4493,9 +4491,10 @@ public abstract class PlayerImpl implements Player, Serializable {
             case allAbilities:
                 return true;
             case onlyManaAbilities:
-                return ability.getAbilityType() == AbilityType.MANA;
+                return ability.isManaAbility();
             case nonSpellnonActivatedAbilities:
-                return ability.getAbilityType() != AbilityType.ACTIVATED && ability.getAbilityType() != AbilityType.SPELL;
+                return !ability.getAbilityType().isActivatedAbility()
+                        && ability.getAbilityType() != AbilityType.SPELL;
             case none:
             default:
                 return false;

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3882,7 +3882,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         } else if (ability instanceof AlternativeSourceCosts) {
             // alternative cost must be replaced by real play ability
             return findActivatedAbilityFromAlternativeSourceCost(object, manaFull, ability, game);
-        } else if (ability instanceof ActivatedAbility) {
+        } else if (ability.isActivatedAbility()) {
             // all other activated ability
             if (canPlay((ActivatedAbility) ability, manaFull, object, game)) {
                 return (ActivatedAbility) ability;
@@ -3962,6 +3962,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         // check "can play" condition as affected controller (BUT play from not own hand zone must be checked as original controller)
         // must check all abilities, not activated only
         for (Ability ability : candidateAbilities) {
+            // Note: SpellAbility and PlayLandAbility are ActivatedAbility
             if (!(ability instanceof ActivatedAbility)) {
                 continue;
             }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2398,7 +2398,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     public void removeCounters(String name, int amount, Ability source, Game game) {
 
         GameEvent removeCountersEvent = new RemoveCountersEvent(name, this, source, amount, false);
-        if (game.replaceEvent(removeCountersEvent)){
+        if (game.replaceEvent(removeCountersEvent)) {
             return;
         }
 
@@ -2406,7 +2406,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         for (int i = 0; i < amount; i++) {
 
             GameEvent event = new RemoveCounterEvent(name, this, source, false);
-            if (game.replaceEvent(event)){
+            if (game.replaceEvent(event)) {
                 continue;
             }
 
@@ -3882,8 +3882,8 @@ public abstract class PlayerImpl implements Player, Serializable {
         } else if (ability instanceof AlternativeSourceCosts) {
             // alternative cost must be replaced by real play ability
             return findActivatedAbilityFromAlternativeSourceCost(object, manaFull, ability, game);
-        } else if (ability.isActivatedAbility()) {
-            // all other activated ability
+        } else if (ability instanceof ActivatedAbility) {
+            // all other abilities (include PlayLandAbility & SpellAbility)
             if (canPlay((ActivatedAbility) ability, manaFull, object, game)) {
                 return (ActivatedAbility) ability;
             }

--- a/Mage/src/main/java/mage/target/TargetImpl.java
+++ b/Mage/src/main/java/mage/target/TargetImpl.java
@@ -203,7 +203,9 @@ public abstract class TargetImpl implements Target {
 
     @Override
     public boolean isRequired(Ability ability) {
-        return ability == null || ability.isActivated() || !(ability.getAbilityType() == AbilityType.SPELL || ability.getAbilityType() == AbilityType.ACTIVATED);
+        return ability == null
+                || ability.isActivated()
+                || !(ability.getAbilityType() == AbilityType.SPELL || ability.getAbilityType().isActivatedAbility());
     }
 
     @Override
@@ -675,10 +677,10 @@ public abstract class TargetImpl implements Target {
         String abilityText = source.getRule(true).toLowerCase();
         boolean strictModeEnabled = player.getStrictChooseMode();
         boolean canAutoChoose = this.getMinNumberOfTargets() == this.getMaxNumberOfTargets() // Targets must be picked
-                                && possibleTargets.size() == this.getNumberOfTargets() - this.getSize() // Available targets are equal to the number that must be picked
-                                && !strictModeEnabled  // Test AI is not set to strictChooseMode(true)
-                                && playerAutoTargetLevel > 0 // Human player has enabled auto-choose in settings
-                                && !abilityText.contains("search"); // Do not autochoose for any effects which involve searching
+                && possibleTargets.size() == this.getNumberOfTargets() - this.getSize() // Available targets are equal to the number that must be picked
+                && !strictModeEnabled  // Test AI is not set to strictChooseMode(true)
+                && playerAutoTargetLevel > 0 // Human player has enabled auto-choose in settings
+                && !abilityText.contains("search"); // Do not autochoose for any effects which involve searching
 
 
         if (canAutoChoose) {

--- a/Mage/src/main/java/mage/target/common/TargetActivatedAbility.java
+++ b/Mage/src/main/java/mage/target/common/TargetActivatedAbility.java
@@ -1,7 +1,6 @@
 package mage.target.common;
 
 import mage.abilities.Ability;
-import mage.constants.AbilityType;
 import mage.constants.Zone;
 import mage.filter.Filter;
 import mage.filter.FilterAbility;
@@ -48,7 +47,7 @@ public class TargetActivatedAbility extends TargetObject {
         StackObject stackObject = game.getStack().getStackObject(id);
         return stackObject != null
                 && stackObject.getStackAbility() != null
-                && stackObject.getStackAbility().getAbilityType() == AbilityType.ACTIVATED
+                && stackObject.getStackAbility().isActivatedAbility()
                 && source != null
                 && filter.match(stackObject, source.getControllerId(), source, game);
     }
@@ -62,8 +61,9 @@ public class TargetActivatedAbility extends TargetObject {
     public boolean canChoose(UUID sourceControllerId, Game game) {
         for (StackObject stackObject : game.getStack()) {
             if (stackObject.getStackAbility() != null
-                    && stackObject.getStackAbility().getAbilityType() == AbilityType.ACTIVATED
-                    && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId())) {
+                    && stackObject.getStackAbility().isActivatedAbility()
+                    && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId()))
+            {
                 return true;
             }
         }
@@ -79,9 +79,9 @@ public class TargetActivatedAbility extends TargetObject {
     public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
         for (StackObject stackObject : game.getStack()) {
-            if (stackObject.getStackAbility().getAbilityType() == AbilityType.ACTIVATED
+            if (stackObject.getStackAbility().isActivatedAbility()
                     && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId())
-                    && filter.match(stackObject, game)) {
+                    && filter.match(stackObject, game)){
                 possibleTargets.add(stackObject.getStackAbility().getId());
             }
         }

--- a/Mage/src/main/java/mage/target/common/TargetActivatedAbility.java
+++ b/Mage/src/main/java/mage/target/common/TargetActivatedAbility.java
@@ -62,8 +62,8 @@ public class TargetActivatedAbility extends TargetObject {
         for (StackObject stackObject : game.getStack()) {
             if (stackObject.getStackAbility() != null
                     && stackObject.getStackAbility().isActivatedAbility()
-                    && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId()))
-            {
+                    && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId())
+            ) {
                 return true;
             }
         }
@@ -81,7 +81,7 @@ public class TargetActivatedAbility extends TargetObject {
         for (StackObject stackObject : game.getStack()) {
             if (stackObject.getStackAbility().isActivatedAbility()
                     && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId())
-                    && filter.match(stackObject, game)){
+                    && filter.match(stackObject, game)) {
                 possibleTargets.add(stackObject.getStackAbility().getId());
             }
         }

--- a/Mage/src/main/java/mage/target/common/TargetTriggeredAbility.java
+++ b/Mage/src/main/java/mage/target/common/TargetTriggeredAbility.java
@@ -1,7 +1,6 @@
 package mage.target.common;
 
 import mage.abilities.Ability;
-import mage.constants.AbilityType;
 import mage.constants.Zone;
 import mage.filter.Filter;
 import mage.filter.FilterStackObject;
@@ -93,7 +92,7 @@ public class TargetTriggeredAbility extends TargetObject {
         }
         if (stackObject instanceof Ability) {
             Ability ability = (Ability) stackObject;
-            return ability.getAbilityType() == AbilityType.TRIGGERED;
+            return ability.getAbilityType().isTriggeredAbility();
         }
         return false;
     }


### PR DESCRIPTION
Followup from #12142

I suspect there was lot of small issues with cards looking for activated abilities and not checking `LOYALTY` before. (Edit: realized that `LOYALTY` was not used before. So ignore that sentence.)

TODO:
- [x] Change Rex Cyber-Hound's use of `instanceof` for the new .isActivatedAbility()
- [x] Take a look at the remaining `instanceof` for `ActivatedAbility` / `ActivatedManaAbility` and their `Impl` counterparts.
- [x] Check that all replaced `instanceof` by `.isXXXAbility()` are doing some kind of null check before.