### PR TITLE
Scryfall normal sized images download option

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSourceNormal.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSourceNormal.java
@@ -1,0 +1,50 @@
+package org.mage.plugins.card.dl.sources;
+
+import org.mage.plugins.card.images.CardDownloadData;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author tiera3
+ */
+public class ScryfallImageSourceNormal extends ScryfallImageSource {
+
+    private static final ScryfallImageSourceNormal instanceNormal = new ScryfallImageSourceNormal();
+    
+    public static ScryfallImageSource getInstance() {
+        return instanceNormal;
+    }
+
+    private static String innerModifyUrlString(String oneUrl) {
+        return oneUrl.replaceFirst("/large/","/normal/").replaceFirst("format=image","format=image&version=normal");
+    }
+
+    private static CardImageUrls innerModifyUrl(CardImageUrls cardUrls) {
+        List<String> downloadUrls = cardUrls.getDownloadList().stream() 
+            .map(ScryfallImageSourceNormal::innerModifyUrlString)
+            .collect(Collectors.toList());
+        return new CardImageUrls(downloadUrls);
+    }
+
+    @Override
+    public String getSourceName() {
+        return "scryfall.com - normal";
+    }
+
+    @Override
+    public CardImageUrls generateCardUrl(CardDownloadData card) throws Exception {
+        return innerModifyUrl(super.generateCardUrl(card));
+    }
+
+    @Override
+    public CardImageUrls generateTokenUrl(CardDownloadData card) throws Exception {
+        return innerModifyUrl(super.generateTokenUrl(card));
+    }
+
+    @Override
+    public float getAverageSize() {
+        return 100; // initial estimate - TODO calculate a more accurate number
+    }
+
+}

--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
@@ -77,6 +77,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
         WIZARDS("1. wizards.com - low quality, cards only, multi-language", WizardCardsImageSource.instance),
         SCRYFALL_BIG("2a. scryfall.com - BIG: high quality, multi-language", ScryfallImageSource.getInstance()),
         SCRYFALL_SMALL("2b. scryfall.com - small: low quality, multi-language", ScryfallImageSourceSmall.getInstance()),
+        SCRYFALL_NORM("2c. scryfall.com - normal: good quality, multi-language", ScryfallImageSourceNormal.getInstance()),
         GRAB_BAG("3. GrabBag - unofficial STAR WARS cards and tokens", GrabbagImageSource.instance),
         COPYPASTE("4. Experimental - copy and paste image URLs", CopyPasteImageSource.instance); // TODO: need rework for user friendly GUI
 


### PR DESCRIPTION
Using the same logic as the small-sized images, this allows an alternate "normal" sized scryfall image download option. The files are about 2/3 the size of the default "large" sized images, and (in my opinion) for the most part the images are visually good. (Some images with only lowres scans are a little worse, but for images with highres scans, I believe normal images work well.)