### PR TITLE
sync part of cards zcc properly

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/ReturnToHandEffectsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/ReturnToHandEffectsTest.java
@@ -213,14 +213,12 @@ public class ReturnToHandEffectsTest extends CardTestPlayerBase {
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wind Zendikon", "Tangled Vale");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("1: check zcc", 1, PhaseStep.BEGIN_COMBAT, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Vale", 2, 1, 1, 2));
+                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Vale", 2, 2, 2, 2));
         castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Disfigure", "Tangled Vale");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("2: check zcc card", 1, PhaseStep.POSTCOMBAT_MAIN, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 2, 2, 4));
+                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 4, 4, 4));
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -244,14 +242,12 @@ public class ReturnToHandEffectsTest extends CardTestPlayerBase {
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wind Zendikon", "Riverglide Pathway");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("1: check zcc pre disfigure", 1, PhaseStep.BEGIN_COMBAT, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Riverglide Pathway", 2, 1, 2, 1));
+                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Riverglide Pathway", 2, 2, 2, 2));
         castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Disfigure", "Riverglide Pathway");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("2: check zcc post disfigure", 1, PhaseStep.POSTCOMBAT_MAIN, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Riverglide Pathway", 2, 4, 2));
+                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Riverglide Pathway", 4, 4, 4));
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -275,14 +271,12 @@ public class ReturnToHandEffectsTest extends CardTestPlayerBase {
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wind Zendikon", "Lavaglide Pathway");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("1: check zcc", 1, PhaseStep.BEGIN_COMBAT, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Lavaglide Pathway", 2, 1, 1, 2));
+                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Lavaglide Pathway", 2, 2, 2, 2));
         castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Disfigure", "Lavaglide Pathway");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("2: check zcc card", 1, PhaseStep.POSTCOMBAT_MAIN, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Riverglide Pathway", 2, 2, 4));
+                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Riverglide Pathway", 4, 4, 4));
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -335,14 +329,12 @@ public class ReturnToHandEffectsTest extends CardTestPlayerBase {
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Demonic Vigor", "Tangled Florahedron");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("1: check zcc", 1, PhaseStep.BEGIN_COMBAT, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Florahedron", 3, 2, 3, 2));
+                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Florahedron", 3, 3, 3, 3));
         castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Disfigure", "Tangled Florahedron");
 
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("2: check zcc card", 1, PhaseStep.POSTCOMBAT_MAIN, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 3, 5, 3));
+                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 5, 5, 5));
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -403,25 +395,21 @@ public class ReturnToHandEffectsTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Tangled Florahedron");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Demonic Vigor", "Tangled Florahedron");
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("1: check zcc", 1, PhaseStep.BEGIN_COMBAT, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Florahedron", 3, 2, 3, 2));
+                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Florahedron", 3, 3, 3, 3));
         castSpell(1, PhaseStep.BEGIN_COMBAT, playerA, "Disfigure", "Tangled Florahedron", true);
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("2: check zcc card", 1, PhaseStep.BEGIN_COMBAT, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 3, 5, 3));
+                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 5, 5, 5));
 
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Tangled Florahedron");
         waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN);
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Demonic Vigor", "Tangled Florahedron", true);
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("3: check zcc", 1, PhaseStep.POSTCOMBAT_MAIN, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Florahedron", 7, 4, 7, 4));
+                (String info, Player player, Game game) -> checkZCCMDFCPermanent(info, player, game, "Tangled Florahedron", 7, 7, 7, 7));
         waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN);
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Disfigure", "Tangled Florahedron", true);
-        // TODO: investigate why MDFC zcc moves separatedly.
         runCode("4: check zcc card", 1, PhaseStep.POSTCOMBAT_MAIN, playerA,
-                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 5, 9, 5));
+                (String info, Player player, Game game) -> checkZCCMDFCCardInHand(info, player, game, "Tangled Florahedron", 9, 9, 9));
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);

--- a/Mage/src/main/java/mage/game/ZonesHandler.java
+++ b/Mage/src/main/java/mage/game/ZonesHandler.java
@@ -438,7 +438,7 @@ public final class ZonesHandler {
             if (event.getToZone() == Zone.BATTLEFIELD && event.getTarget() != null) {
                 event.getTarget().updateZoneChangeCounter(game, event);
             } else if (!(card instanceof Permanent)) {
-                card.updateZoneChangeCounter(game, event);
+                card.getMainCard().updateZoneChangeCounter(game, event);
             }
         }
         return success;

--- a/Mage/src/main/java/mage/game/permanent/PermanentCard.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentCard.java
@@ -227,7 +227,7 @@ public class PermanentCard extends PermanentImpl {
     @Override
     public void updateZoneChangeCounter(Game game, ZoneChangeEvent event) {
         // TODO: wtf, permanent must not change ZCC at all, is it buggy here?!
-        card.updateZoneChangeCounter(game, event);
+        card.getMainCard().updateZoneChangeCounter(game, event);
         zoneChangeCounter = card.getZoneChangeCounter(game);
     }
 


### PR DESCRIPTION
For MDFC / Split / Others. Started from argumenting in #12184

It would make a LOT of sense to keep part of cards zcc sync.
All tests are working here. MDFC are some of the cards with a lot of coverage. There is no issue ensuring the main card and the parts are in zcc sync.

Please @JayDi85, give me an example of behavior this would break. I can add unit tests if you're not convinced.

Fix #10478