### PR TITLE
Tidied up support for scryfall variation cards

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -122,20 +122,18 @@ public class ScryfallImageSource implements CardImageSource {
                     formatSetName(card.getSet(), isToken),
                     cn,
                     localizedCode);
-            alternativeUrl = String.format("https://api.scryfall.com/cards/%s/%s?format=image",
+            alternativeUrl = String.format("https://api.scryfall.com/cards/%s/%s?format=image&include_variations=true",
                     formatSetName(card.getSet(), isToken),
                     cn);
             // with no localisation code, scryfall defaults to first available image - usually english, but may not be for some special cards
             // workaround to use cards without english images (some promos or special cards)
             // bug: https://github.com/magefree/mage/issues/6829
             // example: Mysterious Egg from IKO https://api.scryfall.com/cards/iko/385/?format=image
+            // include_variations=true added to deal with the cards that scryfall has marked as variations that seem to sometimes fail
+            // eg https://api.scryfall.com/cards/4ed/134†?format=image fails
+            // eg https://api.scryfall.com/cards/4ed/134†?format=image&include_variations=true succeeds
 
         }
-
-        // workaround to deal with the cards that scryfall has marked as variations that seem to sometimes fail
-        // eg https://api.scryfall.com/cards/4ed/134†?format=image fails
-        // eg https://api.scryfall.com/cards/4ed/134†?format=image&variation=true succeeds
-        return new CardImageUrls(baseUrl, alternativeUrl , alternativeUrl + "&variation=true");
     }
 
     private String getFaceImageUrl(Proxy proxy, CardDownloadData card, boolean isToken) throws Exception {


### PR DESCRIPTION
Found the include_variations flag so no need for a third search to check for variations - combined it with the second search (that drops the language code).