### PR TITLE
[don't merge] Fix target adjusters sometimes not allowing abilities/cards to be used

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BloodBeckoning.java
+++ b/Mage.Sets/src/mage/cards/b/BloodBeckoning.java
@@ -29,7 +29,7 @@ public final class BloodBeckoning extends CardImpl {
                         "instead return two target creature cards from your graveyard to your hand"));
         this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetCardInYourGraveyard(2, StaticFilters.FILTER_CARD_CREATURE)));
+                new TargetCardInYourGraveyard(2, StaticFilters.FILTER_CARD_CREATURE)).withCheckTargets());
 
     }
 

--- a/Mage.Sets/src/mage/cards/e/ExpelTheUnworthy.java
+++ b/Mage.Sets/src/mage/cards/e/ExpelTheUnworthy.java
@@ -45,7 +45,7 @@ public final class ExpelTheUnworthy extends CardImpl {
         this.getSpellAbility().addEffect(new ExpelTheUnworthyEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetCreaturePermanent()));
+                new TargetCreaturePermanent()).withCheckTargets());
     }
 
     private ExpelTheUnworthy(final ExpelTheUnworthy card) {

--- a/Mage.Sets/src/mage/cards/f/FightWithFire.java
+++ b/Mage.Sets/src/mage/cards/f/FightWithFire.java
@@ -37,7 +37,7 @@ public final class FightWithFire extends CardImpl {
         ));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetAnyTargetAmount(10)));
+                new TargetAnyTargetAmount(10)).withCheckTargets());
     }
 
     private FightWithFire(final FightWithFire card) {

--- a/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
+++ b/Mage.Sets/src/mage/cards/g/GaladrielsDismissal.java
@@ -16,6 +16,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPlayer;
+import mage.target.common.TargetCreatureOrPlayer;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetadjustment.ConditionalTargetAdjuster;
 
@@ -44,7 +45,7 @@ public final class GaladrielsDismissal extends CardImpl {
         ));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetPlayer()));
+                new TargetPlayer()).withSpecificCheckTargets(new TargetCreatureOrPlayer()));
     }
 
     private GaladrielsDismissal(final GaladrielsDismissal card) {

--- a/Mage.Sets/src/mage/cards/i/IntoTheFloodMaw.java
+++ b/Mage.Sets/src/mage/cards/i/IntoTheFloodMaw.java
@@ -31,7 +31,7 @@ public final class IntoTheFloodMaw extends CardImpl {
                         "instead return target nonland permanent an opponent controls to its owner's hand"));
         this.getSpellAbility().addTarget(new TargetOpponentsCreaturePermanent());
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(GiftWasPromisedCondition.TRUE,
-                new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_NON_LAND)));
+                new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_NON_LAND)).withCheckTargets());
     }
 
     private IntoTheFloodMaw(final IntoTheFloodMaw card) {

--- a/Mage.Sets/src/mage/cards/l/LongRiversPull.java
+++ b/Mage.Sets/src/mage/cards/l/LongRiversPull.java
@@ -29,7 +29,7 @@ public final class LongRiversPull extends CardImpl {
                 .setText("counter target creature spell. If the gift was promised, instead counter target spell"));
         this.getSpellAbility().addTarget(new TargetSpell(StaticFilters.FILTER_SPELL_CREATURE));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(GiftWasPromisedCondition.TRUE,
-                new TargetSpell()));
+                new TargetSpell()).withCheckTargets());
     }
 
     private LongRiversPull(final LongRiversPull card) {

--- a/Mage.Sets/src/mage/cards/t/TearAsunder.java
+++ b/Mage.Sets/src/mage/cards/t/TearAsunder.java
@@ -28,7 +28,7 @@ public final class TearAsunder extends CardImpl {
         this.getSpellAbility().addEffect(new ExileTargetEffect().setText("Exile target artifact or enchantment. If this spell was kicked, exile target nonland permanent instead."));
         this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_ENCHANTMENT));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetNonlandPermanent()));
+                new TargetNonlandPermanent()).withCheckTargets());
     }
 
     private TearAsunder(final TearAsunder card) {

--- a/Mage.Sets/src/mage/cards/w/WasteManagement.java
+++ b/Mage.Sets/src/mage/cards/w/WasteManagement.java
@@ -36,7 +36,8 @@ public final class WasteManagement extends CardImpl {
         this.getSpellAbility().addEffect(new WasteManagementEffect());
         this.getSpellAbility().addTarget(new TargetCardInASingleGraveyard(0, 2, StaticFilters.FILTER_CARD));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetPlayer()));
+                new TargetPlayer())); //Could use withSpecificCheckTargets, but not needed since default target is "up to"
+        //And doing so correctly would require a "target card in graveyard or player"
     }
 
     private WasteManagement(final WasteManagement card) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/GiftTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/GiftTest.java
@@ -215,4 +215,26 @@ public class GiftTest extends CardTestPlayerBase {
         assertHandCount(playerA, 1);
         assertHandCount(playerB, 1);
     }
