### PR TITLE
Fixes Force Drain card type

### DIFF
--- a/Mage.Sets/src/mage/cards/f/ForceDrain.java
+++ b/Mage.Sets/src/mage/cards/f/ForceDrain.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 public final class ForceDrain extends CardImpl {
 
     public ForceDrain(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{B}");
 
         // ForceDrain deals 2 damage to any target. If player was dealt damage this way, you gain 2 life.
         this.getSpellAbility().addTarget(new TargetAnyTarget());


### PR DESCRIPTION
Force Drain was implemented as a Sorcery spell, but the card image shows that it is an Instant spell. 
[Force Drain](https://i.imgur.com/prHdDXa.jpeg)