### PR TITLE
Improved target adjusters

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BlatantThievery.java
+++ b/Mage.Sets/src/mage/cards/b/BlatantThievery.java
@@ -6,7 +6,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -24,7 +24,7 @@ public final class BlatantThievery extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, gain control of target permanent that player controls"));
         this.getSpellAbility().addTarget(new TargetPermanent());
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
     }
 
     private BlatantThievery(final BlatantThievery card) {

--- a/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
+++ b/Mage.Sets/src/mage/cards/b/BronzebeakForagers.java
@@ -19,7 +19,7 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInExile;
 import mage.target.common.TargetNonlandPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetadjustment.TargetAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 import mage.util.CardUtil;
@@ -47,7 +47,7 @@ public final class BronzebeakForagers extends CardImpl {
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
         etbAbility.addTarget(new TargetNonlandPermanent(0, 1));
-        etbAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        etbAbility.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(etbAbility);
 
         // {X}{W}: Put target card with mana value X exiled with Bronzebeak Foragers into its owner's graveyard.

--- a/Mage.Sets/src/mage/cards/d/DecoyGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DecoyGambit.java
@@ -14,7 +14,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +34,7 @@ public final class DecoyGambit extends CardImpl {
         // then return that creature to its owner's hand unless its controller has you draw a card.
         this.getSpellAbility().addEffect(new DecoyGambitEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
     }
 
     private DecoyGambit(final DecoyGambit card) {

--- a/Mage.Sets/src/mage/cards/d/DesecrateReality.java
+++ b/Mage.Sets/src/mage/cards/d/DesecrateReality.java
@@ -20,7 +20,7 @@ import mage.players.Player;
 import mage.target.Target;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInYourGraveyard;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 import mage.target.targetpointer.FixedTarget;
 
@@ -45,7 +45,7 @@ public final class DesecrateReality extends CardImpl {
             .setTargetPointer(new EachTargetPointer())
             .setText("for each opponent, exile up to one target permanent that player controls with an even mana value."));
         this.getSpellAbility().addTarget(new TargetPermanent(0, 1, evenFilter));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
 
         // Adamant -- If at least three colorless mana was spent to cast this spell, return a permanent card with an odd mana value from your graveyard to the battlefield.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(

--- a/Mage.Sets/src/mage/cards/d/DiluvianPrimordial.java
+++ b/Mage.Sets/src/mage/cards/d/DiluvianPrimordial.java
@@ -19,7 +19,7 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInOpponentsGraveyard;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
@@ -44,7 +44,7 @@ public final class DiluvianPrimordial extends CardImpl {
         // When Diluvian Primordial enters the battlefield, for each opponent, you may cast up to one target instant or sorcery card from that player's graveyard without paying its mana cost. If a card cast this way would be put into a graveyard this turn, exile it instead.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DiluvianPrimordialEffect(), false);
         ability.addTarget(new TargetCardInOpponentsGraveyard(0, 1, filter));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(true));
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster(true));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DiluvianPrimordial.java
+++ b/Mage.Sets/src/mage/cards/d/DiluvianPrimordial.java
@@ -14,13 +14,12 @@ import mage.constants.CastManaAdjustment;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterCard;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.card.OwnerIdPredicate;
+import mage.filter.common.FilterInstantOrSorceryCard;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInOpponentsGraveyard;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
@@ -29,6 +28,8 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class DiluvianPrimordial extends CardImpl {
+
+    private static final FilterCard filter = new FilterInstantOrSorceryCard("instant or sorcery card from that player's graveyard");
 
     public DiluvianPrimordial(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{U}{U}");
@@ -40,9 +41,10 @@ public final class DiluvianPrimordial extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
 
-        // When Diluvian Primordial enters the battlefield, for each opponent, you may cast up to one target instant or sorcery card from that  player's graveyard without paying its mana cost. If a card cast this way would be put into a graveyard this turn, exile it instead.
+        // When Diluvian Primordial enters the battlefield, for each opponent, you may cast up to one target instant or sorcery card from that player's graveyard without paying its mana cost. If a card cast this way would be put into a graveyard this turn, exile it instead.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DiluvianPrimordialEffect(), false);
-        ability.setTargetAdjuster(DiluvianPrimordialAdjuster.instance);
+        ability.addTarget(new TargetCardInOpponentsGraveyard(0, 1, filter));
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(true));
         this.addAbility(ability);
     }
 
@@ -53,27 +55,6 @@ public final class DiluvianPrimordial extends CardImpl {
     @Override
     public DiluvianPrimordial copy() {
         return new DiluvianPrimordial(this);
-    }
-}
-
-enum DiluvianPrimordialAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterCard filter = new FilterCard("instant or sorcery card from "
-                    + opponent.getLogName() + "'s graveyard");
-            filter.add(new OwnerIdPredicate(opponentId));
-            filter.add(Predicates.or(CardType.INSTANT.getPredicate(), CardType.SORCERY.getPredicate()));
-            TargetCardInOpponentsGraveyard target = new TargetCardInOpponentsGraveyard(0, 1, filter);
-            ability.addTarget(target);
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/d/DismantlingWave.java
+++ b/Mage.Sets/src/mage/cards/d/DismantlingWave.java
@@ -10,7 +10,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.StaticFilters;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -28,7 +28,7 @@ public final class DismantlingWave extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("For each opponent, destroy up to one target artifact or enchantment that player controls."));
         this.getSpellAbility().addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
 
         // Cycling {6}{W}{W}
         this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{6}{W}{W}")));

--- a/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
+++ b/Mage.Sets/src/mage/cards/e/ElminstersSimulacrum.java
@@ -10,7 +10,7 @@ import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -26,7 +26,7 @@ public final class ElminstersSimulacrum extends CardImpl {
         // For each opponent, you create a token that's a copy of up to one target creature that player controls.
         this.getSpellAbility().addEffect(new ElminstersSimulacrumAdjusterEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
     }
 
     private ElminstersSimulacrum(final ElminstersSimulacrum card) {

--- a/Mage.Sets/src/mage/cards/e/EnigmaThief.java
+++ b/Mage.Sets/src/mage/cards/e/EnigmaThief.java
@@ -11,7 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.target.common.TargetNonlandPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -40,7 +40,7 @@ public final class EnigmaThief extends CardImpl {
                 .setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"));
         ability.addTarget(new TargetNonlandPermanent(0,1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GraspOfFate.java
+++ b/Mage.Sets/src/mage/cards/g/GraspOfFate.java
@@ -7,7 +7,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.target.common.TargetNonlandPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -26,7 +26,7 @@ public final class GraspOfFate extends CardImpl {
                 .setText("for each opponent, exile up to one target nonland permanent that player controls until {this} leaves the battlefield")
         );
         ability.addTarget(new TargetNonlandPermanent(0,1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
+++ b/Mage.Sets/src/mage/cards/h/HammersOfMoradin.java
@@ -10,7 +10,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -38,7 +38,7 @@ public final class HammersOfMoradin extends CardImpl {
                         .setText("for each opponent, tap up to one target creature that player controls")
         );
         ability.addTarget(new TargetCreaturePermanent(0,1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HideousTaskmaster.java
+++ b/Mage.Sets/src/mage/cards/h/HideousTaskmaster.java
@@ -16,7 +16,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -42,7 +42,7 @@ public final class HideousTaskmaster extends CardImpl {
                 new GainControlTargetEffect(Duration.EndOfTurn).setTargetPointer(new EachTargetPointer()).setText(
                         "for each opponent, gain control of up to one target creature that player controls until end of turn"));
         ability.addTarget(new TargetCreaturePermanent(0, 1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         ability.addEffect(
                 new UntapTargetEffect().setTargetPointer(new EachTargetPointer()).setText("Untap those creatures"));
         ability.addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn)

--- a/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
+++ b/Mage.Sets/src/mage/cards/i/InTheDarknessBindThem.java
@@ -16,7 +16,7 @@ import mage.constants.SagaChapter;
 import mage.constants.SubType;
 import mage.game.permanent.token.WraithToken;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -58,7 +58,7 @@ public final class InTheDarknessBindThem extends CardImpl {
 
                     ability.getEffects().setTargetPointer(new EachTargetPointer());
                     ability.addTarget(new TargetCreaturePermanent(0,1));
-                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+                    ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
                 }
         );
 

--- a/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
+++ b/Mage.Sets/src/mage/cards/j/JuvenileMistDragon.java
@@ -11,7 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -43,7 +43,7 @@ public final class JuvenileMistDragon extends CardImpl {
                         .setText("Each of those creatures doesn't untap during its controller's next untap step")
         );
         ability.addTarget(new TargetCreaturePermanent(0,1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability.withFlavorWord("Confounding Clouds"));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
+++ b/Mage.Sets/src/mage/cards/l/LuminatePrimordial.java
@@ -17,7 +17,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -41,7 +41,7 @@ public final class LuminatePrimordial extends CardImpl {
         // that player controls and that player gains life equal to its power.
         Ability ability = new EntersBattlefieldTriggeredAbility(new LuminatePrimordialEffect(), false);
         ability.addTarget(new TargetCreaturePermanent(0,1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MassMutiny.java
+++ b/Mage.Sets/src/mage/cards/m/MassMutiny.java
@@ -15,7 +15,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
@@ -32,7 +32,7 @@ public final class MassMutiny extends CardImpl {
         // For each opponent, gain control of up to one target creature that player controls until end of turn. Untap those creatures. They gain haste until end of turn.
         this.getSpellAbility().addEffect(new MassMutinyEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(0,1));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
     }
 
     private MassMutiny(final MassMutiny card) {

--- a/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
+++ b/Mage.Sets/src/mage/cards/m/MoltenPrimordial.java
@@ -19,7 +19,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
@@ -42,7 +42,7 @@ public final class MoltenPrimordial extends CardImpl {
         // When Molten Primordial enters the battlefield, for each opponent, take control of up to one target creature that player controls until end of turn. Untap those creatures. They have haste until end of turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(new MoltenPrimordialEffect(), false);
         ability.addTarget(new TargetCreaturePermanent(0,1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OpenSeason.java
+++ b/Mage.Sets/src/mage/cards/o/OpenSeason.java
@@ -19,7 +19,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 
 import java.util.UUID;
 
@@ -36,7 +36,7 @@ public final class OpenSeason extends CardImpl {
         effect.setText("for each opponent, put a bounty counter on target creature that player controls");
         Ability ability = new EntersBattlefieldTriggeredAbility(effect);
         ability.addTarget(new TargetCreaturePermanent());
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
 
         // Creatures your opponent control with bounty counters on them can't activate abilities

--- a/Mage.Sets/src/mage/cards/s/SepulchralPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SepulchralPrimordial.java
@@ -15,12 +15,11 @@ import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.common.FilterCreatureCard;
-import mage.filter.predicate.card.OwnerIdPredicate;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInOpponentsGraveyard;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -30,6 +29,7 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class SepulchralPrimordial extends CardImpl {
+    private static final FilterCard filter = new FilterCreatureCard("creature card from that player's graveyard");
 
     public SepulchralPrimordial(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{B}{B}");
@@ -44,7 +44,8 @@ public final class SepulchralPrimordial extends CardImpl {
         // When Sepulchral Primordial enters the battlefield, for each opponent, you may put up to one
         // target creature card from that player's graveyard onto the battlefield under your control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new SepulchralPrimordialEffect(), false);
-        ability.setTargetAdjuster(SepulchralPrimordialAdjuster.instance);
+        ability.addTarget(new TargetCardInOpponentsGraveyard(0, 1, filter));
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(true));
         this.addAbility(ability);
     }
 
@@ -55,24 +56,6 @@ public final class SepulchralPrimordial extends CardImpl {
     @Override
     public SepulchralPrimordial copy() {
         return new SepulchralPrimordial(this);
-    }
-}
-
-enum SepulchralPrimordialAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent != null) {
-                FilterCard filter = new FilterCreatureCard("creature card from " + opponent.getName() + "'s graveyard");
-                filter.add(new OwnerIdPredicate(opponentId));
-                TargetCardInOpponentsGraveyard target = new TargetCardInOpponentsGraveyard(0, 1, filter);
-                ability.addTarget(target);
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/s/SepulchralPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SepulchralPrimordial.java
@@ -19,7 +19,7 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInOpponentsGraveyard;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -45,7 +45,7 @@ public final class SepulchralPrimordial extends CardImpl {
         // target creature card from that player's graveyard onto the battlefield under your control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new SepulchralPrimordialEffect(), false);
         ability.addTarget(new TargetCardInOpponentsGraveyard(0, 1, filter));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(true));
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster(true));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
+++ b/Mage.Sets/src/mage/cards/s/SontaranGeneral.java
@@ -13,7 +13,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 
 import java.util.UUID;
 
@@ -43,7 +43,7 @@ public final class SontaranGeneral extends CardImpl {
         ability.addEffect(new CantBlockTargetEffect(Duration.EndOfTurn)
                 .setText("Those creatures can't block this turn."));
         ability.addTarget(new TargetCreaturePermanent(0, 1));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanPrimordial.java
@@ -20,7 +20,7 @@ import mage.game.permanent.Permanent;
 import mage.target.Target;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 
 import java.util.UUID;
 
@@ -47,7 +47,7 @@ public final class SylvanPrimordial extends CardImpl {
         // When Sylvan Primordial enters the battlefield, for each opponent, destroy target noncreature permanent that player controls. For each permanent destroyed this way, search your library for a Forest card and put that card onto the battlefield tapped. Then shuffle your library.
         Ability ability = new EntersBattlefieldTriggeredAbility(new SylvanPrimordialEffect(), false);
         ability.addTarget(new TargetPermanent(filter));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/t/TashaTheWitchQueen.java
+++ b/Mage.Sets/src/mage/cards/t/TashaTheWitchQueen.java
@@ -14,12 +14,11 @@ import mage.filter.FilterCard;
 import mage.filter.FilterSpell;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterInstantOrSorceryCard;
-import mage.filter.predicate.card.OwnerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.token.Demon33Token;
 import mage.players.Player;
 import mage.target.common.TargetCardInOpponentsGraveyard;
-import mage.target.targetadjustment.TargetAdjuster;
+import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 import mage.util.CardUtil;
 
@@ -31,6 +30,7 @@ import java.util.UUID;
 public final class TashaTheWitchQueen extends CardImpl {
 
     private static final FilterSpell filter = new FilterSpell("a spell you don't own");
+    private static final FilterCard filterCard = new FilterInstantOrSorceryCard("instant or sorcery card from that player's graveyard");
 
     static {
         filter.add(TargetController.NOT_YOU.getOwnerPredicate());
@@ -49,7 +49,8 @@ public final class TashaTheWitchQueen extends CardImpl {
         // +1: Draw a card. For each opponent, exile up to one target instant or sorcery card from that player's graveyard and put a page counter on it.
         Ability ability = new LoyaltyAbility(new DrawCardSourceControllerEffect(1), 1);
         ability.addEffect(new TashaTheWitchQueenExileEffect());
-        ability.setTargetAdjuster(TashaTheWitchQueenAdjuster.instance);
+        ability.addTarget(new TargetCardInOpponentsGraveyard(0, 1, filterCard));
+        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(true));
         this.addAbility(ability);
 
         // −3: You may cast a spell from among cards in exile with page counters on them without paying its mana cost.
@@ -66,25 +67,6 @@ public final class TashaTheWitchQueen extends CardImpl {
     @Override
     public TashaTheWitchQueen copy() {
         return new TashaTheWitchQueen(this);
-    }
-}
-
-enum TashaTheWitchQueenAdjuster implements TargetAdjuster {
-    instance;
-
-    @Override
-    public void adjustTargets(Ability ability, Game game) {
-        ability.getTargets().clear();
-        for (UUID opponentId : game.getOpponents(ability.getControllerId())) {
-            Player opponent = game.getPlayer(opponentId);
-            if (opponent == null) {
-                continue;
-            }
-            FilterCard filter = new FilterInstantOrSorceryCard("instant or sorcery card from " + opponent.getLogName() + "'s graveyard");
-            filter.add(new OwnerIdPredicate(opponentId));
-            TargetCardInOpponentsGraveyard target = new TargetCardInOpponentsGraveyard(0, 1, filter);
-            ability.addTarget(target);
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/t/TashaTheWitchQueen.java
+++ b/Mage.Sets/src/mage/cards/t/TashaTheWitchQueen.java
@@ -18,7 +18,7 @@ import mage.game.Game;
 import mage.game.permanent.token.Demon33Token;
 import mage.players.Player;
 import mage.target.common.TargetCardInOpponentsGraveyard;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 import mage.util.CardUtil;
 
@@ -50,7 +50,7 @@ public final class TashaTheWitchQueen extends CardImpl {
         Ability ability = new LoyaltyAbility(new DrawCardSourceControllerEffect(1), 1);
         ability.addEffect(new TashaTheWitchQueenExileEffect());
         ability.addTarget(new TargetCardInOpponentsGraveyard(0, 1, filterCard));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster(true));
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster(true));
         this.addAbility(ability);
 
         // −3: You may cast a spell from among cards in exile with page counters on them without paying its mana cost.

--- a/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
+++ b/Mage.Sets/src/mage/cards/t/TemptedByTheOriq.java
@@ -9,7 +9,7 @@ import mage.constants.Duration;
 import mage.filter.common.FilterCreatureOrPlaneswalkerPermanent;
 import mage.filter.predicate.mageobject.ManaValuePredicate;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -32,7 +32,7 @@ public final class TemptedByTheOriq extends CardImpl {
                 .setText("for each opponent, gain control of up to one target creature " +
                         "or planeswalker that player controls with mana value 3 or less"));
         this.getSpellAbility().addTarget(new TargetPermanent(0, 1, filter));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
     }
 
     private TemptedByTheOriq(final TemptedByTheOriq card) {

--- a/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
+++ b/Mage.Sets/src/mage/cards/t/TheBalrogOfMoria.java
@@ -19,7 +19,7 @@ import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.game.permanent.token.TreasureToken;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -52,7 +52,7 @@ public final class TheBalrogOfMoria extends CardImpl {
             false
         );
         reflexiveAbility.addTarget(new TargetCreaturePermanent(0,1));
-        reflexiveAbility.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        reflexiveAbility.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
 
         this.addAbility(new DiesSourceTriggeredAbility(
             new DoWhenCostPaid(

--- a/Mage.Sets/src/mage/cards/t/TheHorusHeresy.java
+++ b/Mage.Sets/src/mage/cards/t/TheHorusHeresy.java
@@ -22,7 +22,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.HashSet;
@@ -58,7 +58,7 @@ public final class TheHorusHeresy extends CardImpl {
         sagaAbility.addChapterEffect(this, SagaChapter.CHAPTER_I, ability -> {
             ability.addEffect(new TheHorusHeresyControlEffect());
             ability.addTarget(new TargetPermanent(0, 1, filterNonlegendary));
-            ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+            ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         });
 
         // II -- Draw a card for each creature you control but don't own.

--- a/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
+++ b/Mage.Sets/src/mage/cards/t/TheTrueScriptures.java
@@ -17,7 +17,7 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCreatureOrPlaneswalker;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.Collection;
@@ -47,7 +47,7 @@ public final class TheTrueScriptures extends CardImpl {
                     ability.addEffect(new DestroyTargetEffect().setTargetPointer(new EachTargetPointer())
                             .setText("for each opponent, destroy up to one target creature or planeswalker that player controls"));
                     ability.addTarget(new TargetCreatureOrPlaneswalker(0,1));
-                    ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+                    ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
                 }
         );
 

--- a/Mage.Sets/src/mage/cards/t/TimeReaper.java
+++ b/Mage.Sets/src/mage/cards/t/TimeReaper.java
@@ -49,7 +49,7 @@ public final class TimeReaper extends CardImpl {
         Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(new PutOnLibraryTargetEffect(false), false, true);
         ability.addEffect(new GainLifeEffect(3)); //I don't think the move can fail? If there's no target then the trigger won't happen
         ability.addTarget(new TargetCardInExile(filter));
-        ability.setTargetAdjuster(new DamagedPlayerControlsTargetAdjuster());
+        ability.setTargetAdjuster(new DamagedPlayerControlsTargetAdjuster(true));
         ability.withFlavorWord("Consume Anomaly");
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/t/TolarianContempt.java
+++ b/Mage.Sets/src/mage/cards/t/TolarianContempt.java
@@ -18,7 +18,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -48,7 +48,7 @@ public final class TolarianContempt extends CardImpl {
         // At the beginning of your end step, for each opponent, choose up to one target creature they control with a rejection counter on it. That creature's owner puts it on the top or bottom of their library.
         Ability ability = new BeginningOfEndStepTriggeredAbility(new TolarianContemptEffect(), TargetController.YOU, false);
         ability.addTarget(new TargetPermanent(0,1, filterRejection));
-        ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
+++ b/Mage.Sets/src/mage/cards/v/VronosMaskedInquisitor.java
@@ -24,7 +24,7 @@ import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetNonlandPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -57,7 +57,7 @@ public final class VronosMaskedInquisitor extends CardImpl {
         LoyaltyAbility ability2 = new LoyaltyAbility(new ReturnToHandTargetEffect().setTargetPointer(new EachTargetPointer())
                 .setText("for each opponent, return up to one target nonland permanent that player controls to its owner's hand"), -2);
         ability2.addTarget(new TargetNonlandPermanent(0,1));
-        ability2.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        ability2.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability2);
 
         // −7: Target artifact you control becomes a 9/9 Construct artifact creature and gains vigilance, indestructible, and "This creature can't be blocked."

--- a/Mage.Sets/src/mage/cards/w/WelcomeTo.java
+++ b/Mage.Sets/src/mage/cards/w/WelcomeTo.java
@@ -21,7 +21,7 @@ import mage.game.Game;
 import mage.game.permanent.token.DinosaurToken;
 import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 import mage.target.targetpointer.FixedTarget;
 
@@ -64,7 +64,7 @@ public final class WelcomeTo extends CardImpl {
                               "a 0/4 Wall artifact creature with defender for as long as you control this Saga."));
             ability.getEffects().setTargetPointer(new EachTargetPointer());
             ability.addTarget(new TargetPermanent(0, 1, filterNoncreatureArtifact));
-            ability.setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+            ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         });
 
         // II -- Create a 3/3 green Dinosaur creature token with trample. It gains haste until end of turn.

--- a/Mage.Sets/src/mage/cards/w/WindgracesJudgment.java
+++ b/Mage.Sets/src/mage/cards/w/WindgracesJudgment.java
@@ -5,7 +5,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.target.common.TargetNonlandPermanent;
-import mage.target.targetadjustment.EachOpponentPermanentTargetsAdjuster;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
 
 import java.util.UUID;
@@ -24,7 +24,7 @@ public final class WindgracesJudgment extends CardImpl {
                 .setText("For any number of opponents, destroy target nonland permanent that player controls")
         );
         this.getSpellAbility().addTarget(new TargetNonlandPermanent(0, 1));
-        this.getSpellAbility().setTargetAdjuster(new EachOpponentPermanentTargetsAdjuster());
+        this.getSpellAbility().setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
     }
 
     private WindgracesJudgment(final WindgracesJudgment card) {

--- a/Mage/src/main/java/mage/target/targetadjustment/DamagedPlayerControlsTargetAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/DamagedPlayerControlsTargetAdjuster.java
@@ -7,6 +7,7 @@ import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
+import mage.target.TargetCard;
 import mage.target.targetpointer.FirstTargetPointer;
 import mage.util.CardUtil;
 
@@ -35,6 +36,9 @@ public class DamagedPlayerControlsTargetAdjuster extends GenericTargetAdjuster {
     @Override
     public void addDefaultTargets(Ability ability) {
         super.addDefaultTargets(ability);
+        if (blueprintTarget instanceof TargetCard && !owner) {
+            throw new IllegalArgumentException("DamagedPlayerControlsTargetAdjuster has TargetCard but checking for Controller instead of Owner - " + blueprintTarget);
+        }
         CardUtil.AssertNoControllerOwnerPredicates(blueprintTarget);
     }
 

--- a/Mage/src/main/java/mage/target/targetadjustment/ForEachOpponentTargetsAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/ForEachOpponentTargetsAdjuster.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 /**
  * @author notgreat
  */
-public class EachOpponentPermanentTargetsAdjuster extends GenericTargetAdjuster {
+public class ForEachOpponentTargetsAdjuster extends GenericTargetAdjuster {
     private final boolean owner;
 
     /**
@@ -23,11 +23,11 @@ public class EachOpponentPermanentTargetsAdjuster extends GenericTargetAdjuster 
      * Filtering of permanent's controllers will be handled inside, so
      * do not pass a blueprint target with a controller restriction filter/predicate.
      */
-    public EachOpponentPermanentTargetsAdjuster() {
+    public ForEachOpponentTargetsAdjuster() {
         this(false);
     }
 
-    public EachOpponentPermanentTargetsAdjuster(boolean owner) {
+    public ForEachOpponentTargetsAdjuster(boolean owner) {
         this.owner = owner;
     }
 


### PR DESCRIPTION
Improvements to #12528

1) Adds verification check that `TargetCard` is used with "owner" boolean, and fixed Time Reaper which had that set wrongly.
2) Adds support for `TargetCard` to `EachOpponentPermanentTargetsAdjuster`, now named `ForEachOpponentTargetsAdjuster`