### PR TITLE
rework PhantomReplacementEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PhantomCentaur.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomCentaur.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.common.EntersBattlefieldAbility;
@@ -13,8 +12,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
+
+import java.util.UUID;
 
 /**
  * @author LevelX2
@@ -36,7 +36,7 @@ public final class PhantomCentaur extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(3)), "with three +1/+1 counters on it"));
 
         // If damage would be dealt to Phantom Centaur, prevent that damage. Remove a +1/+1 counter from Phantom Centaur.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
     }
 
     private PhantomCentaur(final PhantomCentaur card) {

--- a/Mage.Sets/src/mage/cards/p/PhantomFlock.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomFlock.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -12,8 +11,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
+
+import java.util.UUID;
 
 /**
  * @author emerald000
@@ -35,7 +35,7 @@ public final class PhantomFlock extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(3)), "with three +1/+1 counters on it"));
 
         // If damage would be dealt to Phantom Flock, prevent that damage. Remove a +1/+1 counter from Phantom Flock.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
     }
 
     private PhantomFlock(final PhantomFlock card) {

--- a/Mage.Sets/src/mage/cards/p/PhantomNantuko.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomNantuko.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -17,14 +16,15 @@ import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class PhantomNantuko extends CardImpl {
 
     public PhantomNantuko(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}");
         this.subtype.add(SubType.INSECT);
         this.subtype.add(SubType.SPIRIT);
 
@@ -36,7 +36,7 @@ public final class PhantomNantuko extends CardImpl {
         // Phantom Nantuko enters the battlefield with two +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true), "with two +1/+1 counters on it"));
         // If damage would be dealt to Phantom Nantuko, prevent that damage. Remove a +1/+1 counter from Phantom Nantuko.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
         // {tap}: Put a +1/+1 counter on Phantom Nantuko.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), new TapSourceCost()));
     }

--- a/Mage.Sets/src/mage/cards/p/PhantomNishoba.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomNishoba.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.DealsDamageGainLifeSourceTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldAbility;
@@ -13,8 +12,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
+
+import java.util.UUID;
 
 /**
  * @author fireshoes
@@ -39,7 +39,7 @@ public final class PhantomNishoba extends CardImpl {
         this.addAbility(new DealsDamageGainLifeSourceTriggeredAbility());
 
         // If damage would be dealt to Phantom Nishoba, prevent that damage. Remove a +1/+1 counter from Phantom Nishoba.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
     }
 
     private PhantomNishoba(final PhantomNishoba card) {

--- a/Mage.Sets/src/mage/cards/p/PhantomNomad.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomNomad.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -11,17 +10,17 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class PhantomNomad extends CardImpl {
 
     public PhantomNomad(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}");
         this.subtype.add(SubType.SPIRIT);
         this.subtype.add(SubType.NOMAD);
 
@@ -33,7 +32,7 @@ public final class PhantomNomad extends CardImpl {
                 "with two +1/+1 counters on it"));
 
         // If damage would be dealt to Phantom Nomad, prevent that damage. Remove a +1/+1 counter from Phantom Nomad.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
 
 
     }

--- a/Mage.Sets/src/mage/cards/p/PhantomTiger.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomTiger.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -11,8 +10,9 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
+
+import java.util.UUID;
 
 /**
  * @author Temba
@@ -30,7 +30,7 @@ public final class PhantomTiger extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)), "with two +1/+1 counters on it"));
 
         // If damage would be dealt to Phantom Tiger, prevent that damage. Remove a +1/+1 counter from Phantom Tiger.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
     }
 
     private PhantomTiger(final PhantomTiger card) {

--- a/Mage.Sets/src/mage/cards/p/PhantomWurm.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomWurm.java
@@ -1,7 +1,6 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -11,17 +10,17 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class PhantomWurm extends CardImpl {
 
     public PhantomWurm(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{4}{G}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{G}{G}");
         this.subtype.add(SubType.WURM);
         this.subtype.add(SubType.SPIRIT);
 
@@ -33,7 +32,7 @@ public final class PhantomWurm extends CardImpl {
                 "with four +1/+1 counters on it"));
 
         // If damage would be dealt to Phantom Wurm, prevent that damage. Remove a +1/+1 counter from Phantom Wurm.
-        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new PhantomPreventionEffect()));
+        this.addAbility(new SimpleStaticAbility(new PhantomPreventionEffect()), PhantomPreventionEffect.createWatcher());
     }
 
     private PhantomWurm(final PhantomWurm card) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/tsp/PhantomWurmTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/tsp/PhantomWurmTest.java
@@ -1,0 +1,237 @@
+package org.mage.test.cards.single.tsp;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class PhantomWurmTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.p.PhantomWurm Phantom Wurm} {4}{G}{G}
+     * Creature — Wurm Spirit
+     * Phantom Wurm enters the battlefield with four +1/+1 counters on it.
+     * If damage would be dealt to Phantom Wurm, prevent that damage. Remove a +1/+1 counter from Phantom Wurm.
+     * 2/0
+     */
+    private static final String wurm = "Phantom Wurm";
+
+    @Test
+    public void test_DoubleBlocked() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerB, "Eager Cadet");
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Memnite", wurm);
+        block(1, playerB, "Eager Cadet", wurm);
+
+        setChoice(playerA, "X=1"); // damage assignment
+        setChoice(playerA, "X=3"); // damage assignment
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Memnite", 1);
+        assertGraveyardCount(playerB, "Eager Cadet", 1);
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 1);
+    }
+
+    @Test
+    public void test_BlockedByAnotherPhantom() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Phantom Nomad");
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Phantom Nomad", wurm);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 1);
+        assertDamageReceived(playerB, "Phantom Nomad", 0); // all is prevented
+        assertCounterCount("Phantom Nomad", CounterType.P1P1, 2 - 1);
+    }
+
+    @Test
+    public void test_BlockedByAnotherPhantom_ThenBolt() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Phantom Nomad");
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain");
+        addCard(Zone.HAND, playerB, "Lightning Bolt");
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Phantom Nomad", wurm);
+
+        castSpell(1, PhaseStep.COMBAT_DAMAGE, playerB, "Lightning Bolt", wurm);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 2);
+        assertDamageReceived(playerB, "Phantom Nomad", 0); // all is prevented
+        assertCounterCount("Phantom Nomad", CounterType.P1P1, 2 - 1);
+    }
+
+    @Test
+    public void test_DoubleStrike() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Adorned Pouncer"); // 1/1 double strike
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Adorned Pouncer", wurm);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Adorned Pouncer", 1);
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 2);
+    }
+
+    @Test
+    public void test_DoubleBlocked_OneFirstStrikeOneNormal() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerB, "Goblin Striker", 1); // 1/1 first strike haste
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Memnite", wurm);
+        block(1, playerB, "Goblin Striker", wurm);
+
+        setChoice(playerA, "X=1"); // damage assignment
+        setChoice(playerA, "X=3"); // damage assignment
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Memnite", 1);
+        assertGraveyardCount(playerB, "Goblin Striker", 1);
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 2);
+    }
+
+    @Test
+    public void test_DoubleBlocked_TwoFirstStrike() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Boros Recruit"); // 1/1 first strike
+        addCard(Zone.BATTLEFIELD, playerB, "Goblin Striker", 1); // 1/1 first strike haste
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Boros Recruit", wurm);
+        block(1, playerB, "Goblin Striker", wurm);
+
+        setChoice(playerA, "X=1"); // damage assignment
+        setChoice(playerA, "X=3"); // damage assignment
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Boros Recruit", 1);
+        assertGraveyardCount(playerB, "Goblin Striker", 1);
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 1);
+    }
+
+    @Test
+    public void test_Blocked_ThenBolt() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain");
+        addCard(Zone.HAND, playerB, "Lightning Bolt");
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Memnite", wurm);
+
+        castSpell(1, PhaseStep.COMBAT_DAMAGE, playerB, "Lightning Bolt", wurm);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Memnite", 1);
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 2);
+    }
+
+    @Test
+    public void test_Blocked_FirstStrike_ThenBolt() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Boros Recruit");
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain");
+        addCard(Zone.HAND, playerB, "Lightning Bolt");
+
+        attack(1, playerA, wurm, playerB);
+        block(1, playerB, "Boros Recruit", wurm);
+
+        castSpell(1, PhaseStep.FIRST_COMBAT_DAMAGE, playerB, "Lightning Bolt", wurm);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Boros Recruit", 1);
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 2);
+    }
+
+    @Test
+    public void test_Simultanous_NonCombat() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerA, "Boros Recruit");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+        addCard(Zone.HAND, playerA, "Band Together"); // Up to two target creatures you control each deal damage equal to their power to another target creature.
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Band Together");
+        addTarget(playerA, "Memnite^Boros Recruit");
+        addTarget(playerA, wurm);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 1);
+    }
+
+    @Test
+    public void test_Bolt_ThenBolt() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, wurm);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 2);
+        addCard(Zone.HAND, playerB, "Lightning Bolt", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Lightning Bolt", wurm);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Lightning Bolt", wurm);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertDamageReceived(playerA, wurm, 0); // all is prevented
+        assertCounterCount(wurm, CounterType.P1P1, 4 - 2);
+    }
+}

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -818,6 +818,16 @@ public class GameState implements Serializable, Copyable<GameState> {
         return !simultaneousEvents.isEmpty();
     }
 
