### PR TITLE
Add hints for continuous effects

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BiomancersFamiliar.java
+++ b/Mage.Sets/src/mage/cards/b/BiomancersFamiliar.java
@@ -135,4 +135,18 @@ class BiomancersFamiliarReplacementEffect extends ReplacementEffectImpl {
         discard();
         return false;
     }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!permanent.getId().equals(getTargetPointer().getFirst(game, source))) {
+            return null;
+        }
+
+        return "The next time {this} adapts this turn, it adapts as though it had no +1/+1 counters on it.";
+    }
 }

--- a/Mage.Sets/src/mage/cards/b/BoneMask.java
+++ b/Mage.Sets/src/mage/cards/b/BoneMask.java
@@ -17,6 +17,7 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetSource;
 
@@ -94,5 +95,24 @@ class BoneMaskEffect extends PreventionEffectImpl {
                 && event.getTargetId().equals(source.getControllerId())
                 && event.getSourceId().equals(target.getFirstTarget())
         );
+    }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (this.used || !permanent.getId().equals(target.getFirstTarget())) {
+            return null;
+        }
+
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null)
+            return null;
+
+        return "The next time {this} would deal damage to " + player.getLogName()
+                + " this turn, prevent that damage.";
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DepartedDeckhand.java
+++ b/Mage.Sets/src/mage/cards/d/DepartedDeckhand.java
@@ -27,7 +27,7 @@ import mage.MageInt;
  */
 public final class DepartedDeckhand extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("non-Spirit creatures");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("except by Spirits");
 
     static {
         filter.add(Predicates.not(SubType.SPIRIT.getPredicate()));

--- a/Mage.Sets/src/mage/cards/d/DepartedDeckhand.java
+++ b/Mage.Sets/src/mage/cards/d/DepartedDeckhand.java
@@ -27,7 +27,7 @@ import mage.MageInt;
  */
 public final class DepartedDeckhand extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("non-Spirit creatures");
 
     static {
         filter.add(Predicates.not(SubType.SPIRIT.getPredicate()));

--- a/Mage.Sets/src/mage/cards/d/DesperateGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateGambit.java
@@ -75,6 +75,9 @@ class DesperateGambitEffect extends PreventionEffectImpl {
 
         this.target.choose(Outcome.Benefit, source.getControllerId(), source.getSourceId(), source, game);
         this.wonFlip = you.flipCoin(source, game, true);
+        game.informPlayers("The next time " + game.getObject(target.getFirstTarget()).getLogName()
+                + " would deal combat damage this turn, "
+                + (wonFlip ? "it deals double that damage instead." : "prevent that damage.)"));
     }
 
     @Override
@@ -119,6 +122,24 @@ class DesperateGambitEffect extends PreventionEffectImpl {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!permanent.getId().equals(target.getFirstTarget())) {
+            return null;
+        }
+
+        if (wonFlip) {
+            return "The next time this creature would deal combat damage this turn, it deals double that damage instead.";
+        } else {
+            return "The next time this creature would deal combat damage this turn, prevent that damage.";
+        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/d/DesperateGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateGambit.java
@@ -136,9 +136,9 @@ class DesperateGambitEffect extends PreventionEffectImpl {
         }
 
         if (wonFlip) {
-            return "The next time this creature would deal combat damage this turn, it deals double that damage instead.";
+            return "The next time {this} would deal combat damage this turn, it deals double that damage instead.";
         } else {
-            return "The next time this creature would deal combat damage this turn, prevent that damage.";
+            return "The next time {this} would deal combat damage this turn, prevent that damage.";
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FightingChance.java
+++ b/Mage.Sets/src/mage/cards/f/FightingChance.java
@@ -62,6 +62,9 @@ class FightingChanceEffect extends OneShotEffect {
                     PreventDamageByTargetEffect effect = new PreventDamageByTargetEffect(Duration.EndOfTurn, true);
                     effect.setTargetPointer(new FixedTarget(blocker, game));
                     game.addEffect(effect, source);
+                    game.informPlayers(
+                            "Prevent all combat damage that would be dealt by " + game.getObject(blocker).getLogName()
+                                    + " this turn.");
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/g/GoblinPsychopath.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinPsychopath.java
@@ -126,6 +126,7 @@ class GoblinPsychopathEffect extends ReplacementEffectImpl {
             return null;
         }
 
-        return "The next time this creature would deal combat damage this turn, it deals that damage to you instead.";
+        return "The next time {this} would deal combat damage this turn, it deals that damage to "
+                + game.getPlayer(source.getControllerId()).getLogName() + " instead.";
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GoblinPsychopath.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinPsychopath.java
@@ -14,6 +14,7 @@ import mage.constants.SubType;
 import mage.game.Game;
 import mage.game.events.DamageEvent;
 import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 
 import java.util.UUID;
@@ -68,6 +69,9 @@ class GoblinPsychopathEffect extends ReplacementEffectImpl {
         }
 
         this.wonFlip = controller.flipCoin(source, game, true);
+        game.informPlayers("The next time " + game.getObject(source.getSourceId()).getLogName()
+                + " would deal combat damage this turn, it deals that damage to " + controller.getLogName()
+                + " instead.");
     }
 
     @Override
@@ -109,5 +113,19 @@ class GoblinPsychopathEffect extends ReplacementEffectImpl {
         game.informPlayers(sourceLogName + "Redirected " + event.getAmount() + " damage to " + controller.getLogName());
         this.discard();
         return true;
+    }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (wonFlip || !permanent.getId().equals(source.getSourceId())) {
+            return null;
+        }
+
+        return "The next time this creature would deal combat damage this turn, it deals that damage to you instead.";
     }
 }

--- a/Mage.Sets/src/mage/cards/i/ImpulsiveManeuvers.java
+++ b/Mage.Sets/src/mage/cards/i/ImpulsiveManeuvers.java
@@ -120,9 +120,9 @@ class ImpulsiveManeuversEffect extends PreventionEffectImpl {
         }
 
         if (wonFlip) {
-            return "The next time this creature would deal combat damage this turn, it deals double that damage instead.";
+            return "The next time {this} would deal combat damage this turn, it deals double that damage instead.";
         } else {
-            return "The next time this creature would deal combat damage this turn, prevent that damage.";
+            return "The next time {this} would deal combat damage this turn, prevent that damage.";
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/i/ImpulsiveManeuvers.java
+++ b/Mage.Sets/src/mage/cards/i/ImpulsiveManeuvers.java
@@ -14,6 +14,7 @@ import mage.constants.SetTargetPointer;
 import mage.game.Game;
 import mage.game.events.DamageEvent;
 import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 import mage.filter.StaticFilters;
 import mage.players.Player;
 import mage.util.CardUtil;
@@ -59,6 +60,9 @@ class ImpulsiveManeuversEffect extends PreventionEffectImpl {
     public void init(Ability source, Game game) {
         super.init(source, game);
         this.wonFlip = game.getPlayer(source.getControllerId()).flipCoin(source, game, true);
+        game.informPlayers("The next time " + game.getObject(getTargetPointer().getFirst(game, source)).getLogName()
+                + " would deal combat damage this turn, "
+                + (wonFlip ? "it deals double that damage instead." : "prevent that damage.)"));
     }
 
     @Override
@@ -102,5 +106,23 @@ class ImpulsiveManeuversEffect extends PreventionEffectImpl {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!permanent.getId().equals(this.getTargetPointer().getFirst(game, source))) {
+            return null;
+        }
+
+        if (wonFlip) {
+            return "The next time this creature would deal combat damage this turn, it deals double that damage instead.";
+        } else {
+            return "The next time this creature would deal combat damage this turn, prevent that damage.";
+        }
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MysticReflection.java
+++ b/Mage.Sets/src/mage/cards/m/MysticReflection.java
@@ -147,6 +147,21 @@ class MysticReflectionReplacementEffect extends ReplacementEffectImpl {
     public MysticReflectionReplacementEffect copy() {
         return new MysticReflectionReplacementEffect(this);
     }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        Permanent targetedPermanent = (Permanent) game.getState().getValue("MysticReflection" + identifier);
+        if (targetedPermanent == null || !permanent.getId().equals(targetedPermanent.getId())) {
+            return null;
+        }
+
+        return "The next time one or more creatures or planeswalkers enter the battlefield this turn, they enter as copies of {this}";
+    }
 }
 
 class MysticReflectionWatcher extends Watcher {

--- a/Mage.Sets/src/mage/cards/r/RunForYourLife.java
+++ b/Mage.Sets/src/mage/cards/r/RunForYourLife.java
@@ -20,7 +20,7 @@ import java.util.UUID;
  */
 public final class RunForYourLife extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creatures without haste");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("except by creatures with haste");
 
     static {
         filter.add(Predicates.not(new AbilityPredicate(HasteAbility.class)));

--- a/Mage.Sets/src/mage/cards/r/RunForYourLife.java
+++ b/Mage.Sets/src/mage/cards/r/RunForYourLife.java
@@ -20,7 +20,7 @@ import java.util.UUID;
  */
 public final class RunForYourLife extends CardImpl {
 
-    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent();
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creatures without haste");
 
     static {
         filter.add(Predicates.not(new AbilityPredicate(HasteAbility.class)));

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffect.java
@@ -7,6 +7,7 @@ import mage.constants.Duration;
 import mage.constants.Layer;
 import mage.constants.SubLayer;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.target.targetpointer.TargetPointer;
 
 import java.util.EnumSet;
@@ -85,4 +86,9 @@ public interface ContinuousEffect extends Effect {
 
     @Override
     ContinuousEffect setTargetPointer(TargetPointer targetPointer);
+
+    // Hint info
+    boolean hasHint();
+
+    String getHint(Permanent permanent, Ability source, Game game);
 }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -9,6 +9,7 @@ import mage.filter.Filter;
 import mage.filter.predicate.Predicate;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
 import mage.players.Player;
@@ -514,5 +515,13 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
                     || stackObject.getStackAbility().getManaCostsToPay().isPaid(); // mana payment finished
         }
         return true;
+    }
+
+    public boolean hasHint() {
+        return false;
+    }
+
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        return null;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -1340,6 +1340,13 @@ public class ContinuousEffects implements Serializable {
         return texts;
     }
 
+    public Map<ContinuousEffect, Set<Ability>> getHintEffects() {
+        return allEffectsLists.stream()
+                .flatMap(list -> list.getHintEffects().stream()
+                        .map(effect -> new AbstractMap.SimpleEntry<>(effect, list.getAbility(effect.getId()))))
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+    }
+
     public boolean existRequirementEffects() {
         return !requirementEffects.isEmpty();
     }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectsList.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectsList.java
@@ -11,7 +11,9 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import org.apache.log4j.Logger;
 
+import java.lang.ref.WeakReference;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @param <T>
@@ -23,6 +25,8 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
 
     // the effectAbilityMap holds for each effect all abilities that are connected (used) with this effect
     private final Map<UUID, Set<Ability>> effectAbilityMap = new HashMap<>();
+    // Keep track of which effects have hints
+    private final List<WeakReference<T>> hints = new ArrayList<>();
 
     public ContinuousEffectsList() {
     }
@@ -30,7 +34,11 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
     public ContinuousEffectsList(final ContinuousEffectsList<T> effects) {
         this.ensureCapacity(effects.size());
         for (ContinuousEffect cost : effects) {
-            this.add((T) cost.copy());
+            T copy = (T) cost.copy();
+            this.add(copy);
+            if (copy.hasHint()) {
+                hints.add(new WeakReference<>(copy));
+            }
         }
         for (Map.Entry<UUID, Set<Ability>> entry : effects.effectAbilityMap.entrySet()) {
             Set<Ability> newSet = new HashSet<>();
@@ -67,6 +75,7 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
             if (canRemove) {
                 i.remove();
                 effectAbilityMap.remove(entry.getId());
+                hints.removeIf(effect -> effect.get() == null || effect.get() == entry);
             }
         }
     }
@@ -77,6 +86,7 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
             if (entry.getDuration() == Duration.EndOfCombat) {
                 i.remove();
                 effectAbilityMap.remove(entry.getId());
+                hints.removeIf(effect -> effect.get() == null || effect.get() == entry);
             }
         }
     }
@@ -87,6 +97,7 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
             if (isInactive(entry, game)) {
                 i.remove();
                 effectAbilityMap.remove(entry.getId());
+                hints.removeIf(effect -> effect.get() == null || effect.get() == entry);
             }
         }
     }
@@ -209,6 +220,10 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
         }
         set.add(source);
         this.add(effect);
