### PR TITLE
[BLB] Implement Mockingbird

### DIFF
--- a/Mage.Sets/src/mage/cards/m/Mockingbird.java
+++ b/Mage.Sets/src/mage/cards/m/Mockingbird.java
@@ -1,0 +1,87 @@
+package mage.cards.m;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CopyPermanentEffect;
+import mage.constants.*;
+import mage.abilities.keyword.FlyingAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.Game;
+import mage.util.CardUtil;
+import mage.util.functions.CopyApplier;
+
+/**
+ *
+ * @author Grath
+ */
+public final class Mockingbird extends CardImpl {
+
+    public Mockingbird(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{X}{U}");
+        
+        this.subtype.add(SubType.BIRD);
+        this.subtype.add(SubType.BARD);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // You may have Mockingbird enter the battlefield as a copy of any creature on the battlefield with mana value less than or equal to the mana spent to cast Mockingbird, except it is a Bird in addition to its other types and has flying.
+        this.addAbility(new EntersBattlefieldAbility(
+                new MockingbirdEffect(), true));
+    }
+
+    private Mockingbird(final Mockingbird card) {
+        super(card);
+    }
+
+    @Override
+    public Mockingbird copy() {
+        return new Mockingbird(this);
+    }
+}
+
+class MockingbirdEffect extends OneShotEffect {
+
+    MockingbirdEffect() {
+        super(Outcome.Benefit);
+        staticText = "as a copy of any creature on the battlefield with mana value less than or equal to the mana " +
+                "spent to cast Mockingbird, except it is a Bird in addition to its other types and has flying.";
+    }
+
+    private MockingbirdEffect(final MockingbirdEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MockingbirdEffect copy() {
+        return new MockingbirdEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        int manaSpent = CardUtil.getSourceCostsTag(game, source, "X", 0);
+        FilterCreaturePermanent filter = new FilterCreaturePermanent(
+                "creature on the battlefield with mana value less than or equal to the amount of mana spent " +
+                        "to cast Mockingbird"
+        );
+        filter.add(new ManaValuePredicate(ComparisonType.OR_LESS, manaSpent));
+        CopyPermanentEffect copyEffect = new CopyPermanentEffect(filter, new CopyApplier() {
+            @Override
+            public boolean apply(Game game, MageObject blueprint, Ability source, UUID targetObjectId) {
+                blueprint.addSubType(SubType.BIRD);
+                blueprint.getAbilities().add(FlyingAbility.getInstance());
+                return true;
+            }
+        });
+        return copyEffect.apply(game, source);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Bloomburrow.java
+++ b/Mage.Sets/src/mage/sets/Bloomburrow.java
@@ -159,6 +159,7 @@ public final class Bloomburrow extends ExpansionSet {
         cards.add(new SetCardInfo("Mind Spring", 389, Rarity.RARE, mage.cards.m.MindSpring.class));
         cards.add(new SetCardInfo("Mindwhisker", 60, Rarity.UNCOMMON, mage.cards.m.Mindwhisker.class));
         cards.add(new SetCardInfo("Mistbreath Elder", 184, Rarity.RARE, mage.cards.m.MistbreathElder.class));
+        cards.add(new SetCardInfo("Mockingbird", 61, Rarity.RARE, mage.cards.m.Mockingbird.class));
         cards.add(new SetCardInfo("Moonrise Cleric", 226, Rarity.COMMON, mage.cards.m.MoonriseCleric.class));
         cards.add(new SetCardInfo("Moonstone Harbinger", 101, Rarity.UNCOMMON, mage.cards.m.MoonstoneHarbinger.class));
         cards.add(new SetCardInfo("Mountain", 274, Rarity.LAND, mage.cards.basiclands.Mountain.class, FULL_ART_BFZ_VARIOUS));


### PR DESCRIPTION
Effect target inspired by Activated Sleeper, deferring getting the target until the X cost is available and then using the standard CopyPermanentEffect to do the rest of the lifting.