### PR TITLE
Attempt at a Download Basic Lands option

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
@@ -48,6 +48,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
     private static final String ALL_MODERN_IMAGES = "- MODERN images (can be slow)";
     private static final String ALL_STANDARD_IMAGES = "- STANDARD images";
     private static final String ALL_TOKENS = "- TOKEN images";
+    private static final String ALL_BASICS = "- BASIC LAND images";
 
     private static final int MAX_ERRORS_COUNT_BEFORE_CANCEL = 50;
 
@@ -303,6 +304,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
             setNames.add(ALL_IMAGES);
             setNames.add(ALL_MODERN_IMAGES);
             setNames.add(ALL_STANDARD_IMAGES);
+            setNames.add(ALL_BASICS);
         }
         if (selectedSource.isTokenSource()) {
             setNames.add(ALL_TOKENS);
@@ -328,6 +330,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
         // find selected sets
         selectedSets.clear();
         boolean onlyTokens = false;
+		boolean onlyBasics = false;
         List<String> formatSets;
         List<String> sourceSets = selectedSource.getSupportedSets();
         switch (selectedItem) {
@@ -350,6 +353,11 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
                         .forEachOrdered(selectedSets::add);
                 break;
 
+            case ALL_BASICS:
+                selectedSets.addAll(selectedSource.getSupportedSets());
+                onlyBasics = true;
+                break;
+
             case ALL_TOKENS:
                 selectedSets.addAll(selectedSource.getSupportedSets());
                 onlyTokens = true;
@@ -370,7 +378,8 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
         int numberCardImagesAvailable = 0;
         for (CardDownloadData data : cardsMissing) {
             if (data.isToken()) {
-                if (selectedSource.isTokenSource()
+                if (!onlyBasics
+                        && selectedSource.isTokenSource()
                         && selectedSource.isTokenImageProvided(data.getSet(), data.getName(), data.getImageNumber())
                         && selectedSets.contains(data.getSet())) {
                     numberTokenImagesAvailable++;
@@ -381,8 +390,12 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
                         && selectedSource.isCardSource()
                         && selectedSource.isCardImageProvided(data.getSet(), data.getName())
                         && selectedSets.contains(data.getSet())) {
-                    numberCardImagesAvailable++;
-                    cardsDownloadQueue.add(data);
+					static final List<String> basicList = Arrays.asList("Plains", "Island", "Swamp", "Mountain", "Forest");
+					if (!onlyBasics
+							|| basicList.contains(data.getName())) { 
+						numberCardImagesAvailable++;
+						cardsDownloadQueue.add(data);
+					}
                 }
             }
         }

--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
@@ -50,6 +50,8 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
     private static final String ALL_TOKENS = "- TOKEN images";
     private static final String ALL_BASICS = "- BASIC LAND images";
 
+    private static final List<String> basicList = Arrays.asList("Plains", "Island", "Swamp", "Mountain", "Forest");
+
     private static final int MAX_ERRORS_COUNT_BEFORE_CANCEL = 50;
 
     private static final int MIN_FILE_SIZE_OF_GOOD_IMAGE = 1024 * 10; // protect from wrong data save
@@ -330,7 +332,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
         // find selected sets
         selectedSets.clear();
         boolean onlyTokens = false;
-		boolean onlyBasics = false;
+        boolean onlyBasics = false;
         List<String> formatSets;
         List<String> sourceSets = selectedSource.getSupportedSets();
         switch (selectedItem) {
@@ -390,12 +392,11 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
                         && selectedSource.isCardSource()
                         && selectedSource.isCardImageProvided(data.getSet(), data.getName())
                         && selectedSets.contains(data.getSet())) {
-					static final List<String> basicList = Arrays.asList("Plains", "Island", "Swamp", "Mountain", "Forest");
-					if (!onlyBasics
-							|| basicList.contains(data.getName())) { 
-						numberCardImagesAvailable++;
-						cardsDownloadQueue.add(data);
-					}
+                    if (!onlyBasics
+                            || basicList.contains(data.getName())) { 
+                        numberCardImagesAvailable++;
+                        cardsDownloadQueue.add(data);
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://github.com/magefree/mage/issues/12272

Possible improvement - filter sets to only those that include basic lands.

I also only put in the five main basics. I wasn't sure whether to include the Snow-Covered Basics so left them out (primarily because they cannot be freely added to limited decks, but could see an argument to include them because they can be added to constructed decks.)

Wastes was deliberately excluded because it cannot be freely added to decks.