+
+        if (effect.hasHint()) {
+            hints.add(new WeakReference<>(effect));
+        }
     }
 
     public Set<Ability> getAbility(UUID effectId) {
@@ -229,6 +244,7 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
     public void clear() {
         super.clear();
         effectAbilityMap.clear();
+        hints.clear();
     }
 
     @Override
@@ -249,5 +265,9 @@ public class ContinuousEffectsList<T extends ContinuousEffect> extends ArrayList
             }
         }
         return false;
+    }
+
+    public List<T> getHintEffects() {
+        return hints.stream().map(WeakReference<T>::get).filter(Objects::nonNull).collect(Collectors.toList());
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventDamageByTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventDamageByTargetEffect.java
@@ -7,6 +7,7 @@ import mage.abilities.effects.PreventionEffectImpl;
 import mage.constants.Duration;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
 import mage.target.Target;
 import mage.target.TargetSpell;
 
@@ -75,6 +76,31 @@ public class PreventDamageByTargetEffect extends PreventionEffectImpl {
             preventText += "that would be dealt" + (durationRuleAtEnd ?
                     " by " + targetText + durationText :
                     durationText + " by " + targetText);
+        } else {
+            preventText += targetText + " would deal" + durationText;
+        }
+        return preventText;
+    }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!this.getTargetPointer().getTargets(game, source).contains(permanent.getId())) {
+            return null;
+        }
+
+        String durationText = duration == Duration.EndOfTurn ? " this turn" : ' ' + duration.toString();
+        String targetText = permanent.getName();
+        String preventText = (amountToPrevent == Integer.MAX_VALUE ? "Prevent all"
+                : "Prevent the next" + amountToPrevent)
+                + (onlyCombat ? " combat damage " : " damage ");
+        if (passiveVoice) {
+            preventText += "that would be dealt"
+                    + (durationRuleAtEnd ? " by " + targetText + durationText : durationText + " by " + targetText);
         } else {
             preventText += targetText + " would deal" + durationText;
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/PreventDamageByTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PreventDamageByTargetEffect.java
@@ -94,7 +94,7 @@ public class PreventDamageByTargetEffect extends PreventionEffectImpl {
         }
 
         String durationText = duration == Duration.EndOfTurn ? " this turn" : ' ' + duration.toString();
-        String targetText = permanent.getName();
+        String targetText = "{this}";
         String preventText = (amountToPrevent == Integer.MAX_VALUE ? "Prevent all"
                 : "Prevent the next" + amountToPrevent)
                 + (onlyCombat ? " combat damage " : " damage ");

--- a/Mage/src/main/java/mage/abilities/effects/common/RegenerateTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RegenerateTargetEffect.java
@@ -63,4 +63,18 @@ public class RegenerateTargetEffect extends ReplacementEffectImpl {
         }
         return "regenerate " + getTargetPointer().describeTargets(mode.getTargets(), "that creature");
     }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!permanent.getId().equals(getTargetPointer().getFirst(game, source)) || !this.used) {
+            return null;
+        }
+
+        return "{This} is regenerating.";
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CantBeBlockedByAllTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CantBeBlockedByAllTargetEffect.java
@@ -51,4 +51,21 @@ public class CantBeBlockedByAllTargetEffect extends RestrictionEffect {
                 + (filterBlockedBy.getMessage().startsWith("except by") ? "" : "by ")
                 + filterBlockedBy.getMessage();
     }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!applies(permanent, source, game)) {
+            return null;
+        }
+
+        return "{This} can't be blocked "
+                + (duration == Duration.EndOfTurn ? "this turn " : "")
+                + (filterBlockedBy.getMessage().startsWith("except by") ? "" : "by ")
+                + filterBlockedBy.getMessage();
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CantBeBlockedTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CantBeBlockedTargetEffect.java
@@ -59,4 +59,20 @@ public class CantBeBlockedTargetEffect extends RestrictionEffect {
                 + " can't be blocked"
                 + (duration == Duration.EndOfTurn ? " this turn" : "");
     }
