### PR TITLE
[MH3] Implement Path of Annihilation

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PathOfAnnihilation.java
+++ b/Mage.Sets/src/mage/cards/p/PathOfAnnihilation.java
@@ -1,0 +1,59 @@
+package mage.cards.p;
+
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.keyword.DevoidAbility;
+import mage.abilities.mana.AnyColorManaAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.common.FilterCreatureSpell;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.permanent.token.EldraziSpawnToken;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class PathOfAnnihilation extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent(SubType.ELDRAZI, "Eldrazi");
+    private static final FilterCreatureSpell filter2 = new FilterCreatureSpell("a creature spell with mana value 7 or greater");
+
+    static {
+        filter2.add(new ManaValuePredicate(ComparisonType.MORE_THAN, 7));
+    }
+
+    public PathOfAnnihilation(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{G}");
+
+        // Devoid
+        this.addAbility(new DevoidAbility(this.color));
+
+        // When Path of Annihilation enters the battlefield, create two 0/1 colorless Eldrazi Spawn creature tokens with "Sacrifice this creature: Add {C}."
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new EldraziSpawnToken(), 2)));
+
+        // Eldrazi you control have "{T}: Add one mana of any color."
+        this.addAbility(new SimpleStaticAbility(new GainAbilityControlledEffect(
+                new AnyColorManaAbility(), Duration.WhileOnBattlefield, filter
+        )));
+
+        // Whenever you cast a creature spell with mana value 7 or greater, you gain 4 life.
+        this.addAbility(new SpellCastControllerTriggeredAbility(new GainLifeEffect(4), filter2, false));
+    }
+
+    private PathOfAnnihilation(final PathOfAnnihilation card) {
+        super(card);
+    }
+
+    @Override
+    public PathOfAnnihilation copy() {
+        return new PathOfAnnihilation(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/p/PathOfAnnihilation.java
+++ b/Mage.Sets/src/mage/cards/p/PathOfAnnihilation.java
@@ -27,7 +27,7 @@ public final class PathOfAnnihilation extends CardImpl {
     private static final FilterCreatureSpell filter2 = new FilterCreatureSpell("a creature spell with mana value 7 or greater");
 
     static {
-        filter2.add(new ManaValuePredicate(ComparisonType.MORE_THAN, 7));
+        filter2.add(new ManaValuePredicate(ComparisonType.OR_GREATER, 7));
     }
 
     public PathOfAnnihilation(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Sets/src/mage/sets/ModernHorizons3.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizons3.java
@@ -69,6 +69,7 @@ public final class ModernHorizons3 extends ExpansionSet {
         cards.add(new SetCardInfo("Nulldrifter", 13, Rarity.RARE, mage.cards.n.Nulldrifter.class));
         cards.add(new SetCardInfo("Ophiomancer", 276, Rarity.RARE, mage.cards.o.Ophiomancer.class));
         cards.add(new SetCardInfo("Orim's Chant", 265, Rarity.RARE, mage.cards.o.OrimsChant.class));
+        cards.add(new SetCardInfo("Path of Annihilation", 165, Rarity.UNCOMMON, mage.cards.p.PathOfAnnihilation.class));
         cards.add(new SetCardInfo("Pearl Medallion", 294, Rarity.RARE, mage.cards.p.PearlMedallion.class));
         cards.add(new SetCardInfo("Petrifying Meddler", 66, Rarity.COMMON, mage.cards.p.PetrifyingMeddler.class));
         cards.add(new SetCardInfo("Phelia, Exuberant Shepherd", 40, Rarity.RARE, mage.cards.p.PheliaExuberantShepherd.class));


### PR DESCRIPTION
Very simple card, wouldn't have opened this as a PR however I noticed a text discrepancy. When creating 0/1 Eldrazi Spawn creature tokens, [old cards](https://scryfall.com/search?q=o%3A%22eldrazi+spawn+creature+token%22+%28o%3A%22it+has%22+or+o%3A%22they+have%22%29&unique=cards&as=grid&order=name) say:
> Create a 0/1 colorless Eldrazi Spawn creature token. **It has** "Sacrifice this creature: Add {C}."

However [modern cards](https://scryfall.com/search?q=o%3A%22eldrazi+spawn+creature+token%22+o%3A%27with+%22%27&unique=cards&as=grid&order=name) say:
> Create a 0/1 colorless Eldrazi Spawn creature token **with** “Sacrifice this creature: Add {C}.”

Currently the new cards use the old wording. Are we OK with that or do we want the modern wording? Updating the description in the token class will cause old cards to use the modern wording (which doesn't sound too bad really). However, if we want the old cards to continue to use the old wording and the modern cards to use the modern wording, we currently need to use `.setText` in each of their implementations, and will presumably need to do so for all future cards creating these tokens, which doesn't sound great.

Alternatively, we could modernise the description of the Spawn token, and use `.setText` on all of the old card implementations.