### PR TITLE
Make sure control gain is processed before untapping for 4 cards

### DIFF
--- a/Mage.Sets/src/mage/cards/b/Besmirch.java
+++ b/Mage.Sets/src/mage/cards/b/Besmirch.java
@@ -1,7 +1,5 @@
 package mage.cards.b;
 
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.UntapTargetEffect;
 import mage.abilities.effects.common.combat.GoadTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
@@ -11,11 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.game.Game;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetpointer.FixedTarget;
-import mage.target.targetpointer.TargetPointer;
 
 import java.util.UUID;
 
@@ -28,7 +22,14 @@ public final class Besmirch extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{R}{R}");
 
         // Until end of turn, gain control of target creature and it gains haste. Untap and goad that creature.
-        this.getSpellAbility().addEffect(new BesmirchEffect());
+        this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfTurn)
+                .setText("Until end of turn, gain control of target creature"));
+        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn)
+                .setText("and it gains haste"));
+        this.getSpellAbility().addEffect(new UntapTargetEffect().setText("Untap"));
+        this.getSpellAbility().addEffect(new GoadTargetEffect()
+                .setText("and goad that creature. <i>(Until your next turn, that creature " +
+                        "attacks each combat if able and attacks a player other than you if able.)</i>"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
@@ -39,47 +40,5 @@ public final class Besmirch extends CardImpl {
     @Override
     public Besmirch copy() {
         return new Besmirch(this);
-    }
-}
-
-class BesmirchEffect extends OneShotEffect {
-
-    BesmirchEffect() {
-        super(Outcome.GainControl);
-        staticText = "Until end of turn, gain control of target creature and it gains haste. Untap and goad that creature";
-    }
-
-    private BesmirchEffect(final BesmirchEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public BesmirchEffect copy() {
-        return new BesmirchEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        if (game.getPermanent(source.getFirstTarget()) != null) {
-            TargetPointer blueprintTarget = new FixedTarget(source.getFirstTarget(), game);
-
-            // gain control
-            game.addEffect(new GainControlTargetEffect(Duration.EndOfTurn)
-                    .setTargetPointer(blueprintTarget.copy()), source);
-
-            // haste
-            game.addEffect(new GainAbilityTargetEffect(
-                    HasteAbility.getInstance(), Duration.EndOfTurn
-            ).setTargetPointer(blueprintTarget.copy()), source);
-
-            // goad
-            game.addEffect(new GoadTargetEffect().setTargetPointer(blueprintTarget.copy()), source);
-
-            // untap
-            new UntapTargetEffect().setTargetPointer(blueprintTarget.copy()).apply(game, source);
-
-            return true;
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BondOfPassion.java
+++ b/Mage.Sets/src/mage/cards/b/BondOfPassion.java
@@ -87,6 +87,7 @@ class BondOfPassionEffect extends OneShotEffect {
             ContinuousEffect effect = new GainControlTargetEffect(Duration.EndOfTurn);
             effect.setTargetPointer(new FixedTarget(permanent, game));
             game.addEffect(effect, source);
+            game.getState().processAction(game);
             permanent.untap(game);
             effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
             effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/h/HammerHelper.java
+++ b/Mage.Sets/src/mage/cards/h/HammerHelper.java
@@ -65,6 +65,7 @@ class HammerHelperEffect extends OneShotEffect {
         if (controller != null && targetCreature != null) {
             source.getEffects().get(0).setTargetPointer(new FixedTarget(targetCreature.getId(), game));
             game.addEffect(new GainControlTargetEffect(Duration.EndOfTurn), source);
+            game.getState().processAction(game);
             targetCreature.untap(game);
             int amount = controller.rollDice(outcome, source, game, 6);
             game.addEffect(new BoostTargetEffect(amount, 0, Duration.EndOfTurn), source);

--- a/Mage.Sets/src/mage/cards/u/UnwillingRecruit.java
+++ b/Mage.Sets/src/mage/cards/u/UnwillingRecruit.java
@@ -1,8 +1,9 @@
 package mage.cards.u;
 
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.dynamicvalue.common.ManacostVariableValue;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.common.UntapTargetEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.effects.common.continuous.GainControlTargetEffect;
@@ -11,11 +12,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Outcome;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetpointer.FixedTarget;
 
 /**
  *
@@ -27,7 +24,12 @@ public final class UnwillingRecruit extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{R}{R}{R}");
 
         // Gain control of target creature until end of turn. Untap that creature. It gets +X/+0 and gains haste until end of turn.
-        this.getSpellAbility().addEffect(new UnwillingRecruitEffect());
+        this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new UntapTargetEffect().setText("Untap that creature"));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(ManacostVariableValue.REGULAR, StaticValue.get(0), Duration.EndOfTurn)
+                .setText("It gets +X/+0"));
+        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn)
+                .setText("and gains haste until end of turn."));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
 
     }
@@ -39,36 +41,5 @@ public final class UnwillingRecruit extends CardImpl {
     @Override
     public UnwillingRecruit copy() {
         return new UnwillingRecruit(this);
-    }
-}
-
-class UnwillingRecruitEffect extends OneShotEffect {
-
-    UnwillingRecruitEffect() {
-        super(Outcome.Benefit);
-        staticText = "Gain control of target creature until end of turn. Untap that creature. It gets +X/+0 and gains haste until end of turn";
-    }
-
-    private UnwillingRecruitEffect(final UnwillingRecruitEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public UnwillingRecruitEffect copy() {
-        return new UnwillingRecruitEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent targetCreature = game.getPermanent(source.getFirstTarget());
-        if (targetCreature != null) {
-            source.getEffects().get(0).setTargetPointer(new FixedTarget(targetCreature.getId(), game));
-            game.addEffect(new GainControlTargetEffect(Duration.EndOfTurn), source);
-            targetCreature.untap(game);
-            game.addEffect(new BoostTargetEffect(source.getManaCostsToPay().getX(), 0, Duration.EndOfTurn), source);
-            game.addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn), source);
-            return true;
-        }
-        return false;
     }
 }


### PR DESCRIPTION
After the review of #12249, I took a look at the code I had based mine on, and discovered that several cards had the same issue mentioned [here](https://github.com/magefree/mage/pull/12249#discussion_r1603723236). Two of those cards seemed like good candidates for quick refactors to use common effects; for the other two, I simply added the missing line where necessary.

- Besmirch (also added the reminder text)
- Bond of Passion
- Hammer Helper
- Unwilling Recruit