### PR TITLE
tests: fix some missing choices

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseTargetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseTargetTest.java
@@ -45,7 +45,7 @@ public class ChooseTargetTest extends CardTestPlayerBase {
         //setChoice(playerB, "Silvercoat Lion");
         //setChoice(playerA, true);
 
-        //setStrictChooseMode(true);
+        setStrictChooseMode(false);
         setStopAt(2, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/CopyAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/CopyAITest.java
@@ -167,7 +167,7 @@ public class CopyAITest extends CardTestPlayerBaseWithAIHelps {
         //addTarget(playerA, "Spectral Bears"); // AI must choose
 
         setStopAt(1, PhaseStep.END_TURN);
-        //setStrictChooseMode(true); // AI must choose
+        setStrictChooseMode(false); // AI must choose
         execute();
 
         assertPermanentCount(playerA, "Spectral Bears", 1);
@@ -191,7 +191,7 @@ public class CopyAITest extends CardTestPlayerBaseWithAIHelps {
         //addTarget(playerA, "Spectral Bears"); // AI must choose
 
         setStopAt(1, PhaseStep.END_TURN);
-        //setStrictChooseMode(true); // AI must choose
+        setStrictChooseMode(false); // AI must choose
         execute();
 
         assertPermanentCount(playerA, "Spectral Bears", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ExileTargetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ExileTargetTest.java
@@ -28,7 +28,7 @@ public class ExileTargetTest extends CardTestCommander4Players {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Oblivion Ring");
         //addTarget(playerA, "Balduvian Bears"); // disable to activate AI target choose
 
-        //setStrictChooseMode(true); // disable strict mode to activate AI for choosing
+        setStrictChooseMode(false); // disable strict mode to activate AI for choosing
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetAmountAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetAmountAITest.java
@@ -23,7 +23,7 @@ public class TargetAmountAITest extends CardTestPlayerBaseWithAIHelps {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Blessings of Nature");
 
         setStopAt(1, PhaseStep.END_TURN);
-        //setStrictChooseMode(true); // ai must choose
+        setStrictChooseMode(false); // ai must choose
         execute();
 
         assertPowerToughness(playerA, "Balduvian Bears", 2 + 4, 2 + 4); // boost one creature (it's just a choose code, so can be different from simulation results)

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetControllerChangeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetControllerChangeTest.java
@@ -48,7 +48,7 @@ public class TargetControllerChangeTest extends CardTestPlayerBase {
         //
         //addTarget(playerB, "Balduvian Bears"); // give small bear to A - AI must choose itself
 
-        //setStrictChooseMode(true); // AI must choose
+        setStrictChooseMode(false); // AI must choose
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
@@ -112,7 +112,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
         checkPermanentCounters("counters", 1, PhaseStep.BEGIN_COMBAT, playerB, "Balduvian Bears", CounterType.P1P1, 2);
 
         // AI cast avatar on turn 3 and target 1 creature to kil by 3 damage
-        //setStrictChooseMode(true); // AI
+        setStrictChooseMode(false); // AI
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetRequiredTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetRequiredTest.java
@@ -47,7 +47,7 @@ public class TargetRequiredTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Redcap Melee", "Silvercoat Lion");
         //addTarget(playerA, "Mountain"); AI must select targets
 
-        //setStrictChooseMode(true); AI must select targets
+        setStrictChooseMode(false); // AI must select targets
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 
@@ -87,7 +87,7 @@ public class TargetRequiredTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Redcap Melee", "Silvercoat Lion");
         //addTarget(playerA, "Mountain"); no lands to sacrifice
 
-        //setStrictChooseMode(true);
+        setStrictChooseMode(false);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetStackObjectByAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetStackObjectByAITest.java
@@ -61,7 +61,7 @@ public class TargetStackObjectByAITest extends CardTestPlayerBaseWithAIHelps {
         //setChoice(playerB, "Swamp"); // discard
 
         setStopAt(1, PhaseStep.END_TURN);
-        //setStrictChooseMode(true); // AI must choose
+        setStrictChooseMode(false); // AI must choose
         execute();
 
         assertGraveyardCount(playerB, "Grizzly Bears", 0);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/PutToGraveyardTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/PutToGraveyardTest.java
@@ -66,6 +66,7 @@ public class PutToGraveyardTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Swords to Plowshares", "Silvercoat Lion");
 
         activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{2}");
+        addTarget(playerA, "Silvercoat Lion");
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/ReturnToHandTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/ReturnToHandTest.java
@@ -58,8 +58,9 @@ public class ReturnToHandTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Swamp");
 
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Swamp");
-        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setChoice(playerA, true);
 
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertPermanentCount(playerA, "Swamp", 1);
@@ -82,8 +83,9 @@ public class ReturnToHandTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Urborg, Tomb of Yawgmoth", 1);
 
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Flood Plain");
-        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setChoice(playerA, true);
 
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertPermanentCount(playerA, "Flood Plain", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
@@ -50,6 +50,7 @@ public class CursesTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Curse of Echoes", playerB);
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Jace's Ingenuity");
+        setChoice(playerA, true); // yes to copy
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();
@@ -118,7 +119,7 @@ public class CursesTest extends CardTestPlayerBase {
 
         castSpell(4, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
         castSpell(4, PhaseStep.PRECOMBAT_MAIN, playerB, "Copy Enchantment");
-        // Choices for Copy Enchantment get auto-chosen
+        setStrictChooseMode(false); // auto choose
 
         checkPlayableAbility("Can't cast a 2nd spell", 4, PhaseStep.POSTCOMBAT_MAIN, playerA, "Cast Lightning", false);
 
@@ -211,6 +212,8 @@ public class CursesTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Curse of Misfortunes", playerB);
 
+        setStrictChooseMode(false); // auto choose, not valid choice since same name
+
         setStopAt(3, PhaseStep.DRAW);
         execute();
 
@@ -227,6 +230,9 @@ public class CursesTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Curse of Misfortunes", playerB);
+
+        setChoice(playerA, true);
+        addTarget(playerA, "Curse of Bloodletting");
 
         setStopAt(3, PhaseStep.DRAW);
         execute();
@@ -273,10 +279,12 @@ public class CursesTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Curse of Death's Hold", playerB);
 
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Reclamation Sage");
+        setChoice(playerB, true); // yes to destroy artifact or enchantment
         addTarget(playerB, "Curse of Death's Hold");
 
         // {2}{G/U}{G/U}: Put the top two cards of your library into your graveyard, then return a nonland card of an opponent's choice from your graveyard to your hand.
         activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{G/U}{G/U}: Mill two cards");
+        addTarget(playerB, "Curse of Death's Hold"); // opponent's choice
         castSpell(3, PhaseStep.POSTCOMBAT_MAIN, playerA, "Curse of Death's Hold", playerB);
 
         setStopAt(3, PhaseStep.END_TURN);
@@ -345,6 +353,7 @@ public class CursesTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, memnite);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cReality, playerB);
+        setChoice(playerB, memnite);
 
         setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
         execute();
@@ -363,6 +372,7 @@ public class CursesTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, ugin);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, cReality, playerB);
+        setChoice(playerB, ugin);
 
         setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
@@ -253,6 +253,7 @@ public class CursesTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Curse of Death's Hold", playerB);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/curses/CursesTest.java
@@ -288,6 +288,7 @@ public class CursesTest extends CardTestPlayerBase {
         addTarget(playerB, "Curse of Death's Hold"); // opponent's choice
         castSpell(3, PhaseStep.POSTCOMBAT_MAIN, playerA, "Curse of Death's Hold", playerB);
 
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/AugurOfBolasTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/AugurOfBolasTest.java
@@ -11,16 +11,8 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class AugurOfBolasTest extends CardTestPlayerBase {
 
-    /*
-        Aether Figment   {1}{U}
-        Creature - Illusion
-        1/1
-        Kicker {3} (You may pay an additional as you cast this spell.)
-        Aether Figment can't be blocked.
-        If Aether Figment was kicked, it enters with two +1/+1 counters on it.
-     */
     @Test
-    public void testEnteringWithCounters() {
+    public void testAbility() {
         addCard(Zone.LIBRARY, playerA, "Lightning Bolt", 3);
         skipInitShuffling();
         addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
@@ -29,6 +21,9 @@ public class AugurOfBolasTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Augur of Bolas"); // Creature {1}{U}
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Augur of Bolas");
+        setChoice(playerA, true);
+        addTarget(playerA, "Lightning Bolt"); // to hand
+        setChoice(playerA, "Lightning Bolt"); // order to bottom
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/AugurOfBolasTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/AugurOfBolasTest.java
@@ -25,6 +25,7 @@ public class AugurOfBolasTest extends CardTestPlayerBase {
         addTarget(playerA, "Lightning Bolt"); // to hand
         setChoice(playerA, "Lightning Bolt"); // order to bottom
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/BronzehideLionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/BronzehideLionTest.java
@@ -24,6 +24,8 @@ public class BronzehideLionTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Terror", lion);
+        setChoice(playerA, "Grizzly Bears"); // to enchant
+
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
         assertGraveyardCount(playerA, lion, 0);
@@ -39,6 +41,7 @@ public class BronzehideLionTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 10);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Terror", lion);
+        setStrictChooseMode(false); // auto choose, no legal target
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
         assertGraveyardCount(playerA, lion, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/GreenbeltRampagerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/GreenbeltRampagerTest.java
@@ -76,6 +76,7 @@ public class GreenbeltRampagerTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gonti, Lord of Luxury", true);
         // addTarget(playerA, playerB); playerB is autochosen since only option
+        setStrictChooseMode(false);
         setChoice(playerA, "Greenbelt Rampager");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Greenbelt Rampager");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/MasterBiomancerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/MasterBiomancerTest.java
@@ -98,6 +98,9 @@ public class MasterBiomancerTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Progenitor Mimic");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Progenitor Mimic");
+        setChoice(playerA, true); // yes to copy
+        setChoice(playerA, "Master Biomancer");
+        setStrictChooseMode(false); // something weird with replacement effect ordering?
 
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/ProteanHydraTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/ProteanHydraTest.java
@@ -23,6 +23,7 @@ public class ProteanHydraTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Protean Hydra");
 
+        setStrictChooseMode(false); // test AI use max for X
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/SkylineCascadeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/SkylineCascadeTest.java
@@ -30,7 +30,7 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         attack(1, playerA, "Savannah Lions");
 
         playLand(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Skyline Cascade");
-        addTarget(playerA, "Savannah Lions");
+        addTarget(playerB, "Savannah Lions");
 
         setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
@@ -63,7 +63,7 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerB, "Skyline Cascade");
                 
         playLand(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Skyline Cascade");
-        addTarget(playerA, "Savannah Lions");
+        addTarget(playerB, "Savannah Lions");
 
         setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/SkylineCascadeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/SkylineCascadeTest.java
@@ -32,8 +32,8 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         playLand(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Skyline Cascade");
         addTarget(playerA, "Savannah Lions");
 
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
-        
         execute();
         
         assertTapped("Savannah Lions", true);
@@ -55,7 +55,7 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         // {W} 2/1
         addCard(Zone.BATTLEFIELD, playerA, "Savannah Lions");
         
-        /**
+        /*
          * Skyline Cascade enters the battlefield tapped.
          * When Skyline Cascade enters the battlefield, target creature an opponent controls doesn't untap during its controller's next untap step.
          * Tap: Add {U} .
@@ -65,8 +65,8 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         playLand(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Skyline Cascade");
         addTarget(playerA, "Savannah Lions");
 
+        setStrictChooseMode(true);
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
-        
         execute();
         
         assertTapped("Savannah Lions", false);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/SkylineCascadeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/SkylineCascadeTest.java
@@ -12,7 +12,6 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
 
     /**
      * Reported bug on Skyline Cascade not working properly.
-     * 
      * Test the typical situation - tapped creature not being able to untap during next untap step.
      */
     @Test
@@ -31,7 +30,7 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         attack(1, playerA, "Savannah Lions");
 
         playLand(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Skyline Cascade");
-        // Savannah Lions is autochosen
+        addTarget(playerA, "Savannah Lions");
 
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         
@@ -64,8 +63,8 @@ public class SkylineCascadeTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerB, "Skyline Cascade");
                 
         playLand(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Skyline Cascade");
-        // Savannah Lions is autochosen
-        
+        addTarget(playerA, "Savannah Lions");
+
         setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
         
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/ValakutTheMoltenPinnacleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/ValakutTheMoltenPinnacleTest.java
@@ -41,6 +41,8 @@ public class ValakutTheMoltenPinnacleTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
 
         playLand(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Mountain"); // 3 damage because already 5 Mountains on battlefield
+        setChoice(playerA, true); // yes to deal damage
+        addTarget(playerA, playerB); // to deal damage
 
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -66,6 +68,10 @@ public class ValakutTheMoltenPinnacleTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scapeshift");
         setChoice(playerA, "Forest^Forest^Forest^Forest^Forest^Forest");
+        addTarget(playerA, "Mountain^Mountain^Mountain^Mountain^Mountain^Mountain");
+        setChoice(playerA, "Whenever", 5); // order triggers
+        setChoice(playerA, true, 6); // yes to deal damage
+        addTarget(playerA, playerB, 6); // to deal damage
 
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -89,6 +95,10 @@ public class ValakutTheMoltenPinnacleTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scapeshift");
         setChoice(playerA, "Forest^Forest^Forest^Forest^Forest^Forest^Forest");
+        addTarget(playerA, "Mountain^Mountain^Mountain^Mountain^Mountain^Mountain^Valakut, the Molten Pinnacle");
+        setChoice(playerA, "Whenever", 5); // order triggers
+        setChoice(playerA, true, 6); // yes to deal damage
+        addTarget(playerA, playerB, 6); // to deal damage
 
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -114,9 +124,13 @@ public class ValakutTheMoltenPinnacleTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scapeshift");
         setChoice(playerA, "Forest^Forest^Forest^Forest^Forest^Forest^Forest");
+        addTarget(playerA, "Mountain^Mountain^Mountain^Stomping Ground^Stomping Ground^Stomping Ground^Valakut, the Molten Pinnacle");
         setChoice(playerA, false); // Stomping Ground can be tapped
         setChoice(playerA, false); // Stomping Ground can be tapped
         setChoice(playerA, false); // Stomping Ground can be tapped
+        setChoice(playerA, "Whenever", 5); // order triggers
+        setChoice(playerA, true, 6); // yes to deal damage
+        addTarget(playerA, playerB, 6); // to deal damage
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -153,6 +167,7 @@ public class ValakutTheMoltenPinnacleTest extends CardTestPlayerBase {
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Forest");
         addTarget(playerA, playerB);
 
+        setStrictChooseMode(false); // auto-choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/CloudshiftTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/CloudshiftTest.java
@@ -61,8 +61,10 @@ public class CloudshiftTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Cloudshift");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Clone");
+        setChoice(playerA, true); // Use Clone's ability
         setChoice(playerA, "Knight of Meadowgrain");
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Cloudshift", "Knight of Meadowgrain"); // clone has name of copied permanent
+        setChoice(playerA, true); // Use Clone's ability
         setChoice(playerA, "Heirs of Stromkirk");
 
         setStopAt(1, PhaseStep.END_TURN);
@@ -120,6 +122,7 @@ public class CloudshiftTest extends CardTestPlayerBase {
         addTarget(playerB, "Timberland Guide");
         attack(2, playerB, "Fervent Cathar");
         castSpell(2, PhaseStep.DECLARE_ATTACKERS, playerA, "Cloudshift", "Timberland Guide");
+        addTarget(playerA, "Timberland Guide"); // where to put counter
         block(2, playerA, "Timberland Guide", "Fervent Cathar");
 
         setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
@@ -314,7 +317,8 @@ public class CloudshiftTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Act of Treason", "Silvercoat Lion");
-        // Silvercoat Lion is autochosen
+        setChoice(playerA, true); // yes to flicker
+        addTarget(playerA, "Silvercoat Lion");
 
         setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
         execute();
@@ -356,6 +360,7 @@ public class CloudshiftTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Flickerwisp");
         addTarget(playerA, "Flickerwisp");
         addTarget(playerA, "Courser of Kruphix");
+        setChoice(playerA, "At the beginning"); // order triggers
 
         setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/CloudshiftTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/CloudshiftTest.java
@@ -320,6 +320,7 @@ public class CloudshiftTest extends CardTestPlayerBase {
         setChoice(playerA, true); // yes to flicker
         addTarget(playerA, "Silvercoat Lion");
 
+        setStrictChooseMode(true);
         setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/AuraSwapTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/AuraSwapTest.java
@@ -36,6 +36,7 @@ public class AuraSwapTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA,  "Arcanum Wings", "Silvercoat Lion");
         
         activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Aura swap");
+        setChoice(playerA, "Eldrazi Conscription");
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/AwakenTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/AwakenTest.java
@@ -38,8 +38,7 @@ public class AwakenTest extends CardTestPlayerBase {
      */
     @Test
     public void testShamblingVentAndAnimation() {
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
-        addCard(Zone.BATTLEFIELD, playerA, "Chromatic Lantern", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Underground Sea", 5);
         // Shambling Vent enters the battlefield tapped.
         // {T}: Add {W} or {B}.
         // {1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.
@@ -69,7 +68,6 @@ public class AwakenTest extends CardTestPlayerBase {
     @Test
     public void testShamblingVent() {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
-        addCard(Zone.BATTLEFIELD, playerA, "Chromatic Lantern", 1);
         // Shambling Vent enters the battlefield tapped.
         // {T}: Add {W} or {B}.
         // {1}{W}{B}: Shambling Vent becomes a 2/3 white and black Elemental creature with lifelink until end of turn. It's still a land.

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BattleCryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BattleCryTest.java
@@ -1,5 +1,3 @@
-
-
 package org.mage.test.cards.abilities.keywords;
 
 import mage.constants.PhaseStep;
@@ -34,6 +32,7 @@ public class BattleCryTest extends CardTestPlayerBase {
         attack(2, playerB, "Signal Pest");
         attack(2, playerB, "Signal Pest");
         attack(2, playerB, "Signal Pest");
+        setChoice(playerB, "Battle cry", 2); // order triggers
 
         setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
         execute();
@@ -56,6 +55,7 @@ public class BattleCryTest extends CardTestPlayerBase {
         attack(2, playerB, "Signal Pest");
         attack(2, playerB, "Signal Pest");
         attack(2, playerB, "Signal Pest");
+        setChoice(playerB, "Battle cry", 2); // order triggers
 
         setStopAt(3, PhaseStep.UPKEEP);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BushidoTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BushidoTest.java
@@ -52,18 +52,20 @@ public class BushidoTest extends CardTestPlayerBase {
     @Test
     public void testMultipleBlocker() {
         addCard(Zone.BATTLEFIELD, playerA, "Llanowar Elves", 1);
-        addCard(Zone.BATTLEFIELD, playerA, "Quirion Elves", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Elvish Mystic", 1);
 
         addCard(Zone.BATTLEFIELD, playerB, "Isao, Enlightened Bushi"); // 2/1  Bushido 2
         attack(2, playerB, "Isao, Enlightened Bushi");
         block(2, playerA, "Llanowar Elves", "Isao, Enlightened Bushi");
-        block(2, playerA, "Quirion Elves", "Isao, Enlightened Bushi");
+        block(2, playerA, "Elvish Mystic", "Isao, Enlightened Bushi");
+        setChoice(playerB, "X=1"); // assign damage
+        setChoice(playerB, "X=1"); // assign damage
 
         setStopAt(2, PhaseStep.END_COMBAT);
         execute();
 
         assertPowerToughness(playerB, "Isao, Enlightened Bushi", 4, 3);
         assertPermanentCount(playerA, "Llanowar Elves", 0);
-        assertPermanentCount(playerA, "Quirion Elves", 0);
+        assertPermanentCount(playerA, "Elvish Mystic", 0);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BuybackTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BuybackTest.java
@@ -45,7 +45,7 @@ public class BuybackTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Elvish Fury", "Silvercoat Lion");
         //setChoice(playerA, true); // use buyback - AI must choose
 
-        //setStrictChooseMode(true); - AI must choose
+        setStrictChooseMode(false); // - AI must choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BuybackTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/BuybackTest.java
@@ -75,6 +75,7 @@ public class BuybackTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerB, "Boomerang", 1);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Elvish Fury", "Silvercoat Lion");
+        setChoice(playerA, true); // use buyback
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Boomerang", "Silvercoat Lion", "Elvish Fury");
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -98,6 +99,7 @@ public class BuybackTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerB, "Counterspell", 1);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Elvish Fury", "Silvercoat Lion");
+        setChoice(playerA, true); // use buyback
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Counterspell", "Elvish Fury", "Elvish Fury");
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CascadeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CascadeTest.java
@@ -36,6 +36,7 @@ public class CascadeTest extends CardTestPlayerBase {
         addCard(Zone.LIBRARY, playerA, "Sejiri Merfolk");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Predatory Advantage");
+        setChoice(playerA, true); // yes to cast
 
         setStopAt(2, PhaseStep.END_TURN);
         execute();
@@ -59,6 +60,7 @@ public class CascadeTest extends CardTestPlayerBase {
         addCard(Zone.LIBRARY, playerA, "Sejiri Merfolk");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Predatory Advantage");
+        setChoice(playerA, true); // yes to cast
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Nacatl Outlander");
 
         setStopAt(1, PhaseStep.END_TURN);
@@ -147,9 +149,11 @@ public class CascadeTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerB, "Unsummon"); // Instant  {U}
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Enlisted Wurm");
+        setChoice(playerA, true); // yes to cast
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Unsummon", "Enlisted Wurm", true);
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Enlisted Wurm");
+        setChoice(playerA, true); // yes to cast
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ChampionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ChampionTest.java
@@ -43,8 +43,9 @@ public class ChampionTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Goblin Roughrider");
         addCard(Zone.HAND, playerA, "Lightning Crafter");
 
-
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Crafter");
+        setChoice(playerA, true); // yes to champion
+        setChoice(playerA, "Goblin Roughrider");
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -60,8 +61,9 @@ public class ChampionTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Goblin Roughrider");
         addCard(Zone.HAND, playerA, "Lightning Crafter");
 
-
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lightning Crafter");
+        setChoice(playerA, true); // yes to champion
+        setChoice(playerA, "Goblin Roughrider");
         activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: {this} deals 3 damage to ", "Lightning Crafter");
 
         setStopAt(3, PhaseStep.BEGIN_COMBAT);
@@ -91,6 +93,8 @@ public class ChampionTest extends CardTestPlayerBase {
         addTarget(playerA, playerB);
         
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Mistbind Clique");
+        setChoice(playerA, true); // yes to champion
+        setChoice(playerA, "Zephyr Sprite");
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ChangelingTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ChangelingTest.java
@@ -150,7 +150,7 @@ public class ChangelingTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Merfolk Trickster");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Merfolk Trickster");
-        // Game-Trail Changeling autochosen
+        addTarget(playerA, "Game-Trail Changeling");
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ChangelingTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ChangelingTest.java
@@ -152,6 +152,7 @@ public class ChangelingTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Merfolk Trickster");
         addTarget(playerA, "Game-Trail Changeling");
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CipherTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CipherTest.java
@@ -55,6 +55,7 @@ public class CipherTest extends CardTestPlayerBase {
         // on attack must activated ability to free cast
         attack(5, playerA, "Roil Elemental");
         setChoice(playerA, true); // activate free cast of encoded card
+        addTarget(playerA, "Roil Elemental");
         checkPermanentCount("playerA must have 2 Roil Elemental", 5, PhaseStep.POSTCOMBAT_MAIN, playerA, "Roil Elemental", 2);
         checkPermanentCount("playerB must have Roil Elemental", 5, PhaseStep.POSTCOMBAT_MAIN, playerB, "Roil Elemental", 1);
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConspireTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConspireTest.java
@@ -44,6 +44,8 @@ public class ConspireTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Burn Trail", playerB);
         setChoice(playerA, true);
+        setChoice(playerA, "Goblin Roughrider^Raging Goblin"); // tap for conspire
+        setChoice(playerA, false); // don't change target
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -153,6 +155,9 @@ public class ConspireTest extends CardTestPlayerBase {
         setChoice(playerA, true); // use Conspire from Burn Trail itself
         setChoice(playerA, false); // don't use Conspire gained from Wort, the Raidmother
 
+        setChoice(playerA, "Goblin Warrior Token", 2); // tap for conspire
+        setChoice(playerA, false); // keep targets
+
         setStopAt(1, PhaseStep.END_TURN);
         execute();
         assertPermanentCount(playerA, "Wort, the Raidmother", 1);
@@ -176,6 +181,14 @@ public class ConspireTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Burn Trail", playerB);
         setChoice(playerA, true); // use Conspire from Burn Trail itself
         setChoice(playerA, true); // use Conspire gained from Wort, the Raidmother
+        setChoice(playerA, "When you pay the conspire"); // order triggers
+
+        setChoice(playerA, "Goblin Warrior Token", 2); // tap for conspire
+        setChoice(playerA, false); // keep targets
+
+        setChoice(playerA, "Raging Goblin", 2); // tap for conspire
+        setChoice(playerA, false); // keep targets
+
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();
@@ -198,11 +211,15 @@ public class ConspireTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wort, the Raidmother", true); // {4}{R/G}{R/G}
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Sakashima the Impostor"); // {2}{U}{U}
+        setChoice(playerA, true); // Use Sakashima's ability
         setChoice(playerA, "Wort, the Raidmother");
 
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
         setChoice(playerA, true); // use Conspire gained from Wort, the Raidmother
         setChoice(playerA, false); // don't use Conspire gained from Sakashima the Imposter
+
+        setChoice(playerA, "Goblin Warrior Token", 2); // tap for conspire
+        setChoice(playerA, false); // keep targets
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();
@@ -225,11 +242,18 @@ public class ConspireTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wort, the Raidmother", true); // {4}{R/G}{R/G}
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Sakashima the Impostor"); // {2}{U}{U}
+        setChoice(playerA, true); // Use Sakashima's ability
         setChoice(playerA, "Wort, the Raidmother");
 
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt", playerB);
         setChoice(playerA, true); // use Conspire gained from Wort, the Raidmother
         setChoice(playerA, true); // use Conspire gained from Sakashima the Imposter
+        setChoice(playerA, "When you pay the conspire"); // order triggers
+
+        setChoice(playerA, "Goblin Warrior Token", 2); // tap for conspire
+        setChoice(playerA, false); // keep targets
+        setChoice(playerA, "Goblin Warrior Token", 2); // tap for conspire
+        setChoice(playerA, false); // keep targets
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConspireTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConspireTest.java
@@ -279,7 +279,7 @@ public class ConspireTest extends CardTestPlayerBase {
         //setChoice(playerA, "Goblin Assailant^Goblin Assailant"); - AI must choose
         //setChoice(playerA, false); // don't change target 1 - AI must choose
 
-        //setStrictChooseMode(true); - AI must choose
+        setStrictChooseMode(false); // - AI must choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -303,7 +303,7 @@ public class ConspireTest extends CardTestPlayerBase {
         //setChoice(playerA, "Goblin Assailant^Goblin Assailant"); - AI must choose
         //setChoice(playerA, false); // don't change target 1 - AI must choose
 
-        //setStrictChooseMode(true); - AI must choose
+        setStrictChooseMode(false); // - AI must choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
@@ -127,7 +127,7 @@ public class ConvokeTest extends CardTestPlayerBaseWithAIHelps {
         // AI must use special actions to pay as convoke
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Stoke the Flames", playerB);
 
-        //setStrictChooseMode(true); AI must choose targets
+        setStrictChooseMode(false); // AI must choose targets
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CrewTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CrewTest.java
@@ -119,6 +119,7 @@ public class CrewTest extends CardTestPlayerBase {
         setChoice(playerA, kotori);
         addTarget(playerA, crusher);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CrewTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CrewTest.java
@@ -2,6 +2,8 @@
 package org.mage.test.cards.abilities.keywords;
 
 import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.LifelinkAbility;
+import mage.abilities.keyword.VigilanceAbility;
 import mage.constants.CardType;
 import mage.constants.PhaseStep;
 import mage.constants.SubType;
@@ -99,6 +101,7 @@ public class CrewTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, plow);
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Crew");
+        setChoice(playerA, ox);
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
@@ -113,6 +116,8 @@ public class CrewTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, crusher);
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Crew 2");
+        setChoice(playerA, kotori);
+        addTarget(playerA, crusher);
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();
@@ -120,6 +125,9 @@ public class CrewTest extends CardTestPlayerBase {
         assertTapped(kotori, true);
         assertType(crusher, CardType.ARTIFACT, true);
         assertType(crusher, CardType.CREATURE, SubType.VEHICLE);
+        assertAbility(playerA, crusher, LifelinkAbility.getInstance(), true);
+        assertAbility(playerA, crusher, VigilanceAbility.getInstance(), true);
+
     }
 
     @Test
@@ -128,6 +136,7 @@ public class CrewTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, express);
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Crew 4");
+        setChoice(playerA, mechanic);
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();
@@ -143,6 +152,8 @@ public class CrewTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, heart);
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Crew 3");
+        setChoice(playerA, true); // remove loyalty counter instead
+        setChoice(playerA, jace);
 
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DelveTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DelveTest.java
@@ -56,7 +56,7 @@ public class DelveTest extends CardTestPlayerBaseWithAIHelps {
         // AI must use special actions to pay as delve
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ethereal Forager");
 
-        //setStrictChooseMode(true); AI must choose targets
+        setStrictChooseMode(false); // AI must choose targets
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DiscardTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DiscardTest.java
@@ -91,6 +91,7 @@ public class DiscardTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Liliana's Caress", true);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Coercion", playerB);
+        setChoice(playerA, "Island"); // to discard
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DisturbTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DisturbTest.java
@@ -349,6 +349,7 @@ public class DisturbTest extends CardTestPlayerBase {
         addTarget(playerA, "Alloy Myr");
         setChoice(playerA, "Blue"); // choose mana color
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
         execute();
         assertPermanentCount(playerA, ghastlyMimicry, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DisturbTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DisturbTest.java
@@ -336,7 +336,7 @@ public class DisturbTest extends CardTestPlayerBase {
     @Test
     public void testDisturbAura() {
         String mirrorhallMimic = "Mirrorhall Mimic";
-        String ghastlyMimictry = "Ghastly Mimicry";
+        String ghastlyMimicry = "Ghastly Mimicry";
         String lightningBolt = "Lightning Bolt";
 
         addCard(Zone.GRAVEYARD, playerA, mirrorhallMimic);
@@ -345,11 +345,13 @@ public class DisturbTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
         addCard(Zone.HAND, playerA, lightningBolt);
 
-        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast " + ghastlyMimictry + " using Disturb");
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast " + ghastlyMimicry + " using Disturb");
+        addTarget(playerA, "Alloy Myr");
+        setChoice(playerA, "Blue"); // choose mana color
 
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
         execute();
-        assertPermanentCount(playerA, ghastlyMimictry, 1);
+        assertPermanentCount(playerA, ghastlyMimicry, 1);
 
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, lightningBolt, "Alloy Myr");
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ImproviseTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ImproviseTest.java
@@ -50,7 +50,7 @@ public class ImproviseTest extends CardTestPlayerBaseWithAIHelps {
         // AI must use special actions to pay as delve
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Bastion Inventor");
 
-        //setStrictChooseMode(true); AI must choose targets
+        setStrictChooseMode(false); // AI must choose targets
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerTest.java
@@ -76,7 +76,7 @@ public class KickerTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Aether Figment");
         //setChoice(playerA, true); // with Kicker - AI must choose
 
-        //setStrictChooseMode(true); - AI must choose
+        setStrictChooseMode(false); // - AI must choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -112,7 +112,7 @@ public class KickerTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Aether Figment");
         //setChoice(playerA, false); - AI must choose
 
-        //setStrictChooseMode(true); - AI must choose
+        setStrictChooseMode(false); // - AI must choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ReplicateTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ReplicateTest.java
@@ -186,7 +186,7 @@ public class ReplicateTest extends CardTestPlayerBase {
         //setChoice(playerA, false); // don't change target 1
         //setChoice(playerA, false); // don't change target 2
 
-        //setStrictChooseMode(true); - AI must choice
+        setStrictChooseMode(false); // - AI must choice
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SquadTest.java
@@ -68,7 +68,7 @@ public class SquadTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flagellant);
         //setChoice(playerA, false); - AI must choose
 
-        //setStrictChooseMode(true); - AI must choose
+        setStrictChooseMode(false); // - AI must choose
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -220,7 +220,7 @@ public class SquadTest extends CardTestPlayerBase {
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
         checkStackSize("after copy", 1, PhaseStep.PRECOMBAT_MAIN, playerA, 2); // spell + copy
 
-        //setStrictChooseMode(true);
+        setStrictChooseMode(false);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 
@@ -251,7 +251,7 @@ public class SquadTest extends CardTestPlayerBase {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA,
                 "{2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy.");
 
-        //setStrictChooseMode(true); // Could not make it work for explicitly target the trigger with Lithoform Engine
+        setStrictChooseMode(false); // // Could not make it work for explicitly target the trigger with Lithoform Engine
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
         execute();
 
@@ -273,7 +273,7 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, true); // pay squad once
         setChoice(playerA, false);
 
-        //setStrictChooseMode(true); // There is a double trigger to put in the stack, not sure how to order them.
+        setStrictChooseMode(false); // // There is a double trigger to put in the stack, not sure how to order them.
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 
@@ -300,7 +300,7 @@ public class SquadTest extends CardTestPlayerBase {
         setChoice(playerA, true);  // yes to the 'may copy'
         setChoice(playerA, "@flaggy");  // cloning the original flagellant.
 
-        //setStrictChooseMode(true);
+        setStrictChooseMode(false);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/exile/SearchNameExileTests.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/exile/SearchNameExileTests.java
@@ -106,7 +106,7 @@ public class SearchNameExileTests extends CardTestPlayerBase {
 
         // Should be no choices in the graveyard available since the back side spell doesn't match the front side name
         // Non-strict mode tries to select all possible targets, no current method to check if choosing is impossible
-        // setStrictChooseMode(true);
+        setStrictChooseMode(false);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -136,7 +136,7 @@ public class SearchNameExileTests extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "fused Ready // Willing");
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Test of Talents", "Ready // Willing", "Ready // Willing");
 
-        // setStrictChooseMode(true);
+        setStrictChooseMode(false);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ConcurrentModificationExceptionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/ConcurrentModificationExceptionTest.java
@@ -43,7 +43,7 @@ public class ConcurrentModificationExceptionTest extends CardTestPlayerBaseWithA
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Warp World");
         aiPlayStep(1, PhaseStep.PRECOMBAT_MAIN, playerA);
 
-        //setStrictChooseMode(true); // need AI while cards adding
+        setStrictChooseMode(false); // need AI while cards adding
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/flipcoin/FlipCoinTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/flipcoin/FlipCoinTest.java
@@ -19,7 +19,7 @@ public class FlipCoinTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{3}");
 
-        //setStrictChooseMode(true); // normal play without errors
+        setStrictChooseMode(false); // normal play without errors
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/replacement/SigardaHostOfHeronsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/replacement/SigardaHostOfHeronsTest.java
@@ -38,7 +38,7 @@ public class SigardaHostOfHeronsTest extends CardTestPlayerBase {
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Diabolic Edict", playerA); // sacrificing for player A prevented by Sigarda
         castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Diabolic Edict", playerB); // playerB has to sacrifice Sheldred
 
-        //setStrictChooseMode(true); // TODO: test must be fixed with correct targets
+        setStrictChooseMode(false); // TODO: test must be fixed with correct targets
         setStopAt(3, PhaseStep.END_TURN);
         execute();
 
@@ -70,7 +70,7 @@ public class SigardaHostOfHeronsTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}{B}");
 
-        //setStrictChooseMode(true); // TODO: test must be fixed with correct targets
+        setStrictChooseMode(false); // TODO: test must be fixed with correct targets
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
 
@@ -104,7 +104,7 @@ public class SigardaHostOfHeronsTest extends CardTestPlayerBase {
         setChoice(playerB, "Merciless Executioner");        
         setChoice(playerA, "Sigarda, Host of Herons");
 
-        //setStrictChooseMode(true); // TODO: test must be fixed with correct targets
+        setStrictChooseMode(false); // TODO: test must be fixed with correct targets
         setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
         execute();
         

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/blb/EarlyWinterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/blb/EarlyWinterTest.java
@@ -63,7 +63,7 @@ public class EarlyWinterTest extends CardTestPlayerBase {
 
     @Test
     public void test_ExileEnchantment_CheckControlled() {
-        //setStrictChooseMode(true); // enable once the choice for enchantment can be tested when no choice possible
+        setStrictChooseMode(false); // enable once the choice for enchantment can be tested when no choice possible
 
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
         addCard(Zone.BATTLEFIELD, playerA, "Glorious Anthem");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/EonFrolickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/EonFrolickerTest.java
@@ -34,7 +34,7 @@ public class EonFrolickerTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Chandra's Fury");
         //addTarget(playerB, playerB);
 
-        //setStrictChooseMode(true); // AI must choose target for fury (itself)
+        setStrictChooseMode(false); // AI must choose target for fury (itself)
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/PakoArcaneRetrieverTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c20/PakoArcaneRetrieverTest.java
@@ -54,7 +54,7 @@ public class PakoArcaneRetrieverTest extends CardTestPlayerBase {
     
     @Test
     public void test_CastExiled() {
-        // setStrictChooseMode(true);
+        setStrictChooseMode(false);
         addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 6);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/exo/KeeperOfTheMindTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/exo/KeeperOfTheMindTest.java
@@ -23,7 +23,7 @@ public class KeeperOfTheMindTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{U}, {T}: Choose target opponent ");
 
-        // setStrictChooseMode(true); // targetting is weird due to targetAdjuster.
+        setStrictChooseMode(false); // targetting is weird due to targetAdjuster.
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -38,7 +38,7 @@ public class KeeperOfTheMindTest extends CardTestPlayerBase {
 
         activateAbility(2, PhaseStep.UPKEEP, playerA, "{U}, {T}: Choose target opponent ");
 
-        // setStrictChooseMode(true); // targetting is weird due to targetAdjuster.
+        setStrictChooseMode(false); // targetting is weird due to targetAdjuster.
         setStopAt(2, PhaseStep.DRAW);
         execute();
 
@@ -69,7 +69,7 @@ public class KeeperOfTheMindTest extends CardTestPlayerBase {
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{U}, {T}: Choose target opponent ");
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{U}, {T}: Choose target opponent ");
 
-        // setStrictChooseMode(true); // targetting is weird due to targetAdjuster.
+        setStrictChooseMode(false); // targetting is weird due to targetAdjuster.
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/TheCreationOfAvacynTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/TheCreationOfAvacynTest.java
@@ -83,7 +83,7 @@ public class TheCreationOfAvacynTest extends CardTestPlayerBase {
 
     @Test
     public void test_StrionicResonator_DoubleCreature() {
-        //setStrictChooseMode(true); // targetting the first saga ability is difficult in test
+        setStrictChooseMode(false); // targetting the first saga ability is difficult in test
 
         // {2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy.
         addCard(Zone.BATTLEFIELD, playerA, "Strionic Resonator");
@@ -111,7 +111,7 @@ public class TheCreationOfAvacynTest extends CardTestPlayerBase {
 
     @Test
     public void test_StrionicResonator_CreatureAndPermanent() {
-        //setStrictChooseMode(true); // targetting the first saga ability is difficult in test
+        setStrictChooseMode(false); // targetting the first saga ability is difficult in test
 
         // {2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy.
         addCard(Zone.BATTLEFIELD, playerA, "Strionic Resonator");
@@ -139,7 +139,7 @@ public class TheCreationOfAvacynTest extends CardTestPlayerBase {
 
     @Test
     public void test_StrionicResonator_CreatureAndSpell() {
-        //setStrictChooseMode(true); // targetting the first saga ability is difficult in test
+        setStrictChooseMode(false); // targetting the first saga ability is difficult in test
 
         // {2}, {T}: Copy target triggered ability you control. You may choose new targets for the copy.
         addCard(Zone.BATTLEFIELD, playerA, "Strionic Resonator");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/who/ThijarianWitnessTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/who/ThijarianWitnessTest.java
@@ -70,7 +70,7 @@ public class ThijarianWitnessTest extends CardTestPlayerBase {
     @Test
     public void test_DoubleBlocked() {
         //Auto-assign damage
-        //setStrictChooseMode(true);
+        setStrictChooseMode(false);
         addCard(Zone.BATTLEFIELD, playerA, witness);
         addCard(Zone.BATTLEFIELD, playerA, big);
         addCard(Zone.BATTLEFIELD, playerB, tiny);
@@ -92,7 +92,7 @@ public class ThijarianWitnessTest extends CardTestPlayerBase {
     @Test
     public void test_DoubleBlocker() {
         //Auto-assign damage
-        //setStrictChooseMode(true);
+        setStrictChooseMode(false);
         addCard(Zone.BATTLEFIELD, playerA, witness);
         addCard(Zone.BATTLEFIELD, playerA, tiny);
         addCard(Zone.BATTLEFIELD, playerA, tiny2);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/woe/AlelaCunningConquerorTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/woe/AlelaCunningConquerorTest.java
@@ -63,7 +63,7 @@ public class AlelaCunningConquerorTest extends MultiplayerTriggerTest {
 
     @Test
     public void attackTwoPlayers() {
-        //setStrictChooseMode(true); // did not succesfully differentiate the two very similar triggers to order them in the stack.
+        setStrictChooseMode(false); // did not successfully differentiate the two very similar triggers to order them in the stack.
         addCard(Zone.BATTLEFIELD, playerA, alela);
         addCard(Zone.BATTLEFIELD, playerA, pestermite);
         addCard(Zone.BATTLEFIELD, playerB, bears);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/EnterLeaveBattlefieldExileTargetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/EnterLeaveBattlefieldExileTargetTest.java
@@ -97,7 +97,7 @@ public class EnterLeaveBattlefieldExileTargetTest extends CardTestPlayerBase {
         setChoice(playerA, true);
         //addTarget(playerA, "Silvercoat Lion^Balduvian Bears"); // AI must target
 
-        //setStrictChooseMode(true); // AI must target
+        setStrictChooseMode(false); // AI must target
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/ZadaHedronGrinderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/ZadaHedronGrinderTest.java
@@ -93,7 +93,7 @@ public class ZadaHedronGrinderTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Arbor Armament", "Zada, Hedron Grinder");
         //addTarget(playerA, "Balduvian Bears^Silvercoat Lion");
 
-        //setStrictChooseMode(true); // no strict mode for AI
+        setStrictChooseMode(false); // no strict mode for AI
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 


### PR DESCRIPTION
Related to #9594... this is maybe 5% of the failures that arise if strict choose mode is globally enabled. Still, a little bit of progress towards a more robust test suite.