### PR TITLE
[BLC] Implement Bello, Bard of the Brambles

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BelloBardOfTheBrambles.java
+++ b/Mage.Sets/src/mage/cards/b/BelloBardOfTheBrambles.java
@@ -1,0 +1,135 @@
+package mage.cards.b;
+
+import java.util.UUID;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.MyTurnCondition;
+import mage.abilities.decorator.ConditionalContinuousEffect;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.IndestructibleAbility;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author Grath
+ */
+public final class BelloBardOfTheBrambles extends CardImpl {
+
+    public BelloBardOfTheBrambles(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{R}{G}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.RACCOON);
+        this.subtype.add(SubType.BARD);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // During your turn, each non-Equipment artifact and non-Aura enchantment you control with mana value 4 or greater is a 4/4 Elemental creature in addition to its other types and has indestructible, haste, and "Whenever this creature deals combat damage to a player, draw a card."
+        Ability ability = new SimpleStaticAbility(new ConditionalContinuousEffect(
+                new BelloBardOfTheBramblesEffect(), MyTurnCondition.instance, "During your turn, each " +
+                "non-Equipment artifact and non-Aura enchantment you control with mana value 4 or greater is a 4/4 " +
+                "Elemental creature in addition to its other types and has indestructible, haste, and \"Whenever " +
+                "this creature deals combat damage to a player, draw a card.\""
+        ));
+        this.addAbility(ability);
+    }
+
+    private BelloBardOfTheBrambles(final BelloBardOfTheBrambles card) {
+        super(card);
+    }
+
+    @Override
+    public BelloBardOfTheBrambles copy() {
+        return new BelloBardOfTheBrambles(this);
+    }
+}
+
+class BelloBardOfTheBramblesEffect extends ContinuousEffectImpl {
+
+    private static final FilterPermanent filter = new FilterControlledPermanent();
+
+    static {
+        filter.add(Predicates.and(
+                Predicates.or(
+                        Predicates.and(CardType.ARTIFACT.getPredicate(), Predicates.not(SubType.EQUIPMENT.getPredicate())),
+                        Predicates.and(CardType.ENCHANTMENT.getPredicate(), Predicates.not(SubType.AURA.getPredicate()))
+                ),
+                new ManaValuePredicate(ComparisonType.OR_GREATER, 4)
+        ));
+    }
+
+    public BelloBardOfTheBramblesEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.BecomeCreature);
+        staticText = "each non-Equipment artifact and non-Aura enchantment you control with mana value 4 or greater " +
+                "is a 4/4 Elemental creature in addition to its other types and has indestructible, haste, and " +
+                "\"Whenever this creature deals combat damage to a player, draw a card.\"";
+
+        this.dependendToTypes.add(DependencyType.EnchantmentAddingRemoving); // Enchanted Evening
+        this.dependendToTypes.add(DependencyType.AuraAddingRemoving); // Cloudform
+        this.dependendToTypes.add(DependencyType.BecomeForest); // Song of the Dryads
+        this.dependendToTypes.add(DependencyType.BecomeMountain);
+        this.dependendToTypes.add(DependencyType.BecomePlains);
+        this.dependendToTypes.add(DependencyType.BecomeSwamp);
+        this.dependendToTypes.add(DependencyType.BecomeIsland);
+
+        this.dependencyTypes.add(DependencyType.BecomeCreature);  // Conspiracy
+    }
+
+    private BelloBardOfTheBramblesEffect(final BelloBardOfTheBramblesEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
+        for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
+            switch (layer) {
+                case TypeChangingEffects_4:
+                    permanent.addCardType(game, CardType.CREATURE);
+                    permanent.addSubType(game, SubType.ELEMENTAL);
+                    break;
+                case AbilityAddingRemovingEffects_6:
+                    if (sublayer == SubLayer.NA) {
+                        permanent.addAbility(IndestructibleAbility.getInstance(), source.getSourceId(), game);
+                        permanent.addAbility(HasteAbility.getInstance(), source.getSourceId(), game);
+                        permanent.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new DrawCardSourceControllerEffect(1), false, false), source.getSourceId(), game);
+                    }
+                case PTChangingEffects_7:
+                    if (sublayer == SubLayer.SetPT_7b) {
+                        permanent.getPower().setModifiedBaseValue(4);
+                        permanent.getToughness().setModifiedBaseValue(4);
+                    }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean hasLayer(Layer layer) {
+        return layer == Layer.TypeChangingEffects_4
+                || layer == Layer.AbilityAddingRemovingEffects_6
+                || layer == Layer.PTChangingEffects_7;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return false;
+    }
+
+    @Override
+    public BelloBardOfTheBramblesEffect copy() {
+        return new BelloBardOfTheBramblesEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/BloomburrowCommander.java
+++ b/Mage.Sets/src/mage/sets/BloomburrowCommander.java
@@ -40,6 +40,7 @@ public final class BloomburrowCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Beast Within", 206, Rarity.UNCOMMON, mage.cards.b.BeastWithin.class));
         cards.add(new SetCardInfo("Beastmaster Ascension", 118, Rarity.RARE, mage.cards.b.BeastmasterAscension.class));
         cards.add(new SetCardInfo("Beledros Witherbloom", 247, Rarity.MYTHIC, mage.cards.b.BeledrosWitherbloom.class));
+        cards.add(new SetCardInfo("Bello, Bard of the Brambles", 1, Rarity.MYTHIC, mage.cards.b.BelloBardOfTheBrambles.class));
         cards.add(new SetCardInfo("Berserkers' Onslaught", 192, Rarity.RARE, mage.cards.b.BerserkersOnslaught.class));
         cards.add(new SetCardInfo("Bident of Thassa", 162, Rarity.RARE, mage.cards.b.BidentOfThassa.class));
         cards.add(new SetCardInfo("Big Score", 193, Rarity.COMMON, mage.cards.b.BigScore.class));


### PR DESCRIPTION
Tested with:
- Non-equipment artifact MV >= 4
- Non-aura enchantment MV >= 4
- Non-equipment artifact MV < 4
- Non-aura enchantment MV < 4
- Equipment MV >= 4
- Aura MV >= 4
- Artifact creature MV >= 4
- Theros god in play before Bello, with and without active devotion [always a 4/4 creature with Bello's granted abilities during your turn]
- Theros god in play after Bello, with and without active devotion [is only a creature when you have devotion, becomes noncreature enchantment again when you lose devotion]