### PR TITLE
fix Molten Disaster

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ScourgeOfTheSkyclaves.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfTheSkyclaves.java
@@ -3,7 +3,7 @@ package mage.cards.s;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.condition.Condition;
+import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
@@ -37,7 +37,7 @@ public final class ScourgeOfTheSkyclaves extends CardImpl {
 
         // When you cast this spell, if it was kicked, each player loses half their life, rounded up.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new CastSourceTriggeredAbility(new ScourgeOfTheSkyclavesEffect()), ScourgeOfTheSkyclavesCondition.instance,
+                new CastSourceTriggeredAbility(new ScourgeOfTheSkyclavesEffect()), KickedCondition.ONCE,
                 "When you cast this spell, if it was kicked, each player loses half their life, rounded up."
         ));
 
@@ -55,15 +55,6 @@ public final class ScourgeOfTheSkyclaves extends CardImpl {
     @Override
     public ScourgeOfTheSkyclaves copy() {
         return new ScourgeOfTheSkyclaves(this);
-    }
-}
-
-enum ScourgeOfTheSkyclavesCondition implements Condition {
-    instance;
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return KickerAbility.getSpellKickedCount(game, source.getSourceId()) > 0;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/s/SowingMycospawn.java
+++ b/Mage.Sets/src/mage/cards/s/SowingMycospawn.java
@@ -2,7 +2,7 @@ package mage.cards.s;
 
 import mage.MageInt;
 import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
+import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.CastSourceTriggeredAbility;
 import mage.abilities.effects.common.ExileTargetEffect;
@@ -14,7 +14,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
-import mage.game.Game;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetLandPermanent;
 
@@ -47,7 +46,7 @@ public final class SowingMycospawn extends CardImpl {
         // When you cast this spell, if it was kicked, exile target land.
         Ability ability = new ConditionalInterveningIfTriggeredAbility(
                 new CastSourceTriggeredAbility(new ExileTargetEffect()),
-                SowingMycospawnCondition.instance, "When you cast this spell, " +
+                KickedCondition.ONCE, "When you cast this spell, " +
                 "if it was kicked, exile target land."
         );
         ability.addTarget(new TargetLandPermanent());
@@ -61,14 +60,5 @@ public final class SowingMycospawn extends CardImpl {
     @Override
     public SowingMycospawn copy() {
         return new SowingMycospawn(this);
-    }
-}
-
-enum SowingMycospawnCondition implements Condition {
-    instance;
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return KickerAbility.getSpellKickedCount(game, source.getSourceId()) > 0;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
@@ -13,7 +13,7 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class KickerTest extends CardTestPlayerBase {
 
-    /**
+    /*
      * 702.32. Kicker 702.32a Kicker is a static ability that functions while
      * the spell with kicker is on the stack. “Kicker [cost]” means “You may pay
      * an additional [cost] as you cast this spell.” Paying a spell's kicker
@@ -722,4 +722,49 @@ public class KickerTest extends CardTestPlayerBase {
 
         assertPermanentCount(playerA, "Brain in a Jar", 1);
     }
+
+    @Test
+    public void test_ConditionOnStackNotKicked() {
+        String scourge = "Scourge of the Skyclaves"; // 1B Creature
+        /* Kicker {4}{B}
+        When you cast this spell, if it was kicked, each player loses half their life, rounded up.
+        Scourge of the Skyclaves’s power and toughness are each equal to 20 minus the highest life total among players.
+         */
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+        addCard(Zone.HAND, playerA, scourge);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, scourge);
+        setChoice(playerA, false); // no kicker
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertGraveyardCount(playerA, scourge, 1);
+    }
+
+    @Test
+    public void test_ConditionOnStackKicked() {
+        String scourge = "Scourge of the Skyclaves"; // 1B Creature
+        /* Kicker {4}{B}
+        When you cast this spell, if it was kicked, each player loses half their life, rounded up.
+        Scourge of the Skyclaves’s power and toughness are each equal to 20 minus the highest life total among players.
+         */
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 7);
+        addCard(Zone.HAND, playerA, scourge);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, scourge);
+        setChoice(playerA, true); // kicked
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 10);
+        assertLife(playerB, 10);
+        assertPowerToughness(playerA, scourge, 10, 10);
+    }
+
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/SplitSecondTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/SplitSecondTest.java
@@ -59,4 +59,90 @@ public class SplitSecondTest extends CardTestPlayerBase {
         assertLife(playerB, 20 - 2 - 2);
         assertPermanentCount(playerA, "Raging Goblin", 1);
     }
