### PR TITLE
Fix AnnieJoinsUp.java

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AnnieJoinsUp.java
+++ b/Mage.Sets/src/mage/cards/a/AnnieJoinsUp.java
@@ -85,7 +85,8 @@ class AnnieJoinsUpEffect extends ReplacementEffectImpl {
         Permanent permanent = game.getPermanent(((NumberOfTriggersEvent) event).getSourceId());
         return permanent != null
                 && permanent.isControlledBy(source.getControllerId())
-                && permanent.isLegendary(game);
+                && permanent.isLegendary(game)
+                && permanent.isCreature(game);
     }
 
     @Override


### PR DESCRIPTION
AnnieJoinsUpEffect was missing check to see if legendary permanent is a creature, causing the ability to trigger for all legendary permanents (including itself).

fix #12198