+
+    //Test Conditional Target Adjuster allowing more generic casts
+    @Test
+    public void testLongRiversPull() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+        addCard(Zone.HAND, playerA, "Ponder");
+        addCard(Zone.HAND, playerA, "Long River's Pull"); // UU, counter noncreature only if gift
+
+        setChoice(playerA, true);
+        setChoice(playerA, playerB.getName());
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Ponder");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Long River's Pull");
+        addTarget(playerA, "Ponder");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerA, 0);
+        assertGraveyardCount(playerA, 2);
+        assertHandCount(playerB, 1);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -1070,16 +1070,22 @@ public abstract class AbilityImpl implements Ability {
 
     @Override
     public boolean canChooseTarget(Game game, UUID playerId) {
-        return canChooseTargetAbility(this, getModes(), game, playerId);
+        return canChooseTargetAbility(this, this, game, playerId);
     }
 
-    protected static boolean canChooseTargetAbility(Ability ability, Modes modes, Game game, UUID controllerId) {
+    protected static boolean canChooseTargetAbility(Ability ability, Game game, UUID controllerId) {
+        return canChooseTargetAbility(ability, ability, game, controllerId);
+
+    }
+    protected static boolean canChooseTargetAbility(Ability targetSourceAbility, Ability modesSourceAbility, Game game, UUID controllerId) {
         Ability abilityCopy;
-        if (ability.getTargetAdjuster() != null){
-            abilityCopy = ability.copy();
+        Modes modes;
+        if (modesSourceAbility.getTargetAdjuster() != null){
+            abilityCopy = modesSourceAbility.copy();
         } else {
-            abilityCopy = ability; //if not modifying the ability with the target adjuster, skip copying
+            abilityCopy = modesSourceAbility; //if not modifying the ability with the target adjuster, skip copying
         }
+        modes = abilityCopy.getModes();
         int found = 0;
         for (Mode mode : modes.values()) {
             boolean validTargets = true;
@@ -1092,7 +1098,7 @@ public abstract class AbilityImpl implements Ability {
                 if (target.getTargetController() != null) {
                     abilityControllerId = target.getTargetController();
                 }
-                if (!target.canChoose(abilityControllerId, abilityCopy, game)) {
+                if (!target.canChoose(abilityControllerId, targetSourceAbility, game)) {
                     validTargets = false;
                     break;
                 }

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -1074,20 +1074,25 @@ public abstract class AbilityImpl implements Ability {
     }
 
     protected static boolean canChooseTargetAbility(Ability ability, Modes modes, Game game, UUID controllerId) {
+        Ability abilityCopy;
         if (ability.getTargetAdjuster() != null){
-            // We can't easily determine how the adjuster will adjust the target
-            // So just always treat it as legal to cast
-            return true;
+            abilityCopy = ability.copy();
+        } else {
+            abilityCopy = ability; //if not modifying the ability with the target adjuster, skip copying
         }
         int found = 0;
         for (Mode mode : modes.values()) {
             boolean validTargets = true;
+            if (abilityCopy.getTargetAdjuster() != null){
+                abilityCopy.getModes().setActiveMode(mode);
+                abilityCopy.getTargetAdjuster().adjustTargetsCheck(abilityCopy, game);
+            }
             for (Target target : mode.getTargets()) {
                 UUID abilityControllerId = controllerId;
                 if (target.getTargetController() != null) {
                     abilityControllerId = target.getTargetController();
                 }
-                if (!target.canChoose(abilityControllerId, ability, game)) {
+                if (!target.canChoose(abilityControllerId, abilityCopy, game)) {
                     validTargets = false;
                     break;
                 }

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -1074,6 +1074,11 @@ public abstract class AbilityImpl implements Ability {
     }
 
     protected static boolean canChooseTargetAbility(Ability ability, Modes modes, Game game, UUID controllerId) {
+        if (ability.getTargetAdjuster() != null){
+            // We can't easily determine how the adjuster will adjust the target
+            // So just always treat it as legal to cast
+            return true;
+        }
         int found = 0;
         for (Mode mode : modes.values()) {
             boolean validTargets = true;

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -65,13 +65,13 @@ public class SpellAbility extends ActivatedAbilityImpl {
             }
             SpellAbility left = ((SplitCard) card).getLeftHalfCard().getSpellAbility();
             SpellAbility right = ((SplitCard) card).getRightHalfCard().getSpellAbility();
-            return canChooseTargetAbility(left, left.getModes(), game, playerId) && canChooseTargetAbility(right, right.getModes(), game, playerId);
+            return canChooseTargetAbility(left, game, playerId) && canChooseTargetAbility(right, game, playerId);
         }
         return super.canChooseTarget(game, playerId);
     }
 
     public boolean canSpliceOnto(Ability abilityToModify, Game game) {
-        return canChooseTargetAbility(abilityToModify, getModes(), game, abilityToModify.getControllerId());
+        return canChooseTargetAbility(abilityToModify, this, game, abilityToModify.getControllerId());
     }
 
     /*

--- a/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
@@ -22,8 +22,8 @@ public interface TargetAdjuster extends Serializable {
 
     /**
      * Adjust the targets for checking inside of Ability.canChooseTargetAbility
+     * By default do nothing, but some adjusters will want to modify the target first
      */
-    default void adjustTargetsCheck(Ability ability, Game game){
-        adjustTargets(ability, game);
+    default void adjustTargetsCheck(Ability ability, Game game) {
     }
 }

--- a/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/TargetAdjuster.java
@@ -19,4 +19,11 @@ public interface TargetAdjuster extends Serializable {
      */
     default void addDefaultTargets(Ability ability) {
     }
+
+    /**
+     * Adjust the targets for checking inside of Ability.canChooseTargetAbility
+     */
+    default void adjustTargetsCheck(Ability ability, Game game){
+        adjustTargets(ability, game);
+    }
 }


### PR DESCRIPTION
Currently, the spell or ability always checks the default target to check if it can be used. However, this fails if the target adjuster can adjust the targeting to be more lenient than 

This isn't a perfect solution, as it allows cards to begin to be cast with no legal targets, but I can't think of a way to solve that. This fixes issues like [[Long River's Pull]]'s gift ability being unusable, as the card can only start being cast if there is a noncreature spell on the stack already.