### PR TITLE
Fixed remembering self-referential choices

### DIFF
--- a/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
@@ -92,6 +92,8 @@ public class FeedbackPanel extends javax.swing.JPanel {
                 if (options != null && options.containsKey(AUTO_ANSWER_MESSAGE)) {
                     // Uses a filtered message for remembering choice if the original message contains a self-reference
                     this.helper.setAutoAnswerMessage((String) options.get(AUTO_ANSWER_MESSAGE));
+                } else {
+                    this.helper.setAutoAnswerMessage(message);
                 }
                 break;
             case CONFIRM:

--- a/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
@@ -89,6 +89,10 @@ public class FeedbackPanel extends javax.swing.JPanel {
                     // allows yes/no auto-answers for ability related
                     this.helper.setOriginalId((UUID) options.get(ORIGINAL_ID));
                 }
+                if (options != null && options.containsKey(FILTERED_MESSAGE)) {
+                    // Uses a filtered message for remembering choice if the original message contains a self-reference
+                    this.helper.setFilteredMessage((String) options.get(FILTERED_MESSAGE));
+                }
                 break;
             case CONFIRM:
                 setButtonState("OK", "Cancel", mode);

--- a/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
@@ -89,9 +89,9 @@ public class FeedbackPanel extends javax.swing.JPanel {
                     // allows yes/no auto-answers for ability related
                     this.helper.setOriginalId((UUID) options.get(ORIGINAL_ID));
                 }
-                if (options != null && options.containsKey(FILTERED_MESSAGE)) {
+                if (options != null && options.containsKey(AUTO_ANSWER_MESSAGE)) {
                     // Uses a filtered message for remembering choice if the original message contains a self-reference
-                    this.helper.setFilteredMessage((String) options.get(FILTERED_MESSAGE));
+                    this.helper.setAutoAnswerMessage((String) options.get(AUTO_ANSWER_MESSAGE));
                 }
                 break;
             case CONFIRM:

--- a/Mage.Client/src/main/java/mage/client/game/HelperPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/HelperPanel.java
@@ -64,6 +64,7 @@ public class HelperPanel extends JPanel {
     // originalId of feedback causing ability
     private UUID originalId;
     private String message;
+    private String filteredMessage; // Filtered version of message which is used for remembering answers to text
 
     private UUID gameId;
     private boolean gameNeedFeedback = false;
@@ -462,6 +463,10 @@ public class HelperPanel extends JPanel {
         this.dialogTextArea.setText(message, this.getWidth());
     }
 
+    public void setFilteredMessage(String filteredMessage) {
+        this.filteredMessage = filteredMessage;
+    }
+
     public void setTextArea(String message) {
         this.dialogTextArea.setText(message, this.getWidth());
     }
@@ -523,19 +528,23 @@ public class HelperPanel extends JPanel {
     public void handleAutoAnswerPopupMenuEvent(ActionEvent e) {
         switch (e.getActionCommand()) {
             case CMD_AUTO_ANSWER_ID_YES:
-                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_YES, gameId, originalId.toString() + '#' + message);
+                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_YES, gameId,
+                        originalId.toString() + '#' + (filteredMessage == null ? message : filteredMessage));
                 clickButton(btnLeft);
                 break;
             case CMD_AUTO_ANSWER_ID_NO:
-                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_NO, gameId, originalId.toString() + '#' + message);
+                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_NO, gameId,
+                        originalId.toString() + '#' + (filteredMessage == null ? message : filteredMessage));
                 clickButton(btnRight);
                 break;
             case CMD_AUTO_ANSWER_NAME_YES:
-                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_YES, gameId, message);
+                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_YES, gameId,
+                        (filteredMessage == null ? message : filteredMessage));
                 clickButton(btnLeft);
                 break;
             case CMD_AUTO_ANSWER_NAME_NO:
-                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_NO, gameId, message);
+                SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_NO, gameId,
+                        (filteredMessage == null ? message : filteredMessage));
                 clickButton(btnRight);
                 break;
             case CMD_AUTO_ANSWER_RESET_ALL:

