### PR TITLE
Update Mage.Server sqlite-jdbc from 3.32.3.2 to 3.46.1.3

### DIFF
--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -244,7 +244,7 @@
             <!-- database support - sqlite db engine (additional db for game records and stats) -->
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.32.3.2</version>
+            <version>3.46.1.3</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This allows the service to be run on Apple silicon (M1, M2, M3).