### PR TITLE
Pool of Vigorous Growth

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PoolOfVigorousGrowth.java
+++ b/Mage.Sets/src/mage/cards/p/PoolOfVigorousGrowth.java
@@ -1,0 +1,92 @@
+package mage.cards.p;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.ActivateAsSorceryActivatedAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
+import mage.cards.*;
+import mage.cards.repository.CardCriteria;
+import mage.cards.repository.CardInfo;
+import mage.cards.repository.CardRepository;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+import mage.util.RandomUtil;
+
+/**
+ *
+ * @author karapuzz14
+ */
+public final class PoolOfVigorousGrowth extends CardImpl {
+
+    public PoolOfVigorousGrowth(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{G}");
+        
+
+        // {X}, {T}, Discard a card: Create a token that's a copy of a random creature card with mana value X. Activate only as a sorcery.
+        Ability ability = new ActivateAsSorceryActivatedAbility(
+                new PoolOfVigorousGrowthEffect(), new ManaCostsImpl<>("{X}")
+        );
+        ability.addCost(new TapSourceCost());
+        ability.addCost(new DiscardCardCost());
+        this.addAbility(ability);
+    }
+
+    private PoolOfVigorousGrowth(final PoolOfVigorousGrowth card) {
+        super(card);
+    }
+
+    @Override
+    public PoolOfVigorousGrowth copy() {
+        return new PoolOfVigorousGrowth(this);
+    }
+}
+class PoolOfVigorousGrowthEffect extends OneShotEffect {
+
+    PoolOfVigorousGrowthEffect() {
+        super(Outcome.PutCardInPlay);
+        staticText = "Create a token that's a copy of a random creature card with mana value X";
+    }
+
+    private PoolOfVigorousGrowthEffect(final PoolOfVigorousGrowthEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PoolOfVigorousGrowthEffect copy() {
+        return new PoolOfVigorousGrowthEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        int xValue = source.getManaCostsToPay().getX();
+        CardCriteria creatureWithManaValueX = new CardCriteria().types(CardType.CREATURE).manaValue(xValue);
+        List<CardInfo> cards = CardRepository.instance.findCards(creatureWithManaValueX);
+        if (cards != null) {
+            Card randomCard = Objects.requireNonNull(RandomUtil.randomFromCollection(cards)).createCard();
+            HashSet<Card> card = new HashSet<>();
+            card.add(randomCard);
+            game.loadCards(card, player.getId());
+            Effect effect = new CreateTokenCopyTargetEffect().setTargetPointer(new FixedTarget(randomCard, game));
+            boolean result = effect.apply(game, source);
+            game.getCards().remove(randomCard);
+            return result;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/JumpstartHistoricHorizons.java
+++ b/Mage.Sets/src/mage/sets/JumpstartHistoricHorizons.java
@@ -237,6 +237,7 @@ public final class JumpstartHistoricHorizons extends ExpansionSet {
         cards.add(new SetCardInfo("Phantasmal Form", 229, Rarity.COMMON, mage.cards.p.PhantasmalForm.class));
         cards.add(new SetCardInfo("Phantom Ninja", 230, Rarity.COMMON, mage.cards.p.PhantomNinja.class));
         cards.add(new SetCardInfo("Pondering Mage", 231, Rarity.COMMON, mage.cards.p.PonderingMage.class));
+        cards.add(new SetCardInfo("Pool of Vigorous Growth", 28, Rarity.RARE, mage.cards.p.PoolOfVigorousGrowth.class));
         cards.add(new SetCardInfo("Predatory Sliver", 619, Rarity.COMMON, mage.cards.p.PredatorySliver.class));
         cards.add(new SetCardInfo("Prey's Vengeance", 620, Rarity.COMMON, mage.cards.p.PreysVengeance.class));
         cards.add(new SetCardInfo("Priest of Fell Rites", 707, Rarity.RARE, mage.cards.p.PriestOfFellRites.class));


### PR DESCRIPTION
Implemented Pool of Vigorous Growth, which effect was based on existing Momir's Emblem effect.
I was doubtful about card pool size of its random ability because of possible format limitations, but experiments showed that this card can create a copy of illegal card in Arena (attached screenshot).
However, I decided to set up limitations for joke sets and custom sets. I'm eagerly waiting for comments and opinions.

![image](https://github.com/user-attachments/assets/2de15e1b-ba96-43d8-8a4f-8c4959923745)
