### PR TITLE
Reworking standard legality

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Standard.java
@@ -3,9 +3,7 @@ package mage.deck;
 import mage.cards.ExpansionSet;
 import mage.cards.Sets;
 import mage.cards.decks.Constructed;
-import mage.constants.SetType;
 
-import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -27,15 +25,6 @@ public class Standard extends Constructed {
         banned.add("Invoke Despair");
     }
 
-    private static boolean isFallSet(ExpansionSet set) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(set.getReleaseDate());
-        // Fall sets are normally released during or after September and before November
-        return set.getSetType() == SetType.EXPANSION
-                && Calendar.SEPTEMBER <= cal.get(Calendar.MONTH)
-                && cal.get(Calendar.MONTH) < Calendar.NOVEMBER;
-    }
-
     static List<String> makeLegalSets() {
         GregorianCalendar current = new GregorianCalendar();
         // Get the third most recent fall set that's been released.
@@ -44,7 +33,7 @@ public class Standard extends Constructed {
                 .values()
                 .stream()
                 .filter(set -> !set.getReleaseDate().after(current.getTime()))
-                .filter(Standard::isFallSet)
+                .filter(ExpansionSet::isRotationSet)
                 .sorted(ExpansionSet.getComparator())
                 .skip(2)
                 .findFirst()

--- a/Mage.Sets/src/mage/sets/BattleForZendikar.java
+++ b/Mage.Sets/src/mage/sets/BattleForZendikar.java
@@ -30,6 +30,7 @@ public final class BattleForZendikar extends ExpansionSet {
         this.blockName = "Battle for Zendikar";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Bloomburrow.java
+++ b/Mage.Sets/src/mage/sets/Bloomburrow.java
@@ -19,7 +19,7 @@ public final class Bloomburrow extends ExpansionSet {
         super("Bloomburrow", "BLB", ExpansionSet.buildDate(2024, 8, 2), SetType.EXPANSION);
         this.blockName = "Bloomburrow"; // for sorting in GUI
         this.hasBasicLands = true;
-        this.isRotationSet = true;
+        this.rotationSet = true;
         this.hasBoosters = false; // temporary
 
         cards.add(new SetCardInfo("Agate Assault", 122, Rarity.COMMON, mage.cards.a.AgateAssault.class));

--- a/Mage.Sets/src/mage/sets/Bloomburrow.java
+++ b/Mage.Sets/src/mage/sets/Bloomburrow.java
@@ -19,6 +19,7 @@ public final class Bloomburrow extends ExpansionSet {
         super("Bloomburrow", "BLB", ExpansionSet.buildDate(2024, 8, 2), SetType.EXPANSION);
         this.blockName = "Bloomburrow"; // for sorting in GUI
         this.hasBasicLands = true;
+        this.isRotationSet = true;
         this.hasBoosters = false; // temporary
 
         cards.add(new SetCardInfo("Agate Assault", 122, Rarity.COMMON, mage.cards.a.AgateAssault.class));

--- a/Mage.Sets/src/mage/sets/ChampionsOfKamigawa.java
+++ b/Mage.Sets/src/mage/sets/ChampionsOfKamigawa.java
@@ -16,6 +16,7 @@ public final class ChampionsOfKamigawa extends ExpansionSet {
         super("Champions of Kamigawa", "CHK", ExpansionSet.buildDate(2004, 9, 1), SetType.EXPANSION);
         this.blockName = "Kamigawa";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Coldsnap.java
+++ b/Mage.Sets/src/mage/sets/Coldsnap.java
@@ -24,6 +24,7 @@ public final class Coldsnap extends ExpansionSet {
         super("Coldsnap", "CSP", ExpansionSet.buildDate(2006, 6, 21), SetType.EXPANSION);
         this.blockName = "Ice Age";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/DominariaUnited.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnited.java
@@ -31,7 +31,7 @@ public final class DominariaUnited extends ExpansionSet {
         super("Dominaria United", "DMU", ExpansionSet.buildDate(2022, 9, 9), SetType.EXPANSION);
         this.blockName = "Dominaria United";
         this.hasBoosters = true;
-        this.isRotationSet = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/DominariaUnited.java
+++ b/Mage.Sets/src/mage/sets/DominariaUnited.java
@@ -31,6 +31,7 @@ public final class DominariaUnited extends ExpansionSet {
         super("Dominaria United", "DMU", ExpansionSet.buildDate(2022, 9, 9), SetType.EXPANSION);
         this.blockName = "Dominaria United";
         this.hasBoosters = true;
+        this.isRotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/DragonsOfTarkir.java
+++ b/Mage.Sets/src/mage/sets/DragonsOfTarkir.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author fireshoes
  */
 public final class DragonsOfTarkir extends ExpansionSet {
@@ -28,11 +27,13 @@ public final class DragonsOfTarkir extends ExpansionSet {
         this.blockName = "Khans of Tarkir";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Acid-Spewer Dragon", 86, Rarity.UNCOMMON, mage.cards.a.AcidSpewerDragon.class));
         cards.add(new SetCardInfo("Aerie Bowmasters", 170, Rarity.COMMON, mage.cards.a.AerieBowmasters.class));
         cards.add(new SetCardInfo("Ainok Artillerist", 171, Rarity.COMMON, mage.cards.a.AinokArtillerist.class));

--- a/Mage.Sets/src/mage/sets/GuildsOfRavnica.java
+++ b/Mage.Sets/src/mage/sets/GuildsOfRavnica.java
@@ -1,11 +1,11 @@
 package mage.sets;
 
 import mage.cards.ExpansionSet;
+import mage.cards.repository.CardInfo;
 import mage.collation.BoosterCollator;
 import mage.collation.BoosterStructure;
 import mage.collation.CardRun;
 import mage.collation.RarityConfiguration;
-import mage.cards.repository.CardInfo;
 import mage.constants.Rarity;
 import mage.constants.SetType;
 
@@ -24,6 +24,7 @@ public final class GuildsOfRavnica extends ExpansionSet {
         super("Guilds of Ravnica", "GRN", ExpansionSet.buildDate(2018, 10, 5), SetType.EXPANSION);
         this.blockName = "Guilds of Ravnica";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Innistrad.java
+++ b/Mage.Sets/src/mage/sets/Innistrad.java
@@ -26,6 +26,7 @@ public final class Innistrad extends ExpansionSet {
         super("Innistrad", "ISD", ExpansionSet.buildDate(2011, 9, 30), SetType.EXPANSION);
         this.blockName = "Innistrad";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 9;
         this.numBoosterUncommon = 3;
@@ -343,24 +344,24 @@ class InnistradCollator implements BoosterCollator {
     private final CardRun land = new CardRun(false, "250", "251", "252", "253", "254", "255", "256", "257", "258", "259", "260", "261", "262", "263", "264");
 
     private final BoosterStructure AABBC1C1C1C1C1 = new BoosterStructure(
-        commonA, commonA,
-        commonB, commonB,
-        commonC1, commonC1, commonC1, commonC1, commonC1
+            commonA, commonA,
+            commonB, commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
     );
     private final BoosterStructure AAABC1C1C1C1C1 = new BoosterStructure(
-        commonA, commonA, commonA,
-        commonB,
-        commonC1, commonC1, commonC1, commonC1, commonC1
+            commonA, commonA, commonA,
+            commonB,
+            commonC1, commonC1, commonC1, commonC1, commonC1
     );
     private final BoosterStructure AAABBC2C2C2C2 = new BoosterStructure(
-        commonA, commonA, commonA,
-        commonB, commonB,
-        commonC2, commonC2, commonC2, commonC2
+            commonA, commonA, commonA,
+            commonB, commonB,
+            commonC2, commonC2, commonC2, commonC2
     );
     private final BoosterStructure AAAABBBC2C2 = new BoosterStructure(
-        commonA, commonA, commonA, commonA,
-        commonB, commonB, commonB,
-        commonC2, commonC2
+            commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB,
+            commonC2, commonC2
     );
     private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
     private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
@@ -378,18 +379,18 @@ class InnistradCollator implements BoosterCollator {
     // 2.46 C1 commons (135 / 55)
     // 1.64 C2 commons (90 / 55)
     private final RarityConfiguration commonRuns = new RarityConfiguration(
-    AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1,
-    AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1,
-    AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1,
-    AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1,
-    AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1,
-    AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1,
-    AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2,
-    AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2,
-    AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2,
-    AAABBC2C2C2C2, AAABBC2C2C2C2,
-    AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2,
-    AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2
+            AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1,
+            AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1,
+            AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1, AABBC1C1C1C1C1,
+            AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1,
+            AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1,
+            AAABC1C1C1C1C1, AAABC1C1C1C1C1, AAABC1C1C1C1C1,
+            AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2,
+            AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2,
+            AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2, AAABBC2C2C2C2,
+            AAABBC2C2C2C2, AAABBC2C2C2C2,
+            AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2,
+            AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2, AAAABBBC2C2
     );
     // In order for equal numbers of each uncommon to exist, the average booster must contain:
     // 1.65 A uncommons (33 / 20)

--- a/Mage.Sets/src/mage/sets/InnistradMidnightHunt.java
+++ b/Mage.Sets/src/mage/sets/InnistradMidnightHunt.java
@@ -28,6 +28,7 @@ public final class InnistradMidnightHunt extends ExpansionSet {
         this.blockName = "Innistrad: Midnight Hunt";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.isRotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 9;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/InnistradMidnightHunt.java
+++ b/Mage.Sets/src/mage/sets/InnistradMidnightHunt.java
@@ -28,7 +28,7 @@ public final class InnistradMidnightHunt extends ExpansionSet {
         this.blockName = "Innistrad: Midnight Hunt";
         this.hasBoosters = true;
         this.hasBasicLands = true;
-        this.isRotationSet = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 9;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Invasion.java
+++ b/Mage.Sets/src/mage/sets/Invasion.java
@@ -1,4 +1,3 @@
-
 package mage.sets;
 
 import mage.cards.ExpansionSet;
@@ -6,7 +5,6 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 /**
- *
  * @author North
  */
 public final class Invasion extends ExpansionSet {
@@ -21,6 +19,7 @@ public final class Invasion extends ExpansionSet {
         super("Invasion", "INV", ExpansionSet.buildDate(2000, 9, 2), SetType.EXPANSION);
         this.blockName = "Invasion";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Ixalan.java
+++ b/Mage.Sets/src/mage/sets/Ixalan.java
@@ -27,6 +27,7 @@ public final class Ixalan extends ExpansionSet {
         this.blockName = "Ixalan";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Kaladesh.java
+++ b/Mage.Sets/src/mage/sets/Kaladesh.java
@@ -30,6 +30,7 @@ public final class Kaladesh extends ExpansionSet {
         this.blockName = "Kaladesh";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/KhansOfTarkir.java
+++ b/Mage.Sets/src/mage/sets/KhansOfTarkir.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author LevelX2
  */
 public final class KhansOfTarkir extends ExpansionSet {
@@ -28,11 +27,13 @@ public final class KhansOfTarkir extends ExpansionSet {
         this.blockName = "Khans of Tarkir";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Abomination of Gudul", 159, Rarity.COMMON, mage.cards.a.AbominationOfGudul.class));
         cards.add(new SetCardInfo("Abzan Ascendancy", 160, Rarity.RARE, mage.cards.a.AbzanAscendancy.class));
         cards.add(new SetCardInfo("Abzan Banner", 215, Rarity.COMMON, mage.cards.a.AbzanBanner.class));

--- a/Mage.Sets/src/mage/sets/Lorwyn.java
+++ b/Mage.Sets/src/mage/sets/Lorwyn.java
@@ -1,4 +1,3 @@
-
 package mage.sets;
 
 import mage.cards.ExpansionSet;
@@ -6,7 +5,6 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 /**
- *
  * @author North
  */
 public final class Lorwyn extends ExpansionSet {
@@ -21,11 +19,13 @@ public final class Lorwyn extends ExpansionSet {
         super("Lorwyn", "LRW", ExpansionSet.buildDate(2007, 10, 12), SetType.EXPANSION);
         this.blockName = "Lorwyn";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Adder-Staff Boggart", 148, Rarity.COMMON, mage.cards.a.AdderStaffBoggart.class));
         cards.add(new SetCardInfo("Aethersnipe", 50, Rarity.COMMON, mage.cards.a.Aethersnipe.class));
         cards.add(new SetCardInfo("Ajani Goldmane", 1, Rarity.RARE, mage.cards.a.AjaniGoldmane.class));

--- a/Mage.Sets/src/mage/sets/MercadianMasques.java
+++ b/Mage.Sets/src/mage/sets/MercadianMasques.java
@@ -19,6 +19,7 @@ public final class MercadianMasques extends ExpansionSet {
         super("Mercadian Masques", "MMQ", ExpansionSet.buildDate(1999, 8, 25), SetType.EXPANSION);
         this.blockName = "Masques";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Mirrodin.java
+++ b/Mage.Sets/src/mage/sets/Mirrodin.java
@@ -16,6 +16,7 @@ public final class Mirrodin extends ExpansionSet {
         super("Mirrodin", "MRD", ExpansionSet.buildDate(2003, 9, 2), SetType.EXPANSION);
         this.blockName = "Mirrodin";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Odyssey.java
+++ b/Mage.Sets/src/mage/sets/Odyssey.java
@@ -19,6 +19,7 @@ public final class Odyssey extends ExpansionSet {
         super("Odyssey", "ODY", ExpansionSet.buildDate(2001, 9, 22), SetType.EXPANSION);
         this.blockName = "Odyssey";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Onslaught.java
+++ b/Mage.Sets/src/mage/sets/Onslaught.java
@@ -18,6 +18,7 @@ public final class Onslaught extends ExpansionSet {
         super("Onslaught", "ONS", ExpansionSet.buildDate(2002, 10, 7), SetType.EXPANSION);
         this.blockName = "Onslaught";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/RavnicaCityOfGuilds.java
+++ b/Mage.Sets/src/mage/sets/RavnicaCityOfGuilds.java
@@ -1,4 +1,3 @@
-
 package mage.sets;
 
 import mage.cards.ExpansionSet;
@@ -6,7 +5,6 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 /**
- *
  * @author loki
  */
 public final class RavnicaCityOfGuilds extends ExpansionSet {
@@ -21,11 +19,13 @@ public final class RavnicaCityOfGuilds extends ExpansionSet {
         super("Ravnica: City of Guilds", "RAV", ExpansionSet.buildDate(2005, 9, 24), SetType.EXPANSION);
         this.blockName = "Ravnica";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 0;
         this.numBoosterCommon = 11;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 0;
+
         cards.add(new SetCardInfo("Agrus Kos, Wojek Veteran", 190, Rarity.RARE, mage.cards.a.AgrusKosWojekVeteran.class));
         cards.add(new SetCardInfo("Auratouched Mage", 1, Rarity.UNCOMMON, mage.cards.a.AuratouchedMage.class));
         cards.add(new SetCardInfo("Autochthon Wurm", 191, Rarity.RARE, mage.cards.a.AutochthonWurm.class));

--- a/Mage.Sets/src/mage/sets/ReturnToRavnica.java
+++ b/Mage.Sets/src/mage/sets/ReturnToRavnica.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author magenoxx_at_gmail.com
  */
 public final class ReturnToRavnica extends ExpansionSet {
@@ -27,11 +26,13 @@ public final class ReturnToRavnica extends ExpansionSet {
         super("Return to Ravnica", "RTR", ExpansionSet.buildDate(2012, 10, 5), SetType.EXPANSION);
         this.blockName = "Return to Ravnica";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Abrupt Decay", 141, Rarity.RARE, mage.cards.a.AbruptDecay.class));
         cards.add(new SetCardInfo("Aerial Predation", 113, Rarity.COMMON, mage.cards.a.AerialPredation.class));
         cards.add(new SetCardInfo("Angel of Serenity", 1, Rarity.MYTHIC, mage.cards.a.AngelOfSerenity.class));

--- a/Mage.Sets/src/mage/sets/ScarsOfMirrodin.java
+++ b/Mage.Sets/src/mage/sets/ScarsOfMirrodin.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author nantuko84
  */
 public final class ScarsOfMirrodin extends ExpansionSet {
@@ -27,11 +26,13 @@ public final class ScarsOfMirrodin extends ExpansionSet {
         super("Scars of Mirrodin", "SOM", ExpansionSet.buildDate(2010, 10, 1), SetType.EXPANSION);
         this.blockName = "Scars of Mirrodin";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Abuna Acolyte", 1, Rarity.UNCOMMON, mage.cards.a.AbunaAcolyte.class));
         cards.add(new SetCardInfo("Accorder's Shield", 136, Rarity.COMMON, mage.cards.a.AccordersShield.class));
         cards.add(new SetCardInfo("Acid Web Spider", 108, Rarity.UNCOMMON, mage.cards.a.AcidWebSpider.class));

--- a/Mage.Sets/src/mage/sets/ShardsOfAlara.java
+++ b/Mage.Sets/src/mage/sets/ShardsOfAlara.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author BetaSteward_at_googlemail.com
  */
 public final class ShardsOfAlara extends ExpansionSet {
@@ -28,11 +27,13 @@ public final class ShardsOfAlara extends ExpansionSet {
         super("Shards of Alara", "ALA", ExpansionSet.buildDate(2008, 10, 3), SetType.EXPANSION);
         this.blockName = "Shards of Alara";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Ad Nauseam", 63, Rarity.RARE, mage.cards.a.AdNauseam.class));
         cards.add(new SetCardInfo("Agony Warp", 153, Rarity.COMMON, mage.cards.a.AgonyWarp.class));
         cards.add(new SetCardInfo("Ajani Vengeant", 154, Rarity.MYTHIC, mage.cards.a.AjaniVengeant.class));

--- a/Mage.Sets/src/mage/sets/Theros.java
+++ b/Mage.Sets/src/mage/sets/Theros.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *
  * @author LevelX2
  */
 public final class Theros extends ExpansionSet {
@@ -27,11 +26,13 @@ public final class Theros extends ExpansionSet {
         super("Theros", "THS", ExpansionSet.buildDate(2013, 9, 27), SetType.EXPANSION);
         this.blockName = "Theros";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;
         this.numBoosterRare = 1;
         this.ratioBoosterMythic = 8;
+
         cards.add(new SetCardInfo("Abhorrent Overlord", 75, Rarity.RARE, mage.cards.a.AbhorrentOverlord.class));
         cards.add(new SetCardInfo("Agent of Horizons", 148, Rarity.COMMON, mage.cards.a.AgentOfHorizons.class));
         cards.add(new SetCardInfo("Agent of the Fates", 76, Rarity.RARE, mage.cards.a.AgentOfTheFates.class));

--- a/Mage.Sets/src/mage/sets/ThroneOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/ThroneOfEldraine.java
@@ -26,6 +26,7 @@ public final class ThroneOfEldraine extends ExpansionSet {
         super("Throne of Eldraine", "ELD", ExpansionSet.buildDate(2019, 10, 4), SetType.EXPANSION);
         this.blockName = "Throne of Eldraine";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/WildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraine.java
@@ -24,7 +24,7 @@ public final class WildsOfEldraine extends ExpansionSet {
         this.blockName = "Wilds of Eldraine";
         this.hasBoosters = true;
         this.hasBasicLands = true;
-        this.isRotationSet = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 9;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/WildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/WildsOfEldraine.java
@@ -24,6 +24,7 @@ public final class WildsOfEldraine extends ExpansionSet {
         this.blockName = "Wilds of Eldraine";
         this.hasBoosters = true;
         this.hasBasicLands = true;
+        this.isRotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 9;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/Zendikar.java
+++ b/Mage.Sets/src/mage/sets/Zendikar.java
@@ -29,6 +29,7 @@ public final class Zendikar extends ExpansionSet {
         super("Zendikar", "ZEN", ExpansionSet.buildDate(2009, 10, 2), SetType.EXPANSION); // October 2nd, 2009
         this.blockName = "Zendikar";
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage.Sets/src/mage/sets/ZendikarRising.java
+++ b/Mage.Sets/src/mage/sets/ZendikarRising.java
@@ -30,6 +30,7 @@ public final class ZendikarRising extends ExpansionSet {
         this.blockName = "Zendikar Rising";
         this.hasBasicLands = true;
         this.hasBoosters = true;
+        this.rotationSet = true;
         this.numBoosterLands = 1;
         this.numBoosterCommon = 10;
         this.numBoosterUncommon = 3;

--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -113,7 +113,7 @@ public abstract class ExpansionSet implements Serializable {
     protected boolean hasBasicLands = true;
 
     protected String blockName; // used to group sets in some GUI dialogs like choose set dialog
-    protected boolean isRotationSet = false;
+    protected boolean isRotationSet = false; // used to determine if a set is a standard rotation
     protected boolean hasBoosters = false;
     protected int numBoosterSpecial;
 

--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -113,6 +113,7 @@ public abstract class ExpansionSet implements Serializable {
     protected boolean hasBasicLands = true;
 
     protected String blockName; // used to group sets in some GUI dialogs like choose set dialog
+    protected boolean isRotationSet = false;
     protected boolean hasBoosters = false;
     protected int numBoosterSpecial;
 
@@ -503,6 +504,10 @@ public abstract class ExpansionSet implements Serializable {
 
     public boolean hasBasicLands() {
         return hasBasicLands;
+    }
+
+    public boolean isRotationSet() {
+        return isRotationSet;
     }
 
     /**

--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -113,7 +113,7 @@ public abstract class ExpansionSet implements Serializable {
     protected boolean hasBasicLands = true;
 
     protected String blockName; // used to group sets in some GUI dialogs like choose set dialog
-    protected boolean isRotationSet = false; // used to determine if a set is a standard rotation
+    protected boolean rotationSet = false; // used to determine if a set is a standard rotation
     protected boolean hasBoosters = false;
     protected int numBoosterSpecial;
 
@@ -507,7 +507,7 @@ public abstract class ExpansionSet implements Serializable {
     }
 
     public boolean isRotationSet() {
-        return isRotationSet;
+        return rotationSet;
     }
 
     /**


### PR DESCRIPTION
Until recently we had standard legality determined based on the "fall set" which always fell in September and October. Now that the rotation set is in August and the set that follows it would normally be when rotation would happen, I think we need to rework this system. I don't think it's a bad idea to just manually mark rotation sets as I've done in this PR and simplify the whole process rather than have complicated logic that keeps having to be altered for new exceptions. We know that the upcoming Foundations set will stay in standard even longer but I think that can be handled separately. 

If this method makes sense to everyone I'll go in and add the rotation flag to older sets for consistency.