+
+    @Override
+    public boolean hasHint() {
+        return true;
+    }
+
+    @Override
+    public String getHint(Permanent permanent, Ability source, Game game) {
+        if (!applies(permanent, source, game)) {
+            return null;
+        }
+
+        return "This creature can't be blocked" + (duration == Duration.EndOfTurn ? " this turn" : "")
+                + (this.filter != StaticFilters.FILTER_PERMANENT_CREATURE ? " by " + this.filter.getMessage() : "")
+                + ".";
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/combat/CantBeBlockedTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/combat/CantBeBlockedTargetEffect.java
@@ -71,8 +71,10 @@ public class CantBeBlockedTargetEffect extends RestrictionEffect {
             return null;
         }
 
-        return "This creature can't be blocked" + (duration == Duration.EndOfTurn ? " this turn" : "")
-                + (this.filter != StaticFilters.FILTER_PERMANENT_CREATURE ? " by " + this.filter.getMessage() : "")
+        return "{this} can't be blocked" + (duration == Duration.EndOfTurn ? " this turn" : "")
+                + (this.filter != StaticFilters.FILTER_PERMANENT_CREATURE
+                        ? (this.filter.getMessage().startsWith("except by") ? "" : " by ") + this.filter.getMessage()
+                        : "")
                 + ".";
     }
 }

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -377,6 +377,17 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                     }
                 }
 
