### PR TITLE
Remove KickerAbility.getSpellKickedCount

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BloodstoneGoblin.java
+++ b/Mage.Sets/src/mage/cards/b/BloodstoneGoblin.java
@@ -1,19 +1,17 @@
 package mage.cards.b;
 
 import mage.MageInt;
-import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.TriggeredAbility;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
-import mage.abilities.keyword.KickerAbility;
 import mage.abilities.keyword.MenaceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.Zone;
-import mage.game.Game;
-import mage.game.events.GameEvent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -32,7 +30,14 @@ public final class BloodstoneGoblin extends CardImpl {
 
         // Whenever you cast a spell, if that spell was kicked,
         // Bloodstone Goblin gets +1/+1 and gains menace until end of turn.
-        this.addAbility(new BloodstoneGoblinTriggeredAbility());
+        TriggeredAbility ability = new SpellCastControllerTriggeredAbility(
+                new BoostSourceEffect(1, 1, Duration.EndOfTurn).setText("{this} gets +1/+1"),
+                StaticFilters.FILTER_SPELL_KICKED_A, false);
+        ability.addEffect(new GainAbilitySourceEffect(
+                new MenaceAbility(false), Duration.EndOfTurn)
+                .setText("and gains menace until end of turn. " + "<i>(It can't be blocked except by two or more creatures.)</i>"));
+        ability.setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
+        this.addAbility(ability);
     }
 
     private BloodstoneGoblin(final BloodstoneGoblin card) {
@@ -42,42 +47,5 @@ public final class BloodstoneGoblin extends CardImpl {
     @Override
     public BloodstoneGoblin copy() {
         return new BloodstoneGoblin(this);
-    }
-}
-
-class BloodstoneGoblinTriggeredAbility extends TriggeredAbilityImpl {
-
-    BloodstoneGoblinTriggeredAbility() {
-        super(
-                Zone.BATTLEFIELD,
-                new BoostSourceEffect(1, 1, Duration.EndOfTurn).setText("{this} gets +1/+1"),
-                false);
-        this.addEffect(
-                new GainAbilitySourceEffect(
-                        new MenaceAbility(false),
-                        Duration.EndOfTurn
-                ).setText("and gains menace until end of turn. "
-                        + "<i>(It can't be blocked except by two or more creatures.)</i>"));
-        setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
-    }
-
-    private BloodstoneGoblinTriggeredAbility(final BloodstoneGoblinTriggeredAbility ability) {
-        super(ability);
-    }
-
-    @Override
-    public BloodstoneGoblinTriggeredAbility copy() {
-        return new BloodstoneGoblinTriggeredAbility(this);
-    }
-
-    @Override
-    public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.SPELL_CAST
-                && event.getPlayerId() == this.controllerId;
-    }
-
-    @Override
-    public boolean checkTrigger(GameEvent event, Game game) {
-        return KickerAbility.getSpellKickedCount(game, event.getTargetId()) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HallarTheFirefletcher.java
+++ b/Mage.Sets/src/mage/cards/h/HallarTheFirefletcher.java
@@ -1,18 +1,17 @@
 package mage.cards.h;
 
 import mage.MageInt;
-import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.TriggeredAbility;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.dynamicvalue.common.CountersSourceCount;
 import mage.abilities.effects.common.DamagePlayersEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
-import mage.abilities.keyword.KickerAbility;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.game.Game;
-import mage.game.events.GameEvent;
+import mage.filter.StaticFilters;
 
 import java.util.UUID;
 
@@ -34,7 +33,15 @@ public final class HallarTheFirefletcher extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Whenever you cast a spell, if that spell was kicked, put a +1/+1 counter on Hallar, the Firefletcher, then Hallar deals damage equal to the number of +1/+1 counters on it to each opponent.
-        this.addAbility(new HallarTheFirefletcherTriggeredAbility());
+        TriggeredAbility ability = new SpellCastControllerTriggeredAbility(
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()).setText("put a +1/+1 counter on {this}"),
+                StaticFilters.FILTER_SPELL_KICKED_A, false
+        );
+        ability.addEffect(new DamagePlayersEffect(Outcome.Benefit, new CountersSourceCount(CounterType.P1P1), TargetController.OPPONENT)
+                .setText(", then {this} deals damage equal to the number of +1/+1 counters on it to each opponent")
+        );
+        ability.setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
+        this.addAbility(ability);
     }
 
     private HallarTheFirefletcher(final HallarTheFirefletcher card) {
@@ -44,38 +51,5 @@ public final class HallarTheFirefletcher extends CardImpl {
     @Override
     public HallarTheFirefletcher copy() {
         return new HallarTheFirefletcher(this);
-    }
-}
-
-class HallarTheFirefletcherTriggeredAbility extends TriggeredAbilityImpl {
-
-    HallarTheFirefletcherTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()).setText("put a +1/+1 counter on {this}"), false);
-        this.addEffect(new DamagePlayersEffect(Outcome.Benefit, new CountersSourceCount(CounterType.P1P1), TargetController.OPPONENT)
-                .setText(", then {this} deals damage equal to the number of +1/+1 counters on it to each opponent")
-        );
-        setTriggerPhrase("Whenever you cast a spell, if that spell was kicked, ");
-    }
-
-    private HallarTheFirefletcherTriggeredAbility(final HallarTheFirefletcherTriggeredAbility ability) {
-        super(ability);
-    }
-
-    @Override
-    public HallarTheFirefletcherTriggeredAbility copy() {
-        return new HallarTheFirefletcherTriggeredAbility(this);
-    }
-
-    @Override
-    public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.SPELL_CAST;
-    }
-
-    @Override
-    public boolean checkTrigger(GameEvent event, Game game) {
-        if (!isControlledBy(event.getPlayerId())) {
-            return false;
-        }
-        return KickerAbility.getSpellKickedCount(game, event.getTargetId()) > 0;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RumblingAftershocks.java
+++ b/Mage.Sets/src/mage/cards/r/RumblingAftershocks.java
@@ -12,6 +12,7 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
+import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.target.common.TargetAnyTarget;
 
@@ -66,10 +67,13 @@ class RumblingAftershocksTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        int kickedCount = KickerAbility.getSpellKickedCount(game, event.getTargetId());
-        if (kickedCount > 0) {
-            this.getEffects().get(0).setValue("damageAmount", kickedCount);
-            return true;
+        Spell spell = game.getSpell(event.getTargetId());
+        if (spell != null) {
+            int kickedCount = KickerAbility.getKickedCounter(game, spell.getSpellAbility());
+            if (kickedCount > 0) {
+                this.getEffects().get(0).setValue("damageAmount", kickedCount);
+                return true;
+            }
         }
         return false;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
@@ -814,4 +814,37 @@ public class KickerTest extends CardTestPlayerBase {
         assertTappedCount("Mountain", true, 5);
     }
 
+    @Test
+    public void testWastescapeBattlemage() {
+        String battlemage = "Wastescape Battlemage"; // 1C + kickers G (exile artifact/enchantment) + 1U (bounce creature)
+
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Tropical Island", 3);
+        addCard(Zone.HAND, playerA, battlemage, 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Darksteel Relic", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Squire", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, battlemage);
+        setChoice(playerA, true);
+        setChoice(playerA, false);
+        addTarget(playerA, "Darksteel Relic");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        checkPermanentCount("Darksteel Relic count", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Darksteel Relic", 1);
+        checkPermanentCount("Squire count", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Squire", 2);
+
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, battlemage);
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+        setChoice(playerA, "When you cast this spell, if it was kicked with its {G} kicker, exile");
+        addTarget(playerA, "Darksteel Relic");
+        addTarget(playerA, "Squire");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+        assertPermanentCount(playerB, "Darksteel Relic", 0);
+        assertPermanentCount(playerB, "Squire", 1);
+        assertExileCount(playerB, 2);
+        assertHandCount(playerB, "Squire", 1);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
@@ -823,14 +823,13 @@ public class KickerTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, battlemage, 2);
         addCard(Zone.BATTLEFIELD, playerB, "Darksteel Relic", 2);
         addCard(Zone.BATTLEFIELD, playerB, "Squire", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, "Counterspell", 1);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, battlemage);
         setChoice(playerA, true);
         setChoice(playerA, false);
         addTarget(playerA, "Darksteel Relic");
-        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
-        checkPermanentCount("Darksteel Relic count", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Darksteel Relic", 1);
-        checkPermanentCount("Squire count", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Squire", 2);
 
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, battlemage);
         setChoice(playerA, true);
@@ -838,10 +837,16 @@ public class KickerTest extends CardTestPlayerBase {
         setChoice(playerA, "When you cast this spell, if it was kicked with its {G} kicker, exile");
         addTarget(playerA, "Darksteel Relic");
         addTarget(playerA, "Squire");
+        //Abilities have not resolved yet
+        checkStackSize("Spell+2 Triggers on Stack", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, 3);
+        checkPermanentCount("Darksteel Relic count", 1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Darksteel Relic", 1);
+        checkPermanentCount("Squire count", 1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Squire", 2);
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Counterspell", battlemage);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
+        assertPermanentCount(playerA, battlemage, 1);
         assertPermanentCount(playerB, "Darksteel Relic", 0);
         assertPermanentCount(playerB, "Squire", 1);
         assertExileCount(playerB, 2);

--- a/Mage/src/main/java/mage/abilities/condition/common/KickedCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/KickedCondition.java
@@ -24,8 +24,7 @@ public enum KickedCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return KickerAbility.getKickedCounter(game, source) >= kickedCount // for on battlefield
-                || KickerAbility.getSpellKickedCount(game, source.getSourceId()) >= kickedCount; // for on stack
+        return KickerAbility.getKickedCounter(game, source) >= kickedCount;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/condition/common/KickedCostCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/KickedCostCondition.java
@@ -20,7 +20,6 @@ public class KickedCostCondition implements Condition {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        return KickerAbility.getKickedCounterStrict(game, source, kickerCostText) > 0
-                || KickerAbility.getSpellKickedCountStrict(game, source.getSourceId(), kickerCostText) > 0;
+        return KickerAbility.getKickedCounterStrict(game, source, kickerCostText) > 0;
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/KickerAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/KickerAbility.java
@@ -9,11 +9,13 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.util.CardUtil;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 /**
@@ -269,21 +271,4 @@ public class KickerAbility extends StaticAbility implements OptionalAdditionalSo
         return sb.toString();
     }
 
-    /**
-     * Find spell's kicked stats. Must be used on stack only, e.g. for SPELL_CAST events
-     */
-    public static int getSpellKickedCount(Game game, UUID spellId) {
-        return getSpellKickedCountStrict(game, spellId, "");
-    }
-
-    /**
-     * Find spell's kicked stats. Must be used on stack only, e.g. for SPELL_CAST events
-     */
-    public static int getSpellKickedCountStrict(Game game, UUID spellId, String needKickerCost) {
-        Spell spell = game.getSpellOrLKIStack(spellId);
-        if (spell != null) {
-            return KickerAbility.getKickedCounterStrict(game, spell.getSpellAbility(), needKickerCost);
-        }
-        return 0;
-    }
 }

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -562,7 +562,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
         }
         if (removed) {
             if (fromZone != Zone.OUTSIDE) {
-                game.rememberLKI(lkiObject != null ? lkiObject.getId() : objectId, fromZone, lkiObject != null ? lkiObject : this);
+                game.rememberLKI(fromZone, lkiObject != null ? lkiObject : this);
             }
         } else {
             logger.warn("Couldn't find card in fromZone, card=" + getIdName() + ", fromZone=" + fromZone);

--- a/Mage/src/main/java/mage/filter/predicate/mageobject/KickedSpellPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/mageobject/KickedSpellPredicate.java
@@ -4,13 +4,12 @@ import mage.MageObject;
 import mage.abilities.keyword.KickerAbility;
 import mage.filter.predicate.Predicate;
 import mage.game.Game;
+import mage.game.stack.Spell;
 
 /**
  * Find spell's kicked stats.
  * <p>
  * Warning, must be used for SPELL_CAST events only
- * (if you need kicked stats in ETB effects then search object's abilities instead spell,
- * see MultikickerCount as example)
  *
  * @author TheElk801
  */
@@ -19,7 +18,11 @@ public enum KickedSpellPredicate implements Predicate<MageObject> {
 
     @Override
     public boolean apply(MageObject input, Game game) {
-        return KickerAbility.getSpellKickedCount(game, input.getId()) > 0;
+        if (input instanceof Spell) {
+            return KickerAbility.getKickedCounter(game, ((Spell) input).getSpellAbility()) > 0;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -305,7 +305,7 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
      */
     boolean checkShortLivingLKI(UUID objectId, Zone zone);
 
-    void rememberLKI(UUID objectId, Zone zone, MageObject object);
+    void rememberLKI(Zone zone, MageObject object);
 
     void resetLKI();
 

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -714,12 +714,6 @@ public abstract class GameImpl implements Game {
             // SyrCarahTheBoldTest.java for an example of when this check is relevant.
             if (obj instanceof Spell) {
                 spell = (Spell) obj;
-            } else if (obj != null) {
-                logger.error(String.format(
-                                "getSpellOrLKIStack got non-spell id %s correlating to non-spell object %s.",
-                                obj.getClass().getName(), obj.getName()),
-                        new Throwable()
-                );
             }
         }
         return spell;

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1795,7 +1795,6 @@ public abstract class GameImpl implements Game {
         } finally {
             if (top != null) {
                 state.getStack().remove(top, this); // seems partly redundant because move card from stack to grave is already done and the stack removed
-                rememberLKI(top.getSourceId(), Zone.STACK, top);
                 checkInfiniteLoop(top.getSourceId());
                 if (!getTurn().isEndTurnRequested()) {
                     while (state.hasSimultaneousEvents()) {
@@ -3314,7 +3313,7 @@ public abstract class GameImpl implements Game {
             }
         }
         for (Card card : toOutside) {
-            rememberLKI(card.getId(), Zone.BATTLEFIELD, card);
+            rememberLKI(Zone.BATTLEFIELD, card);
         }
         // needed to send event that permanent leaves the battlefield to allow non stack effects to execute
         player.moveCards(toOutside, Zone.OUTSIDE, null, this);
@@ -3586,12 +3585,12 @@ public abstract class GameImpl implements Game {
     /**
      * Remembers object state to be used as Last Known Information.
      *
-     * @param objectId
      * @param zone
      * @param object
      */
     @Override
-    public void rememberLKI(UUID objectId, Zone zone, MageObject object) {
+    public void rememberLKI(Zone zone, MageObject object) {
+        UUID objectId = object.getId();
         if (object instanceof Permanent || object instanceof StackObject) {
             MageObject copy = object.copy();
 

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1727,7 +1727,8 @@ public final class CardUtil {
     /**
      * Returns the entire cost tags map of either the source ability, or the permanent source of the ability. May be null.
      * Works in any moment (even before source ability activated)
-     * Usually you should use one of the single tag functions instead: getSourceCostsTag() or checkSourceCostsTagExists()
+     * <p>
+     * Usually you should use one of the single tag functions instead: getSourceCostsTag() or checkSourceCostsTagExists().
      * Use this function with caution, as it directly exposes the backing data structure.
      *
      * @param game
@@ -1751,9 +1752,9 @@ public final class CardUtil {
         }
 
         // from any ability before resolve (on stack) - access by spell ability
-        MageObject sourceObject = source.getSourceObject(game);
-        if (sourceObject instanceof Spell) {
-            return ((Spell) sourceObject).getSpellAbility().getCostsTagMap();
+        Spell sourceObject = game.getSpellOrLKIStack(source.getSourceId());
+        if (sourceObject != null) {
+            return sourceObject.getSpellAbility().getCostsTagMap();
         }
 
         return null;


### PR DESCRIPTION
Fixes #12527 (though I'm not quite sure what exactly triggered that)

With the changes from #12522, spells can now just use the standard `getKickedCounter` instead of needing a special `getSpellKickedCount`. Also simplified the "Whenever you cast a spell, if that spell was kicked," cards to use the same code as the "Whenever you cast a kicked spell" cards.