### PR TITLE
Added hints about number of lands to some cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AspectOfWolf.java
+++ b/Mage.Sets/src/mage/cards/a/AspectOfWolf.java
@@ -3,9 +3,12 @@ package mage.cards.a;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -26,6 +29,9 @@ import java.util.UUID;
  */
 public final class AspectOfWolf extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue);
+
     public AspectOfWolf(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{G}");
         this.subtype.add(SubType.AURA);
@@ -41,6 +47,7 @@ public final class AspectOfWolf extends CardImpl {
                 AspectOfWolfValue.UP, AspectOfWolfValue.DOWN, Duration.WhileOnBattlefield
         ).setText("enchanted creature gets +X/+Y, where X is half the number of Forests you control, " +
                 "rounded down, and Y is half the number of Forests you control, rounded up")));
+        this.getSpellAbility().addHint(hint);
     }
 
     private AspectOfWolf(final AspectOfWolf card) {

--- a/Mage.Sets/src/mage/cards/b/BeaconOfCreation.java
+++ b/Mage.Sets/src/mage/cards/b/BeaconOfCreation.java
@@ -1,10 +1,12 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.ShuffleSpellEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -12,11 +14,15 @@ import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.permanent.token.InsectToken;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class BeaconOfCreation extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Forest you control");
 
@@ -25,13 +31,14 @@ public final class BeaconOfCreation extends CardImpl {
     }
 
     public BeaconOfCreation(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}");
 
 
         // Create a 1/1 green Insect creature token for each Forest you control.
         this.getSpellAbility().addEffect(new CreateTokenEffect(new InsectToken(), new PermanentsOnBattlefieldCount(filter)));
         // Shuffle Beacon of Creation into its owner's library.
         this.getSpellAbility().addEffect(ShuffleSpellEffect.getInstance());
+        this.getSpellAbility().addHint(hint);
     }
 
     private BeaconOfCreation(final BeaconOfCreation card) {

--- a/Mage.Sets/src/mage/cards/b/BlanchwoodArmor.java
+++ b/Mage.Sets/src/mage/cards/b/BlanchwoodArmor.java
@@ -1,12 +1,14 @@
 
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -15,11 +17,15 @@ import mage.filter.common.FilterControlledPermanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author Loki
  */
 public final class BlanchwoodArmor extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Forest you control");
 
@@ -28,7 +34,7 @@ public final class BlanchwoodArmor extends CardImpl {
     }
 
     public BlanchwoodArmor(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{G}");
         this.subtype.add(SubType.AURA);
 
         TargetPermanent auraTarget = new TargetCreaturePermanent();
@@ -37,6 +43,7 @@ public final class BlanchwoodArmor extends CardImpl {
         Ability ability = new EnchantAbility(auraTarget);
         this.addAbility(ability);
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(new PermanentsOnBattlefieldCount(filter), new PermanentsOnBattlefieldCount(filter), Duration.WhileOnBattlefield)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private BlanchwoodArmor(final BlanchwoodArmor card) {

--- a/Mage.Sets/src/mage/cards/c/CharixTheRagingIsle.java
+++ b/Mage.Sets/src/mage/cards/c/CharixTheRagingIsle.java
@@ -9,6 +9,8 @@ import mage.abilities.dynamicvalue.MultipliedValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.effects.common.cost.SpellsCostModificationThatTargetSourceEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -22,6 +24,10 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class CharixTheRagingIsle extends CardImpl {
+
+    private static final DynamicValue xValue3 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue3);
+
 
     private static final FilterCard filter = new FilterCard("Spells");
     private static final FilterPermanent filter2 = new FilterControlledPermanent(SubType.ISLAND);
@@ -46,6 +52,7 @@ public final class CharixTheRagingIsle extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(
                 xValue, xValue2, Duration.EndOfTurn
         ).setText("{this} gets +X/-X until end of turn, where X is the number of Islands you control"), new GenericManaCost(3)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private CharixTheRagingIsle(final CharixTheRagingIsle card) {

--- a/Mage.Sets/src/mage/cards/c/Corrupt.java
+++ b/Mage.Sets/src/mage/cards/c/Corrupt.java
@@ -1,13 +1,18 @@
 package mage.cards.c;
 
 import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -21,12 +26,17 @@ import java.util.UUID;
  */
 public final class Corrupt extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
+
+
     public Corrupt(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{B}");
 
         // Corrupt deals damage to any target equal to the number of Swamps you control. You gain life equal to the damage dealt this way.
         this.getSpellAbility().addTarget(new TargetAnyTarget());
         this.getSpellAbility().addEffect(new CorruptEffect());
+        this.getSpellAbility().addHint(hint);
     }
 
     private Corrupt(final Corrupt card) {

--- a/Mage.Sets/src/mage/cards/c/CrashLanding.java
+++ b/Mage.Sets/src/mage/cards/c/CrashLanding.java
@@ -1,11 +1,12 @@
 
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.continuous.LoseAbilityTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -17,11 +18,15 @@ import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.AbilityPredicate;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public final class CrashLanding extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Forests you control");
     private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("creature with flying");
@@ -40,6 +45,7 @@ public final class CrashLanding extends CardImpl {
                 FlyingAbility.getInstance(), Duration.EndOfTurn));
         this.getSpellAbility().addEffect(new DamageTargetEffect(amount).setText("{this} deals damage to that creature equal to the number of Forests you control"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent(filter2));
+        this.getSpellAbility().addHint(hint);
     }
 
     private CrashLanding(final CrashLanding card) {

--- a/Mage.Sets/src/mage/cards/d/DownhillCharge.java
+++ b/Mage.Sets/src/mage/cards/d/DownhillCharge.java
@@ -1,27 +1,31 @@
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.abilities.costs.AlternativeCostSourceAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
-import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
  * @author LoneFox
  */
 public final class DownhillCharge extends CardImpl {
+
+    private static final DynamicValue xValue2 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue2);
 
      private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.MOUNTAIN, "a Mountain");
      private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(
@@ -37,6 +41,7 @@ public final class DownhillCharge extends CardImpl {
         // Target creature gets +X/+0 until end of turn, where X is the number of Mountains you control.
         this.getSpellAbility().addEffect(new BoostTargetEffect(xValue, StaticValue.get(0), Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private DownhillCharge(final DownhillCharge card) {

--- a/Mage.Sets/src/mage/cards/e/EngulfTheShore.java
+++ b/Mage.Sets/src/mage/cards/e/EngulfTheShore.java
@@ -5,7 +5,11 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -24,11 +28,15 @@ import mage.players.Player;
  */
 public final class EngulfTheShore extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
+
     public EngulfTheShore(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{U}");
 
         // Return to their owners' hands all creatures with toughness less than or equal to the number of Islands you control.
         getSpellAbility().addEffect(new EngulfTheShoreEffect());
+        this.getSpellAbility().addHint(hint);
     }
 
     private EngulfTheShore(final EngulfTheShore card) {

--- a/Mage.Sets/src/mage/cards/e/EternalFlame.java
+++ b/Mage.Sets/src/mage/cards/e/EternalFlame.java
@@ -1,11 +1,13 @@
 
 package mage.cards.e;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.HalfValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageControllerEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -13,11 +15,15 @@ import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 import mage.target.common.TargetOpponentOrPlaneswalker;
 
+import java.util.UUID;
+
 /**
- *
  * @author L_J
  */
 public final class EternalFlame extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountains you control");
 
@@ -32,6 +38,7 @@ public final class EternalFlame extends CardImpl {
         this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)).setText("{this} deals X damage to target opponent, where X is the number of Mountains you control"));
         this.getSpellAbility().addEffect(new DamageControllerEffect(new HalfValue(new PermanentsOnBattlefieldCount(filter), true)).setText("It deals half X damage, rounded up, to you"));
         this.getSpellAbility().addTarget(new TargetOpponentOrPlaneswalker());
+        this.getSpellAbility().addHint(hint);
     }
 
     private EternalFlame(final EternalFlame card) {

--- a/Mage.Sets/src/mage/cards/f/FireDragon.java
+++ b/Mage.Sets/src/mage/cards/f/FireDragon.java
@@ -5,9 +5,12 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -21,6 +24,9 @@ import mage.target.common.TargetCreaturePermanent;
  * @author fireshoes
  */
 public final class FireDragon extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
     
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("for each Mountain you control");
 
@@ -43,6 +49,7 @@ public final class FireDragon extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(effect, false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
+        this.getSpellAbility().addHint(hint);
     }
 
     private FireDragon(final FireDragon card) {

--- a/Mage.Sets/src/mage/cards/f/Floodgate.java
+++ b/Mage.Sets/src/mage/cards/f/Floodgate.java
@@ -1,22 +1,24 @@
 package mage.cards.f;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.StateTriggeredAbility;
 import mage.abilities.common.LeavesBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DamageAllEffect;
 import mage.abilities.effects.common.SacrificeSourceEffect;
-import mage.constants.SubType;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterCreaturePermanent;
@@ -27,11 +29,15 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author TheElk801
  */
 public final class Floodgate extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
 
     public Floodgate(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
@@ -48,6 +54,7 @@ public final class Floodgate extends CardImpl {
 
         // When Floodgate leaves the battlefield, it deals damage equal to half the number of Islands you control, rounded down, to each nonblue creature without flying.
         this.addAbility(new LeavesBattlefieldTriggeredAbility(new FloodgateDamageEffect(), false));
+        this.getSpellAbility().addHint(hint);
     }
 
     private Floodgate(final Floodgate card) {

--- a/Mage.Sets/src/mage/cards/f/FlowOfIdeas.java
+++ b/Mage.Sets/src/mage/cards/f/FlowOfIdeas.java
@@ -1,20 +1,26 @@
 
 package mage.cards.f;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class FlowOfIdeas extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Island you control");
 
@@ -23,11 +29,12 @@ public final class FlowOfIdeas extends CardImpl {
     }
 
     public FlowOfIdeas(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{5}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{U}");
 
 
         // Draw a card for each Island you control.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private FlowOfIdeas(final FlowOfIdeas card) {

--- a/Mage.Sets/src/mage/cards/f/FlowOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/f/FlowOfKnowledge.java
@@ -2,9 +2,12 @@ package mage.cards.f;
 
 import java.util.UUID;
 
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.discard.DiscardControllerEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -17,6 +20,9 @@ import mage.filter.common.FilterControlledPermanent;
  */
 public final class FlowOfKnowledge extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
+
     private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.ISLAND);
 
     public FlowOfKnowledge(UUID ownerId, CardSetInfo setInfo) {
@@ -25,6 +31,7 @@ public final class FlowOfKnowledge extends CardImpl {
         // Draw a card for each Island you control, then discard two cards.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filter)));
         this.getSpellAbility().addEffect(new DiscardControllerEffect(2).concatBy(", then"));
+        this.getSpellAbility().addHint(hint);
     }
 
     private FlowOfKnowledge(final FlowOfKnowledge card) {

--- a/Mage.Sets/src/mage/cards/h/HowlOfTheNightPack.java
+++ b/Mage.Sets/src/mage/cards/h/HowlOfTheNightPack.java
@@ -1,9 +1,11 @@
 
 package mage.cards.h;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -11,11 +13,15 @@ import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.permanent.token.WolfToken;
 
+import java.util.UUID;
+
 /**
- *
  * @author Loki
  */
 public final class HowlOfTheNightPack extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Forest you control");
 
@@ -24,9 +30,10 @@ public final class HowlOfTheNightPack extends CardImpl {
     }
 
     public HowlOfTheNightPack(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{6}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{6}{G}");
 
         this.getSpellAbility().addEffect(new CreateTokenEffect(new WolfToken(), new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private HowlOfTheNightPack(final HowlOfTheNightPack card) {

--- a/Mage.Sets/src/mage/cards/j/JawsOfStone.java
+++ b/Mage.Sets/src/mage/cards/j/JawsOfStone.java
@@ -1,21 +1,28 @@
 package mage.cards.j;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageMultiEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.target.common.TargetAnyTargetAmount;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
  */
 public final class JawsOfStone extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
 
     static final private FilterControlledLandPermanent filter = new FilterControlledLandPermanent("mountains you control");
 
@@ -26,7 +33,7 @@ public final class JawsOfStone extends CardImpl {
     static final private String rule = "{this} deals X damage divided as you choose among any number of targets, where X is the number of Mountains you control as you cast this spell";
 
     public JawsOfStone(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{5}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{R}");
 
         // Jaws of Stone deals X damage divided as you choose among any number of targets, where X is the number of Mountains you control as you cast this spell.
         PermanentsOnBattlefieldCount mountains = new PermanentsOnBattlefieldCount(filter, null);
@@ -34,6 +41,7 @@ public final class JawsOfStone extends CardImpl {
         effect.setText(rule);
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(mountains));
+        this.getSpellAbility().addHint(hint);
     }
 
     private JawsOfStone(final JawsOfStone card) {

--- a/Mage.Sets/src/mage/cards/k/KothFireOfResistance.java
+++ b/Mage.Sets/src/mage/cards/k/KothFireOfResistance.java
@@ -2,10 +2,13 @@ package mage.cards.k;
 
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.GetEmblemEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInHandEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -23,6 +26,9 @@ import java.util.UUID;
  * @author PurpleCrowbar
  */
 public final class KothFireOfResistance extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
 
     private static final FilterCard filter = new FilterCard("basic Mountain card");
     private static final FilterControlledPermanent filter2 = new FilterControlledPermanent("Mountains you control");
@@ -51,6 +57,7 @@ public final class KothFireOfResistance extends CardImpl {
 
         // −7: You get an emblem with "Whenever a Mountain you control enters, this emblem deals 4 damage to any target."
         this.addAbility(new LoyaltyAbility(new GetEmblemEffect(new KothFireOfResistanceEmblem()), -7));
+        this.getSpellAbility().addHint(hint);
     }
 
     private KothFireOfResistance(final KothFireOfResistance card) {

--- a/Mage.Sets/src/mage/cards/k/KrakenOfTheStraits.java
+++ b/Mage.Sets/src/mage/cards/k/KrakenOfTheStraits.java
@@ -6,6 +6,8 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.RestrictionEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -23,6 +25,9 @@ import java.util.UUID;
  */
 public final class KrakenOfTheStraits extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
+
     public KrakenOfTheStraits(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{U}{U}");
         this.subtype.add(SubType.KRAKEN);
@@ -32,6 +37,7 @@ public final class KrakenOfTheStraits extends CardImpl {
 
         // Creatures with power less than the number of Islands you control can't block Kraken of the Straits.
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new CantBeBlockedByCreaturesWithLessPowerEffect()));
+        this.getSpellAbility().addHint(hint);
     }
 
     private KrakenOfTheStraits(final KrakenOfTheStraits card) {

--- a/Mage.Sets/src/mage/cards/l/LandbindRitual.java
+++ b/Mage.Sets/src/mage/cards/l/LandbindRitual.java
@@ -1,21 +1,28 @@
 
 package mage.cards.l;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class LandbindRitual extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.PLAINS));
+    private static final Hint hint = new ValueHint("Plains you control", xValue);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Plains you control");
 
@@ -25,10 +32,11 @@ public final class LandbindRitual extends CardImpl {
     }
 
     public LandbindRitual(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{W}{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{W}{W}");
 
 
         this.getSpellAbility().addEffect(new GainLifeEffect(new PermanentsOnBattlefieldCount(filter, 2)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private LandbindRitual(final LandbindRitual card) {

--- a/Mage.Sets/src/mage/cards/l/Lashwrithe.java
+++ b/Mage.Sets/src/mage/cards/l/Lashwrithe.java
@@ -1,23 +1,30 @@
 
 package mage.cards.l;
 
-import java.util.UUID;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.EquipAbility;
 import mage.abilities.keyword.LivingWeaponAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class Lashwrithe extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Swamp you control");
 
@@ -27,7 +34,7 @@ public final class Lashwrithe extends CardImpl {
     }
 
     public Lashwrithe(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{4}");
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}");
         this.subtype.add(SubType.EQUIPMENT);
 
         // Living weapon (When this Equipment enters the battlefield, create a 0/0 black Phyrexian Germ creature token, then attach this to it.)
@@ -39,6 +46,7 @@ public final class Lashwrithe extends CardImpl {
 
         // Equip {B/P}{B/P} (Phyrexian Black can be paid with either Black or 2 life.)
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new ManaCostsImpl<>("{B/P}{B/P}"), false));
+        this.getSpellAbility().addHint(hint);
     }
 
     private Lashwrithe(final Lashwrithe card) {

--- a/Mage.Sets/src/mage/cards/l/LastStand.java
+++ b/Mage.Sets/src/mage/cards/l/LastStand.java
@@ -1,16 +1,20 @@
 
 package mage.cards.l;
 
-import java.util.UUID;
 import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledLandPermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.token.SaprolingToken;
@@ -18,19 +22,37 @@ import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.common.TargetOpponent;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class LastStand extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
+    private static final DynamicValue xValue2 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint2 = new ValueHint("Mountains you control", xValue2);
+    private static final DynamicValue xValue3 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint3 = new ValueHint("Forests you control", xValue3);
+    private static final DynamicValue xValue4 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.PLAINS));
+    private static final Hint hint4 = new ValueHint("Plains you control", xValue4);
+    private static final DynamicValue xValue5 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint5 = new ValueHint("Islands you control", xValue5);
+
+
     public LastStand(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{W}{U}{B}{R}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{W}{U}{B}{R}{G}");
 
         // Target opponent loses 2 life for each Swamp you control. Last Stand deals damage to target creature equal to the number of Mountains you control. Create a 1/1 green Saproling creature token for each Forest you control. You gain 2 life for each Plains you control. Draw a card for each Island you control, then discard that many cards.
         this.getSpellAbility().addEffect(new LastStandEffect());
         this.getSpellAbility().addTarget(new TargetOpponent());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
+        this.getSpellAbility().addHint(hint2);
+        this.getSpellAbility().addHint(hint3);
+        this.getSpellAbility().addHint(hint4);
+        this.getSpellAbility().addHint(hint5);
     }
 
     private LastStand(final LastStand card) {
@@ -50,6 +72,7 @@ class LastStandEffect extends OneShotEffect {
     private static final FilterControlledLandPermanent filterPlains = new FilterControlledLandPermanent();
     private static final FilterControlledLandPermanent filterForest = new FilterControlledLandPermanent();
     private static final FilterControlledLandPermanent filterIsland = new FilterControlledLandPermanent();
+
     static {
         filterSwamp.add(SubType.SWAMP.getPredicate());
         filterMountain.add(SubType.MOUNTAIN.getPredicate());

--- a/Mage.Sets/src/mage/cards/l/LilianaOfTheDarkRealms.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaOfTheDarkRealms.java
@@ -2,10 +2,14 @@ package mage.cards.l;
 
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.GetEmblemEffect;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInHandEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -24,6 +28,9 @@ import java.util.UUID;
  * @author North
  */
 public final class LilianaOfTheDarkRealms extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
 
     private static final FilterLandCard filter = new FilterLandCard("Swamp card");
 
@@ -48,6 +55,7 @@ public final class LilianaOfTheDarkRealms extends CardImpl {
 
         // -6: You get an emblem with "Swamps you control have '{tap}: Add {B}{B}{B}{B}.'"
         this.addAbility(new LoyaltyAbility(new GetEmblemEffect(new LilianaOfTheDarkRealmsEmblem()), -6));
+        this.getSpellAbility().addHint(hint);
     }
 
     private LilianaOfTheDarkRealms(final LilianaOfTheDarkRealms card) {

--- a/Mage.Sets/src/mage/cards/m/MagusOfTheCoffers.java
+++ b/Mage.Sets/src/mage/cards/m/MagusOfTheCoffers.java
@@ -1,13 +1,15 @@
 
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.mana.DynamicManaAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -15,11 +17,16 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 
+import java.util.UUID;
+
 /**
  *
  * @author LevelX2
  */
 public final class MagusOfTheCoffers extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Swamp you control");
 
@@ -39,6 +46,7 @@ public final class MagusOfTheCoffers extends CardImpl {
         Ability ability = new DynamicManaAbility(Mana.BlackMana(1), new PermanentsOnBattlefieldCount(filter), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
+        this.getSpellAbility().addHint(hint);
     }
 
     private MagusOfTheCoffers(final MagusOfTheCoffers card) {

--- a/Mage.Sets/src/mage/cards/m/MindSludge.java
+++ b/Mage.Sets/src/mage/cards/m/MindSludge.java
@@ -2,13 +2,18 @@
 package mage.cards.m;
 
 import java.util.UUID;
+
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.discard.DiscardTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.target.TargetPlayer;
 
@@ -17,6 +22,9 @@ import mage.target.TargetPlayer;
  * @author North
  */
 public final class MindSludge extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Swamp you control");
 
@@ -31,6 +39,7 @@ public final class MindSludge extends CardImpl {
 
         this.getSpellAbility().addTarget(new TargetPlayer());
         this.getSpellAbility().addEffect(new DiscardTargetEffect(new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private MindSludge(final MindSludge card) {

--- a/Mage.Sets/src/mage/cards/m/MiresToll.java
+++ b/Mage.Sets/src/mage/cards/m/MiresToll.java
@@ -1,37 +1,45 @@
 
 package mage.cards.m;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.discard.DiscardCardYouChooseTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.target.TargetPlayer;
 
+import java.util.UUID;
+
 /**
- *
  * @author jeffwadsworth
  */
 public final class MiresToll extends CardImpl {
-    
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
+
     private static final FilterLandPermanent filter = new FilterLandPermanent("the number of Swamps you control");
 
     static {
         filter.add(SubType.SWAMP.getPredicate());
         filter.add(TargetController.YOU.getControllerPredicate());
     }
-    
+
     public MiresToll(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
 
 
         // Target player reveals a number of cards from their hand equal to the number of Swamps you control. You choose one of them. That player discards that card.
         this.getSpellAbility().addTarget(new TargetPlayer());
         this.getSpellAbility().addEffect(new DiscardCardYouChooseTargetEffect(new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addHint(hint);
 
     }
 

--- a/Mage.Sets/src/mage/cards/m/Mutilate.java
+++ b/Mage.Sets/src/mage/cards/m/Mutilate.java
@@ -1,7 +1,10 @@
 package mage.cards.m;
 
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -9,6 +12,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 
 import java.util.UUID;
@@ -18,6 +22,9 @@ import java.util.UUID;
  * @author North
  */
 public final class Mutilate extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
 
     private static final String ruleText = "All creatures get -1/-1 until end of turn for each Swamp you control";
 
@@ -38,6 +45,7 @@ public final class Mutilate extends CardImpl {
                 new BoostAllEffect(count, count, Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURES, false, null)
                         .setText(ruleText)
         );
+        this.getSpellAbility().addHint(hint);
     }
 
     private Mutilate(final Mutilate card) {

--- a/Mage.Sets/src/mage/cards/n/NessianGameWarden.java
+++ b/Mage.Sets/src/mage/cards/n/NessianGameWarden.java
@@ -1,11 +1,12 @@
 package mage.cards.n;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.LookLibraryAndPickControllerEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -14,11 +15,16 @@ import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author awjackson
  */
 public final class NessianGameWarden extends CardImpl {
+
+    private static final DynamicValue xValue2 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue2);
+
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Forests you control");
 
@@ -39,6 +45,7 @@ public final class NessianGameWarden extends CardImpl {
         // You may reveal a creature card from among them and put it into your hand. Put the rest on the bottom of your library in any order.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new LookLibraryAndPickControllerEffect(
                 xValue, 1, StaticFilters.FILTER_CARD_CREATURE_A, PutCards.HAND, PutCards.BOTTOM_ANY)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private NessianGameWarden(final NessianGameWarden card) {

--- a/Mage.Sets/src/mage/cards/n/NightmareIncursion.java
+++ b/Mage.Sets/src/mage/cards/n/NightmareIncursion.java
@@ -1,7 +1,11 @@
 package mage.cards.n;
 
 import mage.abilities.Ability;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.cards.Cards;
@@ -25,12 +29,16 @@ import java.util.UUID;
  */
 public final class NightmareIncursion extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
+
     public NightmareIncursion(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{B}");
 
         // Search target player's library for up to X cards, where X is the number of Swamps you control, and exile them. Then that player shuffles their library.
         this.getSpellAbility().addEffect(new NightmareIncursionEffect());
         this.getSpellAbility().addTarget(new TargetPlayer());
+        this.getSpellAbility().addHint(hint);
     }
 
     private NightmareIncursion(final NightmareIncursion card) {

--- a/Mage.Sets/src/mage/cards/n/NightmareLash.java
+++ b/Mage.Sets/src/mage/cards/n/NightmareLash.java
@@ -1,22 +1,30 @@
 
 package mage.cards.n;
 
-import java.util.UUID;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
+
+import java.util.UUID;
 
 /**
  *
  * @author Loki
  */
 public final class NightmareLash extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
     private static final FilterLandPermanent filter = new FilterLandPermanent("Swamp you control");
 
     static {
@@ -33,6 +41,7 @@ public final class NightmareLash extends CardImpl {
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEquippedEffect(value, value)));
         // Equip-Pay 3 life.
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new PayLifeCost(3)));
+        this.getSpellAbility().addHint(hint);
     }
 
     private NightmareLash(final NightmareLash card) {

--- a/Mage.Sets/src/mage/cards/p/PrimalBellow.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalBellow.java
@@ -1,23 +1,30 @@
 
 package mage.cards.p;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class PrimalBellow extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Forest you control");
 
@@ -28,11 +35,12 @@ public final class PrimalBellow extends CardImpl {
     }
 
     public PrimalBellow(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{G}");
 
         PermanentsOnBattlefieldCount value = new PermanentsOnBattlefieldCount(filter);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new BoostTargetEffect(value, value, Duration.EndOfTurn));
+        this.getSpellAbility().addHint(hint);
     }
 
     private PrimalBellow(final PrimalBellow card) {

--- a/Mage.Sets/src/mage/cards/q/QuagSickness.java
+++ b/Mage.Sets/src/mage/cards/q/QuagSickness.java
@@ -2,24 +2,31 @@
 
 package mage.cards.q;
 
-import java.util.UUID;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author BetaSteward_at_googlemail.com, North
  */
 public final class QuagSickness extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Swamp you control");
 
@@ -29,7 +36,7 @@ public final class QuagSickness extends CardImpl {
     }
 
     public QuagSickness(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{2}{B}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{B}");
 
         this.subtype.add(SubType.AURA);
 
@@ -40,6 +47,7 @@ public final class QuagSickness extends CardImpl {
 
         PermanentsOnBattlefieldCount amount = new PermanentsOnBattlefieldCount(filter, -1);
         this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new BoostEnchantedEffect(amount, amount, Duration.WhileOnBattlefield)));
+        this.getSpellAbility().addHint(hint);
 
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuarryColossus.java
+++ b/Mage.Sets/src/mage/cards/q/QuarryColossus.java
@@ -3,13 +3,18 @@ package mage.cards.q;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -21,6 +26,9 @@ import java.util.UUID;
  * @author LevelX2
  */
 public final class QuarryColossus extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.PLAINS));
+    private static final Hint hint = new ValueHint("Plains you control", xValue);
 
     public QuarryColossus(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{W}{W}");
@@ -34,6 +42,7 @@ public final class QuarryColossus extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new QuarryColossusReturnLibraryEffect(), false);
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);
+        this.getSpellAbility().addHint(hint);
     }
 
     private QuarryColossus(final QuarryColossus card) {

--- a/Mage.Sets/src/mage/cards/r/RockslideAmbush.java
+++ b/Mage.Sets/src/mage/cards/r/RockslideAmbush.java
@@ -1,9 +1,11 @@
 
 package mage.cards.r;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -11,11 +13,15 @@ import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
+import java.util.UUID;
+
 /**
- *
  * @author LoneFox
  */
 public final class RockslideAmbush extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountain you control");
 
@@ -24,10 +30,12 @@ public final class RockslideAmbush extends CardImpl {
     }
 
     public RockslideAmbush(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{R}");
 
         // Rockslide Ambush deals damage to target creature equal to the number of Mountains you control.
-        this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)));                                                                                                     this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter)));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private RockslideAmbush(final RockslideAmbush card) {

--- a/Mage.Sets/src/mage/cards/s/SardianCliffstomper.java
+++ b/Mage.Sets/src/mage/cards/s/SardianCliffstomper.java
@@ -1,28 +1,34 @@
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
-import mage.constants.Duration;
-import mage.constants.SubType;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 
+import java.util.UUID;
+
 /**
- *
  * @author weirddan455
  */
 public final class SardianCliffstomper extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.MOUNTAIN);
     private static final PermanentsOnBattlefieldCount count = new PermanentsOnBattlefieldCount(filter);
@@ -42,6 +48,7 @@ public final class SardianCliffstomper extends CardImpl {
                 condition,
                 "As long as it's your turn and you control four or more Mountains, {this} gets +X/+0, where X is the number of Mountains you control."
         )));
+        this.getSpellAbility().addHint(hint);
     }
 
     private SardianCliffstomper(final SardianCliffstomper card) {

--- a/Mage.Sets/src/mage/cards/s/ScourgeOfFleets.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfFleets.java
@@ -1,11 +1,14 @@
 
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.cards.Cards;
@@ -19,14 +22,18 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class ScourgeOfFleets extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
+
     public ScourgeOfFleets(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{U}{U}");
         this.subtype.add(SubType.KRAKEN);
 
         this.power = new MageInt(6);
@@ -34,6 +41,7 @@ public final class ScourgeOfFleets extends CardImpl {
 
         // When Scourge of Fleets enters the battlefield, return each creature your opponents control with toughness X or less, where X is the number of Islands you control.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new ScourgeOfFleetsEffect(), false));
+        this.getSpellAbility().addHint(hint);
     }
 
     private ScourgeOfFleets(final ScourgeOfFleets card) {

--- a/Mage.Sets/src/mage/cards/s/SeismicStrike.java
+++ b/Mage.Sets/src/mage/cards/s/SeismicStrike.java
@@ -2,8 +2,12 @@
 package mage.cards.s;
 
 import java.util.UUID;
+
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -17,6 +21,9 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class SeismicStrike extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
+
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountains you control");
 
     static {
@@ -29,6 +36,7 @@ public final class SeismicStrike extends CardImpl {
         this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter))
                 .setText("{this} deals damage to target creature equal to the number of Mountains you control."));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private SeismicStrike(final SeismicStrike card) {

--- a/Mage.Sets/src/mage/cards/s/SoulhunterRakshasa.java
+++ b/Mage.Sets/src/mage/cards/s/SoulhunterRakshasa.java
@@ -6,7 +6,11 @@ import mage.abilities.common.CantBlockAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.CastFromEverywhereSourceCondition;
 import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -26,6 +30,9 @@ import java.util.UUID;
  */
 public final class SoulhunterRakshasa extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue);
+
     public SoulhunterRakshasa(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{B}{B}");
         this.subtype.add(SubType.DEMON);
@@ -43,6 +50,7 @@ public final class SoulhunterRakshasa extends CardImpl {
                 "When {this} enters, if you cast it from your hand, it deals 1 damage to target opponent for each Swamp you control.");
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability, new CastFromHandWatcher());
+        this.getSpellAbility().addHint(hint);
     }
 
     private SoulhunterRakshasa(final SoulhunterRakshasa card) {

--- a/Mage.Sets/src/mage/cards/s/SpawnOfThraxes.java
+++ b/Mage.Sets/src/mage/cards/s/SpawnOfThraxes.java
@@ -1,12 +1,14 @@
 
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -15,20 +17,24 @@ import mage.constants.SubType;
 import mage.filter.common.FilterControlledPermanent;
 import mage.target.common.TargetAnyTarget;
 
+import java.util.UUID;
+
 /**
- *
  * @author LevelX2
  */
 public final class SpawnOfThraxes extends CardImpl {
-    
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
+
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountains you control");
 
     static {
         filter.add(SubType.MOUNTAIN.getPredicate());
     }
-    
+
     public SpawnOfThraxes(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{5}{R}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{5}{R}{R}");
         this.subtype.add(SubType.DRAGON);
 
         this.power = new MageInt(5);
@@ -40,7 +46,8 @@ public final class SpawnOfThraxes extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter))
                 .setText("it deals damage to any target equal to the number of Mountains you control"));
         ability.addTarget(new TargetAnyTarget());
-        this.addAbility(ability);        
+        this.addAbility(ability);
+        this.getSpellAbility().addHint(hint);
     }
 
     private SpawnOfThraxes(final SpawnOfThraxes card) {

--- a/Mage.Sets/src/mage/cards/s/SpectralDeluge.java
+++ b/Mage.Sets/src/mage/cards/s/SpectralDeluge.java
@@ -1,7 +1,11 @@
 package mage.cards.s;
 
 import mage.MageObject;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.ReturnToHandFromBattlefieldAllEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.ForetellAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -21,6 +25,9 @@ import java.util.UUID;
  */
 public final class SpectralDeluge extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.ISLAND));
+    private static final Hint hint = new ValueHint("Islands you control", xValue);
+
     private static final FilterPermanent filter = new FilterOpponentsCreaturePermanent();
 
     static {
@@ -34,10 +41,12 @@ public final class SpectralDeluge extends CardImpl {
         this.getSpellAbility().addEffect(new ReturnToHandFromBattlefieldAllEffect(filter).setText(
                 "return each creature your opponents control with toughness X or less to its owner's hand, " +
                         "where X is the number of Islands you control"
-        ));
+        ))
+        ;
 
         // Foretell {1}{U}{U}
         this.addAbility(new ForetellAbility(this, "{1}{U}{U}"));
+        this.getSpellAbility().addHint(hint);
     }
 
     private SpectralDeluge(final SpectralDeluge card) {

--- a/Mage.Sets/src/mage/cards/s/SpireBarrage.java
+++ b/Mage.Sets/src/mage/cards/s/SpireBarrage.java
@@ -1,22 +1,29 @@
 
 package mage.cards.s;
 
-import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 import mage.target.common.TargetAnyTarget;
 
+import java.util.UUID;
+
 /**
- *
  * @author North
  */
 public final class SpireBarrage extends CardImpl {
+
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Mountain you control");
 
@@ -26,12 +33,13 @@ public final class SpireBarrage extends CardImpl {
     }
 
     public SpireBarrage(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{4}{R}");
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{R}");
 
         // Spire Barrage deals damage to any target equal to the number of Mountains you control.
         this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter))
                 .setText("{this} deals damage to any target equal to the number of Mountains you control"));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
+        this.getSpellAbility().addHint(hint);
     }
 
     private SpireBarrage(final SpireBarrage card) {

--- a/Mage.Sets/src/mage/cards/s/SpittingEarth.java
+++ b/Mage.Sets/src/mage/cards/s/SpittingEarth.java
@@ -2,8 +2,12 @@
 package mage.cards.s;
 
 import java.util.UUID;
+
+import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -17,6 +21,9 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class SpittingEarth extends CardImpl {
 
+    private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.MOUNTAIN));
+    private static final Hint hint = new ValueHint("Mountains you control", xValue);
+
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("Mountain you control");
 
     static {
@@ -29,6 +36,7 @@ public final class SpittingEarth extends CardImpl {
         this.getSpellAbility().addEffect(new DamageTargetEffect(new PermanentsOnBattlefieldCount(filter))
                 .setText("{this} deals damage to target creature equal to the number of Mountains you control"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private SpittingEarth(final SpittingEarth card) {

--- a/Mage.Sets/src/mage/cards/t/TendrilsOfCorruption.java
+++ b/Mage.Sets/src/mage/cards/t/TendrilsOfCorruption.java
@@ -4,6 +4,8 @@ import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -18,6 +20,9 @@ import java.util.UUID;
  * @author Loki
  */
 public final class TendrilsOfCorruption extends CardImpl {
+
+    private static final DynamicValue xValue2 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.SWAMP));
+    private static final Hint hint = new ValueHint("Swamps you control", xValue2);
 
     private static final FilterPermanent filter = new FilterControlledPermanent();
 
@@ -35,6 +40,7 @@ public final class TendrilsOfCorruption extends CardImpl {
         this.getSpellAbility().addEffect(new GainLifeEffect(xValue)
                 .setText("and you gain X life, where X is the number of Swamps you control"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
+        this.getSpellAbility().addHint(hint);
     }
 
     private TendrilsOfCorruption(final TendrilsOfCorruption card) {

--- a/Mage.Sets/src/mage/cards/t/TimbermawLarva.java
+++ b/Mage.Sets/src/mage/cards/t/TimbermawLarva.java
@@ -5,12 +5,15 @@ import mage.abilities.common.AttacksTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.TargetController;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.common.FilterLandPermanent;
 
 import java.util.UUID;
@@ -19,6 +22,9 @@ import java.util.UUID;
  * @author North
  */
 public final class TimbermawLarva extends CardImpl {
+
+    private static final DynamicValue xValue2 = new PermanentsOnBattlefieldCount(new FilterControlledPermanent(SubType.FOREST));
+    private static final Hint hint = new ValueHint("Forests you control", xValue2);
 
     private static final FilterLandPermanent filter = new FilterLandPermanent("Forest you control");
 
@@ -40,6 +46,7 @@ public final class TimbermawLarva extends CardImpl {
         this.addAbility(new AttacksTriggeredAbility(new BoostSourceEffect(
                 xValue, xValue, Duration.EndOfTurn, "it"
         ), false));
+        this.getSpellAbility().addHint(hint);
     }
 
     private TimbermawLarva(final TimbermawLarva card) {


### PR DESCRIPTION
Added hints to 42 cards which care about having certain amount of lands of the basic type
My implementation of Last Stand is somewhat cumbersome and bothers me, but I haven't found any better ways in the current hints implementation. Probably missing something
Also I didn't add hints to creatures with x/x of stats where x if the amount of (Basic land type), but I may still add them if they are needed 