### PR TITLE
Fix Urborg Scavengers

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UrborgScavengers.java
+++ b/Mage.Sets/src/mage/cards/u/UrborgScavengers.java
@@ -74,12 +74,15 @@ class UrborgScavengersEffect extends ContinuousEffectImpl {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
+        if (sourcePermanent == null){
+            return false;
+        }
         ExileZone exileZone = game
                 .getExile()
                 .getExileZone(CardUtil.getExileZoneId(
-                        game, source.getSourceId(), source.getSourceObjectZoneChangeCounter()
+                        game, source.getSourceId(), sourcePermanent.getZoneChangeCounter(game)
                 ));
-        if (sourcePermanent == null || exileZone == null || exileZone.isEmpty()) {
+        if (exileZone == null || exileZone.isEmpty()) {
             return false;
         }
         exileZone

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/UrborgScavengersTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/UrborgScavengersTests.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- * @author Susucr
+ * @author jimga150
  */
 public class UrborgScavengersTests extends CardTestPlayerBase {
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/UrborgScavengersTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/UrborgScavengersTests.java
@@ -1,0 +1,42 @@
+package org.mage.test.cards.single.mat;
+
+import mage.abilities.Abilities;
+import mage.abilities.AbilitiesImpl;
+import mage.abilities.Ability;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.HexproofAbility;
+import mage.abilities.keyword.LifelinkAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class UrborgScavengersTests extends CardTestPlayerBase {
+
+    @Test
+    public void getsHexproofHasteTest() {
+
+        addCard(Zone.HAND, playerA, "Urborg Scavengers");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.GRAVEYARD, playerA, "Cragplate Baloth");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Urborg Scavengers", true);
+        addTarget(playerA, "Cragplate Baloth");
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+
+        Abilities<Ability> abilities = new AbilitiesImpl<>();
+        abilities.add(HasteAbility.getInstance());
+        abilities.add(HexproofAbility.getInstance());
+        assertAbilities(playerA, "Urborg Scavengers", abilities);
+
+        assertCounterCount(playerA, "Urborg Scavengers", CounterType.P1P1, 1);
+    }
+
+}


### PR DESCRIPTION
Fixes #10409

Looks like calling `source.getSourceObjectZoneChangeCounter()` doesn't get the proper ZCC--the returned exile zone was always null. i pulled this by comparing with [Death-Mask Duplicant](https://scryfall.com/card/dst/115/death-mask-duplicant). 

Is this a bug? there are other cards that use `source.getSourceObjectZoneChangeCounter()` and they seem to work fine.