### PR TITLE
feat: publish official docker images on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# .dockerignore
+Dockerfile
+docker-compose.yml

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,44 @@
+name: build & push docker container
+on:
+  push:
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Docker meta
+        id: metal
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metal.outputs.tags }}
+          labels: ${{ steps.metal.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM odinuge/maven-javafx:3-jdk-8 AS builder
-
-RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
-
-# additional tools
-RUN apt update && apt install -y \
-    build-essential
+FROM maven:3.9 AS builder
 
 COPY . .
 RUN mvn clean install -DskipTests \ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM maven:3.9 AS builder
+FROM odinuge/maven-javafx:3-jdk-8 AS builder
+
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+
+# additional tools
+RUN apt update && apt install -y \
+    build-essential
 
 COPY . .
 RUN mvn clean install -DskipTests \ 
-    && cd ./Mage.Client \
-    && mvn package assembly:single \
-    && cd ../Mage.Server \
+    && cd ./Mage.Server \
     && mvn package assembly:single
 
 FROM openjdk:8-jre

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# build xmage
+# currently fails due to mismatching versions. how did this build ever work?
+
+# FROM maven:3-jdk-8 AS builder
+
+# COPY . .
+# RUN ls -la  \
+#  && mvn clean install -DskipTests \ 
+#  && cd ./Mage.Client \
+#  && ls -la \
+#  && mvn package assembly:single \
+#  && cd ./Mage.Server \
+#  && ls -la \
+#  && mvn package assembly:single \
+#  && ls -la target \
+#  && unzip target/mage-server.zip -d xmage-server
+
+# instead of building, pull from current release
+FROM curlimages/curl AS builder
+
+WORKDIR /tmp
+
+RUN curl https://github.com/magefree/mage/releases/download/xmage_1.4.53V1/mage-full_1.4.53-dev_2024-08-16_15-45.zip -L -o xmage.zip \
+&& ls -la \
+&& unzip -q xmage.zip -d xmage
+
+FROM openjdk:8-jre
+
+ENV XMAGE_DOCKER_SERVER_ADDRESS="0.0.0.0" \
+    XMAGE_DOCKER_PORT="17171" \
+    XMAGE_DOCKER_SEONDARY_BIND_PORT="17179" \
+    XMAGE_DOCKER_MAX_SECONDS_IDLE="600" \
+    XMAGE_DOCKER_AUTHENTICATION_ACTIVATED="false" \
+    XMAGE_DOCKER_SERVER_NAME="mage-server"
+
+EXPOSE 17171 17179
+WORKDIR /xmage
+
+# from being built
+# COPY --from=builder /Utils/xmage-server .
+
+# from release
+COPY --from=builder tmp/xmage/xmage/mage-server /xmage/
+COPY dockerContainerStart.sh /xmage/
+
+RUN chmod +x \
+    /xmage/startServer.sh \
+    /xmage/dockerContainerStart.sh
+
+CMD [ "./dockerContainerStart.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,29 @@
-# build xmage
-# currently fails due to mismatching versions. how did this build ever work?
+FROM maven:3.9 AS builder
 
-# FROM maven:3-jdk-8 AS builder
-
-# COPY . .
-# RUN ls -la  \
-#  && mvn clean install -DskipTests \ 
-#  && cd ./Mage.Client \
-#  && ls -la \
-#  && mvn package assembly:single \
-#  && cd ./Mage.Server \
-#  && ls -la \
-#  && mvn package assembly:single \
-#  && ls -la target \
-#  && unzip target/mage-server.zip -d xmage-server
-
-# instead of building, pull from current release
-FROM curlimages/curl AS builder
-
-WORKDIR /tmp
-
-RUN curl https://github.com/magefree/mage/releases/download/xmage_1.4.53V1/mage-full_1.4.53-dev_2024-08-16_15-45.zip -L -o xmage.zip \
-&& ls -la \
-&& unzip -q xmage.zip -d xmage
+COPY . .
+RUN mvn clean install -DskipTests \ 
+    && cd ./Mage.Client \
+    && mvn package assembly:single \
+    && cd ../Mage.Server \
+    && mvn package assembly:single
 
 FROM openjdk:8-jre
 
-ENV XMAGE_DOCKER_SERVER_ADDRESS="0.0.0.0" \
-    XMAGE_DOCKER_PORT="17171" \
-    XMAGE_DOCKER_SEONDARY_BIND_PORT="17179" \
-    XMAGE_DOCKER_MAX_SECONDS_IDLE="600" \
-    XMAGE_DOCKER_AUTHENTICATION_ACTIVATED="false" \
-    XMAGE_DOCKER_SERVER_NAME="mage-server"
+ENV MAGE_SERVER_ADDRESS="0.0.0.0" \
+    MAGE_PORT="17171" \
+    MAGE_SECONDARY_BIND_PORT="17179" \
+    MAGE_MAX_SECONDS_IDLE="600" \
+    MAGE_AUTHENTICATION_ACTIVATED="false" \
+    MAGE_SERVER_NAME="mage-server"
 
 EXPOSE 17171 17179
 WORKDIR /xmage
 
-# from being built
-# COPY --from=builder /Utils/xmage-server .
+COPY --from=builder Mage.Server/target/mage-server.zip .
 
-# from release
-COPY --from=builder tmp/xmage/xmage/mage-server /xmage/
+RUN unzip mage-server.zip \
+    && rm mage-server.zip
+
 COPY dockerContainerStart.sh /xmage/
 
 RUN chmod +x \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,23 @@
 services:
   server:
     build: .
-    # TODO
+    image: ghcr.io/magefree/mage
+    ports:
+      - '17171:17171'
+      - '17179:17179'
+    # Uncomment this to configure the server for your deployment URL
+    # extra_hosts:
+    #   - 'your-mage-domain.com:0.0.0.0'
+    environment:
+      # Uncomment this to configure the server for your deployment URL
+      # - MAGE_SERVER_ADDRESS=your-mage-domain.com
+      # Give the server a name, if you want to
+      - MAGE_SERVER_NAME=mage-server
+      - MAGE_MAX_SECONDS_IDLE=6000
+      - MAGE_AUTHENTICATION_ACTIVATED=false
+    volumes:
+      - xmage-db:/xmage/db
+      - xmage-saved:/xmage/saved
+volumes:
+  xmage-db:
+  xmage-saved:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     ports:
       - '17171:17171'
       - '17179:17179'
-    # Uncomment this to configure the server for your deployment URL
-    # extra_hosts:
-    #   - 'your-mage-domain.com:0.0.0.0'
+    extra_hosts:
+      # Adjust this to configure the server for your deployment URL (`localhost` -> `yourDomain.com`)
+      - 'localhost:0.0.0.0'
     environment:
-      # Uncomment this to configure the server for your deployment URL
-      # - MAGE_SERVER_ADDRESS=your-mage-domain.com
+      # Adjust this to configure the server for your deployment URL (`localhost` -> `yourDomain.com`)
+      - MAGE_SERVER_ADDRESS=localhost
       # Give the server a name, if you want to
       - MAGE_SERVER_NAME=mage-server
       - MAGE_MAX_SECONDS_IDLE=6000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    build: .
+    # TODO

--- a/dockerContainerStart.sh
+++ b/dockerContainerStart.sh
@@ -2,11 +2,11 @@
 
 XMAGE_CONFIG=/xmage/config/config.xml
 
-sed -i -e "s#\(serverAddress=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SERVER_ADDRESS\"#g" ${XMAGE_CONFIG}
-sed -i -e "s#\(serverName=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SERVER_NAME\"#g" ${XMAGE_CONFIG}
-sed -i -e "s#\(port=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_PORT\"#g" ${XMAGE_CONFIG}
-sed -i -e "s#\(secondaryBindPort=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SEONDARY_BIND_PORT\"#g" ${XMAGE_CONFIG}
-sed -i -e "s#\(maxSecondsIdle=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_MAX_SECONDS_IDLE\"#g" ${XMAGE_CONFIG}
-sed -i -e "s#\(authenticationActivated=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_AUTHENTICATION_ACTIVATED\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(serverAddress=\)[\"].*[\"]#\1\"$MAGE_SERVER_ADDRESS\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(serverName=\)[\"].*[\"]#\1\"$MAGE_SERVER_NAME\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(port=\)[\"].*[\"]#\1\"$MAGE_PORT\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(secondaryBindPort=\)[\"].*[\"]#\1\"$MAGE_SECONDARY_BIND_PORT\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(maxSecondsIdle=\)[\"].*[\"]#\1\"$MAGE_MAX_SECONDS_IDLE\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(authenticationActivated=\)[\"].*[\"]#\1\"$MAGE_AUTHENTICATION_ACTIVATED\"#g" ${XMAGE_CONFIG}
 
 java -Xms256M -Xmx512M -XX:MaxPermSize=256m -Djava.security.policy=./config/security.policy -Djava.util.logging.config.file=./config/logging.config -Dlog4j.configuration=file:./config/log4j.properties -jar ./lib/mage-server-*.jar

--- a/dockerContainerStart.sh
+++ b/dockerContainerStart.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+XMAGE_CONFIG=/xmage/config/config.xml
+
+sed -i -e "s#\(serverAddress=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SERVER_ADDRESS\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(serverName=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SERVER_NAME\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(port=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_PORT\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(secondaryBindPort=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_SEONDARY_BIND_PORT\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(maxSecondsIdle=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_MAX_SECONDS_IDLE\"#g" ${XMAGE_CONFIG}
+sed -i -e "s#\(authenticationActivated=\)[\"].*[\"]#\1\"$XMAGE_DOCKER_AUTHENTICATION_ACTIVATED\"#g" ${XMAGE_CONFIG}
+
+java -Xms256M -Xmx512M -XX:MaxPermSize=256m -Djava.security.policy=./config/security.policy -Djava.util.logging.config.file=./config/logging.config -Dlog4j.configuration=file:./config/log4j.properties -jar ./lib/mage-server-*.jar


### PR DESCRIPTION
this fixes https://github.com/magefree/mage/issues/12748 

This PR adds a few things:
- a docker-compose and Dockerfile to build the server from source and then be able to deploy with the resulting image
- pipelines to build and publish this image whenever a tag is pushed (this happens when a GitHub release is made, e.g.)

# The pipelines run in two cases:
## 1. on tag/release
Whenever a tag is committed (which happens when a GitHub release is made), the pipeline will be triggered on this tag.
It will use the version the tag provides to tag the resulting image publish it on this repository using the GitHub registry. It will also tag the release as "latest" version as well.

It will build and publish both linux/amd64 and linux/arm64 variants of the image.

You can see an example of the resulting images on my fork, where I published them for testing: https://github.com/maybeanerd/mage/pkgs/container/mage
## 2. on pull requests
Whenever a PR is opened, it will run the image build, which will only succeed if the server can be built.
It will **not** publish this image anywhere.

This is IMO useful to make sure no single PR will break the entire build process, but the builds take time (~25mins, since its done for multiple architectures) so one could think about making this check optional before merging, or even disabling it entirely.
Since I personally prefer running these things on PRs, this proposal includes it. The nice thing is also that, since this repo is open source, GitHub gives us unlimited build minutes - so there's no fear of running out of CI/CD minutes or needing to pay at some point.