+                // General continuous effect hints
+                for (Map.Entry<ContinuousEffect, Set<Ability>> entry : game.getContinuousEffects().getHintEffects()
+                        .entrySet()) {
+                    for (Ability ability : entry.getValue()) {
+                        String hint = entry.getKey().getHint(this, ability, game);
+                        if (hint != null) {
+                            restrictHints.add(HintUtils.prepareText(hint, null));
+                        }
+                    }
+
+                }
                 restrictHints.sort(String::compareTo);
             }
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -321,7 +321,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
                             restrictHints.add(HintUtils.prepareText("Can't block" + addSourceObjectName(game, ability), null, HintUtils.HINT_ICON_RESTRICT));
                         }
                         if (!entry.getKey().canBeUntapped(this, ability, game, false)) {
-                            restrictHints.add(HintUtils.prepareText("Can't untapped" + addSourceObjectName(game, ability), null, HintUtils.HINT_ICON_RESTRICT));
+                            restrictHints.add(HintUtils.prepareText("Can't be untapped" + addSourceObjectName(game, ability), null, HintUtils.HINT_ICON_RESTRICT));
                         }
                         if (!entry.getKey().canUseActivatedAbilities(this, ability, game, false)) {
                             restrictHints.add(HintUtils.prepareText("Can't use activated abilities" + addSourceObjectName(game, ability), null, HintUtils.HINT_ICON_RESTRICT));


### PR DESCRIPTION
There are a bunch of continuous effects that last for a while but aren't produced by static abilities, so they can be quite difficult to keep track of - especially when they are applied randomly. I've added the ability for continuous effects to add hints to permanents, and I've adjusted hints and log messages for a variety of confusing continuous effects.

I think there are potentially a lot more continuous effects that could benefit from this kind of hint, as well as more work on making the system more robust (perhaps continuous effects can add hints to more objects than just permanents? Also maybe they can add icons to permanents like combat restrictions do - then combat restrictions could be folded into this new system). Let me know what you think, and I'll add it.