### PR TITLE
Stack land creatue token fix

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -141,7 +141,7 @@ public class CardPluginImpl implements CardPlugin {
             MagePermanent perm = (MagePermanent) card.getMainPanel(); // all cards must be MagePermanent on battlefield
 
             if (!rowType.isType(perm) || perm.getOriginalPermanent().isAttachedToPermanent()
-                    || (perm.isCreature() && rowType.equals(RowType.land))) {
+                    || (perm.isCreature() && !rowType.equals(RowType.creature))) {
                 continue;
             }
 

--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -141,7 +141,7 @@ public class CardPluginImpl implements CardPlugin {
             MagePermanent perm = (MagePermanent) card.getMainPanel(); // all cards must be MagePermanent on battlefield
 
             if (!rowType.isType(perm) || perm.getOriginalPermanent().isAttachedToPermanent()
-                    || (perm.isLand() && rowType.equals(RowType.creature))) {
+                    || (perm.isCreature() && rowType.equals(RowType.land))) {
                 continue;
             }
 

--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -140,7 +140,8 @@ public class CardPluginImpl implements CardPlugin {
         for (MageCard card : cards.values()) {
             MagePermanent perm = (MagePermanent) card.getMainPanel(); // all cards must be MagePermanent on battlefield
 
-            if (!rowType.isType(perm) || perm.getOriginalPermanent().isAttachedToPermanent()) {
+            if (!rowType.isType(perm) || perm.getOriginalPermanent().isAttachedToPermanent()
+                    || (perm.isLand() && rowType.equals(RowType.creature))) {
                 continue;
             }
 


### PR DESCRIPTION
Tokens that get turned into creatures were creating gaps in the creature row when they were moved to another row.
Creatures will now always be drawn in the creature row.

Before:
![Screenshot 2024-05-28 114207](https://github.com/magefree/mage/assets/19590931/5886c370-e815-4d98-93ff-1df331505d25)

After:
![image](https://github.com/magefree/mage/assets/19590931/93339ae8-638f-4048-90b6-9abb8f65df18)