--- a/Mage.Client/src/main/java/mage/client/game/HelperPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/HelperPanel.java
@@ -64,7 +64,7 @@ public class HelperPanel extends JPanel {
     // originalId of feedback causing ability
     private UUID originalId;
     private String message;
-    private String filteredMessage; // Filtered version of message which is used for remembering answers to text
+    private String autoAnswerMessage; // Filtered version of message which is used for remembering answers to text
 
     private UUID gameId;
     private boolean gameNeedFeedback = false;
@@ -463,8 +463,8 @@ public class HelperPanel extends JPanel {
         this.dialogTextArea.setText(message, this.getWidth());
     }
 
-    public void setFilteredMessage(String filteredMessage) {
-        this.filteredMessage = filteredMessage;
+    public void setAutoAnswerMessage(String autoAnswerMessage) {
+        this.autoAnswerMessage = autoAnswerMessage;
     }
 
     public void setTextArea(String message) {
@@ -529,22 +529,22 @@ public class HelperPanel extends JPanel {
         switch (e.getActionCommand()) {
             case CMD_AUTO_ANSWER_ID_YES:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_YES, gameId,
-                        originalId.toString() + '#' + (filteredMessage == null ? message : filteredMessage));
+                        originalId.toString() + '#' + (autoAnswerMessage == null ? message : autoAnswerMessage));
                 clickButton(btnLeft);
                 break;
             case CMD_AUTO_ANSWER_ID_NO:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_NO, gameId,
-                        originalId.toString() + '#' + (filteredMessage == null ? message : filteredMessage));
+                        originalId.toString() + '#' + (autoAnswerMessage == null ? message : autoAnswerMessage));
                 clickButton(btnRight);
                 break;
             case CMD_AUTO_ANSWER_NAME_YES:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_YES, gameId,
-                        (filteredMessage == null ? message : filteredMessage));
+                        (autoAnswerMessage == null ? message : autoAnswerMessage));
                 clickButton(btnLeft);
                 break;
             case CMD_AUTO_ANSWER_NAME_NO:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_NO, gameId,
-                        (filteredMessage == null ? message : filteredMessage));
+                        (autoAnswerMessage == null ? message : autoAnswerMessage));
                 clickButton(btnRight);
                 break;
             case CMD_AUTO_ANSWER_RESET_ALL:

--- a/Mage.Client/src/main/java/mage/client/game/HelperPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/HelperPanel.java
@@ -529,22 +529,22 @@ public class HelperPanel extends JPanel {
         switch (e.getActionCommand()) {
             case CMD_AUTO_ANSWER_ID_YES:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_YES, gameId,
-                        originalId.toString() + '#' + (autoAnswerMessage == null ? message : autoAnswerMessage));
+                        originalId.toString() + '#' + autoAnswerMessage);
                 clickButton(btnLeft);
                 break;
             case CMD_AUTO_ANSWER_ID_NO:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_ID_NO, gameId,
-                        originalId.toString() + '#' + (autoAnswerMessage == null ? message : autoAnswerMessage));
+                        originalId.toString() + '#' + autoAnswerMessage);
                 clickButton(btnRight);
                 break;
             case CMD_AUTO_ANSWER_NAME_YES:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_YES, gameId,
-                        (autoAnswerMessage == null ? message : autoAnswerMessage));
+                        autoAnswerMessage);
                 clickButton(btnLeft);
                 break;
             case CMD_AUTO_ANSWER_NAME_NO:
                 SessionHandler.sendPlayerAction(REQUEST_AUTO_ANSWER_TEXT_NO, gameId,
-                        (autoAnswerMessage == null ? message : autoAnswerMessage));
+                        autoAnswerMessage);
                 clickButton(btnRight);
                 break;
             case CMD_AUTO_ANSWER_RESET_ALL:

--- a/Mage.Common/src/main/java/mage/constants/Constants.java
+++ b/Mage.Common/src/main/java/mage/constants/Constants.java
@@ -59,6 +59,6 @@ public final class Constants {
         public static final String ORIGINAL_ID = "originalId";
         public static final String SECOND_MESSAGE = "secondMessage";
         public static final String HINT_TEXT = "hintText";
-        public static final String FILTERED_MESSAGE = "filteredMessage";
+        public static final String AUTO_ANSWER_MESSAGE = "autoAnswerMessage";
     }
 }

