### PR TITLE
fix short living lki bug for Chromatic Star

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/SerraParagonTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/SerraParagonTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- * @author TheElk801
+ * @author TheElk801, Susucr
  */
 public class SerraParagonTest extends CardTestPlayerBase {
 
@@ -92,5 +92,29 @@ public class SerraParagonTest extends CardTestPlayerBase {
                 Assert.fail("Should have had error about not being able to cast spell, but got:\n" + e.getMessage());
             }
         }
+    }
+
+    /**
+     * bug: Chromatic Star was not triggering the gained trigger.
+     */
+    @Test
+    public void testChromaticStar() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, paragon);
+        addCard(Zone.GRAVEYARD, playerA, "Chromatic Star");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Chromatic Star", true);
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {W}");
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, {T}, Sacrifice");
+        setChoice(playerA, "Red"); // mana added with Star
+        setChoice(playerA, "When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life."); // stack triggers
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, 1);
+        assertLife(playerA, 20 + 2);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/SerraParagonTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/SerraParagonTest.java
@@ -126,9 +126,6 @@ public class SerraParagonTest extends CardTestPlayerBase {
         Assert.assertEquals(message, expected, player.getCountersCount(CounterType.ENERGY));
     }
 
-    /**
-     * bug: short lived lki was not right for Aetherworks Marvel's trigger.
-     */
     @Test
     public void testAetherworksMarvel() {
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/SerraParagonTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dmu/SerraParagonTest.java
@@ -2,6 +2,8 @@ package org.mage.test.cards.single.dmu;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.counters.CounterType;
+import mage.players.Player;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -110,11 +112,48 @@ public class SerraParagonTest extends CardTestPlayerBase {
         activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, {T}, Sacrifice");
         setChoice(playerA, "Red"); // mana added with Star
         setChoice(playerA, "When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life."); // stack triggers
+        // Last trigger is: "When {this} is put into a graveyard from the battlefield, draw a card." from Chromatic Star
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertHandCount(playerA, 1);
+        assertLife(playerA, 20 + 2);
+        assertExileCount(playerA, "Chromatic Star", 1);
+    }
+
+    private static void checkEnergyCount(String message, Player player, int expected) {
+        Assert.assertEquals(message, expected, player.getCountersCount(CounterType.ENERGY));
+    }
+
+    /**
+     * bug: short lived lki was not right for Aetherworks Marvel's trigger.
+     */
+    @Test
+    public void testAetherworksMarvel() {
+        setStrictChooseMode(true);
+
+        // Whenever a permanent you control is put into a graveyard from the battlefield, you get {E}
+        addCard(Zone.BATTLEFIELD, playerA, "Aetherworks Marvel");
+        addCard(Zone.BATTLEFIELD, playerA, paragon);
+        addCard(Zone.GRAVEYARD, playerA, "Chromatic Star");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+        addCard(Zone.HAND, playerA, "Creeping Corrosion"); // Destroy all artifacts
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Chromatic Star", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Creeping Corrosion", true);
+        setChoice(playerA, "When this permanent is put into a graveyard from the battlefield, exile it and you gain 2 life."); // stack triggers
+        setChoice(playerA, "Whenever a permanent you control is put into a graveyard from the battlefield, you get {E}", 2); // stack triggers
+        // Last trigger is: "When {this} is put into a graveyard from the battlefield, draw a card." from Chromatic Star
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        runCode("energy counter is 2", 1, PhaseStep.PRECOMBAT_MAIN, playerA, (info, player, game) -> checkEnergyCount(info, player, 2));
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertHandCount(playerA, 1);
+        assertExileCount(playerA, "Chromatic Star", 1);
+        assertGraveyardCount(playerA, 2);
         assertLife(playerA, 20 + 2);
     }
 }

--- a/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromBattlefieldAllTriggeredAbility.java
@@ -1,6 +1,7 @@
 
 package mage.abilities.common;
 
+import mage.MageObject;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.constants.Zone;
@@ -64,10 +65,8 @@ public class PutIntoGraveFromBattlefieldAllTriggeredAbility extends TriggeredAbi
         return new PutIntoGraveFromBattlefieldAllTriggeredAbility(this);
     }
 
-    // Not sure if needed?
-    //
-    //@Override
-    //public boolean isInUseableZone(Game game, MageObject source, GameEvent event) {
-    //    return TriggeredAbilityImpl.isInUseableZoneDiesTrigger(this, event, game);
-    //}
+    @Override
+    public boolean isInUseableZone(Game game, MageObject source, GameEvent event) {
+        return TriggeredAbilityImpl.isInUseableZoneDiesTrigger(this, event, game);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromBattlefieldAllTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromBattlefieldAllTriggeredAbility.java
@@ -63,4 +63,11 @@ public class PutIntoGraveFromBattlefieldAllTriggeredAbility extends TriggeredAbi
     public PutIntoGraveFromBattlefieldAllTriggeredAbility copy() {
         return new PutIntoGraveFromBattlefieldAllTriggeredAbility(this);
     }
+
+    // Not sure if needed?
+    //
+    //@Override
+    //public boolean isInUseableZone(Game game, MageObject source, GameEvent event) {
+    //    return TriggeredAbilityImpl.isInUseableZoneDiesTrigger(this, event, game);
+    //}
 }

--- a/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromBattlefieldSourceTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/PutIntoGraveFromBattlefieldSourceTriggeredAbility.java
@@ -1,5 +1,6 @@
 package mage.abilities.common;
 
+import mage.MageObject;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.effects.Effect;
 import mage.constants.Zone;
@@ -54,5 +55,10 @@ public class PutIntoGraveFromBattlefieldSourceTriggeredAbility extends Triggered
         }
         this.getEffects().setValue("permanentWasCreature", permanent.isCreature(game));
         return true;
+    }
+
+    @Override
+    public boolean isInUseableZone(Game game, MageObject source, GameEvent event) {
+        return TriggeredAbilityImpl.isInUseableZoneDiesTrigger(this, event, game);
     }
 }


### PR DESCRIPTION
So the Chromatic Star's trigger was not using short living lki properly, and for some reason that prevented the trigger gained from Paragon to trigger.

Question: should some of the following Trigger also be set up with short living lki the same way?
![image](https://github.com/magefree/mage/assets/34709007/3afd4ccf-38c1-4cf3-8aeb-fdaecfdc876d)

fix #12330