### PR TITLE
[don't merge] throw error on applyEffects with unhandled events

### DIFF
--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -671,7 +671,7 @@ public class GameState implements Serializable, Copyable<GameState> {
             String message = "Warning, found " + simultaneousEvents.size() + " unhandled events while calling applyEffects: "
                     + simultaneousEvents.stream().map(Objects::toString).collect(Collectors.joining(", "))
                     + " --- Stack: " + stack.toString();
-            throw new IllegalStateException(message);
+            throw new AssertionError(message);
         }
         applyEffectsCounter++;
         for (Player player : players.values()) {

--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -667,6 +667,12 @@ public class GameState implements Serializable, Copyable<GameState> {
     }
 
     void applyEffects(Game game) {
+        if (hasSimultaneousEvents()) {
+            String message = "Warning, found " + simultaneousEvents.size() + " unhandled events while calling applyEffects: "
+                    + simultaneousEvents.stream().map(Objects::toString).collect(Collectors.joining(", "))
+                    + " --- Stack: " + stack.toString();
+            throw new IllegalStateException(message);
+        }
         applyEffectsCounter++;
         for (Player player : players.values()) {
             player.reset();


### PR DESCRIPTION
Curious how many tests break on this one - this catches potentially dangerous usages of applyEffects alone, and should never throw error on processAction since that handles simultaneous events right before.