### PR TITLE
Fixed some text colors not using the theme color.

### DIFF
--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -431,7 +431,7 @@
              text = text + Integer.toString(second);
          }
          this.editTimeRemaining.setText(text);
-         
+
          // red color for small time
          Color timerColor;
          if (s <= 10) {
@@ -439,10 +439,10 @@
          } else if (s <= 30) {
              timerColor = new Color(255, 160, 60); // orange
          } else {
-             timerColor = Color.BLACK;
+             timerColor = PreferencesDialog.getCurrentTheme().getTextColor();
          }
          this.editTimeRemaining.setForeground(timerColor);
-         
+
          // warning sound at the end
          if (s == 6 && !draftBooster.isEmptyGrid()) {
              AudioManager.playOnCountdown1();

--- a/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
+++ b/Mage.Client/src/main/java/mage/client/game/PlayerPanelExt.java
@@ -287,10 +287,10 @@ public class PlayerPanelExt extends javax.swing.JPanel {
             changedFontLife = false;
         }
         setTextForLabel("life", lifeLabel, life, playerLife, false, PreferencesDialog.getCurrentTheme().getTextColor());
-        setTextForLabel("poison", poisonLabel, poison, counterOfName(player, "poison"), false);
-        setTextForLabel("energy", energyLabel, energy, counterOfName(player, "energy"), false);
-        setTextForLabel("experience", experienceLabel, experience, counterOfName(player, "experience"), false);
-        setTextForLabel("rad", radLabel, rad, counterOfName(player, "rad"), false);
+        setTextForLabel("poison", poisonLabel, poison, counterOfName(player, "poison"), false, PreferencesDialog.getCurrentTheme().getTextColor());
+        setTextForLabel("energy", energyLabel, energy, counterOfName(player, "energy"), false, PreferencesDialog.getCurrentTheme().getTextColor());
+        setTextForLabel("experience", experienceLabel, experience, counterOfName(player, "experience"), false, PreferencesDialog.getCurrentTheme().getTextColor());
+        setTextForLabel("rad", radLabel, rad, counterOfName(player, "rad"), false, PreferencesDialog.getCurrentTheme().getTextColor());
         setTextForLabel("hand zone", handLabel, hand, player.getHandCount(), false, PreferencesDialog.getCurrentTheme().getTextColor());
         int libraryCards = player.getLibraryCount();
         if (libraryCards > 99) {
@@ -325,7 +325,7 @@ public class PlayerPanelExt extends javax.swing.JPanel {
         setTextForLabel("graveyard zone", graveLabel, grave, graveCards, false, graveColor);
         graveLabel.setToolTipText("Card Types: " + qtyCardTypes(player.getGraveyard()));
 
-        Color commandColor = Color.BLACK;
+        Color commandColor = PreferencesDialog.getCurrentTheme().getTextColor();
         for (CommandObjectView com : player.getCommandObjectList()) {
             if (game != null && game.getCanPlayObjects() != null && game.getCanPlayObjects().containsObject(com.getId())) {
                 commandColor = activeValueColor;


### PR DESCRIPTION
When creating the Carbon Fiber theme I missed a few places where Color.BLACK was used as a default color: The draft count down timer, counters (poison, rad etc) on the in-game player panel and the commander count on the player panel. These now get the text color from the theme.