### PR TITLE
Improve/add tests, fix Tolarian Contempt

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TolarianContempt.java
+++ b/Mage.Sets/src/mage/cards/t/TolarianContempt.java
@@ -34,7 +34,7 @@ public final class TolarianContempt extends CardImpl {
             = new FilterCreaturePermanent("creature with a rejection counter on it");
 
     static {
-        filter.add(CounterType.REJECTION.getPredicate());
+        filterRejection.add(CounterType.REJECTION.getPredicate());
     }
 
     public TolarianContempt(UUID ownerId, CardSetInfo setInfo) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/exile/SearchNameExileTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/exile/SearchNameExileTests.java
@@ -14,7 +14,7 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  * Search its owner’s graveyard, hand, and library for any number of cards with the same name as that card and exile them.
  * Then that player shuffles.
  *
- * @author LevelX2
+ * @author LevelX2, notgreat
  */
 public class SearchNameExileTests extends CardTestPlayerBase {
     /**
@@ -67,12 +67,11 @@ public class SearchNameExileTests extends CardTestPlayerBase {
         addCard(Zone.GRAVEYARD, playerB, "Ready // Willing", 1);
         addCard(Zone.HAND, playerB, "Ready // Willing", 2);
         addCard(Zone.LIBRARY, playerB, "Ready // Willing", 1);
-        addCard(Zone.BATTLEFIELD, playerB, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 1);
         addCard(Zone.BATTLEFIELD, playerB, "Forest", 2);
-        addCard(Zone.BATTLEFIELD, playerB, "Swamp", 2);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "fused Ready // Willing");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Test of Talents", "Ready // Willing", "Ready // Willing");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Ready");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Test of Talents", "Ready", "Ready");
         setChoice(playerA, "Ready // Willing^Ready // Willing"); // Should be 2 in Graveyard now, take both
         setChoice(playerA, "Ready // Willing"); // Hand
         setChoice(playerA, "Ready // Willing"); // Library
@@ -120,7 +119,7 @@ public class SearchNameExileTests extends CardTestPlayerBase {
         assertExileCount(playerB, "Flamescroll Celebrant", 0);
     }
 
-    //Asserts "exile all possible" behavior for MDFC test above
+    //Asserts "exile all possible" behavior for MDFC test above, also tests fused split card
     @Test
     public void testSearchAndExileSplitSpellNonstrict() {
         addCard(Zone.HAND, playerA, "Test of Talents", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/TolarianContemptTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/TolarianContemptTest.java
@@ -1,0 +1,40 @@
+package org.mage.test.cards.single.mat;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommander4Players;
+
+/**
+ * @author notgreat
+ */
+public class TolarianContemptTest extends CardTestCommander4Players {
+
+    @Test
+    public void testEachOpponent() {
+
+        addCard(Zone.HAND, playerA, "Tolarian Contempt");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.BATTLEFIELD, playerD, "Raging Goblin");
+        addCard(Zone.BATTLEFIELD, playerC, "Memnite", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Tolarian Contempt", true);
+
+        addTarget(playerA, "Raging Goblin");
+        addTarget(playerA, "Memnite");
+        setChoice(playerD, true);
+        setChoice(playerC, true);
+
+        setStopAt(2, PhaseStep.UNTAP);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerD, 0);
+        assertLibraryCount(playerD, "Raging Goblin", 1);
+        assertPermanentCount(playerC, 1);
+        assertCounterCount(playerC, "Memnite", CounterType.REJECTION, 1);
+        assertLibraryCount(playerC, "Memnite", 1);
+    }
+
+}


### PR DESCRIPTION
When I made the generic `EachOpponentPermanentTargetsAdjuster`, it looks like I accidentally used the wrong filter for Tolarian Contempt. Fixed that, and added a test of the behavior.

In addition, the recent `SearchNameExileTests` is enough mine that I should probably add my name to the author section, and changed one of the tests of split card behavior to check un-fused.