+
+    private static final String molten = "Molten Disaster";
+    /* {X}{R}{R} Sorcery
+     Kicker {R}
+     If this spell was kicked, it has split second.
+     Molten Disaster deals X damage to each creature without flying and each player.
+     */
+    private static final String shock = "Shock";
+    private static final String crab = "Fortress Crab"; // 1/6
+    private static final String gnomes = "Bottle Gnomes"; // Sacrifice Bottle Gnomes: You gain 3 life.
+    private static final String bear = "Runeclaw Bear"; // 2/2
+    private static final String drake = "Seacoast Drake"; // 1/3 flying
+
+    public void setupMoltenDisaster() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 1);
+        addCard(Zone.HAND, playerA, molten);
+        addCard(Zone.HAND, playerB, shock);
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerA, gnomes);
+        addCard(Zone.BATTLEFIELD, playerB, bear);
+        addCard(Zone.BATTLEFIELD, playerB, drake);
+    }
+
+    @Test
+    public void testMoltenDisasterUnkicked() {
+        setupMoltenDisaster();
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, molten);
+        setChoice(playerA, false); // no kicker
+        setChoice(playerA, "X=1");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, shock, crab);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Sacrifice");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 20 - 1 + 3);
+        assertLife(playerB, 20 - 1);
+        assertDamageReceived(playerA, crab, 1 + 2);
+        assertGraveyardCount(playerA, gnomes, 1);
+        assertDamageReceived(playerB, bear, 1);
+        assertDamageReceived(playerB, drake, 0);
+    }
+
+    @Test
+    public void testMoltenDisasterKickedNoSpell() {
+        setupMoltenDisaster();
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, molten);
+        setChoice(playerA, true); // no kicker
+        setChoice(playerA, "X=1");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, shock, crab);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+
+        try {
+            execute();
+            throw new AssertionError("expected failure to cast Shock");
+        } catch (AssertionError e) {
+            Assert.assertTrue(e.getMessage().contains("Can't find ability to activate command: Cast Shock$target=Fortress Crab"));
+        }
+
+
+    }
+
+    @Test
+    public void testMoltenDisasterKickedNoAbility() {
+        setupMoltenDisaster();
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, molten);
+        setChoice(playerA, true); // no kicker
+        setChoice(playerA, "X=1");
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Sacrifice");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+
+        try {
+            execute();
+            throw new AssertionError("expected failure to activate sacrifice ability");
+        } catch (AssertionError e) {
+            Assert.assertTrue(e.getMessage().contains("Can't find ability to activate command: Sacrifice"));
+        }
+
+    }
+
 }

--- a/Mage/src/main/java/mage/abilities/condition/common/KickedCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/KickedCondition.java
@@ -24,7 +24,8 @@ public enum KickedCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return KickerAbility.getKickedCounter(game, source) >= kickedCount;
+        return KickerAbility.getKickedCounter(game, source) >= kickedCount // for on battlefield
+                || KickerAbility.getSpellKickedCount(game, source.getSourceId()) >= kickedCount; // for on stack
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/keyword/KickerAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/KickerAbility.java
@@ -105,9 +105,7 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
 
     private void addKickerCostAndSetup(OptionalAdditionalCost newCost) {
         this.kickerCosts.add(newCost);
-        this.kickerCosts.forEach(cost -> {
-            cost.setCostType(VariableCostType.ADDITIONAL);
-        });
+        this.kickerCosts.forEach(cost -> cost.setCostType(VariableCostType.ADDITIONAL));
     }
 
     private void resetKicker() {
@@ -124,10 +122,7 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
      * Return total kicker activations with the specified Cost (blank for all kickers/multikickers)
      * Checks the start of the tags, to work for that blank method, which requires direct access
      *
-     * @param game
-     * @param source
      * @param needKickerCost use cost.getText(true)
-     * @return
      */
     public static int getKickedCounterStrict(Game game, Ability source, String needKickerCost) {
         Map<String, Object> costsTags = CardUtil.getSourceCostsTagsMap(game, source);
@@ -148,10 +143,6 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
 
     /**
      * Return total kicker activations (kicker + multikicker)
-     *
-     * @param game
-     * @param source
-     * @return
      */
     public static int getKickedCounter(Game game, Ability source) {
         return getKickedCounterStrict(game, source, "");
@@ -159,10 +150,6 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
 
     /**
      * If spell was kicked
-     *
-     * @param game
-     * @param source
-     * @return
      */
     public boolean isKicked(Game game, Ability source) {
         return isKicked(game, source, "");
@@ -171,10 +158,7 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
     /**
      * If spell was kicked by specific kicker cost
      *
-     * @param game
-     * @param source
      * @param needKickerCost use cost.getText(true)
-     * @return
      */
     public boolean isKicked(Game game, Ability source, String needKickerCost) {
         return getKickedCounterStrict(game, source, needKickerCost) > 0;
@@ -287,10 +271,6 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
 
     /**
      * Find spell's kicked stats. Must be used on stack only, e.g. for SPELL_CAST events
-     *
-     * @param game
-     * @param spellId
-     * @return
      */
     public static int getSpellKickedCount(Game game, UUID spellId) {
         Spell spell = game.getSpellOrLKIStack(spellId);

--- a/Mage/src/main/java/mage/abilities/keyword/SplitSecondAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SplitSecondAbility.java
@@ -2,6 +2,8 @@ package mage.abilities.keyword;
 
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.decorator.ConditionalContinuousRuleModifyingEffect;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.constants.Duration;
 import mage.constants.Outcome;
@@ -37,9 +39,13 @@ public class SplitSecondAbility extends SimpleStaticAbility {
     public SplitSecondAbility copy() {
         return new SplitSecondAbility(this);
     }
-}
 
-// Molten Disaster has a copy of this effect in it's class, so in case this effect has to be changed check also there
+    // For abilities that need the effect conditionally. Must set text manually.
+    public static ConditionalContinuousRuleModifyingEffect getSplitSecondEffectWithCondition(Condition condition) {
+        return new ConditionalContinuousRuleModifyingEffect(new SplitSecondEffect(), condition);
+    }
+
+}
 
 class SplitSecondEffect extends ContinuousRuleModifyingEffectImpl {
 


### PR DESCRIPTION
Updated for a proper fix instead of a quick fix:

1. Expands `KickedCondition` to cover usage on stack, removing the need for custom conditions in [[Scourge of the Skyclaves]] and [[Sowing Mycospawn]]. Adds test for that use case.
2. Reworks MoltenDisaster to not duplicate code from SplitSecondEffect but use a helper method to add a condition. Adds test for both kicked and unkicked cases.

fix #12290 