--- a/Mage.Common/src/main/java/mage/constants/Constants.java
+++ b/Mage.Common/src/main/java/mage/constants/Constants.java
@@ -59,5 +59,6 @@ public final class Constants {
         public static final String ORIGINAL_ID = "originalId";
         public static final String SECOND_MESSAGE = "secondMessage";
         public static final String HINT_TEXT = "hintText";
+        public static final String FILTERED_MESSAGE = "filteredMessage";
     }
 }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -406,6 +406,7 @@ public class HumanPlayer extends PlayerImpl {
 
         MessageToClient messageToClient = new MessageToClient(message, secondMessage);
         Map<String, Serializable> options = new HashMap<>(2);
+        String filteredMessage = null; // Removes self-referential text for the purposes of remembering options
         if (trueText != null) {
             options.put("UI.left.btn.text", trueText);
         }
@@ -414,6 +415,8 @@ public class HumanPlayer extends PlayerImpl {
         }
         if (source != null) {
             //options.put(Constants.Option.ORIGINAL_ID, "")
+            filteredMessage = message.replace(getRelatedObjectName(source, game), "{this}");
+            options.put(Constants.Option.FILTERED_MESSAGE, filteredMessage);
         }
 
 
@@ -421,11 +424,12 @@ public class HumanPlayer extends PlayerImpl {
         Boolean answer = null;
         if (source != null) {
             // ability + text
-            answer = requestAutoAnswerId.get(source.getOriginalId() + "#" + message);
+            answer = requestAutoAnswerId
+                    .get(source.getOriginalId() + "#" + (filteredMessage == null ? message : filteredMessage));
         }
         if (answer == null) {
             // text
-            answer = requestAutoAnswerText.get(message);
+            answer = requestAutoAnswerText.get((filteredMessage == null ? message : filteredMessage));
         }
         if (answer != null) {
             return answer;

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -406,7 +406,7 @@ public class HumanPlayer extends PlayerImpl {
 
         MessageToClient messageToClient = new MessageToClient(message, secondMessage);
         Map<String, Serializable> options = new HashMap<>(2);
-        String filteredMessage = null; // Removes self-referential text for the purposes of remembering options
+        String autoAnswerMessage = null; // Removes self-referential text for the purposes of auto-answering
         if (trueText != null) {
             options.put("UI.left.btn.text", trueText);
         }
@@ -415,8 +415,8 @@ public class HumanPlayer extends PlayerImpl {
         }
         if (source != null) {
             //options.put(Constants.Option.ORIGINAL_ID, "")
-            filteredMessage = message.replace(getRelatedObjectName(source, game), "{this}");
-            options.put(Constants.Option.FILTERED_MESSAGE, filteredMessage);
+            autoAnswerMessage = message.replace(getRelatedObjectName(source, game), "{this}");
+            options.put(Constants.Option.AUTO_ANSWER_MESSAGE, autoAnswerMessage);
         }
 
 
@@ -425,11 +425,11 @@ public class HumanPlayer extends PlayerImpl {
         if (source != null) {
             // ability + text
             answer = requestAutoAnswerId
-                    .get(source.getOriginalId() + "#" + (filteredMessage == null ? message : filteredMessage));
+                    .get(source.getOriginalId() + "#" + (autoAnswerMessage == null ? message : autoAnswerMessage));
         }
         if (answer == null) {
             // text
-            answer = requestAutoAnswerText.get((filteredMessage == null ? message : filteredMessage));
+            answer = requestAutoAnswerText.get((autoAnswerMessage == null ? message : autoAnswerMessage));
         }
         if (answer != null) {
             return answer;

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -406,7 +406,7 @@ public class HumanPlayer extends PlayerImpl {
 
         MessageToClient messageToClient = new MessageToClient(message, secondMessage);
         Map<String, Serializable> options = new HashMap<>(2);
-        String autoAnswerMessage = null; // Removes self-referential text for the purposes of auto-answering
+        String autoAnswerMessage = message; // Removes self-referential text for the purposes of auto-answering
         if (trueText != null) {
             options.put("UI.left.btn.text", trueText);
         }
@@ -415,21 +415,21 @@ public class HumanPlayer extends PlayerImpl {
         }
         if (source != null) {
             //options.put(Constants.Option.ORIGINAL_ID, "")
-            autoAnswerMessage = message.replace(getRelatedObjectName(source, game), "{this}");
-            options.put(Constants.Option.AUTO_ANSWER_MESSAGE, autoAnswerMessage);
+            autoAnswerMessage = autoAnswerMessage.replace(getRelatedObjectName(source, game), "{this}");
         }
 
+        options.put(Constants.Option.AUTO_ANSWER_MESSAGE, autoAnswerMessage);
 
         // auto-answer
         Boolean answer = null;
         if (source != null) {
             // ability + text
             answer = requestAutoAnswerId
-                    .get(source.getOriginalId() + "#" + (autoAnswerMessage == null ? message : autoAnswerMessage));
+                    .get(source.getOriginalId() + "#" + autoAnswerMessage);
         }
         if (answer == null) {
             // text
-            answer = requestAutoAnswerText.get((autoAnswerMessage == null ? message : autoAnswerMessage));
+            answer = requestAutoAnswerText.get(autoAnswerMessage);
         }
         if (answer != null) {
             return answer;


### PR DESCRIPTION
Fixes #12088. Now when a yes/no choice asks a player for input, it will remember a version of the text which does not contain any references to the source object, and store that if the player asks it to remember their choice instead of the original message.

I had thought about going back and identifying all effects which ask a yes/no question to a player and refer to themselves, however I think this is a more robust way of doing it without weird templating and missed effects. Let me know your opinions.