+    // There might be no damage dealt, but we want to fire that damage (in a batch) could have been dealt.
+    public void addBatchDamageCouldHaveBeenFired(boolean combat, Game game) {
+        for (GameEvent event : simultaneousEvents) {
+            if (event instanceof DamagedBatchCouldHaveFiredEvent && event.getFlag() == combat) {
+                return;
+            }
+        }
+        addSimultaneousEvent(new DamagedBatchCouldHaveFiredEvent(combat), game);
+    }
+
     public void addSimultaneousDamage(DamagedEvent damagedEvent, Game game) {
         // Combine multiple damage events in the single event (batch)
         // Note: one event can be stored in multiple batches

--- a/Mage/src/main/java/mage/game/events/DamagedBatchCouldHaveFiredEvent.java
+++ b/Mage/src/main/java/mage/game/events/DamagedBatchCouldHaveFiredEvent.java
@@ -1,0 +1,15 @@
+package mage.game.events;
+
+/**
+ * Does not contain any info on damage events, and can fire even when all damage is prevented.
+ * Fire any time a DAMAGED_BATCH_FOR_ALL could have fired (combat & noncombat).
+ * It is not a batch event (doesn't contain sub events), the name is a little ambiguous.
+ *
+ * @author Susucr
+ */
+public class DamagedBatchCouldHaveFiredEvent extends DamagedEvent {
+
+    public DamagedBatchCouldHaveFiredEvent(boolean combat) {
+        super(EventType.DAMAGED_BATCH_COULD_HAVE_FIRED, null, null, null, 0, combat);
+    }
+}

--- a/Mage/src/main/java/mage/game/events/DamagedBatchCouldHaveFiredEvent.java
+++ b/Mage/src/main/java/mage/game/events/DamagedBatchCouldHaveFiredEvent.java
@@ -7,7 +7,7 @@ package mage.game.events;
  *
  * @author Susucr
  */
-public class DamagedBatchCouldHaveFiredEvent extends DamagedEvent {
+public class DamagedBatchCouldHaveFiredEvent extends GameEvent {
 
     public DamagedBatchCouldHaveFiredEvent(boolean combat) {
         super(EventType.DAMAGED_BATCH_COULD_HAVE_FIRED, null, null, null, 0, combat);

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -129,6 +129,12 @@ public class GameEvent implements Serializable {
         includes all damage events, both permanent damage and player damage, in single batch event
          */
         DAMAGED_BATCH_FOR_ALL,
+        /* DAMAGED_BATCH_FIRED
+         * Does not contain any info on damage events, and can fire even when all damage is prevented.
+         * Fire any time a DAMAGED_BATCH_FOR_ALL could have fired (combat & noncombat).
+         * It is not a batch event (doesn't contain sub events), the name is a little ambiguous.
+         */
+        DAMAGED_BATCH_COULD_HAVE_FIRED,
 
         /* DAMAGE_CAUSES_LIFE_LOSS,
          targetId    the id of the damaged player

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -1024,6 +1024,9 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         }
         DamageEvent event = new DamagePermanentEvent(objectId, attackerId, controllerId, damageAmount, preventable, combat);
         event.setAppliedEffects(appliedEffects);
+        // Even if no damage was dealt, some watchers would need a reset next time actions are processed.
+        // For instance PhantomPreventionWatcher used by the [[Phantom Wurm]] type of replacement effect.
+        game.getState().addBatchDamageCouldHaveBeenFired(combat, game);
         if (game.replaceEvent(event)) {
             return 0;
         }

--- a/Mage/src/main/java/mage/game/turn/CombatDamageStep.java
+++ b/Mage/src/main/java/mage/game/turn/CombatDamageStep.java
@@ -1,12 +1,12 @@
 package mage.game.turn;
 
-import java.util.UUID;
-
 import mage.constants.PhaseStep;
 import mage.game.Game;
 import mage.game.combat.CombatGroup;
 import mage.game.events.GameEvent;
 import mage.game.events.GameEvent.EventType;
+
+import java.util.UUID;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -65,6 +65,9 @@ public class CombatDamageStep extends Step {
         for (CombatGroup group : game.getCombat().getBlockingGroups()) {
             group.applyDamage(game);
         }
+
+        // Even if no damage was dealt, some watchers need a reset. For instance PhantomPreventionWatcher.
+        game.getState().addBatchDamageCouldHaveBeenFired(true, game);
         // Must fire damage batch events now, before SBA (https://github.com/magefree/mage/issues/9129)
         game.getState().handleSimultaneousEvent(game);
     }


### PR DESCRIPTION
Fix #12179

I think I covered a lot of the different situations with the added tests.
As talked about in #12179, there was the need for the new event, as when all damage is replaced, there is no Batch Damaged event fired.