### PR TITLE
solve stack objects highlighted as legal target for itself

### DIFF
--- a/Mage/src/main/java/mage/target/TargetSpell.java
+++ b/Mage/src/main/java/mage/target/TargetSpell.java
@@ -108,6 +108,7 @@ public class TargetSpell extends TargetObject {
 
     private boolean canBeChosen(StackObject stackObject, UUID sourceControllerId, Ability source, Game game) {
         return stackObject instanceof Spell
+                && !stackObject.getId().equals(source.getId()) // 115.5. A spell or ability on the stack is an illegal target for itself.
                 && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
                 && canTarget(sourceControllerId, stackObject.getId(), source, game);
     }


### PR DESCRIPTION
Fixes #9611, fixes #9849.

Addresses the issue where Cancel appears visually highlighted as if it were a legal target for itself.

Probably the whole target logic could be streamlined, but I wanted to keep this fix narrow.

This does not solve failure to auto-choose targets; that is a separate body of work.