### PR TITLE
Update ScryfallImageSourceSmall.java

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSourceSmall.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSourceSmall.java
@@ -44,7 +44,7 @@ public class ScryfallImageSourceSmall extends ScryfallImageSource {
 
     @Override
     public float getAverageSize() {
-        return 13; // initial estimate - TODO calculate a more accurate number
+        return 14; // 1,035,907,575 bytes / 73,637 files = 14,068 bytes/file (or 13.78kb/file)
     }
 
 }


### PR DESCRIPTION
Downloaded all current images as small images on a windows machine (not in zip files), checked properties of the containing folder and did the math.
![image](https://github.com/magefree/mage/assets/87589219/5187ac89-5186-4fbd-8ede-a19d7ba007ac)
