### PR TITLE
Rework CreaturesYouControlCount wrt AngelicExaltation

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AngelicExaltation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelicExaltation.java
@@ -16,12 +16,14 @@ import java.util.UUID;
  */
 public final class AngelicExaltation extends CardImpl {
 
+    private static CreaturesYouControlCount xValue;
+
     public AngelicExaltation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{W}");
 
         // Whenever a creature you control attacks alone, it gets +X/+X until end of turn, where X is the number of creatures you control.
         this.addAbility(new AttacksAloneControlledTriggeredAbility(
-                new BoostTargetEffect(CreaturesYouControlCount.instance, CreaturesYouControlCount.instance, Duration.EndOfTurn),
+                new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn),
                 true, false).addHint(CreaturesYouControlHint.instance));
     }
 

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/DynamicValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/DynamicValue.java
@@ -11,19 +11,78 @@ import java.io.Serializable;
  * Dynamic value can be called multiple times from different places, so don't use inner/changeable fields. If you
  * use it then think x100 times and override Copy method with copy constructor.
  */
-public interface DynamicValue extends Serializable, Copyable<DynamicValue> {
+public abstract class DynamicValue implements Serializable, Copyable<DynamicValue> {
 
-    int calculate(Game game, Ability sourceAbility, Effect effect);
+    public enum Phrasing {
+        NUMBER_OF,
+        FOR_EACH
+    }
 
-    DynamicValue copy();
+    private static String[] numberWords = {
+            "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"
+    };
 
-    String getMessage();
+    protected int multiplier;
+
+    public DynamicValue() {
+        this(1);
+    }
+
+    public DynamicValue(int multiplier) {
+        this.multiplier = multiplier;
+    }
+
+    public int calculate(Game game, Ability sourceAbility, Effect effect){
+        return multiplier * calculateBase(game, sourceAbility, effect);
+    }
+
+    /**
+     *
+     * @return A calculation of this value with the current game state, before the multiplier is applied.
+     */
+    public abstract int calculateBase(Game game, Ability sourceAbility, Effect effect);
+
+    protected DynamicValue(final DynamicValue other) {
+        this.multiplier = other.multiplier;
+    }
+
+    //TODO: find all usages of implementations of toString
+
+    public String getMessage(){
+        return getMessage(Phrasing.NUMBER_OF, true);
+    }
+
+    public String getMessage(Phrasing phrasing){
+        return getMessage(phrasing, true);
+    }
+
+    /**
+     *
+     * @return A description of what this Dynamic Value represents.
+     * Factor in the Phrasing, which changes the grammar slightly too.
+     * If this value represents something that isnt normally phrased like a discreet count, feel free to ignore the phrasing argument.
+     * For example:
+     *      "the number of creatures you control" or "for each creature you control" (discreet count) vs
+     *      "the sacrificed creature's power" (non-discreet)
+     */
+    public abstract String getMessage(Phrasing phrasing, boolean useMultiplier);
+
+    public int getMultiplier(){
+        return multiplier;
+    }
+
+    public String getMultiplierAsWord(){
+        if (multiplier >= numberWords.length){
+            return Integer.toString(multiplier);
+        }
+        return numberWords[multiplier];
+    }
 
     /**
      *
      * @return A positive value if the result of calculate() is usually positive, and a negative value if it is usually negative.
      */
-    default int getSign() {
-        return 1;
+    public int getSign() {
+        return getMultiplier();
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CreaturesYouControlCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CreaturesYouControlCount.java
@@ -6,21 +6,25 @@ import mage.abilities.effects.Effect;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 
+import java.util.Objects;
+
 /**
  * @author JayDi85
  */
-public enum CreaturesYouControlCount implements DynamicValue {
-
-    instance;
+public class CreaturesYouControlCount extends DynamicValue {
 
     @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+    public int calculateBase(Game game, Ability sourceAbility, Effect effect) {
         return game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURES, sourceAbility.getControllerId(), sourceAbility, game);
+    }
+
+    protected CreaturesYouControlCount(final CreaturesYouControlCount other) {
+        super(other);
     }
 
     @Override
     public CreaturesYouControlCount copy() {
-        return instance;
+        return new CreaturesYouControlCount(this);
     }
 
     @Override
@@ -29,7 +33,10 @@ public enum CreaturesYouControlCount implements DynamicValue {
     }
 
     @Override
-    public String getMessage() {
-        return "creatures you control";
+    public String getMessage(Phrasing phrasing, boolean useMultiplier) {
+        if (Objects.requireNonNull(phrasing) == Phrasing.NUMBER_OF) {
+            return (useMultiplier && multiplier > 1 ? getMultiplierAsWord() + " times " : "") + "the number of creatures you control";
+        }
+        return "for each creature you control";
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/StaticValue.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/StaticValue.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
-public class StaticValue implements DynamicValue {
+public class StaticValue extends DynamicValue {
 
     private static final List<StaticValue> staticValues = new ArrayList();
 
@@ -19,15 +19,13 @@ public class StaticValue implements DynamicValue {
                 .forEachOrdered(staticValues::add);
     }
 
-    private final int value;
-
     private StaticValue(int value) {
-        this.value = value;
+        super(value);
     }
 
     @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        return value;
+    public int calculateBase(Game game, Ability sourceAbility, Effect effect) {
+        return multiplier;
     }
 
     @Override
@@ -37,21 +35,21 @@ public class StaticValue implements DynamicValue {
 
     @Override
     public String toString() {
-        return Integer.toString(value);
+        return Integer.toString(multiplier);
     }
 
     @Override
-    public String getMessage() {
+    public String getSingleMessage() {
         return "";
     }
 
     @Override
-    public int getSign() {
-        return value;
+    public String getPluralMessage() {
+        return "";
     }
 
     public int getValue() {
-        return value;
+        return multiplier;
     }
 
     public static StaticValue get(int value) {

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -869,14 +869,28 @@ public final class CardUtil {
         // sign fix for zero values
         // -1/+0 must be -1/-0
         // +0/-1 must be -0/-1
-        String p = power.toString();
-        String t = toughness.toString();
+        String p = Integer.toString(power.getMultiplier());
+        String t = Integer.toString(toughness.getMultiplier());
+
         if (!p.startsWith("-")) {
             p = t.startsWith("-") && p.equals("0") ? "-0" : "+" + p;
         }
         if (!t.startsWith("-")) {
             t = p.startsWith("-") && t.equals("0") ? "-0" : "+" + t;
         }
+
+        //Replace 1s with Xs, using Y if necessary
+        if (p.substring(1).equals("1")){
+            p = p.replace("1", "X");
+        }
+        if (t.substring(1).equals("1")){
+            if (p.contains("X") && (!power.getClass().equals(toughness.getClass()))){
+                t = t.replace("1", "Y");
+            } else {
+                t = t.replace("1", "X");
+            }
+        }
+
         return p + "/" + t;
     }
 
@@ -894,13 +908,21 @@ public final class CardUtil {
                 sb.append(' ').append(d);
             }
         }
-        String message = power.getMessage();
-        if (message.isEmpty()) {
-            message = toughness.getMessage();
+
+        if (boostCount.contains("X")) {
+
+            String powerMessage = power.getMessage(DynamicValue.Phrasing.NUMBER_OF, true);
+            String toughnessMessage = toughness.getMessage(DynamicValue.Phrasing.NUMBER_OF, true);
+
+            sb.append(", where X is ").append(powerMessage.isEmpty() ? toughnessMessage : powerMessage);
+            if (boostCount.contains("Y")) {
+                sb.append(", and Y is ").append(toughnessMessage);
+            }
+        } else {
+            String powerMessage = power.getMessage(DynamicValue.Phrasing.FOR_EACH);
+            sb.append(" ").append(powerMessage.isEmpty() ? toughness.getMessage(DynamicValue.Phrasing.FOR_EACH) : powerMessage);
         }
-        if (!message.isEmpty()) {
-            sb.append(boostCount.contains("X") ? ", where X is " : " for each ").append(message);
-        }
+
         return sb.toString();
     }
 


### PR DESCRIPTION
#12595

This will certainly not pass build, but it does demonstrate the solution i've landed on, and i'm presenting this for review before i continue.

I found it will generally be easier to go with the solution @xenohedron proposed [here](https://github.com/magefree/mage/issues/12595#issuecomment-2242163757), since there are some values that need to be phrased as if they were an _amount_, rather than a _count_ (power or toughness, versus creatures on the battlefield, for example).

The big implication of this is that in order to own a `multiplier`, `DynamicValue` had to become an abstract class, rather than an interface.

I plan to use this PR to continue implementing this, which will certainly hit every single subclass of `DynamicValue` as well as many effects that use this type, not to mention cleaning up the following:

1. Any use of toString() on a `DynamicValue`
2. All uses of `.instance` on a `DynamicValue` (since subclasses wont be a singleton anymore)

Open to feedback.