### PR TITLE
Implement [M3C] Hourglass of the Lost

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HourglassOfTheLost.java
+++ b/Mage.Sets/src/mage/cards/h/HourglassOfTheLost.java
@@ -48,7 +48,8 @@ public final class HourglassOfTheLost extends CardImpl {
         ability.addEffect(new AddCountersSourceEffect(CounterType.TIME.createInstance()));
         this.addAbility(ability);
         // {T}, Remove X time counters from Hourglass of the Lost and exile it: Return each nonland permanent card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.
-        Ability returnAbility = new ActivateAsSorceryActivatedAbility(new HourglassOfTheLostEffect(), new TapSourceCost());
+        Ability returnAbility = new ActivateAsSorceryActivatedAbility(new HourglassOfTheLostEffect(), null);
+        returnAbility.addCost(new TapSourceCost());
         returnAbility.addCost(new RemoveVariableCountersSourceCost(CounterType.TIME));
         returnAbility.addCost(new ExileSourceCost().setText("and exile it"));
         this.addAbility(returnAbility);

--- a/Mage.Sets/src/mage/cards/h/HourglassOfTheLost.java
+++ b/Mage.Sets/src/mage/cards/h/HourglassOfTheLost.java
@@ -3,16 +3,35 @@ package mage.cards.h;
 import java.util.UUID;
 
 import mage.abilities.Ability;
-import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.common.ActivateAsSorceryActivatedAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.*;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CountersSourceCount;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.mana.WhiteManaAbility;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.ComparisonType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.filter.FilterCard;
+import mage.filter.common.FilterCreatureCard;
+import mage.filter.common.FilterNonlandCard;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.target.Target;
+import mage.target.common.TargetCardInGraveyard;
+import mage.util.CardUtil;
 
 /**
  *
@@ -20,20 +39,19 @@ import mage.counters.CounterType;
  */
 public final class HourglassOfTheLost extends CardImpl {
 
-    private static final DynamicValue timeCounter = new CountersSourceCount(CounterType.TIME);
 
     public HourglassOfTheLost(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}{W}");
-        
 
         // {T}: Add {W}. Put a time counter on Hourglass of the Lost.
         Ability ability = new WhiteManaAbility();
         ability.addEffect(new AddCountersSourceEffect(CounterType.TIME.createInstance()));
-        ability.addCost(new TapSourceCost());
         this.addAbility(ability);
         // {T}, Remove X time counters from Hourglass of the Lost and exile it: Return each nonland permanent card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.
-        ability = new Return(timeCounter);
-        this.addAbility(new HourglassOfTheLostAbility());
+        Ability returnAbility = new ActivateAsSorceryActivatedAbility(new HourglassOfTheLostEffect(), new TapSourceCost());
+        returnAbility.addCost(new RemoveVariableCountersSourceCost(CounterType.TIME));
+        returnAbility.addCost(new ExileSourceCost().setText("and exile it"));
+        this.addAbility(returnAbility);
     }
 
     private HourglassOfTheLost(final HourglassOfTheLost card) {
@@ -43,5 +61,36 @@ public final class HourglassOfTheLost extends CardImpl {
     @Override
     public HourglassOfTheLost copy() {
         return new HourglassOfTheLost(this);
+    }
+}
+
+class HourglassOfTheLostEffect extends OneShotEffect {
+
+    HourglassOfTheLostEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Return each nonland permanent card with mana value X from your graveyard to the battlefield.";
+    }
+
+    private HourglassOfTheLostEffect(final HourglassOfTheLostEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public HourglassOfTheLostEffect copy() {
+        return new HourglassOfTheLostEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            FilterCard filter = new FilterNonlandCard();
+            int xValue = CardUtil.getSourceCostsTag(game, source, "X", 0);
+            game.informPlayers(xValue + " Time counters removed");
+            filter.add(new ManaValuePredicate(ComparisonType.EQUAL_TO, xValue));
+            return controller.moveCards(controller.getGraveyard().getCards(filter, game), Zone.BATTLEFIELD, source, game);
+        }
+        game.informPlayers("controller is null");
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HourglassOfTheLost.java
+++ b/Mage.Sets/src/mage/cards/h/HourglassOfTheLost.java
@@ -1,0 +1,47 @@
+package mage.cards.h;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.CountersSourceCount;
+import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.mana.WhiteManaAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.counters.CounterType;
+
+/**
+ *
+ * @author grimreap124
+ */
+public final class HourglassOfTheLost extends CardImpl {
+
+    private static final DynamicValue timeCounter = new CountersSourceCount(CounterType.TIME);
+
+    public HourglassOfTheLost(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}{W}");
+        
+
+        // {T}: Add {W}. Put a time counter on Hourglass of the Lost.
+        Ability ability = new WhiteManaAbility();
+        ability.addEffect(new AddCountersSourceEffect(CounterType.TIME.createInstance()));
+        ability.addCost(new TapSourceCost());
+        this.addAbility(ability);
+        // {T}, Remove X time counters from Hourglass of the Lost and exile it: Return each nonland permanent card with mana value X from your graveyard to the battlefield. Activate only as a sorcery.
+        ability = new Return(timeCounter);
+        this.addAbility(new HourglassOfTheLostAbility());
+    }
+
+    private HourglassOfTheLost(final HourglassOfTheLost card) {
+        super(card);
+    }
+
+    @Override
+    public HourglassOfTheLost copy() {
+        return new HourglassOfTheLost(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/ModernHorizons3Commander.java
+++ b/Mage.Sets/src/mage/sets/ModernHorizons3Commander.java
@@ -141,6 +141,7 @@ public final class ModernHorizons3Commander extends ExpansionSet {
         cards.add(new SetCardInfo("Hideous Taskmaster", 57, Rarity.RARE, mage.cards.h.HideousTaskmaster.class));
         cards.add(new SetCardInfo("Horizon of Progress", 78, Rarity.RARE, mage.cards.h.HorizonOfProgress.class));
         cards.add(new SetCardInfo("Hour of Promise", 232, Rarity.RARE, mage.cards.h.HourOfPromise.class));
+        cards.add(new SetCardInfo("Hourglass of the Lost", 40, Rarity.RARE, mage.cards.h.HourglassOfTheLost.class));
         cards.add(new SetCardInfo("Hydra Broodmaster", 233, Rarity.RARE, mage.cards.h.HydraBroodmaster.class));
         cards.add(new SetCardInfo("Hydroid Krasis", 266, Rarity.RARE, mage.cards.h.HydroidKrasis.class));
         cards.add(new SetCardInfo("Idol of Oblivion", 297, Rarity.UNCOMMON, mage.cards.i.IdolOfOblivion.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
@@ -22,21 +22,23 @@ public class HourglassOfTheLostTest extends CardTestPlayerBase {
         skipInitShuffling();
 
         addCard(Zone.BATTLEFIELD, playerA, hourglass);
-            addCard(Zone.GRAVEYARD, playerA, "Birds of Paradise"); // Tribal Enchantment
+        addCard(Zone.GRAVEYARD, playerA, "Birds of Paradise"); // Mana value 1
+        addCard(Zone.GRAVEYARD, playerA, "+2 Mace"); // Mana value 2
         
         activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {W}");
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
         assertCounterCount(playerA, hourglass, CounterType.TIME,1);
+        assertExileCount(playerA, 0);
+        assertGraveyardCount(playerA, 2);
 
-        showAvailableAbilities("Abilities: ", 3, PhaseStep.PRECOMBAT_MAIN, playerA);
-        setChoiceAmount(playerA, 1);
-        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Remove X");
+        setChoiceAmount(playerA, 1); // Remove 1 counter
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Remove X"); // Return all with mana value 1
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
 
         execute();
         assertExileCount(playerA, 1);
-        assertGraveyardCount(playerA, 0);
+        assertGraveyardCount(playerA, 1); // +2 Mace still in graveyard
         assertPermanentCount(playerA, "Birds of Paradise", 1);
 
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
@@ -4,7 +4,6 @@ import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import org.junit.Test;
-import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -15,7 +14,7 @@ public class HourglassOfTheLostTest extends CardTestPlayerBase {
     /**
      * {@link mage.cards.h.HourglassOfTheLost HourglassOfTheLost} {2}{U}
      */
-    private static final String hourglass = "Hourglass Of The Lost";
+    private static final String hourglass = "Hourglass of the Lost";
 
     @Test
     public void test_Simple() {
@@ -23,14 +22,18 @@ public class HourglassOfTheLostTest extends CardTestPlayerBase {
         skipInitShuffling();
 
         addCard(Zone.BATTLEFIELD, playerA, hourglass);
-        addCard(Zone.GRAVEYARD, playerA, "Birds of Paradise"); // Tribal Enchantment
-
+            addCard(Zone.GRAVEYARD, playerA, "Birds of Paradise"); // Tribal Enchantment
+        
         activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {W}");
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
         assertCounterCount(playerA, hourglass, CounterType.TIME,1);
-        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T},");
+
+        showAvailableAbilities("Abilities: ", 3, PhaseStep.PRECOMBAT_MAIN, playerA);
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Remove X");
+        setChoice(playerA, "X=1");
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+
         execute();
         assertExileCount(playerA, 1);
         assertGraveyardCount(playerA, 0);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
@@ -1,0 +1,40 @@
+package org.mage.test.cards.single.m3c;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.player.TestPlayer;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author Susucr
+ */
+public class HourglassOfTheLostTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.h.HourglassOfTheLost HourglassOfTheLost} {2}{U}
+     */
+    private static final String hourglass = "Hourglass Of The Lost";
+
+    @Test
+    public void test_Simple() {
+        setStrictChooseMode(true);
+        skipInitShuffling();
+
+        addCard(Zone.BATTLEFIELD, playerA, hourglass);
+        addCard(Zone.GRAVEYARD, playerA, "Birds of Paradise"); // Tribal Enchantment
+
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {W}");
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertCounterCount(playerA, hourglass, CounterType.TIME,1);
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T},");
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+        assertExileCount(playerA, 1);
+        assertGraveyardCount(playerA, 0);
+        assertPermanentCount(playerA, "Birds of Paradise", 1);
+
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
@@ -30,8 +30,8 @@ public class HourglassOfTheLostTest extends CardTestPlayerBase {
         assertCounterCount(playerA, hourglass, CounterType.TIME,1);
 
         showAvailableAbilities("Abilities: ", 3, PhaseStep.PRECOMBAT_MAIN, playerA);
-        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Remove X");
         setChoice(playerA, "X=1");
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Remove X");
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
 
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/HourglassOfTheLostTest.java
@@ -30,7 +30,7 @@ public class HourglassOfTheLostTest extends CardTestPlayerBase {
         assertCounterCount(playerA, hourglass, CounterType.TIME,1);
 
         showAvailableAbilities("Abilities: ", 3, PhaseStep.PRECOMBAT_MAIN, playerA);
-        setChoice(playerA, "X=1");
+        setChoiceAmount(playerA, 1);
         activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}, Remove X");
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
 

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -550,7 +550,12 @@ public abstract class AbilityImpl implements Ability {
             if (!(variableCost instanceof VariableManaCost) && !((Cost) variableCost).isPaid()) {
                 int xValue = variableCost.announceXValue(this, game);
                 Cost fixedCost = variableCost.getFixedCostsFromAnnouncedValue(xValue);
-                addCost(fixedCost);
+                int index = getCosts().indexOf(variableCost);
+                if (index == -1) {
+                    addCost(fixedCost);
+                } else {
+                    addCost(fixedCost, index + 1);
+                }
                 // set the xcosts to paid
                 // no x events - rules from Unbound Flourishing:
                 // - Spells with additional costs that include X won't be affected by Unbound Flourishing. X must be in the spell's mana cost.
@@ -924,6 +929,32 @@ public abstract class AbilityImpl implements Ability {
                 manaCostsToPay.add((ManaCost) cost);
             } else {
                 costs.add(cost);
+            }
+        }
+    }
+
+    public void addCost(Cost cost, int index) {
+        if (cost == null) {
+            return;
+        }
+        if (cost instanceof Costs) {
+            // as list of costs
+            Costs<Cost> list = (Costs<Cost>) cost;
+            for (Cost single : list) {
+                addCost(single);
+            }
+        } else {
+            // as single cost
+            if (cost instanceof ManaCost) {
+                manaCosts.add((ManaCost) cost);
+                manaCostsToPay.add((ManaCost) cost);
+            } else {
+                if (index > costs.size()) {
+                    costs.add(cost);
+                } else {
+                    costs.add(index, cost);
+                }
+                costs.add(index, cost);
             }
         }
     }

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -941,7 +941,7 @@ public abstract class AbilityImpl implements Ability {
             // as list of costs
             Costs<Cost> list = (Costs<Cost>) cost;
             for (Cost single : list) {
-                addCost(single);
+                addCost(single, index);
             }
         } else {
             // as single cost

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -954,7 +954,6 @@ public abstract class AbilityImpl implements Ability {
                 } else {
                     costs.add(index, cost);
                 }
-                costs.add(index, cost);
             }
         }
     }


### PR DESCRIPTION
https://scryfall.com/card/m3c/40/hourglass-of-the-lost

Needed to change the way variableCost's are added to the costs list making sure they are added directly after the fixedCost is gotten from the player so that the card will keep the order of costs. 
I this case the card got exiled before the counters could be removed.