### PR TITLE
Fixed commander colors with large color identity

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AbstractCommander.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AbstractCommander.java
@@ -872,7 +872,7 @@ public abstract class AbstractCommander extends Constructed {
             int thisMaxPower = 0;
             String cn = commander.getName().toLowerCase(Locale.ENGLISH);
             if (color == null) {
-                color = commander.getColor(null);
+                color = commander.getColor(null).copy();
             } else {
                 color = color.union(commander.getColor(null));
             }


### PR DESCRIPTION
Fixed a bug where commanders with color identites larger than their color would gain a larger color than intended.

Fixes #7983 (wow three years ago 🥲)
Fixes #9852

Turns out the reason some people always had the issue and others never had it, was because some devs never actually loaded up a commander game to check the bug - they just added the card to the command zone through cheat commands, which skips commander deck validation.

Woooo~ Java. I love everything being mutable pointers.