### PR TITLE
Implement Alania, Divergent Storm

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -93,7 +93,7 @@ class AlaniaDivergentStormCost extends CostImpl {
                 return true;
             }
         }
-        return true;
+        return false;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -1,0 +1,222 @@
+package mage.cards.a;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.CostImpl;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.effects.common.CopyTargetStackObjectEffect;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.stack.Spell;
+import mage.players.Player;
+import mage.target.common.TargetOpponent;
+import mage.watchers.Watcher;
+import org.apache.log4j.Logger;
+
+/**
+ *
+ * @author jimga150
+ */
+public final class AlaniaDivergentStorm extends CardImpl {
+
+    public AlaniaDivergentStorm(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}{R}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.OTTER);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(5);
+
+        // Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter
+        // spell other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy
+        // that spell. You may choose new targets for the copy.
+        Ability ability = new ConditionalInterveningIfTriggeredAbility(
+                new SpellCastControllerTriggeredAbility(new DoIfCostPaid(
+                        new CopyTargetStackObjectEffect(true),
+                        new AlaniaDivergentStormCost()
+                ), null, false, SetTargetPointer.SPELL),
+                AlaniaDivergentStormCondition.instance, ""
+        );
+        ability.addWatcher(new AlaniaDivergentStormWatcher());
+        this.addAbility(ability);
+
+    }
+
+    private AlaniaDivergentStorm(final AlaniaDivergentStorm card) {
+        super(card);
+    }
+
+    @Override
+    public AlaniaDivergentStorm copy() {
+        return new AlaniaDivergentStorm(this);
+    }
+}
+
+// Based on MarathWillOfTheWildRemoveCountersCost
+class AlaniaDivergentStormCost extends CostImpl {
+
+    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCost.class);
+
+    AlaniaDivergentStormCost() {
+        this.text = "have target opponent draw a card";
+        this.addTarget(new TargetOpponent());
+    }
+
+    private AlaniaDivergentStormCost(AlaniaDivergentStormCost cost) {
+        super(cost);
+    }
+
+    @Override
+    public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
+        if (!game.isSimulation()){
+            logger.info("entering canPay()");
+        }
+        Player player = game.getPlayer(controllerId);
+        if (player == null) {
+            return false;
+        }
+        for (UUID opponentID : game.getOpponents(controllerId)){
+            Player opponent = game.getPlayer(opponentID);
+            if (opponent == null) {
+                continue;
+            }
+            if (opponent.canBeTargetedBy(source.getSourceObject(game), controllerId, source, game)) {
+                return true;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
+        if (!game.isSimulation()) {
+            logger.info("entering pay()");
+        }
+        this.getTargets().clearChosen();
+        paid = false;
+        if (this.getTargets().choose(Outcome.DrawCard, controllerId, source.getSourceId(), source, game)) {
+            Player opponent = game.getPlayer(this.getTargets().get(0).getTargets().get(0));
+            if (opponent == null || !opponent.canRespond()){
+                return false;
+            }
+            paid = opponent.drawCards(1, source, game) != 0;
+        }
+        return paid;
+    }
+
+    @Override
+    public AlaniaDivergentStormCost copy() {
+        return new AlaniaDivergentStormCost(this);
+    }
+}
+
+// Based on MastermindPlumCondition
+enum AlaniaDivergentStormCondition implements Condition {
+    instance;
+
+    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCost.class);
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        if (!game.isSimulation()) {
+            logger.info("entering apply()");
+        }
+        Spell spell = (Spell) source.getEffects().get(0).getValue("spellCast");
+        if (spell == null) {
+            if (!game.isSimulation()) {
+                logger.info("spell is null, returning false");
+            }
+            return false;
+        }
+        AlaniaDivergentStormWatcher watcher = game.getState().getWatcher(AlaniaDivergentStormWatcher.class);
+        return spell.getId().equals(watcher.getIdOfFirstInstantCast(source.getControllerId())) ||
+                spell.getId().equals(watcher.getIdOfFirstSorceryCast(source.getControllerId())) ||
+                spell.getId().equals(watcher.getIdOfFirstOtterCast(source.getControllerId()));
+    }
+}
+
+// Based on FirstSpellCastThisTurnWatcher
+class AlaniaDivergentStormWatcher extends Watcher {
+
+    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCost.class);
+
+    private final Map<UUID, UUID> playerFirstInstantCast = new HashMap<>();
+    private final Map<UUID, UUID> playerFirstSorceryCast = new HashMap<>();
+    private final Map<UUID, UUID> playerFirstOtterCast = new HashMap<>();
+
+    public AlaniaDivergentStormWatcher() {
+        super(WatcherScope.GAME);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (event.getType() != GameEvent.EventType.SPELL_CAST) {
+            return;
+        }
+        if (!game.isSimulation()) {
+            logger.info("SPELL_CAST event detected");
+        }
+        Spell spell = (Spell) game.getObject(event.getTargetId());
+        if (spell == null) {
+            if (!game.isSimulation()) {
+                logger.info("spell is null, returning false");
+            }
+            return;
+        }
+        if (spell.getCardType(game).contains(CardType.INSTANT) &&
+                !playerFirstInstantCast.containsKey(spell.getControllerId())) {
+            if (!game.isSimulation()) {
+                logger.info("Adding instant spell");
+            }
+            playerFirstInstantCast.put(spell.getControllerId(), spell.getId());
+        }
+        if (spell.getCardType(game).contains(CardType.SORCERY) &&
+                !playerFirstSorceryCast.containsKey(spell.getControllerId())) {
+            if (!game.isSimulation()) {
+                logger.info("Adding sorcery spell");
+            }
+            playerFirstSorceryCast.put(spell.getControllerId(), spell.getId());
+        }
+        if (spell.getSubtype(game).contains(SubType.OTTER) &&
+                !playerFirstOtterCast.containsKey(spell.getControllerId())) {
+            if (!game.isSimulation()) {
+                logger.info("Adding otter spell");
+            }
+            playerFirstOtterCast.put(spell.getControllerId(), spell.getId());
+        }
+
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        logger.info("resetting watcher...");
+        playerFirstInstantCast.clear();
+        playerFirstSorceryCast.clear();
+        playerFirstOtterCast.clear();
+    }
+
+    public UUID getIdOfFirstInstantCast(UUID playerId) {
+        return playerFirstInstantCast.get(playerId);
+    }
+
+    public UUID getIdOfFirstSorceryCast(UUID playerId) {
+        return playerFirstSorceryCast.get(playerId);
+    }
+
+    public UUID getIdOfFirstOtterCast(UUID playerId) {
+        return playerFirstOtterCast.get(playerId);
+    }
+}

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -121,6 +121,8 @@ class AlaniaDivergentStormCost extends CostImpl {
 enum AlaniaDivergentStormCondition implements Condition {
     instance;
 
+    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCondition.class);
+
     @Override
     public boolean apply(Game game, Ability source) {
         if (!game.isSimulation()){
@@ -131,6 +133,10 @@ enum AlaniaDivergentStormCondition implements Condition {
             return false;
         }
         Permanent sourcePermanent = source.getSourcePermanentOrLKI(game);
+        if (!game.isSimulation()){
+            logger.info("sourcePermanent: " + sourcePermanent);
+            logger.info("name: " + sourcePermanent.getName());
+        }
         // Get source permanent MOR from when it was on the stack
         MageObjectReference sourceSpellMOR = new MageObjectReference(sourcePermanent, game, -1);
         AlaniaDivergentStormWatcher watcher = game.getState().getWatcher(AlaniaDivergentStormWatcher.class);
@@ -213,7 +219,7 @@ class AlaniaDivergentStormWatcher extends Watcher {
             logger.info("firstOtterMOR: " + firstOtterMOR.getSourceId());
             logger.info("spell: " + spell.getSourceId());
             logger.info("AlaniaMOR: " + AlaniaMOR.getSourceId());
-            logger.info(AlaniaMOR.getCard(game).getName());
+//            logger.info(AlaniaMOR.getCard(game).getName());
         }
 
         if (firstOtterMOR != null && firstOtterMOR.equals(AlaniaMOR)) {

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -106,7 +106,7 @@ class AlaniaDivergentStormCost extends CostImpl {
             if (opponent == null || !opponent.canRespond()){
                 return false;
             }
-            paid = opponent.drawCards(1, source, game) != 0;
+            paid = opponent.drawCards(1, source, game) > 0;
         }
         return paid;
     }

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -162,20 +162,19 @@ class AlaniaDivergentStormWatcher extends Watcher {
         }
         UUID spellControllerID = spell.getControllerId();
         MageObjectReference spellMOR = new MageObjectReference(spell, game);
-        if (spell.getCardType(game).contains(CardType.INSTANT) &&
-                !playerFirstInstantCast.containsKey(spellControllerID)) {
-            playerFirstInstantCast.put(spellControllerID, spellMOR);
+        if (spell.getCardType(game).contains(CardType.INSTANT)) {
+            playerFirstInstantCast.putIfAbsent(spellControllerID, spellMOR);
         }
-        if (spell.getCardType(game).contains(CardType.SORCERY) &&
-                !playerFirstSorceryCast.containsKey(spellControllerID)) {
-            playerFirstSorceryCast.put(spellControllerID, spellMOR);
+        if (spell.getCardType(game).contains(CardType.SORCERY)) {
+            playerFirstSorceryCast.putIfAbsent(spellControllerID, spellMOR);
         }
         if (spell.getSubtype(game).contains(SubType.OTTER)){
-            if (!playerFirstOtterCast.containsKey(spellControllerID)) {
-                playerFirstOtterCast.put(spellControllerID, spellMOR);
-            } else if (!playerSecondOtterCast.containsKey(spellControllerID)) {
-                playerSecondOtterCast.put(spellControllerID, spellMOR);
+            if (playerFirstOtterCast.containsKey(spellControllerID)) {
+                // We already cast an otter this turn, put it on the second otter list
+                playerSecondOtterCast.putIfAbsent(spellControllerID, spellMOR);
             }
+            // Will only put if we didnt cast an otter this turn yet
+            playerFirstOtterCast.putIfAbsent(spellControllerID, spellMOR);
         }
     }
 
@@ -193,6 +192,7 @@ class AlaniaDivergentStormWatcher extends Watcher {
         MageObjectReference firstOtterMOR = playerFirstOtterCast.get(controllerID);
 
         if (firstOtterMOR != null && firstOtterMOR.equals(AlaniaMOR)) {
+            // The first otter we cast was the triggering Alania! check if the second otter matches instead
             firstOtterMOR = playerSecondOtterCast.get(controllerID);
         }
 

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
@@ -133,12 +134,15 @@ enum AlaniaDivergentStormCondition implements Condition {
             return false;
         }
         Permanent sourcePermanent = source.getSourcePermanentOrLKI(game);
+        SpellAbility sourceCastAbility = sourcePermanent.getSpellAbility();
         if (!game.isSimulation()){
-            logger.info("sourcePermanent: " + sourcePermanent);
+            logger.info("sourcePermanent: " + new MageObjectReference(sourcePermanent, game));
             logger.info("name: " + sourcePermanent.getName());
+            logger.info("sourceCastAbility: " + sourceCastAbility.getId());
         }
         // Get source permanent MOR from when it was on the stack
-        MageObjectReference sourceSpellMOR = new MageObjectReference(sourcePermanent, game, -1);
+
+        MageObjectReference sourceSpellMOR = new MageObjectReference(sourceCastAbility.getId(), sourcePermanent.getZoneChangeCounter(game) - 1, game);
         AlaniaDivergentStormWatcher watcher = game.getState().getWatcher(AlaniaDivergentStormWatcher.class);
         UUID spellControllerID = spell.getControllerId();
         MageObjectReference spellMOR = new MageObjectReference(spell, game);
@@ -172,7 +176,7 @@ class AlaniaDivergentStormWatcher extends Watcher {
         if (!game.isSimulation()){
 //            int x = 3;
             logger.info("Spell cast: " + spell.getName());
-            logger.info("Spell ID: " + spell.getId());
+            logger.info("Spell MOR: " + new MageObjectReference(spell, game));
         }
         UUID spellControllerID = spell.getControllerId();
         MageObjectReference spellMOR = new MageObjectReference(spell, game);
@@ -216,9 +220,9 @@ class AlaniaDivergentStormWatcher extends Watcher {
         MageObjectReference firstOtterMOR = playerFirstOtterCast.get(controllerID);
 
         if (!game.isSimulation()){
-            logger.info("firstOtterMOR: " + firstOtterMOR.getSourceId());
-            logger.info("spell: " + spell.getSourceId());
-            logger.info("AlaniaMOR: " + AlaniaMOR.getSourceId());
+            logger.info("firstOtterMOR: " + firstOtterMOR);
+            logger.info("spell: " + spell);
+            logger.info("AlaniaMOR: " + AlaniaMOR);
 //            logger.info(AlaniaMOR.getCard(game).getName());
         }
 

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -46,7 +46,9 @@ public final class AlaniaDivergentStorm extends CardImpl {
                 new SpellCastControllerTriggeredAbility(new DoIfCostPaid(
                         new CopyTargetStackObjectEffect(true),
                         new AlaniaDivergentStormCost()
-                ), null, false, SetTargetPointer.SPELL),
+                ), null, false, SetTargetPointer.SPELL)
+                .setTriggerPhrase("Whenever you cast a spell, if it's the first instant spell, the first sorcery " +
+                        "spell, or the first Otter spell other than Alania you've cast this turn, "),
                 AlaniaDivergentStormCondition.instance, ""
         );
         ability.addWatcher(new AlaniaDivergentStormWatcher());

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -69,8 +69,6 @@ public final class AlaniaDivergentStorm extends CardImpl {
 // Based on MarathWillOfTheWildRemoveCountersCost
 class AlaniaDivergentStormCost extends CostImpl {
 
-    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCost.class);
-
     AlaniaDivergentStormCost() {
         this.text = "have target opponent draw a card";
         this.addTarget(new TargetOpponent());
@@ -82,9 +80,6 @@ class AlaniaDivergentStormCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        if (!game.isSimulation()){
-            logger.info("entering canPay()");
-        }
         Player player = game.getPlayer(controllerId);
         if (player == null) {
             return false;
@@ -103,9 +98,6 @@ class AlaniaDivergentStormCost extends CostImpl {
 
     @Override
     public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
-        if (!game.isSimulation()) {
-            logger.info("entering pay()");
-        }
         this.getTargets().clearChosen();
         paid = false;
         if (this.getTargets().choose(Outcome.DrawCard, controllerId, source.getSourceId(), source, game)) {
@@ -128,18 +120,10 @@ class AlaniaDivergentStormCost extends CostImpl {
 enum AlaniaDivergentStormCondition implements Condition {
     instance;
 
-    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCost.class);
-
     @Override
     public boolean apply(Game game, Ability source) {
-        if (!game.isSimulation()) {
-            logger.info("entering apply()");
-        }
         Spell spell = (Spell) source.getEffects().get(0).getValue("spellCast");
         if (spell == null) {
-            if (!game.isSimulation()) {
-                logger.info("spell is null, returning false");
-            }
             return false;
         }
         AlaniaDivergentStormWatcher watcher = game.getState().getWatcher(AlaniaDivergentStormWatcher.class);
@@ -151,8 +135,6 @@ enum AlaniaDivergentStormCondition implements Condition {
 
 // Based on FirstSpellCastThisTurnWatcher
 class AlaniaDivergentStormWatcher extends Watcher {
-
-    private static final Logger logger = Logger.getLogger(AlaniaDivergentStormCost.class);
 
     private final Map<UUID, UUID> playerFirstInstantCast = new HashMap<>();
     private final Map<UUID, UUID> playerFirstSorceryCast = new HashMap<>();
@@ -167,35 +149,20 @@ class AlaniaDivergentStormWatcher extends Watcher {
         if (event.getType() != GameEvent.EventType.SPELL_CAST) {
             return;
         }
-        if (!game.isSimulation()) {
-            logger.info("SPELL_CAST event detected");
-        }
         Spell spell = (Spell) game.getObject(event.getTargetId());
         if (spell == null) {
-            if (!game.isSimulation()) {
-                logger.info("spell is null, returning false");
-            }
             return;
         }
         if (spell.getCardType(game).contains(CardType.INSTANT) &&
                 !playerFirstInstantCast.containsKey(spell.getControllerId())) {
-            if (!game.isSimulation()) {
-                logger.info("Adding instant spell");
-            }
             playerFirstInstantCast.put(spell.getControllerId(), spell.getId());
         }
         if (spell.getCardType(game).contains(CardType.SORCERY) &&
                 !playerFirstSorceryCast.containsKey(spell.getControllerId())) {
-            if (!game.isSimulation()) {
-                logger.info("Adding sorcery spell");
-            }
             playerFirstSorceryCast.put(spell.getControllerId(), spell.getId());
         }
         if (spell.getSubtype(game).contains(SubType.OTTER) &&
                 !playerFirstOtterCast.containsKey(spell.getControllerId())) {
-            if (!game.isSimulation()) {
-                logger.info("Adding otter spell");
-            }
             playerFirstOtterCast.put(spell.getControllerId(), spell.getId());
         }
 
@@ -204,7 +171,6 @@ class AlaniaDivergentStormWatcher extends Watcher {
     @Override
     public void reset() {
         super.reset();
-        logger.info("resetting watcher...");
         playerFirstInstantCast.clear();
         playerFirstSorceryCast.clear();
         playerFirstOtterCast.clear();

--- a/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
+++ b/Mage.Sets/src/mage/cards/a/AlaniaDivergentStorm.java
@@ -102,7 +102,7 @@ class AlaniaDivergentStormCost extends CostImpl {
         this.getTargets().clearChosen();
         paid = false;
         if (this.getTargets().choose(Outcome.DrawCard, controllerId, source.getSourceId(), source, game)) {
-            Player opponent = game.getPlayer(this.getTargets().get(0).getTargets().get(0));
+            Player opponent = game.getPlayer(this.getTargets().getFirstTarget());
             if (opponent == null || !opponent.canRespond()){
                 return false;
             }

--- a/Mage.Sets/src/mage/sets/Bloomburrow.java
+++ b/Mage.Sets/src/mage/sets/Bloomburrow.java
@@ -24,6 +24,7 @@ public final class Bloomburrow extends ExpansionSet {
         cards.add(new SetCardInfo("Agate Assault", 122, Rarity.COMMON, mage.cards.a.AgateAssault.class));
         cards.add(new SetCardInfo("Agate-Blade Assassin", 82, Rarity.COMMON, mage.cards.a.AgateBladeAssassin.class));
         cards.add(new SetCardInfo("Alania's Pathmaker", 123, Rarity.COMMON, mage.cards.a.AlaniasPathmaker.class));
+        cards.add(new SetCardInfo("Alania, Divergent Storm", 204, Rarity.RARE, mage.cards.a.AlaniaDivergentStorm.class));
         cards.add(new SetCardInfo("Artist's Talent", 124, Rarity.RARE, mage.cards.a.ArtistsTalent.class));
         cards.add(new SetCardInfo("Azure Beastbinder", 41, Rarity.RARE, mage.cards.a.AzureBeastbinder.class));
         cards.add(new SetCardInfo("Bakersbane Duo", 163, Rarity.COMMON, mage.cards.b.BakersbaneDuo.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/blb/AlaniaDivergentStormTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/blb/AlaniaDivergentStormTest.java
@@ -1,0 +1,241 @@
+package org.mage.test.cards.single.blb;
+
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author jimga150
+ */
+public class AlaniaDivergentStormTest extends CardTestPlayerBase {
+
+    /**
+     * {@link mage.cards.a.AlaniaDivergentStorm Alania, Divergent Storm} {3}{U}{R}
+     * Legendary Creature — Otter Wizard
+     * Whenever you cast a spell, if it's the first instant spell, the first sorcery spell, or the first Otter spell
+     * other than Alania you've cast this turn, you may have target opponent draw a card. If you do, copy that spell.
+     * You may choose new targets for the copy.
+     */
+    private static final String alania = "Alania, Divergent Storm";
+
+    @Test
+    public void test_TwoOtters() {
+        // Test that the "first Otter spell other than Alania you've cast this turn" clause works
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.HAND, playerA, "Coruscation Mage");
+        addCard(Zone.HAND, playerA, alania);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, alania, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Coruscation Mage", true);
+        setChoice(playerA, "No"); // Offspring?
+        setChoice(playerA, "Yes"); // Copy spell?
+        setChoice(playerA, "PlayerB"); // Who draws?
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Copied
+        assertPermanentCount(playerA, "Coruscation Mage", 2);
+        // Not copied
+        assertPermanentCount(playerA, alania, 1);
+        // Opponent drew a card
+        assertHandCount(playerB, 1);
+    }
+
+    @Test
+    public void test_TwoOttersNextTurn() {
+        // Test that the "first Otter spell other than Alania you've cast this turn" clause works on the next turn
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.HAND, playerA, "Coruscation Mage");
+        addCard(Zone.HAND, playerA, "Stormcatch Mentor");
+        addCard(Zone.HAND, playerA, alania);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, alania, true);
+
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Stormcatch Mentor", true);
+        setChoice(playerA, "Yes"); // Copy spell?
+        setChoice(playerA, "PlayerB"); // Who draws?
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Coruscation Mage", true);
+        setChoice(playerA, "No"); // Offspring?
+
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Copied
+        assertPermanentCount(playerA, "Stormcatch Mentor", 2);
+        // Not copied
+        assertPermanentCount(playerA, alania, 1);
+        assertPermanentCount(playerA, "Coruscation Mage", 1);
+        // Opponent drew a card (plus the one for turn draw)
+        assertHandCount(playerB, 1 + 1);
+    }
+
+    @Test
+    public void test_ThreeOttersAdventureInstant() {
+        // Test that the "first Otter spell other than Alania you've cast this turn" clause excludes the third otter cast on the same turn you cast Alania
+        // Also throws in an adventure otter, cast for creature and instant
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 10);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 10);
+        addCard(Zone.HAND, playerA, "Coruscation Mage");
+        addCard(Zone.HAND, playerA, "Frolicking Familiar", 2);
+        addCard(Zone.HAND, playerA, alania);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, alania, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Frolicking Familiar", true);
+        setChoice(playerA, "Yes"); // Copy spell?
+        setChoice(playerA, "PlayerB"); // Who draws?
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Coruscation Mage", true);
+        setChoice(playerA, "No"); // Offspring?
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Blow Off Steam", true);
+        setChoice(playerA, "Whenever you cast an instant", 2); // Add Frolicking Familiar triggers first
+        setChoice(playerA, "Whenever you cast a noncreature"); // Add Coruscation Mage trigger
+        // Alania's trigger will add last
+        setChoice(playerA, "Yes"); // Copy spell?
+        setChoice(playerA, "PlayerB"); // Who draws?
+        addTarget(playerA, playerB);
+        setChoice(playerA, "No"); // Change target?
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Copied
+        assertPermanentCount(playerA, "Frolicking Familiar", 2);
+        // Got boost from single cast of Blow Off Steam (copy =/= cast)
+        assertPowerToughness(playerA, "Frolicking Familiar", 3, 3);
+        // Not copied
+        assertPermanentCount(playerA, "Coruscation Mage", 1);
+        // Not copied
+        assertPermanentCount(playerA, alania, 1);
+        // Blow Off Steam copied, pinged twice, plus the Coruscation Mage ping
+        assertLife(playerB, currentGame.getStartingLife() - 3);
+        // opponent drew 2 cards
+        assertHandCount(playerB, 2);
+    }
+
+    @Test
+    public void test_TwoInstants() {
+        // Test that the "first instant you've cast this turn" clause works
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+        addCard(Zone.HAND, playerA, "Acrobatic Leap");
+        addCard(Zone.HAND, playerA, "Ancestral Recall");
+        addCard(Zone.HAND, playerA, alania);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, alania, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Acrobatic Leap", true);
+        setChoice(playerA, "Yes"); // Copy spell?
+        setChoice(playerA, "PlayerB"); // Who draws?
+        addTarget(playerA, alania); // Target creature
+        setChoice(playerA, "No"); // Change target?
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ancestral Recall", true);
+        addTarget(playerA, playerA); // Target player
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Copied: Acrobatic Leap
+        assertPowerToughness(playerA, alania, 3 + 2, 5 + 2*3);
+        // Not copied: Ancestral Recall
+        assertHandCount(playerA, 3);
+        // Opponent drew a card
+        assertHandCount(playerB, 1);
+    }
+
+    @Test
+    public void test_TwoSorceries() {
+        // Test that the "first sorcery you've cast this turn" clause works
+        // Also copies an adventure sorcery
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.HAND, playerA, "Faerie Guidemother"); // adventure card
+        addCard(Zone.HAND, playerA, "Maximize Velocity");
+        addCard(Zone.HAND, playerA, alania);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, alania, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gift of the Fae", true);
+        setChoice(playerA, "Yes"); // Copy spell?
+        setChoice(playerA, "PlayerB"); // Who draws?
+        addTarget(playerA, alania); // Target creature
+        setChoice(playerA, "No"); // Change target?
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Maximize Velocity", true);
+        addTarget(playerA, alania); // Target creature
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Copied: Gift of the Fae, Not copied: Ancestral Recall
+        assertPowerToughness(playerA, alania, 3 + 2*2 + 1, 5 + 2 + 1);
+        assertAbility(playerA, alania, FlyingAbility.getInstance(), true);
+        assertAbility(playerA, alania, HasteAbility.getInstance(), true);
+        // Opponent drew a card
+        assertHandCount(playerB, 1);
+    }
+
+    @Test
+    public void test_OtherCard() {
+        // Test that card cast that is first of its type but is not an instant, sorcery, or otter will not trigger Alania
+
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+        addCard(Zone.HAND, playerA, "Memnite");
+        addCard(Zone.HAND, playerA, "Arcane Signet");
+        addCard(Zone.HAND, playerA, "Ajani's Welcome");
+        addCard(Zone.BATTLEFIELD, playerA, alania);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Memnite", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Arcane Signet", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ajani's Welcome", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Nothing copied
+        assertPermanentCount(playerA, "Memnite", 1);
+        assertPermanentCount(playerA, "Arcane Signet", 1);
+        assertPermanentCount(playerA, "Ajani's Welcome", 1);
+        // Opponent did not draw a card
+        assertHandCount(playerB, 0);
+    }
+
+    @Test
+    public void test_TwoOttersOpponentsHexproof() {
+        // Test that Alania cannot copy spells if all opponents have hexproof
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Plains", 1);
+        addCard(Zone.HAND, playerA, "Coruscation Mage");
+        addCard(Zone.BATTLEFIELD, playerA, alania);
+        addCard(Zone.HAND, playerB, "Blossoming Calm");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Blossoming Calm");
+
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Coruscation Mage", true);
+        setChoice(playerA, "No"); // Offspring?
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // Not Copied
+        assertPermanentCount(playerA, "Coruscation Mage", 1);
+    }
+
+}


### PR DESCRIPTION
#11853

Assumption made here:
"if it's the first instant spell, the first sorcery spell, or the first Otter spell other than Alania you've cast this turn" means that this will trigger up to three times per turn, once for each spell of those three criteria, assuming that none of those three spells fits both of those criteria.

Question: How can I cause the `AlaniaDivergentStormWatcher` not count the cast of Alania, Divergent Storm, like in the oracle text? I assume this would happen by having the watcher check to see if the `SPELL_CAST` event belongs to a Spell that owns this instance of the watcher, but its possible that there's a better strategy.

- [x] Add "other than Alania" clause functionality

Write test:
- [x] Two otters (on turn Alania is cast, as well as next turn)
- [x] Two instants
- [x] Two sorceries
- [x] Card that isnt any of the above
- [x] Case where all opponents have hexproof (no valid target, ergo no copy)