### PR TITLE
refactor: simpler processAction syntax

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbstruseAppropriation.java
+++ b/Mage.Sets/src/mage/cards/a/AbstruseAppropriation.java
@@ -73,7 +73,7 @@ class AbstruseAppropriationEffect extends OneShotEffect {
                 .setToSourceExileZone(true)
                 .setTargetPointer(getTargetPointer().copy())
                 .apply(game, source);
-        game.getState().processAction(game);
+        game.processAction();
         Card card = game.getCard(getTargetPointer().getFirst(game, source));
         if (card == null || !game.getState().getZone(card.getId()).equals(Zone.EXILED)) {
             return true;

--- a/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
+++ b/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
@@ -80,7 +80,7 @@ class AladdinsLampEffect extends ReplacementEffectImpl {
             cards.remove(target.getFirstTarget());
         }
         controller.putCardsOnBottomOfLibrary(cards, game, source, false);
-        game.getState().processAction(game);
+        game.processAction();
         controller.drawCards(1, source, game, event);
         discard();
         return true;

--- a/Mage.Sets/src/mage/cards/a/AngrathMinotaurPirate.java
+++ b/Mage.Sets/src/mage/cards/a/AngrathMinotaurPirate.java
@@ -93,7 +93,7 @@ class AngrathMinotaurPirateThirdAbilityEffect extends OneShotEffect {
                 permanent.destroy(source, game, false);
                 powerSum += permanent.getPower().getValue();
             }
-            game.getState().processAction(game);
+            game.processAction();
             targetOpponent.damage(powerSum, source.getSourceId(), source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/a/AnotherChance.java
+++ b/Mage.Sets/src/mage/cards/a/AnotherChance.java
@@ -70,7 +70,7 @@ class AnotherChanceEffect extends OneShotEffect {
         }
 
         // Make sure the mill has been processed.
-        game.getState().processAction(game);
+        game.processAction();
 
         TargetCard target = new TargetCardInYourGraveyard(
                 0, 2, StaticFilters.FILTER_CARD_CREATURES_YOUR_GRAVEYARD, true

--- a/Mage.Sets/src/mage/cards/a/AnotherRound.java
+++ b/Mage.Sets/src/mage/cards/a/AnotherRound.java
@@ -77,7 +77,7 @@ class AnotherRoundEffect extends OneShotEffect {
                                     .map(id -> new MageObjectReference(id, game))
                                     .collect(Collectors.toList())
                     )).apply(game, source);
-            game.getState().processAction(game);
+            game.processAction();
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
@@ -91,7 +91,7 @@ class AwakenTheMaelstromEffect extends OneShotEffect {
             return false;
         }
         makeToken(player, game, source);
-        game.getState().processAction(game);
+        game.processAction();
         distributeCounters(player, game, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/b/BeseechTheMirror.java
+++ b/Mage.Sets/src/mage/cards/b/BeseechTheMirror.java
@@ -95,7 +95,7 @@ class BeseechTheMirrorEffect extends OneShotEffect {
                     // you may cast the exiled card without paying its mana cost if that spell's mana value is 4 or less.
                     CardUtil.castSpellWithAttributesForFree(controller, source, game, card, filter);
                 }
-                game.getState().processAction(game);
+                game.processAction();
 
                 if (game.getState().getZone(card.getId()).equals(Zone.EXILED)) {
                     // Put the exiled card into your hand if it wasn't cast this way.

--- a/Mage.Sets/src/mage/cards/b/BillFernyBreeSwindler.java
+++ b/Mage.Sets/src/mage/cards/b/BillFernyBreeSwindler.java
@@ -92,7 +92,7 @@ class BillFernyEffect extends OneShotEffect {
         game.addEffect(new GainControlTargetEffect(
                 Duration.Custom, true, opponentToGainControl
         ).setTargetPointer(new FixedTarget(permanent.getId(), game)), source);
-        game.getState().processAction(game);
+        game.processAction();
         if (permanent.isControlledBy(opponentToGainControl)) {
             removeFromCombat.apply(game, source);
             create3TreasureTokens.apply(game, source);

--- a/Mage.Sets/src/mage/cards/b/BlessedReincarnation.java
+++ b/Mage.Sets/src/mage/cards/b/BlessedReincarnation.java
@@ -67,7 +67,7 @@ class BlessedReincarnationEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (permanent != null && controller != null) {
             controller.moveCards(permanent, Zone.EXILED, source, game);
-            game.getState().processAction(game);
+            game.processAction();
 
             Player permanentController = game.getPlayer(permanent.getControllerId());
             if (permanentController != null) {

--- a/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
@@ -91,7 +91,7 @@ class BlessingOfFrostEffect extends OneShotEffect {
                 permanent.addCounters(CounterType.P1P1.createInstance(target.getTargetAmount(targetId)), source.getControllerId(), source, game);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         player.drawCards(game.getBattlefield().count(
                 filter, source.getControllerId(), source, game
         ), source, game);

--- a/Mage.Sets/src/mage/cards/b/BlimComedicGenius.java
+++ b/Mage.Sets/src/mage/cards/b/BlimComedicGenius.java
@@ -86,7 +86,7 @@ class BlimComedicGeniusEffect extends OneShotEffect {
         game.addEffect(new GainControlTargetEffect(
                 Duration.Custom, true, getTargetPointer().getFirst(game, source)
         ).setTargetPointer(new FixedTarget(source.getFirstTarget(), game)), source);
-        game.getState().processAction(game);
+        game.processAction();
         Map<UUID, Cards> cardsMap = new HashMap<>();
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);

--- a/Mage.Sets/src/mage/cards/b/BondOfPassion.java
+++ b/Mage.Sets/src/mage/cards/b/BondOfPassion.java
@@ -87,7 +87,7 @@ class BondOfPassionEffect extends OneShotEffect {
             ContinuousEffect effect = new GainControlTargetEffect(Duration.EndOfTurn);
             effect.setTargetPointer(new FixedTarget(permanent, game));
             game.addEffect(effect, source);
-            game.getState().processAction(game);
+            game.processAction();
             permanent.untap(game);
             effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
             effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/b/BoundDetermined.java
+++ b/Mage.Sets/src/mage/cards/b/BoundDetermined.java
@@ -88,7 +88,7 @@ class BoundEffect extends OneShotEffect {
             Permanent toSacrifice = game.getPermanent(target.getFirstTarget());
             if (toSacrifice != null) {
                 toSacrifice.sacrifice(source, game);
-                game.getState().processAction(game);
+                game.processAction();
                 int colors = toSacrifice.getColor(game).getColorCount();
                 if (colors > 0) {
                     TargetCardInYourGraveyard targetCard = new TargetCardInYourGraveyard(0, colors,

--- a/Mage.Sets/src/mage/cards/b/BreakTheSpell.java
+++ b/Mage.Sets/src/mage/cards/b/BreakTheSpell.java
@@ -63,7 +63,7 @@ class BreakTheSpellEffect extends OneShotEffect {
         boolean followupEffect = permanent.isControlledBy(source.getControllerId())
                 || StaticFilters.FILTER_PERMANENT_TOKEN.match(permanent, game);
         boolean destroyed = permanent.destroy(source, game, false);
-        game.getState().processAction(game);
+        game.processAction();
 
         if (followupEffect && destroyed) {
             new DrawCardSourceControllerEffect(1).apply(game, source);

--- a/Mage.Sets/src/mage/cards/b/BringerOfTheLastGift.java
+++ b/Mage.Sets/src/mage/cards/b/BringerOfTheLastGift.java
@@ -95,7 +95,7 @@ class BringerOfTheLastGiftEffect extends OneShotEffect {
         }
 
         // Make sure the sacrifices are processed.
-        game.getState().processAction(game);
+        game.processAction();
 
         Set<Card> toReturn = new HashSet<>();
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {

--- a/Mage.Sets/src/mage/cards/b/BuildersBane.java
+++ b/Mage.Sets/src/mage/cards/b/BuildersBane.java
@@ -66,7 +66,7 @@ class BuildersBaneEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(targetID);
             if (permanent != null) {
                 if (permanent.destroy(source, game, false)) {
-                    game.getState().processAction(game);
+                    game.processAction();
                     if (permanent.getZoneChangeCounter(game) + 1 == game.getState().getZoneChangeCounter(permanent.getId())
                             && game.getState().getZone(permanent.getId()) != Zone.GRAVEYARD) {
                         // A replacement effect has moved the card to another zone as grvayard

--- a/Mage.Sets/src/mage/cards/c/CallForAid.java
+++ b/Mage.Sets/src/mage/cards/c/CallForAid.java
@@ -75,7 +75,7 @@ class CallForAidEffect extends OneShotEffect {
 
         //"Gain control of all creatures target opponent controls until end of turn"
         new GainControlAllEffect(Duration.EndOfTurn, filter).apply(game, source);
-        game.getState().processAction(game);
+        game.processAction();
 
         //"Untap those creatures".
         new UntapAllEffect(filter).apply(game, source);

--- a/Mage.Sets/src/mage/cards/c/ChaosMutation.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosMutation.java
@@ -82,7 +82,7 @@ class ChaosMutationEffect extends OneShotEffect {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         controller.moveCards(permanents, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         for (Player player : players) {
             Cards cards = new CardsImpl();
             Card card = getCreatureCard(player, cards, game);

--- a/Mage.Sets/src/mage/cards/c/CinderCloud.java
+++ b/Mage.Sets/src/mage/cards/c/CinderCloud.java
@@ -59,7 +59,7 @@ class CinderCloudEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (permanent != null && permanent.destroy(source, game, false) && permanent.getColor(game).equals(ObjectColor.WHITE)) {
-            game.getState().processAction(game);
+            game.processAction();
             if (permanent.getZoneChangeCounter(game) + 1 == game.getState().getZoneChangeCounter(permanent.getId())
                     && game.getState().getZone(permanent.getId()) != Zone.GRAVEYARD) {
                 // A replacement effect has moved the card to another zone as grvayard

--- a/Mage.Sets/src/mage/cards/c/ClericClass.java
+++ b/Mage.Sets/src/mage/cards/c/ClericClass.java
@@ -97,7 +97,7 @@ class ClericClassReturnEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         Permanent permanent = game.getPermanent(card.getId());
         int toughness = permanent != null ? permanent.getToughness().getValue() : card.getToughness().getValue();
         player.gainLife(toughness, game, source);

--- a/Mage.Sets/src/mage/cards/c/CoercedConfession.java
+++ b/Mage.Sets/src/mage/cards/c/CoercedConfession.java
@@ -75,7 +75,7 @@ class CoercedConfessionMillEffect extends OneShotEffect {
         if (controller == null) {
             return true;
         }
-        game.getState().processAction(game);
+        game.processAction();
         controller.drawCards(creaturesMilled, source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/c/ColossalBadger.java
+++ b/Mage.Sets/src/mage/cards/c/ColossalBadger.java
@@ -78,7 +78,7 @@ class ColossalBadgerEffect extends OneShotEffect {
         int amount = player.millCards(4, source, game).count(StaticFilters.FILTER_CARD_CREATURE, game);
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (amount > 0 && permanent != null) {
-            game.getState().processAction(game);
+            game.processAction();
             permanent.addCounters(CounterType.P1P1.createInstance(amount), source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/c/CompellingDeterrence.java
+++ b/Mage.Sets/src/mage/cards/c/CompellingDeterrence.java
@@ -63,7 +63,7 @@ class CompellingDeterrenceEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && player != null) {
             player.moveCards(target, Zone.HAND, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             FilterPermanent zombieFilter = new FilterPermanent();
             zombieFilter.add(SubType.ZOMBIE.getPredicate());
             if (game.getBattlefield().countAll(zombieFilter, controller.getId(), game) > 0) {

--- a/Mage.Sets/src/mage/cards/c/CovetedFalcon.java
+++ b/Mage.Sets/src/mage/cards/c/CovetedFalcon.java
@@ -98,7 +98,7 @@ class CovetedFalconEffect extends OneShotEffect {
                     source);
         }
 
-        game.getState().processAction(game);
+        game.processAction();
 
         int cardsToDraw = 0;
         for (UUID permanentId : targetPermanentIds) {

--- a/Mage.Sets/src/mage/cards/c/Crabomination.java
+++ b/Mage.Sets/src/mage/cards/c/Crabomination.java
@@ -90,7 +90,7 @@ class CrabominationEffect extends OneShotEffect {
             cards.add(fromHand);
         }
         opponent.moveCardsToExile(cards.getCards(game), source, game, true, null, "");
-        game.getState().processAction(game);
+        game.processAction();
         cards.retainZone(Zone.EXILED, game);
         CardUtil.castSpellWithAttributesForFree(controller, source, game, cards, StaticFilters.FILTER_CARD);
         return true;

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheSwine.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheSwine.java
@@ -94,7 +94,7 @@ class CurseOfTheSwineEffect extends OneShotEffect {
                             playersWithTargets.getOrDefault(lkiP.getControllerId(), 0) + 1);
                 }
             }
-            game.getState().processAction(game);
+            game.processAction();
             Boar2Token swineToken = new Boar2Token();
             for (Map.Entry<UUID, Integer> exiledByController : playersWithTargets.entrySet()) {
                 swineToken.putOntoBattlefield(exiledByController.getValue(), game, source, exiledByController.getKey());

--- a/Mage.Sets/src/mage/cards/d/DeclarationInStone.java
+++ b/Mage.Sets/src/mage/cards/d/DeclarationInStone.java
@@ -90,7 +90,7 @@ class DeclarationInStoneEffect extends OneShotEffect {
             }
         }
         controller.moveCards(cardsToExile, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         if (nonTokenCount > 0) {
             new InvestigateTargetEffect(nonTokenCount)
                     .setTargetPointer(new FixedTarget(targetPermanent.getControllerId()))

--- a/Mage.Sets/src/mage/cards/d/DecreeOfPain.java
+++ b/Mage.Sets/src/mage/cards/d/DecreeOfPain.java
@@ -72,7 +72,7 @@ class DecreeOfPainEffect extends OneShotEffect {
                 }
             }
             if (destroyedCreature > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 controller.drawCards(destroyedCreature, source, game);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/d/Defossilize.java
+++ b/Mage.Sets/src/mage/cards/d/Defossilize.java
@@ -65,7 +65,7 @@ class DefossilizeEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         Permanent permanent = game.getPermanent(card.getId());
         if (permanent == null) {
             return false;

--- a/Mage.Sets/src/mage/cards/d/Deicide.java
+++ b/Mage.Sets/src/mage/cards/d/Deicide.java
@@ -62,7 +62,7 @@ class DeicideExileEffect extends SearchTargetGraveyardHandLibraryForCardNameAndE
             return false;
         }
         controller.moveCards(targetEnchantment, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
 
         // 4/26/2014
         // Deicide looks at the card in exile, not the permanent that was exiled, to determine

--- a/Mage.Sets/src/mage/cards/d/DescentOfTheDragons.java
+++ b/Mage.Sets/src/mage/cards/d/DescentOfTheDragons.java
@@ -75,7 +75,7 @@ class DescentOfTheDragonsEffect extends OneShotEffect {
                     }
                 }
             }
-            game.getState().processAction(game);
+            game.processAction();
             DragonToken dragonToken = new DragonToken();
             for (Map.Entry<UUID, Integer> amountTokensPerPlayer : playersWithTargets.entrySet()) {
                 dragonToken.putOntoBattlefield(amountTokensPerPlayer.getValue(), game, source, amountTokensPerPlayer.getKey());

--- a/Mage.Sets/src/mage/cards/d/DevourFlesh.java
+++ b/Mage.Sets/src/mage/cards/d/DevourFlesh.java
@@ -71,7 +71,7 @@ class DevourFleshSacrificeEffect extends OneShotEffect {
             if (permanent != null) {
                 int gainLife = permanent.getToughness().getValue();
                 permanent.sacrifice(source, game);
-                game.getState().processAction(game);
+                game.processAction();
                 player.gainLife(gainLife, game, source);
             } else {
                 return false;

--- a/Mage.Sets/src/mage/cards/d/DiminishingReturns.java
+++ b/Mage.Sets/src/mage/cards/d/DiminishingReturns.java
@@ -53,7 +53,7 @@ class DiminishingReturnsEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             controller.moveCards(controller.getLibrary().getTopCards(game, 10), Zone.EXILED, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             for (UUID playerId : game.getState().getPlayersInRange(controller.getId(), game)) {
                 Player player = game.getPlayer(playerId);
                 if (player != null) {

--- a/Mage.Sets/src/mage/cards/d/DireStrainRampage.java
+++ b/Mage.Sets/src/mage/cards/d/DireStrainRampage.java
@@ -84,7 +84,7 @@ class DireStrainRampageEffect extends OneShotEffect {
         }
         boolean landTargeted = permanent.isLand(game);
         boolean destroyed = permanent.destroy(source, game, false);
-        game.getState().processAction(game);
+        game.processAction();
         TargetCardInLibrary target = landTargeted && destroyed ?
                 new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS) :
                 new TargetCardInLibrary(1, 1, StaticFilters.FILTER_CARD_BASIC_LAND);

--- a/Mage.Sets/src/mage/cards/d/DisorderInTheCourt.java
+++ b/Mage.Sets/src/mage/cards/d/DisorderInTheCourt.java
@@ -78,7 +78,7 @@ class DisorderInTheCourtEffect extends OneShotEffect {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         if (!toExile.isEmpty()) {
             controller.moveCardsToExile(toExile, source, game, true, CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source));
-            game.getState().processAction(game);
+            game.processAction();
         }
         new InvestigateEffect(ManacostVariableValue.REGULAR).apply(game, source);
         if (!toExile.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/d/DreadSummons.java
+++ b/Mage.Sets/src/mage/cards/d/DreadSummons.java
@@ -74,7 +74,7 @@ class DreadSummonsEffect extends OneShotEffect {
                     .count();
         }
         if (creatureCount > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             token.putOntoBattlefield(creatureCount, game, source, source.getControllerId(), true, false);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/e/ElrondOfTheWhiteCouncil.java
+++ b/Mage.Sets/src/mage/cards/e/ElrondOfTheWhiteCouncil.java
@@ -141,7 +141,7 @@ class ElrondOfWhiteCouncilEffect extends OneShotEffect {
         ).setTargetPointer(blueprintTarget.copy()), source);
 
         // Need to process the control change.
-        game.getState().processAction(game);
+        game.processAction();
 
         // Then for each aid vote, put a +1/+1 counter on each creature you control.
         int countAid = vote.getVoteCount(false);

--- a/Mage.Sets/src/mage/cards/e/EmpoweredAutogenerator.java
+++ b/Mage.Sets/src/mage/cards/e/EmpoweredAutogenerator.java
@@ -88,7 +88,7 @@ class EmpoweredAutogeneratorManaEffect extends ManaEffect {
         if (game == null) {
             return mana;
         }
-        game.getState().processAction(game);
+        game.processAction();
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (sourcePermanent == null) {
             return mana;

--- a/Mage.Sets/src/mage/cards/e/EnigmaticIncarnation.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaticIncarnation.java
@@ -87,7 +87,7 @@ class EnigmaticIncarnationEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
         int cmc = permanent.getManaValue();
         if (!permanent.sacrifice(source, game)) {
             return false;

--- a/Mage.Sets/src/mage/cards/e/EtchedSlith.java
+++ b/Mage.Sets/src/mage/cards/e/EtchedSlith.java
@@ -95,7 +95,7 @@ class EtchedSlithPutWhenDoEffect extends OneShotEffect {
         }
         int beforeP1P1 = permanent.getCounters(game).getCount(CounterType.P1P1);
         new AddCountersSourceEffect(CounterType.P1P1.createInstance()).apply(game, source);
-        game.getState().processAction(game);
+        game.processAction();
         int afterP1P1 = permanent.getCounters(game).getCount(CounterType.P1P1);
         for (int i = beforeP1P1 + 1; i <= afterP1P1; ++i) {
             // Releases notes rulling:

--- a/Mage.Sets/src/mage/cards/e/EvolvedSleeper.java
+++ b/Mage.Sets/src/mage/cards/e/EvolvedSleeper.java
@@ -119,7 +119,7 @@ class EvolvedSleeperPhyrexianEffect extends OneShotEffect {
             permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }
         Player player = game.getPlayer(source.getControllerId());
-        game.getState().processAction(game);
+        game.processAction();
         player.drawCards(1, source, game);
         player.loseLife(1, game, source, false);
         return true;

--- a/Mage.Sets/src/mage/cards/e/ExtraordinaryJourney.java
+++ b/Mage.Sets/src/mage/cards/e/ExtraordinaryJourney.java
@@ -92,7 +92,7 @@ class ExtraordinaryJourneyEffect extends OneShotEffect {
         if (!effect.apply(game, source)) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
 
         Set<Card> cards = permanents
                 .stream()

--- a/Mage.Sets/src/mage/cards/f/FiligreeFracture.java
+++ b/Mage.Sets/src/mage/cards/f/FiligreeFracture.java
@@ -61,7 +61,7 @@ class FiligreeFractureEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (player != null && permanent != null) {
             permanent.destroy(source, game, true);
-            game.getState().processAction(game);
+            game.processAction();
             if (permanent.getColor(game).isBlack() || permanent.getColor(game).isBlue()) {
                 player.drawCards(1, source, game);
             }

--- a/Mage.Sets/src/mage/cards/f/FracturingGust.java
+++ b/Mage.Sets/src/mage/cards/f/FracturingGust.java
@@ -67,7 +67,7 @@ class FracturingGustDestroyEffect extends OneShotEffect {
                     ++destroyedPermanents;
                 }
             }
-            game.getState().processAction(game); // needed in case a destroyed permanent did prevent life gain
+            game.processAction(); // needed in case a destroyed permanent did prevent life gain
             if (destroyedPermanents > 0) {
                 controller.gainLife(2 * destroyedPermanents, game, source);
             }

--- a/Mage.Sets/src/mage/cards/f/Froghemoth.java
+++ b/Mage.Sets/src/mage/cards/f/Froghemoth.java
@@ -125,7 +125,7 @@ class FroghemothEffect extends OneShotEffect {
         }
         if (!cardsToExile.isEmpty()) {
             controller.moveCards(cardsToExile, Zone.EXILED, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             if (numCounters > 0) {
                 Permanent permanent = source.getSourcePermanentIfItStillExists(game);
                 if (permanent != null) {

--- a/Mage.Sets/src/mage/cards/f/FromTheAshes.java
+++ b/Mage.Sets/src/mage/cards/f/FromTheAshes.java
@@ -71,7 +71,7 @@ class FromTheAshesEffect extends OneShotEffect {
                 playerAmount.merge(controllerId, 1, Integer::sum);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
 
         // For each land destroyed this way, its controller may search their library for a basic land card and put it onto the battlefield.
         for (Map.Entry<UUID, Integer> entry : playerAmount.entrySet()) {
@@ -91,7 +91,7 @@ class FromTheAshesEffect extends OneShotEffect {
                 entry.setValue(0); // no search no shuffling
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
 
         // Then each player who searched their library this way shuffles. 
         for (Map.Entry<UUID, Integer> entry : playerAmount.entrySet()) {

--- a/Mage.Sets/src/mage/cards/f/Fumigate.java
+++ b/Mage.Sets/src/mage/cards/f/Fumigate.java
@@ -63,7 +63,7 @@ class FumigateEffect extends OneShotEffect {
                 }
             }
             if (destroyedCreature > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 controller.gainLife(destroyedCreature, game, source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/g/GaladrielElvenQueen.java
+++ b/Mage.Sets/src/mage/cards/g/GaladrielElvenQueen.java
@@ -167,7 +167,7 @@ class GaladrielElvenQueenEffect extends OneShotEffect {
             game.temptWithTheRing(controller.getId());
 
             // make sure the new ringbearer has been chosen.
-            game.getState().processAction(game);
+            game.processAction();
             controller = game.getPlayer(source.getControllerId());
             if (controller == null) {
                 return false;

--- a/Mage.Sets/src/mage/cards/g/GhastlyConscription.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlyConscription.java
@@ -77,7 +77,7 @@ class GhastlyConscriptionEffect extends OneShotEffect {
         }
         Collections.shuffle(cardsToManifest);
         game.informPlayers(controller.getLogName() + " shuffles the face-down pile");
-        game.getState().processAction(game);
+        game.processAction();
         ManifestEffect.doManifestCards(game, source, controller, new LinkedHashSet<>(cardsToManifest));
         return true;
     }

--- a/Mage.Sets/src/mage/cards/g/GideonsDefeat.java
+++ b/Mage.Sets/src/mage/cards/g/GideonsDefeat.java
@@ -71,7 +71,7 @@ class GideonsDefeatEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (controller != null && permanent != null) {
             controller.moveCards(permanent, Zone.EXILED, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             if (permanent.isPlaneswalker(game) && permanent.hasSubtype(SubType.GIDEON, game)) {
                 controller.gainLife(5, game, source);
             }

--- a/Mage.Sets/src/mage/cards/g/GilraenDunedainProtector.java
+++ b/Mage.Sets/src/mage/cards/g/GilraenDunedainProtector.java
@@ -96,7 +96,7 @@ class GilraenDunedainProtectorEffect extends OneShotEffect {
 
         // Exile another target creature you control.
         permanent.moveToExile(source.getSourceId(), sourcePermanent.getName(), source, game);
-        game.getState().processAction(game);
+        game.processAction();
 
         Card card = game.getExile().getCard(permanent.getId(), game);
         boolean choice = controller.chooseUse(Outcome.Neutral, "Return that card to the battlefield now?", source, game);

--- a/Mage.Sets/src/mage/cards/g/GlimpseTheImpossible.java
+++ b/Mage.Sets/src/mage/cards/g/GlimpseTheImpossible.java
@@ -96,7 +96,7 @@ class GlimpseTheImpossibleEffect extends OneShotEffect {
         }
         Cards cards = new CardsImpl(exileZone.getCards(game));
         controller.moveCards(cards, Zone.GRAVEYARD, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         cards.retainZone(Zone.GRAVEYARD, game);
         new CreateTokenEffect(new EldraziSpawnToken(), cards.size())
                 .apply(game, source);

--- a/Mage.Sets/src/mage/cards/g/GlyphOfReincarnation.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfReincarnation.java
@@ -97,7 +97,7 @@ class GlyphOfReincarnationEffect extends OneShotEffect {
                         }
                     }
                 }
-                game.getState().processAction(game);
+                game.processAction();
                 // For each creature that died this way, put a creature card from the graveyard of the player who controlled that creature the last time it became blocked by that Wall 
                 // onto the battlefield under its owner’s control
                 for (Map.Entry<UUID, Player> entry : destroyed.entrySet()) {

--- a/Mage.Sets/src/mage/cards/g/GorgingVulture.java
+++ b/Mage.Sets/src/mage/cards/g/GorgingVulture.java
@@ -75,7 +75,7 @@ class GorgingVultureEffect extends OneShotEffect {
                 .mapToInt(card -> game.getState().getZone(card.getId()) == Zone.GRAVEYARD ? 1 : 0)
                 .sum();
         if (lifeToGain > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             player.gainLife(lifeToGain, game, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/g/GraveyardTrespasser.java
+++ b/Mage.Sets/src/mage/cards/g/GraveyardTrespasser.java
@@ -87,7 +87,7 @@ class GraveyardTrespasserEffect extends OneShotEffect {
         if (amount < 1) {
             return true;
         }
-        game.getState().processAction(game);
+        game.processAction();
         player.gainLife(amount, game, source);
         for (UUID opponentId : game.getOpponents(source.getControllerId())) {
             Player opponent = game.getPlayer(opponentId);

--- a/Mage.Sets/src/mage/cards/h/HammerHelper.java
+++ b/Mage.Sets/src/mage/cards/h/HammerHelper.java
@@ -65,7 +65,7 @@ class HammerHelperEffect extends OneShotEffect {
         if (controller != null && targetCreature != null) {
             source.getEffects().get(0).setTargetPointer(new FixedTarget(targetCreature.getId(), game));
             game.addEffect(new GainControlTargetEffect(Duration.EndOfTurn), source);
-            game.getState().processAction(game);
+            game.processAction();
             targetCreature.untap(game);
             int amount = controller.rollDice(outcome, source, game, 6);
             game.addEffect(new BoostTargetEffect(amount, 0, Duration.EndOfTurn), source);

--- a/Mage.Sets/src/mage/cards/h/HeartlessConscription.java
+++ b/Mage.Sets/src/mage/cards/h/HeartlessConscription.java
@@ -74,7 +74,7 @@ class HeartlessConscriptionEffect extends OneShotEffect {
                 cards.getCards(game), source, game, true,
                 CardUtil.getExileZoneId(game, source), CardUtil.getSourceName(game, source)
         );
-        game.getState().processAction(game);
+        game.processAction();
         cards.retainZone(Zone.EXILED, game);
         for (Card card : cards.getCards(game)) {
             CardUtil.makeCardPlayable(game, source, card, false, Duration.EndOfGame, true);

--- a/Mage.Sets/src/mage/cards/h/HeraldOfLeshrac.java
+++ b/Mage.Sets/src/mage/cards/h/HeraldOfLeshrac.java
@@ -93,7 +93,7 @@ class HeraldOfLeshracCumulativeCost extends CostImpl {
             ContinuousEffect effect = new GainControlTargetEffect(Duration.EndOfGame);
             effect.setTargetPointer(new FixedTarget(target.getFirstTarget(), game));
             game.addEffect(effect, ability);
-            game.getState().processAction(game);
+            game.processAction();
             paid = true;
         }
         return paid;

--- a/Mage.Sets/src/mage/cards/h/HourOfGlory.java
+++ b/Mage.Sets/src/mage/cards/h/HourOfGlory.java
@@ -69,7 +69,7 @@ class HourOfGloryEffect extends OneShotEffect {
             if (targetCreature != null) {
                 controller.moveCards(targetCreature, Zone.EXILED, source, game);
                 if (targetCreature.hasSubtype(SubType.GOD, game)) {
-                    game.getState().processAction(game);
+                    game.processAction();
                     Player targetController = game.getPlayer(targetCreature.getControllerId());
                     if (targetController != null) {
                         targetController.revealCards(sourceObject.getIdName(), targetController.getHand(), game);

--- a/Mage.Sets/src/mage/cards/h/HourOfNeed.java
+++ b/Mage.Sets/src/mage/cards/h/HourOfNeed.java
@@ -75,7 +75,7 @@ class HourOfNeedExileEffect extends OneShotEffect {
         if (tokenCounts.values().stream().noneMatch(i -> (i > 0))) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
         Token token = new HourOfNeedSphinxToken();
         for (Map.Entry<UUID, Integer> playerTokenCount : tokenCounts.entrySet()) {
             token.putOntoBattlefield(playerTokenCount.getValue(), game, source, playerTokenCount.getKey());

--- a/Mage.Sets/src/mage/cards/i/IndominusRexAlpha.java
+++ b/Mage.Sets/src/mage/cards/i/IndominusRexAlpha.java
@@ -125,7 +125,7 @@ class IndominusRexAlphaCountersEffect extends OneShotEffect {
         controller.discard(new CardsImpl(target.getTargets()), false, source, game);
 
         //allow cards to move to graveyard before checking for abilities
-        game.getState().processAction(game);
+        game.processAction();
 
         // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
         List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");

--- a/Mage.Sets/src/mage/cards/j/JeskaiInfiltrator.java
+++ b/Mage.Sets/src/mage/cards/j/JeskaiInfiltrator.java
@@ -93,7 +93,7 @@ class JeskaiInfiltratorEffect extends OneShotEffect {
         }
         Collections.shuffle(cardsToManifest);
         game.informPlayers(controller.getLogName() + " shuffles the face-down pile");
-        game.getState().processAction(game);
+        game.processAction();
         ManifestEffect.doManifestCards(game, source, controller, new LinkedHashSet<>(cardsToManifest));
         return true;
     }

--- a/Mage.Sets/src/mage/cards/j/JodahTheUnifier.java
+++ b/Mage.Sets/src/mage/cards/j/JodahTheUnifier.java
@@ -101,7 +101,7 @@ class JodahTheUnifierEffect extends OneShotEffect {
         for (Card card : controller.getLibrary().getCards(game)) {
             exiledCards.add(card);
             controller.moveCards(card, Zone.EXILED, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             if (card.isLegendary(game) && !card.isLand(game) && card.getManaValue() < manaValue) {
                 CardUtil.castSpellWithAttributesForFree(controller, source, game, card);
                 break;

--- a/Mage.Sets/src/mage/cards/j/JonIrenicusShatteredOne.java
+++ b/Mage.Sets/src/mage/cards/j/JonIrenicusShatteredOne.java
@@ -93,7 +93,7 @@ class JonIrenicusShatteredOneEffect extends OneShotEffect {
         ContinuousEffect effect = new GainControlTargetEffect(Duration.EndOfGame, opponent.getId());
         effect.setTargetPointer(new FixedTarget(creature, game));
         game.addEffect(effect, source);
-        game.getState().processAction(game);
+        game.processAction();
         creature.addCounters(CounterType.P1P1.createInstance(2), source.getControllerId(), source, game);
         creature.tap(source, game);
         game.addEffect(new GoadTargetEffect()

--- a/Mage.Sets/src/mage/cards/k/KaerveksPurge.java
+++ b/Mage.Sets/src/mage/cards/k/KaerveksPurge.java
@@ -63,7 +63,7 @@ class KaerveksPurgeEffect extends OneShotEffect {
         // Destroy target creature with converted mana cost X.
         Permanent targetCreature = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (targetCreature != null && targetCreature.destroy(source, game, false)) {
-            game.getState().processAction(game);
+            game.processAction();
             if (targetCreature.getZoneChangeCounter(game) + 1 == game.getState().getZoneChangeCounter(targetCreature.getId())
                     && game.getState().getZone(targetCreature.getId()) != Zone.GRAVEYARD) {
                 // A replacement effect has moved the card to another zone as graveyard

--- a/Mage.Sets/src/mage/cards/k/KraulHarpooner.java
+++ b/Mage.Sets/src/mage/cards/k/KraulHarpooner.java
@@ -91,7 +91,7 @@ class KraulHarpoonerEffect extends OneShotEffect {
         }
         int xValue = player.getGraveyard().count(StaticFilters.FILTER_CARD_CREATURE, game);
         game.addEffect(new BoostSourceEffect(xValue, 0, Duration.EndOfTurn), source);
-        game.getState().processAction(game);
+        game.processAction();
         Permanent creature = game.getPermanent(source.getFirstTarget());
         if (creature == null || !player.chooseUse(outcome, "Have " + sourcePerm.getLogName() + " fight " + creature.getLogName() + "?", source, game)) {
             return true;

--- a/Mage.Sets/src/mage/cards/k/KrenkoTinStreetKingpin.java
+++ b/Mage.Sets/src/mage/cards/k/KrenkoTinStreetKingpin.java
@@ -70,7 +70,7 @@ class KrenkoTinStreetKingpinEffect extends OneShotEffect {
             return false;
         }
         new AddCountersSourceEffect(CounterType.P1P1.createInstance()).apply(game, source);
-        game.getState().processAction(game);
+        game.processAction();
         int xValue = permanent.getPower().getValue();
         return new CreateTokenEffect(new GoblinToken(), xValue).apply(game, source);
     }

--- a/Mage.Sets/src/mage/cards/l/LaezelsAcrobatics.java
+++ b/Mage.Sets/src/mage/cards/l/LaezelsAcrobatics.java
@@ -74,7 +74,7 @@ class LaezelsAcrobaticsEffect extends RollDieWithResultTableEffect {
         }
         Cards toFlicker = new CardsImpl(game.getBattlefield().getActivePermanents(creatureFilter, controller.getId(), game));
         controller.moveCards(toFlicker, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         int result = controller.rollDice(outcome, source, game, 20);
         if (result >= 1 && result <= 9) {
             Effect effect = new ReturnToBattlefieldUnderOwnerControlTargetEffect(false, false);
@@ -87,7 +87,7 @@ class LaezelsAcrobaticsEffect extends RollDieWithResultTableEffect {
                     PutCards.BATTLEFIELD.moveCard(game.getPlayer(card.getOwnerId()), card.getMainCard(), source, game, "card");
                 }
             }
-            game.getState().processAction(game);
+            game.processAction();
             Effect effect = new ExileReturnBattlefieldNextEndStepTargetEffect();
             effect.setTargetPointer(new FixedTargets(toFlicker, game));
             effect.apply(game, source);

--- a/Mage.Sets/src/mage/cards/l/LiberatedLivestock.java
+++ b/Mage.Sets/src/mage/cards/l/LiberatedLivestock.java
@@ -66,7 +66,7 @@ class LiberatedLivestockEffect extends OneShotEffect {
         }
         List<Token> tokens = Arrays.asList(new CatToken2(), new BirdToken(), new OxToken());
         tokens.forEach(token -> token.putOntoBattlefield(1, game, source, source.getControllerId()));
-        game.getState().processAction(game);
+        game.processAction();
 
         for (Token token : tokens) {
             for (UUID tokenId : token.getLastAddedTokenIds()) {

--- a/Mage.Sets/src/mage/cards/l/LichKnightsConquest.java
+++ b/Mage.Sets/src/mage/cards/l/LichKnightsConquest.java
@@ -106,7 +106,7 @@ class LichKnightsConquestEffect extends OneShotEffect {
             new SacrificeTargetEffect()
                     .setTargetPointer(new FixedTargets(toSacrifice, game))
                     .apply(game, source);
-            game.getState().processAction(game);
+            game.processAction();
 
             int cardsToMove = Math.min(
                     sacrificeCount,

--- a/Mage.Sets/src/mage/cards/l/LichsMirror.java
+++ b/Mage.Sets/src/mage/cards/l/LichsMirror.java
@@ -69,7 +69,7 @@ class LichsMirrorEffect extends ReplacementEffectImpl {
                 toLib.add(permanent);
             }            
             player.shuffleCardsToLibrary(toLib, game, source);
-            game.getState().processAction(game);
+            game.processAction();
             player.drawCards(7, source, game); // original event is not a draw event, so skip it in params
             player.setLife(20, game, source);            
         }

--- a/Mage.Sets/src/mage/cards/l/LiegeOfTheHollows.java
+++ b/Mage.Sets/src/mage/cards/l/LiegeOfTheHollows.java
@@ -84,7 +84,7 @@ class LiegeOfTheHollowsEffect extends OneShotEffect {
                     token.putOntoBattlefield(entry.getValue(), game, source, player.getId());
                 }
             }
-            game.getState().processAction(game);
+            game.processAction();
             
             // prevent undo
             controller.resetStoredBookmark(game);

--- a/Mage.Sets/src/mage/cards/l/LilianasDefeat.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasDefeat.java
@@ -67,7 +67,7 @@ class LilianasDefeatEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(getTargetPointer().getFirst(game, source));
         if (player != null && permanent != null) {
             permanent.destroy(source, game, true);
-            game.getState().processAction(game);
+            game.processAction();
             if (permanent.isPlaneswalker(game) && permanent.hasSubtype(SubType.LILIANA, game)) {
                 Player permanentController = game.getPlayer(permanent.getControllerId());
                 if (permanentController != null) {

--- a/Mage.Sets/src/mage/cards/l/LilianasIndignation.java
+++ b/Mage.Sets/src/mage/cards/l/LilianasIndignation.java
@@ -75,7 +75,7 @@ class LilianasIndignationEffect extends OneShotEffect {
         if (creatures > 0) {
             Player targetPlayer = game.getPlayer(source.getFirstTarget());
             if (targetPlayer != null) {
-                game.getState().processAction(game);
+                game.processAction();
                 targetPlayer.loseLife(creatures, game, source, false);
             }
         }

--- a/Mage.Sets/src/mage/cards/m/Malanthrope.java
+++ b/Mage.Sets/src/mage/cards/m/Malanthrope.java
@@ -78,7 +78,7 @@ class MalanthropeEffect extends OneShotEffect {
         player.moveCards(player.getGraveyard(), Zone.EXILED, source, game);
         Permanent permanent = source.getSourcePermanentIfItStillExists(game);
         if (permanent != null && count > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             permanent.addCounters(CounterType.P1P1.createInstance(count), source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/MarchOfSouls.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfSouls.java
@@ -66,7 +66,7 @@ class MarchOfSoulsEffect extends OneShotEffect {
                 playersWithCreatures.put(controllerId, playersWithCreatures.getOrDefault(controllerId, 0) + 1);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         SpiritWhiteToken token = new SpiritWhiteToken();
         for (Map.Entry<UUID, Integer> destroyedCreaturePerPlayer : playersWithCreatures.entrySet()) {
             token.putOntoBattlefield(destroyedCreaturePerPlayer.getValue(), game, source, destroyedCreaturePerPlayer.getKey());

--- a/Mage.Sets/src/mage/cards/m/MartyrsCry.java
+++ b/Mage.Sets/src/mage/cards/m/MartyrsCry.java
@@ -87,7 +87,7 @@ class MartyrsCryEffect extends OneShotEffect {
                         Integer::sum
                 ));
         controller.moveCards(new CardsImpl(permanents), Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         for (Map.Entry<UUID, Integer> entry : playerMap.entrySet()) {
             Player player = game.getPlayer(entry.getKey());
             if (player == null) {

--- a/Mage.Sets/src/mage/cards/m/MasterOfCeremonies.java
+++ b/Mage.Sets/src/mage/cards/m/MasterOfCeremonies.java
@@ -113,7 +113,7 @@ class MasterOfCeremoniesChoiceEffect extends OneShotEffect {
             Token treasureOpponent = new TreasureToken();
             treasureOpponent.putOntoBattlefield(1, game, source, opponentId);
         }
-        game.getState().processAction(game);
+        game.processAction();
 
         // Friends - You and that player each create a 1/1 green and white Citizen creature token.
         for (UUID opponentId : friendChoosers) {
@@ -123,7 +123,7 @@ class MasterOfCeremoniesChoiceEffect extends OneShotEffect {
             Token citizenOpponent = new CitizenGreenWhiteToken();
             citizenOpponent.putOntoBattlefield(1, game, source, opponentId);
         }
-        game.getState().processAction(game);
+        game.processAction();
 
         // Secrets - You and that player each draw a card.
         for (UUID opponentId : secretsChoosers) {

--- a/Mage.Sets/src/mage/cards/m/MayaelsAria.java
+++ b/Mage.Sets/src/mage/cards/m/MayaelsAria.java
@@ -75,7 +75,7 @@ class MayaelsAriaEffect extends OneShotEffect {
                 creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
             }
         }
-        game.getState().processAction(game); // needed because otehrwise the +1/+1 counters wouldn't be taken into account
+        game.processAction(); // needed because otehrwise the +1/+1 counters wouldn't be taken into account
 
         // Then you gain 10 life if you control a creature with power 10 or greater.
         filter = new FilterCreaturePermanent();

--- a/Mage.Sets/src/mage/cards/m/MidnightRitual.java
+++ b/Mage.Sets/src/mage/cards/m/MidnightRitual.java
@@ -67,7 +67,7 @@ class MidnightRitualEffect extends OneShotEffect {
             Cards cardsToExile = new CardsImpl(getTargetPointer().getTargets(game, source));
             controller.moveCards(cardsToExile, Zone.EXILED, source, game);
             if (!cardsToExile.isEmpty()) {
-                game.getState().processAction(game);
+                game.processAction();
                 new ZombieToken().putOntoBattlefield(cardsToExile.size(), game, source, controller.getId());
             }
             return true;

--- a/Mage.Sets/src/mage/cards/m/MoggInfestation.java
+++ b/Mage.Sets/src/mage/cards/m/MoggInfestation.java
@@ -79,7 +79,7 @@ class MoggInfestationEffect extends OneShotEffect {
             if (creaturesDied.isEmpty()) {
                 return true;
             }
-            game.getState().processAction(game);  // Bug #8548
+            game.processAction();  // Bug #8548
             for (UUID uuid : creaturesDied) {
                 if (game.getState().getZone(uuid) == Zone.GRAVEYARD
                         || (game.getLastKnownInformation(uuid, Zone.BATTLEFIELD) instanceof PermanentToken

--- a/Mage.Sets/src/mage/cards/m/MoltenPsyche.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPsyche.java
@@ -72,7 +72,7 @@ class MoltenPsycheEffect extends OneShotEffect {
                 }
             }
 
-            game.getState().processAction(game); // so effects from creatures that were on the battlefield won't trigger from draw action
+            game.processAction(); // so effects from creatures that were on the battlefield won't trigger from draw action
 
             for (UUID playerId : cardsToDraw.keySet()) {
                 Player player = game.getPlayer(playerId);

--- a/Mage.Sets/src/mage/cards/n/Necromentia.java
+++ b/Mage.Sets/src/mage/cards/n/Necromentia.java
@@ -116,7 +116,7 @@ class NecromentiaEffect extends OneShotEffect {
             targetPlayer.shuffleLibrary(source, game);
 
             if (numberOfCardsExiledFromHand > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 Token zombieToken = new ZombieToken();
                 zombieToken.putOntoBattlefield(numberOfCardsExiledFromHand, game, source, targetPlayer.getId());
             }

--- a/Mage.Sets/src/mage/cards/n/NecronMonolith.java
+++ b/Mage.Sets/src/mage/cards/n/NecronMonolith.java
@@ -81,7 +81,7 @@ class NecronMonolithEffect extends OneShotEffect {
                 .millCards(3, source, game)
                 .count(StaticFilters.FILTER_CARD_CREATURE, game);
         if (count > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             new NecronWarriorToken().putOntoBattlefield(count, game, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/o/Oblation.java
+++ b/Mage.Sets/src/mage/cards/o/Oblation.java
@@ -63,7 +63,7 @@ class OblationEffect extends OneShotEffect {
                 player.moveCardToLibraryWithInfo(permanent, source, game, Zone.BATTLEFIELD, true, true);
                 player.shuffleLibrary(source, game);
 
-                game.getState().processAction(game); // so effects from creatures that were on the battlefield won't trigger from draw 
+                game.processAction(); // so effects from creatures that were on the battlefield won't trigger from draw 
 
                 player.drawCards(2, source, game);
                 return true;

--- a/Mage.Sets/src/mage/cards/o/OlorinsSearingLight.java
+++ b/Mage.Sets/src/mage/cards/o/OlorinsSearingLight.java
@@ -92,7 +92,7 @@ class OlorinsSearingLightEffect extends OneShotEffect {
                 }
             }
             if (SpellMasteryCondition.instance.apply(game, source)){
-                game.getState().processAction(game);
+                game.processAction();
                 for (Map.Entry<Player, Integer> entry : damageList) {
                     entry.getKey().damage(entry.getValue(), source, game);
                 }

--- a/Mage.Sets/src/mage/cards/o/OnceAndFuture.java
+++ b/Mage.Sets/src/mage/cards/o/OnceAndFuture.java
@@ -89,10 +89,10 @@ class OnceAndFutureEffect extends OneShotEffect {
             player.moveCards(cards, Zone.HAND, source, game);
         } else {
             player.moveCards(card1, Zone.HAND, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             player.putCardsOnTopOfLibrary(card2, game, source, true);
         }
-        game.getState().processAction(game);
+        game.processAction();
         return new ExileSpellEffect().apply(game, source);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OutOfTime.java
+++ b/Mage.Sets/src/mage/cards/o/OutOfTime.java
@@ -82,7 +82,7 @@ class OutOfTimePhaseOutEffect extends OneShotEffect {
             Permanent outOfTime = game.getPermanent(source.getSourceId());
             if (outOfTime != null) {
                 new PhaseOutAllEffect(new ArrayList<>(creatureIds)).apply(game, source);
-                game.getState().processAction(game);
+                game.processAction();
                 new AddCountersSourceEffect(CounterType.TIME.createInstance(numCreatures)).apply(game, source);
                 game.getState().setValue("phasedOutCreatures"
                         + source.getId().toString(), creatureIds);

--- a/Mage.Sets/src/mage/cards/o/Outmuscle.java
+++ b/Mage.Sets/src/mage/cards/o/Outmuscle.java
@@ -83,7 +83,7 @@ class OutmuscleEffect extends OneShotEffect {
         if (creature == null) {
             return true;
         }
-        game.getState().processAction(game);
+        game.processAction();
         return creature.fight(permanent, source, game);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OverwhelmingForces.java
+++ b/Mage.Sets/src/mage/cards/o/OverwhelmingForces.java
@@ -66,7 +66,7 @@ class OverwhelmingForcesEffect extends OneShotEffect {
                 }
             }
             if (destroyedCreature > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 new DrawCardSourceControllerEffect(destroyedCreature).apply(game, source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/p/PartyThrasher.java
+++ b/Mage.Sets/src/mage/cards/p/PartyThrasher.java
@@ -98,7 +98,7 @@ class PartyThrasherEffect extends OneShotEffect {
             return false;
         }
         controller.moveCardsToExile(cards.getCards(game), source, game, true, null, "");
-        game.getState().processAction(game);
+        game.processAction();
         cards.retainZone(Zone.EXILED, game);
         if (cards.isEmpty()) {
             return true;

--- a/Mage.Sets/src/mage/cards/p/PhabineBosssConfidant.java
+++ b/Mage.Sets/src/mage/cards/p/PhabineBosssConfidant.java
@@ -107,7 +107,7 @@ class PhabineBosssConfidantParleyEffect extends OneShotEffect {
         if (landCount > 0) {
             Token citizenToken = new CitizenGreenWhiteToken();
             citizenToken.putOntoBattlefield(landCount, game, source, source.getControllerId(), false, false);
-            game.getState().processAction(game);
+            game.processAction();
         }
 
         if (nonLandCount > 0) {

--- a/Mage.Sets/src/mage/cards/p/PheliaExuberantShepherd.java
+++ b/Mage.Sets/src/mage/cards/p/PheliaExuberantShepherd.java
@@ -97,7 +97,7 @@ class PheliaExuberantShepherdEffect extends OneShotEffect {
         }
         Set<Card> cards = exileZone.getCards(game);
         player.moveCards(cards, Zone.BATTLEFIELD, source, game, false, false, true, null);
-        game.getState().processAction(game);
+        game.processAction();
 
         Permanent phelia = source.getSourcePermanentIfItStillExists(game);
         if (phelia == null) {

--- a/Mage.Sets/src/mage/cards/p/PresumedDead.java
+++ b/Mage.Sets/src/mage/cards/p/PresumedDead.java
@@ -70,7 +70,7 @@ class PresumedDeadEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, true, null);
-        game.getState().processAction(game);
+        game.processAction();
         Permanent permanent = game.getPermanent(card.getId());
         if (permanent != null) {
             permanent.setSuspected(true, game, source);

--- a/Mage.Sets/src/mage/cards/p/ProfaneProcession.java
+++ b/Mage.Sets/src/mage/cards/p/ProfaneProcession.java
@@ -75,7 +75,7 @@ class ProfaneProcessionEffect extends OneShotEffect {
         MageObject sourceObject = source.getSourceObject(game);
         if (controller != null && exileId != null && sourceObject != null) {
             new ExileTargetEffect(exileId, sourceObject.getIdName()).setTargetPointer(this.getTargetPointer().copy()).apply(game, source);
-            game.getState().processAction(game);
+            game.processAction();
             ExileZone exileZone = game.getExile().getExileZone(exileId);
             if (exileZone != null && exileZone.size() > 2) {
                 new TransformSourceEffect().apply(game, source);

--- a/Mage.Sets/src/mage/cards/p/PureReflection.java
+++ b/Mage.Sets/src/mage/cards/p/PureReflection.java
@@ -69,7 +69,7 @@ class PureReflectionEffect extends OneShotEffect {
         filter.add(SubType.REFLECTION.getPredicate());
         game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)
                 .forEach(permanent -> permanent.destroy(source, game,false));
-        game.getState().processAction(game);
+        game.processAction();
 
         // Then that player creates an X/X white Reflection creature token, where X is the converted mana cost of that spell.
         ReflectionPureToken token = new ReflectionPureToken(spell.getManaValue());

--- a/Mage.Sets/src/mage/cards/r/RainOfDaggers.java
+++ b/Mage.Sets/src/mage/cards/r/RainOfDaggers.java
@@ -66,7 +66,7 @@ class RainOfDaggersEffect extends OneShotEffect {
                 }
             }
             if (destroyedCreature > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 new LoseLifeSourceControllerEffect(destroyedCreature * 2).apply(game, source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/r/RampageOfTheClans.java
+++ b/Mage.Sets/src/mage/cards/r/RampageOfTheClans.java
@@ -68,7 +68,7 @@ class RampageOfTheClansEffect extends OneShotEffect {
                 playersWithPermanents.put(controllerId, playersWithPermanents.getOrDefault(controllerId, 0) + 1);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         Token token = new CentaurToken();
         for (Map.Entry<UUID, Integer> amountDestroyedByPlayer : playersWithPermanents.entrySet()) {
             token.putOntoBattlefield(amountDestroyedByPlayer.getValue(), game, source, amountDestroyedByPlayer.getKey());

--- a/Mage.Sets/src/mage/cards/r/RareBGone.java
+++ b/Mage.Sets/src/mage/cards/r/RareBGone.java
@@ -76,7 +76,7 @@ class RareBGoneEffect extends OneShotEffect {
             for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filterPermanent, playerId, game)) {
                 permanent.sacrifice(source, game);
             }
-            game.getState().processAction(game);
+            game.processAction();
             Cards cards = player.getHand();
             player.revealCards(source, cards, game);
             player.discard(new CardsImpl(cards.getCards(filterCard, game)), false, source, game);

--- a/Mage.Sets/src/mage/cards/r/RedSunsTwilight.java
+++ b/Mage.Sets/src/mage/cards/r/RedSunsTwilight.java
@@ -78,7 +78,7 @@ class RedSunsTwilightEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(targetID);
             if (permanent != null) {
                 if (permanent.destroy(source, game, false)) {
-                    game.getState().processAction(game);
+                    game.processAction();
                     // Note which were destroyed
                     destroyedArtifacts.add(permanent);
                 }

--- a/Mage.Sets/src/mage/cards/r/ReignOfTerror.java
+++ b/Mage.Sets/src/mage/cards/r/ReignOfTerror.java
@@ -78,7 +78,7 @@ class ReignOfTerrorEffect extends OneShotEffect {
                 .mapToInt(permanent -> permanent.destroy(source, game, true) ? 1 : 0)
                 .sum();
         if (died > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             player.loseLife(2 * died, game, source, false);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/r/ReleaseToMemory.java
+++ b/Mage.Sets/src/mage/cards/r/ReleaseToMemory.java
@@ -64,7 +64,7 @@ class ReleaseToMemoryEffect extends OneShotEffect {
         int creatures = player.getGraveyard().count(StaticFilters.FILTER_CARD_CREATURE, game);
         player.moveCards(player.getGraveyard(), Zone.EXILED, source, game);
         if (creatures > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             new SpiritToken().putOntoBattlefield(creatures, game, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/r/RighteousFury.java
+++ b/Mage.Sets/src/mage/cards/r/RighteousFury.java
@@ -67,7 +67,7 @@ class RighteousFuryEffect extends OneShotEffect {
                 }
             }
             if (destroyedCreature > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 new GainLifeEffect(destroyedCreature * 2).apply(game, source);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/r/RosecotKnight.java
+++ b/Mage.Sets/src/mage/cards/r/RosecotKnight.java
@@ -76,7 +76,7 @@ class RosecotKnightEffect extends LookLibraryAndPickControllerEffect {
     @Override
     protected boolean actionWithPickedCards(Game game, Ability source, Player player, Cards pickedCards, Cards otherCards) {
         super.actionWithPickedCards(game, source, player, pickedCards, otherCards);
-        game.getState().processAction(game);
+        game.processAction();
         pickedCards.retainZone(Zone.HAND, game);
         if (pickedCards.isEmpty()) {
             new AddCountersSourceEffect(CounterType.P1P1.createInstance()).apply(game, source);

--- a/Mage.Sets/src/mage/cards/s/SavageSwipe.java
+++ b/Mage.Sets/src/mage/cards/s/SavageSwipe.java
@@ -71,7 +71,7 @@ class SavageSwipeEffect extends OneShotEffect {
             ContinuousEffect effect = new BoostTargetEffect(2, 2, Duration.EndOfTurn);
             effect.setTargetPointer(new FixedTarget(permanent, game));
             game.addEffect(effect, source);
-            game.getState().processAction(game);
+            game.processAction();
         }
         return new FightTargetsEffect().apply(game, source);
     }

--- a/Mage.Sets/src/mage/cards/s/SawInHalf.java
+++ b/Mage.Sets/src/mage/cards/s/SawInHalf.java
@@ -64,7 +64,7 @@ class SawInHalfEffect extends OneShotEffect {
                 || game.getState().getZone(permanent.getId()) != Zone.GRAVEYARD) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
         return new CreateTokenCopyTargetEffect(
                 permanent.getControllerId(), null, false, 2, false, false, null,
                 divide(permanent.getPower()), divide(permanent.getToughness()), false

--- a/Mage.Sets/src/mage/cards/s/SeizeTheSpotlight.java
+++ b/Mage.Sets/src/mage/cards/s/SeizeTheSpotlight.java
@@ -107,7 +107,7 @@ class SeizeTheSpotlightEffect extends OneShotEffect {
             FilterPermanent affectedFilter = new FilterPermanent();
             affectedFilter.add(new PermanentReferenceInCollectionPredicate(permanents, game));
             new GainControlAllEffect(Duration.EndOfTurn, affectedFilter).apply(game, source);
-            game.getState().processAction(game);
+            game.processAction();
             new UntapAllEffect(affectedFilter).apply(game, source);
             game.addEffect(new GainAbilityAllEffect(HasteAbility.getInstance(), Duration.EndOfTurn, affectedFilter), source);
         }

--- a/Mage.Sets/src/mage/cards/s/SelflessExorcist.java
+++ b/Mage.Sets/src/mage/cards/s/SelflessExorcist.java
@@ -75,7 +75,7 @@ class SelflessExorcistEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         Permanent permanent = source.getSourcePermanentIfItStillExists(game);
         if (permanent == null) {
             return true;

--- a/Mage.Sets/src/mage/cards/s/SettleTheWreckage.java
+++ b/Mage.Sets/src/mage/cards/s/SettleTheWreckage.java
@@ -71,7 +71,7 @@ class SettleTheWreckageEffect extends OneShotEffect {
             return true;
         }
         controller.moveCards(toExile, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
 
         TargetCardInLibrary target = new TargetCardInLibrary(0, attackers,
                 attackers > 1 ? StaticFilters.FILTER_CARD_BASIC_LANDS : StaticFilters.FILTER_CARD_BASIC_LAND

--- a/Mage.Sets/src/mage/cards/s/ShiftingShadow.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftingShadow.java
@@ -124,7 +124,7 @@ class ShiftingShadowEffect extends OneShotEffect {
         Permanent permanent = source.getSourcePermanentIfItStillExists(game);
         if (permanent != null) {
             permanent.destroy(source, game);
-            game.getState().processAction(game);
+            game.processAction();
         }
         Player player = game.getPlayer(source.getControllerId());
         if (player == null) {

--- a/Mage.Sets/src/mage/cards/s/ShilgengarSireOfFamine.java
+++ b/Mage.Sets/src/mage/cards/s/ShilgengarSireOfFamine.java
@@ -135,7 +135,7 @@ class ShilgengarSireOfFamineEffect extends OneShotEffect {
         );
         effect.setTargetPointer(new FixedTargets(cards, game));
         effect.apply(game, source);
-        game.getState().processAction(game);
+        game.processAction();
         List<Permanent> permanents = cards
                 .stream()
                 .map(game::getPermanent)

--- a/Mage.Sets/src/mage/cards/s/ShowstoppingSurprise.java
+++ b/Mage.Sets/src/mage/cards/s/ShowstoppingSurprise.java
@@ -61,7 +61,7 @@ class ShowstoppingSurpriseEffect extends OneShotEffect {
         }
         if (permanent.isFaceDown(game)) {
             permanent.turnFaceUp(source, game, source.getControllerId());
-            game.getState().processAction(game);
+            game.processAction();
         }
         int power = permanent.getPower().getValue();
         if (power < 1) {

--- a/Mage.Sets/src/mage/cards/s/SlicerHiredMuscle.java
+++ b/Mage.Sets/src/mage/cards/s/SlicerHiredMuscle.java
@@ -98,7 +98,7 @@ class SlicerHiredMuscleUpkeepEffect extends OneShotEffect {
                     .setTargetPointer(new FixedTarget(sourcePermanent, game)), source);
 
             // process action so that untap effects the new controller
-            game.getState().processAction(game);
+            game.processAction();
 
             // Untap
             sourcePermanent.untap(game);

--- a/Mage.Sets/src/mage/cards/s/SludgeTitan.java
+++ b/Mage.Sets/src/mage/cards/s/SludgeTitan.java
@@ -74,7 +74,7 @@ class SludgeTitanEffect extends OneShotEffect {
             return false;
         }
         Cards cards = controller.millCards(5, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         cards.removeIf(card -> !game.getState().getZone(card).isPublicZone());
         if (!cards.isEmpty()) {
             TargetCard target = new TargetCardAndOrCard(CardType.CREATURE, CardType.LAND);

--- a/Mage.Sets/src/mage/cards/s/SorinLordOfInnistrad.java
+++ b/Mage.Sets/src/mage/cards/s/SorinLordOfInnistrad.java
@@ -100,7 +100,7 @@ class SorinLordOfInnistradEffect extends OneShotEffect {
                 }
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             return controller.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);

--- a/Mage.Sets/src/mage/cards/s/SurroundedByOrcs.java
+++ b/Mage.Sets/src/mage/cards/s/SurroundedByOrcs.java
@@ -61,7 +61,7 @@ class SurroundedByOrcsEffect extends OneShotEffect {
         if (permanent == null || player == null) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
         player.millCards(permanent.getPower().getValue(), source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TahngarthFirstMate.java
+++ b/Mage.Sets/src/mage/cards/t/TahngarthFirstMate.java
@@ -135,7 +135,7 @@ class TahngarthFirstMateEffect extends OneShotEffect {
         ContinuousEffect effect = new GainControlTargetEffect(Duration.EndOfCombat, player.getId());
         effect.setTargetPointer(new FixedTarget(permanent, game));
         game.addEffect(effect, source);
-        game.getState().processAction(game);
+        game.processAction();
         return game.getCombat().addAttackerToCombat(permanent.getId(), target.getFirstTarget(), game);
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TaintedPact.java
+++ b/Mage.Sets/src/mage/cards/t/TaintedPact.java
@@ -69,7 +69,7 @@ class TaintedPactEffect extends OneShotEffect {
             if (card != null) {
                 // the card move is sequential, not all at once.
                 controller.moveCards(card, Zone.EXILED, source, game);
-                game.getState().processAction(game);  // Laelia, the Blade Reforged
+                game.processAction();  // Laelia, the Blade Reforged
                 // Checks if there was already exiled a card with the same name
                 if (names.contains(card.getName())) {
                     break;

--- a/Mage.Sets/src/mage/cards/t/TeferiTemporalPilgrim.java
+++ b/Mage.Sets/src/mage/cards/t/TeferiTemporalPilgrim.java
@@ -88,7 +88,7 @@ class TeferiTemporalPilgrimEffect extends OneShotEffect {
         Permanent toHand = game.getPermanent(target.getFirstTarget());
         if (toHand != null) {
             opponent.moveCards(toHand, Zone.HAND, source, game);
-            game.getState().processAction(game);
+            game.processAction();
         }
         HashSet<Permanent> toLibrary = new HashSet<>(game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_NON_LAND, opponent.getId(), game));
         if (toLibrary.isEmpty()) {

--- a/Mage.Sets/src/mage/cards/t/TeleminPerformance.java
+++ b/Mage.Sets/src/mage/cards/t/TeleminPerformance.java
@@ -77,7 +77,7 @@ class TeleminPerformanceEffect extends OneShotEffect {
                 opponent.revealCards(source, reveal, game);
                 opponent.moveCards(nonCreatures, Zone.GRAVEYARD, source, game);
                 if (creature != null) {
-                    game.getState().processAction(game);
+                    game.processAction();
                     controller.moveCards(creature, Zone.BATTLEFIELD, source, game);
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/Terastodon.java
+++ b/Mage.Sets/src/mage/cards/t/Terastodon.java
@@ -88,7 +88,7 @@ class TerastodonEffect extends OneShotEffect {
                 }
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         ElephantToken elephantToken = new ElephantToken();
         for (Entry<UUID, Integer> entry : destroyedPermanents.entrySet()) {
             elephantToken.putOntoBattlefield(entry.getValue(), game, source, entry.getKey());

--- a/Mage.Sets/src/mage/cards/t/TheCreationOfAvacyn.java
+++ b/Mage.Sets/src/mage/cards/t/TheCreationOfAvacyn.java
@@ -176,7 +176,7 @@ class TheCreationOfAvacynThreeEffect extends OneShotEffect {
         if (creatureCard) {
             if (controller.chooseUse(Outcome.PutCreatureInPlay, "Put the permanent in play?", source, game)) {
                 controller.moveCards(exileZone, Zone.BATTLEFIELD, source, game);
-                game.getState().processAction(game);
+                game.processAction();
             }
         }
         controller.moveCards(exileZone, Zone.HAND, source, game);

--- a/Mage.Sets/src/mage/cards/t/TheGreatAurora.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatAurora.java
@@ -90,7 +90,7 @@ class TheGreatAuroraEffect extends OneShotEffect {
                 }
             }
 
-            game.getState().processAction(game); // so effects from creatures that were on the battlefield won't trigger from draw or put into play
+            game.processAction(); // so effects from creatures that were on the battlefield won't trigger from draw or put into play
 
             // Draw cards
             for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {

--- a/Mage.Sets/src/mage/cards/t/TheNiptonLottery.java
+++ b/Mage.Sets/src/mage/cards/t/TheNiptonLottery.java
@@ -74,7 +74,7 @@ class TheNiptonLotteryEffect extends OneShotEffect {
         ContinuousEffect controlEffect = new GainControlTargetEffect(Duration.EndOfTurn);
         controlEffect.setTargetPointer(new FixedTarget(permanentToSteal, game));
         game.addEffect(controlEffect, source);
-        game.getState().processAction(game);
+        game.processAction();
         permanentToSteal.untap(game);
         ContinuousEffect hasteEffect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
         hasteEffect.setTargetPointer(new FixedTarget(permanentToSteal, game));

--- a/Mage.Sets/src/mage/cards/t/ThePhasingOfZhalfir.java
+++ b/Mage.Sets/src/mage/cards/t/ThePhasingOfZhalfir.java
@@ -122,7 +122,7 @@ class ThePhasingOfZhalfirDestroyEffect extends OneShotEffect {
                 playerMap.compute(permanent.getControllerId(), CardUtil::setOrIncrementValue);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         Token token = new PhyrexianToken();
         for (Map.Entry<UUID, Integer> entry : playerMap.entrySet()) {
             token.putOntoBattlefield(entry.getValue(), game, source, entry.getKey());

--- a/Mage.Sets/src/mage/cards/t/TheStoneBrain.java
+++ b/Mage.Sets/src/mage/cards/t/TheStoneBrain.java
@@ -123,7 +123,7 @@ class TheStoneBrainEffect extends OneShotEffect {
                 targetPlayer.shuffleLibrary(source, game);
 
                 if (numberOfCardsExiledFromHand > 0) {
-                    game.getState().processAction(game);
+                    game.processAction();
                     targetPlayer.drawCards(numberOfCardsExiledFromHand, source, game);
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/ThievingSkydiver.java
+++ b/Mage.Sets/src/mage/cards/t/ThievingSkydiver.java
@@ -91,7 +91,7 @@ class ThievingSkydiverEffect extends OneShotEffect {
                 || !artifact.hasSubtype(SubType.EQUIPMENT, game)) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
         permanent.addAttachment(artifact.getId(), source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/ThoughtDissector.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtDissector.java
@@ -90,7 +90,7 @@ class ThoughtDissectorEffect extends OneShotEffect {
             }
             targetOpponent.revealCards(source, reveal, game);
             if (artifact != null) {
-                game.getState().processAction(game);
+                game.processAction();
                 controller.moveCards(artifact, Zone.BATTLEFIELD, source, game);
                 Permanent sourcePermanent = source.getSourcePermanentIfItStillExists(game);
                 if (sourcePermanent != null) {

--- a/Mage.Sets/src/mage/cards/t/TooGreedilyTooDeep.java
+++ b/Mage.Sets/src/mage/cards/t/TooGreedilyTooDeep.java
@@ -65,7 +65,7 @@ class TooGreedilyTooDeepEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         Permanent returnedCreature = game.getPermanent(card.getId());
         if (returnedCreature != null && returnedCreature.getPower().getValue() > 0) {
             for (Permanent creature : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), source, game)) {

--- a/Mage.Sets/src/mage/cards/t/TribuneOfRot.java
+++ b/Mage.Sets/src/mage/cards/t/TribuneOfRot.java
@@ -70,7 +70,7 @@ class TribuneOfRotEffect extends OneShotEffect {
                     .millCards(2, source, game)
                     .count(StaticFilters.FILTER_CARD_CREATURE, game);
             if (numOfCreatureCardsMilled > 0) {
-                game.getState().processAction(game);
+                game.processAction();
                 token.putOntoBattlefield(numOfCreatureCardsMilled, game, source, source.getControllerId(), false, false);
             }
             return true;

--- a/Mage.Sets/src/mage/cards/t/TwilightProphet.java
+++ b/Mage.Sets/src/mage/cards/t/TwilightProphet.java
@@ -86,7 +86,7 @@ class TwilightProphetEffect extends OneShotEffect {
             if (card != null) {
                 controller.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
                 controller.moveCards(card, Zone.HAND, source, game);
-                game.getState().processAction(game);
+                game.processAction();
                 int amount = card.getManaValue();
                 if (amount > 0) {
                     new LoseLifeOpponentsEffect(amount).apply(game, source);

--- a/Mage.Sets/src/mage/cards/t/TymaretChosenFromDeath.java
+++ b/Mage.Sets/src/mage/cards/t/TymaretChosenFromDeath.java
@@ -97,7 +97,7 @@ class TymaretChosenFromDeathEffect extends OneShotEffect {
                 .mapToInt(x -> 1)
                 .sum();
         if (lifeGain > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             player.gainLife(lifeGain, game, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/u/UnfinishedBusiness.java
+++ b/Mage.Sets/src/mage/cards/u/UnfinishedBusiness.java
@@ -73,7 +73,7 @@ class UnfinishedBusinessEffect extends OneShotEffect{
 
         if (targetCreature != null){
             controller.moveCards(targetCreature, Zone.BATTLEFIELD, source, game);
-            game.getState().processAction(game);
+            game.processAction();
         }
         Permanent permanentCreature = targetCreature == null ? null : game.getPermanent(targetCreature.getId());
 

--- a/Mage.Sets/src/mage/cards/u/UnmooredEgo.java
+++ b/Mage.Sets/src/mage/cards/u/UnmooredEgo.java
@@ -110,7 +110,7 @@ class UnmooredEgoEffect extends OneShotEffect {
                 targetPlayer.shuffleLibrary(source, game);
 
                 if (numberOfCardsExiledFromHand > 0) {
-                    game.getState().processAction(game);
+                    game.processAction();
                     targetPlayer.drawCards(numberOfCardsExiledFromHand, source, game);
                 }
             }

--- a/Mage.Sets/src/mage/cards/u/UnstableAmulet.java
+++ b/Mage.Sets/src/mage/cards/u/UnstableAmulet.java
@@ -98,7 +98,7 @@ class UnstableAmuletEffect extends OneShotEffect {
         UUID exileId = CardUtil.getExileZoneId(game, source);
         String exileName = CardUtil.getSourceIdName(game, source);
         controller.moveCardsToExile(card, source, game, true, exileId, exileName);
-        game.getState().processAction(game);
+        game.processAction();
         if (!Zone.EXILED.equals(game.getState().getZone(card.getId()))) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/v/VesuvanShapeshifter.java
+++ b/Mage.Sets/src/mage/cards/v/VesuvanShapeshifter.java
@@ -114,7 +114,7 @@ class VesuvanShapeshifterEffect extends OneShotEffect {
                 if (copyFromCreature != null) {
                     game.copyPermanent(Duration.Custom, copyFromCreature, copyToCreature.getId(), source, new VesuvanShapeShifterFaceUpCopyApplier());
                     source.getTargets().clear();
-                    game.getState().processAction(game); // needed to get effects ready if copy happens in replacment and the copied abilities react of the same event (e.g. turn face up)
+                    game.processAction(); // needed to get effects ready if copy happens in replacment and the copied abilities react of the same event (e.g. turn face up)
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/v/Victimize.java
+++ b/Mage.Sets/src/mage/cards/v/Victimize.java
@@ -64,7 +64,7 @@ class VictimizeEffect extends OneShotEffect {
         if (controller != null) {
             SacrificeTargetCost cost = new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE);
             if (cost.pay(source, game, source, source.getControllerId(), false, null)) {
-                game.getState().processAction(game); // To end effects of the sacrificed creature
+                game.processAction(); // To end effects of the sacrificed creature
                 controller.moveCards(new CardsImpl(getTargetPointer().getTargets(game, source)).getCards(game),
                         Zone.BATTLEFIELD, source, game, true, false, false, null);
             }

--- a/Mage.Sets/src/mage/cards/v/VolatileStormdrake.java
+++ b/Mage.Sets/src/mage/cards/v/VolatileStormdrake.java
@@ -136,7 +136,7 @@ class VolatileStormdrakeEffect extends OneShotEffect {
         ContinuousEffect effect = new ExchangeControlTargetEffect(Duration.EndOfGame, "", true);
         effect.setTargetPointer(this.getTargetPointer().copy());
         game.addEffect(effect, source);
-        game.getState().processAction(game);
+        game.processAction();
         controller.addCounters(CounterType.ENERGY.createInstance(4), controller.getId(), source, game);
         new DoIfCostPaid(
                 null, new SacrificeTargetEffect("", controller.getId()),

--- a/Mage.Sets/src/mage/cards/v/VoraciousFellBeast.java
+++ b/Mage.Sets/src/mage/cards/v/VoraciousFellBeast.java
@@ -105,7 +105,7 @@ class VoraciousFellBeastEffect extends OneShotEffect {
             }
         }
         if (sacrificeCount > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             new CreateTokenEffect(new FoodToken(), sacrificeCount).apply(game, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/w/WarpWorld.java
+++ b/Mage.Sets/src/mage/cards/w/WarpWorld.java
@@ -97,7 +97,7 @@ class WarpWorldEffect extends OneShotEffect {
             }
         }
 
-        game.getState().processAction(game); // so effects from creatures that were on the battlefield won't trigger from draw or later put into play
+        game.processAction(); // so effects from creatures that were on the battlefield won't trigger from draw or later put into play
 
         Map<UUID, CardsImpl> cardsRevealed = new HashMap<>();
 
@@ -111,7 +111,7 @@ class WarpWorldEffect extends OneShotEffect {
                 cardsRevealed.put(player.getId(), cards);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         // put artifacts, creaturs and lands onto the battlefield
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);
@@ -129,7 +129,7 @@ class WarpWorldEffect extends OneShotEffect {
                 player.moveCards(toBattlefield, Zone.BATTLEFIELD, source, game);
             }
         }
-        game.getState().processAction(game);
+        game.processAction();
         // put enchantments onto the battlefield
         for (UUID playerId : game.getState().getPlayersInRange(source.getControllerId(), game)) {
             Player player = game.getPlayer(playerId);

--- a/Mage.Sets/src/mage/cards/w/WasteManagement.java
+++ b/Mage.Sets/src/mage/cards/w/WasteManagement.java
@@ -101,7 +101,7 @@ class WasteManagementEffect extends OneShotEffect {
         cards.retainZone(Zone.EXILED, game);
         int count = cards.count(StaticFilters.FILTER_CARD_CREATURE, game);
         if (count > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             new RogueToken().putOntoBattlefield(count, game, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/w/WaveOfVitriol.java
+++ b/Mage.Sets/src/mage/cards/w/WaveOfVitriol.java
@@ -92,7 +92,7 @@ class WaveOfVitriolEffect extends OneShotEffect {
                     }
                 }
             }
-            game.getState().processAction(game);
+            game.processAction();
             Cards toBattlefield = new CardsImpl();
             Set<Player> playersToShuffle = new LinkedHashSet<>();
             for (Map.Entry<Player, Integer> entry : sacrificedLands.entrySet()) {

--- a/Mage.Sets/src/mage/cards/w/WheelOfPotential.java
+++ b/Mage.Sets/src/mage/cards/w/WheelOfPotential.java
@@ -91,7 +91,7 @@ class WheelOfPotentialEffect extends OneShotEffect {
             player.drawCards(numberPaid, source, game);
         }
         if (numberPaid >= 7) {
-            game.getState().processAction(game);
+            game.processAction();
             cardsExiled.removeIf(cardId -> {
                 Card card = game.getCard(cardId);
                 return card == null || !card.getOwnerId().equals(controller.getId());

--- a/Mage.Sets/src/mage/cards/w/WhiptongueHydra.java
+++ b/Mage.Sets/src/mage/cards/w/WhiptongueHydra.java
@@ -81,7 +81,7 @@ class WhiptongueHydraEffect extends OneShotEffect {
                 (permanent) -> (permanent.destroy(source, game, false))
         ).map((_item) -> 1).reduce(destroyedPermanents, Integer::sum);
         if (destroyedPermanents > 0) {
-            game.getState().processAction(game);
+            game.processAction();
             new AddCountersSourceEffect(
                     CounterType.P1P1.createInstance(destroyedPermanents), true
             ).apply(game, source);

--- a/Mage.Sets/src/mage/cards/w/WidespreadBrutality.java
+++ b/Mage.Sets/src/mage/cards/w/WidespreadBrutality.java
@@ -68,7 +68,7 @@ class WidespreadBrutalityEffect extends OneShotEffect {
         if (amassedArmy == null) {
             return false;
         }
-        game.getState().processAction(game);
+        game.processAction();
         int power = amassedArmy.getPower().getValue();
         for (Permanent permanent : game.getBattlefield().getActivePermanents(
                 filter, source.getControllerId(), source, game

--- a/Mage.Sets/src/mage/cards/w/WindsOfAbandon.java
+++ b/Mage.Sets/src/mage/cards/w/WindsOfAbandon.java
@@ -80,7 +80,7 @@ class WindsOfAbandonEffect extends OneShotEffect {
         if (!controller.moveCards(permanent, Zone.EXILED, source, game)) {
             return true;
         }
-        game.getState().processAction(game);
+        game.processAction();
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
         if (player.searchLibrary(target, source, game)) {
             Card card = player.getLibrary().getCard(target.getFirstTarget(), game);
@@ -126,7 +126,7 @@ class WindsOfAbandonOverloadEffect extends OneShotEffect {
         if (!controller.moveCards(cards, Zone.EXILED, source, game)) {
             return true;
         }
-        game.getState().processAction(game);
+        game.processAction();
         for (Map.Entry<UUID, Integer> entry : playerAmount.entrySet()) {
             Player player = game.getPlayer(entry.getKey());
             if (player == null) {

--- a/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/y/YorvoLordOfGarenbrig.java
@@ -91,7 +91,7 @@ class YorvoLordOfGarenbrigEffect extends OneShotEffect {
         if (permanent == null) {
             return true;
         }
-        game.getState().processAction(game);
+        game.processAction();
         if (permanent.getPower().getValue() > sourcePerm.getPower().getValue()) {
             sourcePerm.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
         }

--- a/Mage.Sets/src/mage/cards/z/ZombieApocalypse.java
+++ b/Mage.Sets/src/mage/cards/z/ZombieApocalypse.java
@@ -66,7 +66,7 @@ class ZombieApocalypseEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             controller.moveCards(controller.getGraveyard().getCards(filterZombie, game), Zone.BATTLEFIELD, source, game, true, false, false, null);
-            game.getState().processAction(game);
+            game.processAction();
             for (Permanent permanent : game.getBattlefield().getActivePermanents(
                     new FilterPermanent(SubType.HUMAN, "Humans"), source.getControllerId(), game)) {
                 permanent.destroy(source, game, false);

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -248,7 +248,7 @@ public abstract class AbilityImpl implements Ability {
              * abilities with replacement effects deactivated too late Example:
              * {@link org.mage.test.cards.replacement.DryadMilitantTest#testDiesByDestroy testDiesByDestroy}
              */
-            game.getState().processAction(game);
+            game.processAction();
         }
         return result;
     }

--- a/Mage/src/main/java/mage/abilities/common/AnimateDeadTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/AnimateDeadTriggeredAbility.java
@@ -190,7 +190,7 @@ class AnimateDeadPutOntoBattlefieldEffect extends OneShotEffect {
         }
         // Put card onto the battlefield under your control...
         player.moveCards(card, Zone.BATTLEFIELD, source, game, tapped, false, false, null);
-        game.getState().processAction(game);
+        game.processAction();
 
         Permanent creature = game.getPermanent(CardUtil.getDefaultCardSideForBattlefield(game, card).getId());
         if (creature == null) {

--- a/Mage/src/main/java/mage/abilities/effects/common/DevourEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DevourEffect.java
@@ -114,7 +114,7 @@ public class DevourEffect extends ReplacementEffectImpl {
                 + filterDevoured.getMessage() + (devouredCreatures > 1 ? "s" : "")
         );
         
-        game.getState().processAction(game); // need for multistep effects
+        game.processAction(); // need for multistep effects
 
         int amountCounters;
         if (devourFactor == Integer.MAX_VALUE) {

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileThenReturnTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileThenReturnTargetEffect.java
@@ -62,7 +62,7 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(toFlicker, Zone.EXILED, source, game);
-        game.getState().processAction(game);
+        game.processAction();
         for (Card card : toFlicker) {
             putCards.moveCard(
                     yourControl ? controller : game.getPlayer(card.getOwnerId()),

--- a/Mage/src/main/java/mage/abilities/effects/common/LivingDeathEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/LivingDeathEffect.java
@@ -47,14 +47,14 @@ public class LivingDeathEffect extends OneShotEffect {
                     }
                 }
             }
-            game.getState().processAction(game);
+            game.processAction();
 
             // Sacrifice all creatures
             for (Permanent permanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), game)) {
                 permanent.sacrifice(source, game);
             }
 
-            game.getState().processAction(game);
+            game.processAction();
 
             // Exiled cards are put onto the battlefield at the same time under their owner's control
             Set<Card> cardsToReturnFromExile = new HashSet<>();

--- a/Mage/src/main/java/mage/abilities/effects/common/ShuffleHandIntoLibraryDrawThatManySourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ShuffleHandIntoLibraryDrawThatManySourceEffect.java
@@ -35,7 +35,7 @@ public class ShuffleHandIntoLibraryDrawThatManySourceEffect extends OneShotEffec
             if (cardsHand > 0) {
                 controller.moveCards(controller.getHand(), Zone.LIBRARY, source, game);
                 controller.shuffleLibrary(source, game);
-                game.getState().processAction(game); // then
+                game.processAction(); // then
                 controller.drawCards(cardsHand, source, game);
             }
             return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/GainControlAllUntapGainHasteEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/GainControlAllUntapGainHasteEffect.java
@@ -48,7 +48,7 @@ public class GainControlAllUntapGainHasteEffect extends OneShotEffect {
         FilterPermanent affectedFilter = new FilterPermanent();
         affectedFilter.add(new PermanentReferenceInCollectionPredicate(affectedObjects, game));
         new GainControlAllEffect(Duration.EndOfTurn, affectedFilter).apply(game, source);
-        game.getState().processAction(game);
+        game.processAction();
         new UntapAllEffect(affectedFilter).apply(game, source);
         game.addEffect(new GainAbilityAllEffect(HasteAbility.getInstance(), Duration.EndOfTurn, affectedFilter), source);
         return true;

--- a/Mage/src/main/java/mage/abilities/effects/keyword/DiscoverEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/DiscoverEffect.java
@@ -68,7 +68,7 @@ public class DiscoverEffect extends OneShotEffect {
         for (Card card : player.getLibrary().getCards(game)) {
             cards.add(card);
             player.moveCards(card, Zone.EXILED, source, game);
-            game.getState().processAction(game);
+            game.processAction();
             if (filter.match(card, game)) {
                 return card;
             }

--- a/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/ExploreSourceEffect.java
@@ -116,7 +116,7 @@ public class ExploreSourceEffect extends OneShotEffect {
             // the exploring creature receives a +1/+1 counter.
             addCounter(game, permanent, source);
         }
-        game.getState().processAction(game);
+        game.processAction();
         // 701.40b A permanent “explores” after the process described in rule 701.40a is complete, even if some or all of
         // those actions were impossible.
         game.fireEvent(new ExploredEvent(permanent, source, card));

--- a/Mage/src/main/java/mage/abilities/keyword/CascadeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CascadeAbility.java
@@ -124,7 +124,7 @@ class CascadeEffect extends OneShotEffect {
             cardsToExile.add(card);
             // the card move is sequential, not all at once.
             controller.moveCards(card, Zone.EXILED, source, game);
-            game.getState().processAction(game);  // Laelia, the Blade Reforged
+            game.processAction();  // Laelia, the Blade Reforged
             if (!card.isLand(game)
                     && card.getManaValue() < sourceCost) {
                 cardToCast = card;

--- a/Mage/src/main/java/mage/abilities/keyword/MadnessAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/MadnessAbility.java
@@ -136,7 +136,7 @@ class MadnessReplacementEffect extends ReplacementEffectImpl {
         }
 
         // needed to add Madness ability to cards (e.g. by Falkenrath Gorger)
-        game.getState().processAction(game);
+        game.processAction();
 
         GameEvent gameEvent = new MadnessCardExiledEvent(card.getId(), source, controller.getId());
         game.fireEvent(gameEvent);

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -610,7 +610,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
             // This is somewhat a band-aid on the special action nature of turning a permanent face up.
             // 708.8. As a face-down permanent is turned face up, its copiable values revert to its normal copiable values.
             // Any effects that have been applied to the face-down permanent still apply to the face-up permanent.
-            game.getState().processAction(game);
+            game.processAction();
             game.fireEvent(GameEvent.getEvent(GameEvent.EventType.TURNED_FACE_UP, getId(), source, playerId));
             return true;
         }

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -505,13 +505,29 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
     UUID fireReflexiveTriggeredAbility(ReflexiveTriggeredAbility reflexiveAbility, Ability source, boolean fireAsSimultaneousEvent);
 
     /**
-     * Inner game engine call to reset game objects to actual versions
-     * (reset all objects and apply all effects due layer system)
-     * <p>
-     * Warning, if you need to process object moves in the middle of the effect/ability
-     * then call game.getState().processAction(game) instead
+     * Inner engine call to reset all game objects and re-apply all layered continuous effects.
+     * Do NOT use indiscriminately. See processAction() instead.
      */
+    @Deprecated
     void applyEffects();
+
+    /**
+     * Handles simultaneous events for triggers and then re-applies all layered continuous effects.
+     * Must be called between sequential steps of a resolving one-shot effect.
+     * <p>
+     * 608.2e. Some spells and abilities have multiple steps or actions, denoted by separate sentences or clauses,
+     * that involve multiple players. In these cases, the choices for the first action are made in APNAP order,
+     * and then the first action is processed simultaneously. Then the choices for the second action are made in
+     * APNAP order, and then that action is processed simultaneously, and so on. See rule 101.4.
+     * <p>
+     * 608.2f. Some spells and abilities include actions taken on multiple players and/or objects. In most cases,
+     * each such action is processed simultaneously. If the action can't be processed simultaneously, it's instead
+     * processed considering each affected player or object individually. APNAP order is used to make the primary
+     * determination of the order of those actions. Secondarily, if the action is to be taken on both a player
+     * and an object they control or on multiple objects controlled by the same player, the player who controls
+     * the resolving spell or ability chooses the relative order of those actions.
+     */
+    void processAction();
 
     @Deprecated // TODO: must research usage and remove it from all non engine code (example: Bestow ability, ProcessActions must be used instead)
     boolean checkStateAndTriggered();

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1928,6 +1928,14 @@ public abstract class GameImpl implements Game {
     }
 
     @Override
+    public void processAction() {
+        state.handleSimultaneousEvent(this);
+        resetShortLivingLKI();
+        applyEffects();
+        state.getTriggers().checkStateTriggers(this);
+    }
+
+    @Override
     public void addEffect(ContinuousEffect continuousEffect, Ability source) {
         Ability newAbility = source.copy();
         newAbility.setSourceObjectZoneChangeCounter(getState().getZoneChangeCounter(source.getSourceId()));
@@ -2241,20 +2249,17 @@ public abstract class GameImpl implements Game {
     }
 
     /**
-     * 116.5. Each time a player would get priority, the game first performs all
+     * 117.5. Each time a player would get priority, the game first performs all
      * applicable state-based actions as a single event (see rule 704,
      * “State-Based Actions”), then repeats this process until no state-based
      * actions are performed. Then triggered abilities are put on the stack (see
      * rule 603, “Handling Triggered Abilities”). These steps repeat in order
      * until no further state-based actions are performed and no abilities
      * trigger. Then the player who would have received priority does so.
-     *
-     * @return
      */
     @Override
     public boolean checkStateAndTriggered() {
         boolean somethingHappened = false;
-        //20091005 - 115.5
         while (!isPaused() && !checkIfGameIsOver()) {
             if (!checkStateBasedActions()) {
                 // nothing happened so check triggers
@@ -2263,7 +2268,7 @@ public abstract class GameImpl implements Game {
                     break;
                 }
             }
-            this.getState().processAction(this); // needed e.g if boost effects end and cause creatures to die
+            processAction(); // needed e.g if boost effects end and cause creatures to die
             somethingHappened = true;
         }
         checkConcede();
@@ -2273,10 +2278,8 @@ public abstract class GameImpl implements Game {
     /**
      * Sets the waiting triggered abilities (if there are any) to the stack in
      * the chosen order by player
-     *
-     * @return
      */
-    public boolean checkTriggered() {
+    boolean checkTriggered() {
         boolean played = false;
         state.getTriggers().checkStateTriggers(this);
         for (UUID playerId : state.getPlayerList(state.getActivePlayerId())) {
@@ -2314,15 +2317,13 @@ public abstract class GameImpl implements Game {
     }
 
     /**
-     * 116.5. Each time a player would get priority, the game first performs all
+     * 117.5. Each time a player would get priority, the game first performs all
      * applicable state-based actions as a single event (see rule 704,
      * “State-Based Actions”), then repeats this process until no state-based
      * actions are performed. Then triggered abilities are put on the stack (see
      * rule 603, “Handling Triggered Abilities”). These steps repeat in order
      * until no further state-based actions are performed and no abilities
      * trigger. Then the player who would have received priority does so.
-     *
-     * @return
      */
     protected boolean checkStateBasedActions() {
         boolean somethingHappened = false;

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -666,22 +666,6 @@ public class GameState implements Serializable, Copyable<GameState> {
         this.gameOver = true;
     }
 
-    /**
-     * Must be called between effects/steps in the ability's resolve
-     * <p>
-     * 608.2e
-     * Some spells and abilities have multiple steps or actions, denoted by separate sentences or clauses,
-     * that involve multiple players. In these cases, the choices for the first action are made in APNAP order,
-     * and then the first action is processed simultaneously. Then the choices for the second action are made in
-     * APNAP order, and then that action is processed simultaneously, and so on. See rule 101.4.
-     */
-    public void processAction(Game game) {
-        game.getState().handleSimultaneousEvent(game);
-        game.resetShortLivingLKI();
-        game.applyEffects();
-        game.getState().getTriggers().checkStateTriggers(game);
-    }
-
     void applyEffects(Game game) {
         applyEffectsCounter++;
         for (Player player : players.values()) {


### PR DESCRIPTION
`game.processAction()` instead of `game.getState().processAction(game)`

added "deprecated" annotation to applyEffects