### PR TITLE
GUI: Fix tokens stacking on non tokens

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -186,7 +186,8 @@ public class CardPluginImpl implements CardPlugin {
                         ? firstPanelPerm.getOriginal().getRules()
                         : new ArrayList<>();
                 // Check the names are equal and are creatures with the same summoning sickness
-                if (firstPanelPerm.getOriginal().isToken() && firstPanelPerm.getOriginal().getName().equals(perm.getOriginal().getName())
+                if (firstPanelPerm.getOriginal().isToken() == perm.getOriginal().isToken()
+                        && firstPanelPerm.getOriginal().getName().equals(perm.getOriginal().getName())
                         && stackPower == cardPower && stackToughness == cardToughness
                         && stackAbilities.equals(cardAbilities) && stackCounters.equals(cardCounters)
                         && (!perm.isCreature() || firstPanelPerm.getOriginalPermanent().hasSummoningSickness() == perm

--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -186,7 +186,7 @@ public class CardPluginImpl implements CardPlugin {
                         ? firstPanelPerm.getOriginal().getRules()
                         : new ArrayList<>();
                 // Check the names are equal and are creatures with the same summoning sickness
-                if (firstPanelPerm.getOriginal().getName().equals(perm.getOriginal().getName())
+                if (firstPanelPerm.getOriginal().isToken() && firstPanelPerm.getOriginal().getName().equals(perm.getOriginal().getName())
                         && stackPower == cardPower && stackToughness == cardToughness
                         && stackAbilities.equals(cardAbilities) && stackCounters.equals(cardCounters)
                         && (!perm.isCreature() || firstPanelPerm.getOriginalPermanent().hasSummoningSickness() == perm


### PR DESCRIPTION
Checks that the base permanent is a token before stacking on it. 

Fixes #12395

![image](https://github.com/magefree/mage/assets/19590931/378dbcdb-9fd8-405b-833b-1b784a20d58e)
