### PR TITLE
Fix TargetsCountAdjuster to always add target even if the max is 0.

### DIFF
--- a/Mage/src/main/java/mage/target/targetadjustment/TargetsCountAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/TargetsCountAdjuster.java
@@ -41,8 +41,6 @@ public class TargetsCountAdjuster implements TargetAdjuster {
             newTarget.setTargetName(filter.getMessage() + " (up to " + count + " targets)");
         }
         ability.getTargets().clear();
-        if (count > 0) {
-            ability.addTarget(newTarget);
-        }
+        ability.addTarget(newTarget);
     }
 }


### PR DESCRIPTION
Fixes #12424

I've now tested the cards in the list mentioned there and they work as expected for X=0.