### PR TITLE
Tests: fix choice on notTarget wrongly not checking Filter

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/BirthingRitualTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/BirthingRitualTest.java
@@ -3,7 +3,6 @@ package org.mage.test.cards.single.mh3;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -108,7 +107,6 @@ public class BirthingRitualTest extends CardTestPlayerBase {
         assertHandCount(playerA, "Centaur Courser", 1);
     }
 
-    @Ignore // TODO: something weird with unit test, will be fixed separately.
     @Test
     public void test_Trigger_Sacrifice_MVRestriction() {
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -4143,7 +4143,7 @@ public class TestPlayer implements Player {
                             continue;
                         }
                         if (hasObjectTargetNameOrAlias(card, targetName)) {
-                            if (target.isNotTarget() || target.canTarget(card.getId(), source, game)) {
+                            if (target.canTarget(getId(), card.getId(), source, game)) {
                                 target.add(card.getId(), game);
                                 targetFound = true;
                                 break;


### PR DESCRIPTION
Fix an issue with `setChoice` of non-target choices not validating that the choice matched the target's `Filter` (also was not using the one with a 4-argument `Filter::match`).

Of note, we don't have a way to check that is choice is invalid through the checkXXX methods. It would be nice to add at some point. The try/catch way is the current workaround.