### PR TITLE
More precise server user control

### DIFF
--- a/Mage.Server/src/main/java/mage/server/AuthorizedUserRepository.java
+++ b/Mage.Server/src/main/java/mage/server/AuthorizedUserRepository.java
@@ -43,8 +43,6 @@ public class AuthorizedUserRepository {
             file.mkdirs();
         }
 
-        Logger.getLogger(AuthorizedUserRepository.class).info("Authorized users DB connection string: " + connectionString);
-
         try {
             ConnectionSource connectionSource = new JdbcConnectionSource(connectionString);
             TableUtils.createTableIfNotExists(connectionSource, AuthorizedUser.class);

--- a/Mage.Server/src/main/java/mage/server/AuthorizedUserRepository.java
+++ b/Mage.Server/src/main/java/mage/server/AuthorizedUserRepository.java
@@ -32,7 +32,7 @@ public class AuthorizedUserRepository {
 
     private static final AuthorizedUserRepository instance;
     static {
-        instance = new AuthorizedUserRepository(DatabaseUtils.prepareH2Connection(DatabaseUtils.DB_NAME_USERS, false));
+        instance = new AuthorizedUserRepository(DatabaseUtils.prepareSqliteConnection(DatabaseUtils.DB_NAME_USERS));
     }
 
     private Dao<AuthorizedUser, Object> usersDao;
@@ -42,6 +42,9 @@ public class AuthorizedUserRepository {
         if (!file.exists()) {
             file.mkdirs();
         }
+
+        Logger.getLogger(AuthorizedUserRepository.class).info("Authorized users DB connection string: " + connectionString);
+
         try {
             ConnectionSource connectionSource = new JdbcConnectionSource(connectionString);
             TableUtils.createTableIfNotExists(connectionSource, AuthorizedUser.class);

--- a/Mage.Server/src/main/java/mage/server/MageServerImpl.java
+++ b/Mage.Server/src/main/java/mage/server/MageServerImpl.java
@@ -83,7 +83,7 @@ public class MageServerImpl implements MageServer {
 
     @Override
     public boolean authSendTokenToEmail(String sessionId, String email) throws MageException {
-        if (!managerFactory.configSettings().isAuthenticationActivated()) {
+        if (!managerFactory.configSettings().isRegistrationEnabled()) {
             sendErrorMessageToClient(sessionId, Session.REGISTRATION_DISABLED_MESSAGE);
             return false;
         }
@@ -115,7 +115,7 @@ public class MageServerImpl implements MageServer {
 
     @Override
     public boolean authResetPassword(String sessionId, String email, String authToken, String password) throws MageException {
-        if (!managerFactory.configSettings().isAuthenticationActivated()) {
+        if (!managerFactory.configSettings().isRegistrationEnabled()) {
             sendErrorMessageToClient(sessionId, Session.REGISTRATION_DISABLED_MESSAGE);
             return false;
         }

--- a/Mage.Server/src/main/java/mage/server/Main.java
+++ b/Mage.Server/src/main/java/mage/server/Main.java
@@ -138,7 +138,7 @@ public final class Main {
         final ConfigWrapper config = new ConfigWrapper(ConfigFactory.loadFromFile(configPath));
 
 
-        if (config.isAuthenticationActivated()) {
+        if (config.isRegistrationEnabled() || config.shouldCheckUsers()) {
             logger.info("Check authorized user DB version ...");
             if (!AuthorizedUserRepository.getInstance().checkAlterAndMigrateAuthorizedUser()) {
                 logger.fatal("Failed to start server.");
@@ -260,8 +260,8 @@ public final class Main {
         logger.info("Config - max pool size   : " + config.getMaxPoolSize());
         logger.info("Config - num accp.threads: " + config.getNumAcceptThreads());
         logger.info("Config - second.bind port: " + config.getSecondaryBindPort());
-        logger.info("Config - users registr.:   " + (config.isAuthenticationActivated() ? "true" : "false"));
-        logger.info("Config - users anon:       " + (!config.isAuthenticationActivated() ? "true" : "false"));
+        logger.info("Config - reg. enabled    : " + (config.isRegistrationEnabled() ? "true" : "false"));
+        logger.info("Config - check users     : " + (config.shouldCheckUsers() ? "true" : "false"));
         logger.info("Config - mailgun api key : " + config.getMailgunApiKey());
         logger.info("Config - mailgun domain  : " + config.getMailgunDomain());
         logger.info("Config - mail smtp Host  : " + config.getMailSmtpHost());

--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -85,7 +85,7 @@ public class Session {
     }
 
     public String registerUser(String userName, String password, String email) {
-        if (!managerFactory.configSettings().isAuthenticationActivated()) {
+        if (!managerFactory.configSettings().isRegistrationEnabled()) {
             String returnMessage = REGISTRATION_DISABLED_MESSAGE;
             sendErrorMessageToClient(returnMessage);
             return returnMessage;
@@ -242,7 +242,7 @@ public class Session {
 
         // find auth user
         AuthorizedUser authorizedUser = null;
-        if (managerFactory.configSettings().isAuthenticationActivated()) {
+        if (managerFactory.configSettings().shouldCheckUsers()) {
             authorizedUser = AuthorizedUserRepository.getInstance().getByName(userName);
             String errorMsg = "Wrong username or password. You must register your account first.";
             if (authorizedUser == null) {
@@ -276,8 +276,8 @@ public class Session {
         if (newUser == null) {
             User anotherUser = managerFactory.userManager().getUserByName(userName).orElse(null);
             if (anotherUser != null) {
-                boolean canDisconnectAuthDueAnotherInstance = managerFactory.configSettings().isAuthenticationActivated();
-                boolean canDisconnectAnonDueSameHost = !managerFactory.configSettings().isAuthenticationActivated()
+                boolean canDisconnectAuthDueAnotherInstance = managerFactory.configSettings().isRegistrationEnabled();
+                boolean canDisconnectAnonDueSameHost = !managerFactory.configSettings().isRegistrationEnabled()
                         && ANON_IDENTIFY_BY_HOST
                         && Objects.equals(anotherUser.getHost(), host);
                 boolean canDisconnectAnyDueSessionRestore = Objects.equals(restoreSessionId, anotherUser.getRestoreSessionId());

--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -276,8 +276,8 @@ public class Session {
         if (newUser == null) {
             User anotherUser = managerFactory.userManager().getUserByName(userName).orElse(null);
             if (anotherUser != null) {
-                boolean canDisconnectAuthDueAnotherInstance = managerFactory.configSettings().isRegistrationEnabled();
-                boolean canDisconnectAnonDueSameHost = !managerFactory.configSettings().isRegistrationEnabled()
+                boolean canDisconnectAuthDueAnotherInstance = managerFactory.configSettings().shouldCheckUsers();
+                boolean canDisconnectAnonDueSameHost = !managerFactory.configSettings().shouldCheckUsers()
                         && ANON_IDENTIFY_BY_HOST
                         && Objects.equals(anotherUser.getHost(), host);
                 boolean canDisconnectAnyDueSessionRestore = Objects.equals(restoreSessionId, anotherUser.getRestoreSessionId());

--- a/Mage.Server/src/main/java/mage/server/managers/ConfigSettings.java
+++ b/Mage.Server/src/main/java/mage/server/managers/ConfigSettings.java
@@ -42,7 +42,7 @@ public interface ConfigSettings {
 
     Boolean isSaveGameActivated();
 
-    Boolean isAuthenticationActivated();
+    Boolean isRegistrationEnabled();
 
     String getGoogleAccount();
 
@@ -69,4 +69,6 @@ public interface ConfigSettings {
     List<Plugin> getDraftCubes();
 
     List<Plugin> getDeckTypes();
+
+    Boolean shouldCheckUsers();
 }

--- a/Mage.Server/src/main/java/mage/server/util/Config.xsd
+++ b/Mage.Server/src/main/java/mage/server/util/Config.xsd
@@ -31,6 +31,7 @@
                         <xs:attribute name="userNamePattern" type="xs:string" use="required"/>
                         <xs:attribute name="maxAiOpponents" type="xs:string" use="optional"/>
                         <xs:attribute name="saveGameActivated" type="xs:boolean" use="optional"/>
+
 		</xs:complexType>
 	</xs:element>
 

--- a/Mage.Server/src/main/java/mage/server/util/ConfigWrapper.java
+++ b/Mage.Server/src/main/java/mage/server/util/ConfigWrapper.java
@@ -87,8 +87,12 @@ public class ConfigWrapper implements ConfigSettings {
         return config.getServer().isSaveGameActivated();
     }
 
-    public Boolean isAuthenticationActivated() {
-        return config.getServer().isAuthenticationActivated();
+    public Boolean isRegistrationEnabled() {
+        return config.getServer().isRegistrationEnabled();
+    }
+
+    public Boolean shouldCheckUsers() {
+        return config.getServer().isCheckUsers();
     }
 
     public String getGoogleAccount() {

--- a/Mage.Server/src/main/xml-resources/jaxb/Config/Config.xsd
+++ b/Mage.Server/src/main/xml-resources/jaxb/Config/Config.xsd
@@ -35,7 +35,6 @@
             <xs:attribute name="maxPasswordLength" type="xs:positiveInteger" use="required"/>
             <xs:attribute name="maxAiOpponents" type="xs:string" use="optional"/>
             <xs:attribute name="saveGameActivated" type="xs:boolean" use="optional"/>
-            <xs:attribute name="authenticationActivated" type="xs:boolean" use="optional"/>
             <xs:attribute name="googleAccount" type="xs:string" use="optional"/>
             <xs:attribute name="mailgunApiKey" type="xs:string" use="optional"/>
             <xs:attribute name="mailgunDomain" type="xs:string" use="optional"/>
@@ -44,6 +43,8 @@
             <xs:attribute name="mailUser" type="xs:string" use="optional"/>
             <xs:attribute name="mailPassword" type="xs:string" use="optional"/>
             <xs:attribute name="mailFromAddress" type="xs:string" use="optional"/>
+            <xs:attribute name="registrationEnabled" type="xs:boolean" use="required"/>
+            <xs:attribute name="checkUsers" type="xs:boolean" use="required"/>
         </xs:complexType>
     </xs:element>
 

--- a/Mage.Server/src/test/java/mage/server/util/ConfigWrapperTest.java
+++ b/Mage.Server/src/test/java/mage/server/util/ConfigWrapperTest.java
@@ -43,7 +43,8 @@ public class ConfigWrapperTest {
         public int maxPasswordLength;
         public String maxAiOpponents;
         public boolean saveGameActivated;
-        public boolean authenticationActivated;
+        public boolean shouldCheckUsers;
+        public boolean registrationEnabled;
         public String googleAccount;
         public String mailgunApiKey;
         public String mailgunDomain;
@@ -94,8 +95,8 @@ public class ConfigWrapperTest {
             server.setMaxPasswordLength(bi(maxPasswordLength));
             server.setMaxAiOpponents(maxAiOpponents);
             server.setSaveGameActivated(saveGameActivated);
-            //server.setRegistrationEnabled(registrationEnabled);
-            //server.setCheckUsers(checkUsers);
+            server.setRegistrationEnabled(registrationEnabled);
+            server.setCheckUsers(shouldCheckUsers);
             server.setGoogleAccount(googleAccount);
             server.setMailgunApiKey(mailgunApiKey);
             server.setMailgunDomain(mailgunDomain);
@@ -172,7 +173,8 @@ public class ConfigWrapperTest {
                 testInt("max password length", c -> c.maxPasswordLength = expectedPositiveInt, ConfigWrapper::getMaxPasswordLength),
                 testString("max AI opponents", c -> c.maxAiOpponents = expectedString, ConfigWrapper::getMaxAiOpponents),
                 testTrue("save game activated", c -> c.saveGameActivated = true, ConfigWrapper::isSaveGameActivated),
-                //testTrue("registration enabled", c -> c.registrationEnabled = true, ConfigWrapper::isRegistrationEnabled),
+                testTrue("registration enabled", c -> c.registrationEnabled = true, ConfigWrapper::isRegistrationEnabled),
+                testTrue("should check users", c -> c.shouldCheckUsers = true, ConfigWrapper::shouldCheckUsers),
                 testString("google account", c -> c.googleAccount = expectedString, ConfigWrapper::getGoogleAccount),
                 testString("mailgun api key", c -> c.mailgunApiKey = expectedString, ConfigWrapper::getMailgunApiKey),
                 testString("mailgun domain", c -> c.mailgunDomain = expectedString, ConfigWrapper::getMailgunDomain),

--- a/Mage.Server/src/test/java/mage/server/util/ConfigWrapperTest.java
+++ b/Mage.Server/src/test/java/mage/server/util/ConfigWrapperTest.java
@@ -94,7 +94,8 @@ public class ConfigWrapperTest {
             server.setMaxPasswordLength(bi(maxPasswordLength));
             server.setMaxAiOpponents(maxAiOpponents);
             server.setSaveGameActivated(saveGameActivated);
-            server.setAuthenticationActivated(authenticationActivated);
+            //server.setRegistrationEnabled(registrationEnabled);
+            //server.setCheckUsers(checkUsers);
             server.setGoogleAccount(googleAccount);
             server.setMailgunApiKey(mailgunApiKey);
             server.setMailgunDomain(mailgunDomain);
@@ -171,7 +172,7 @@ public class ConfigWrapperTest {
                 testInt("max password length", c -> c.maxPasswordLength = expectedPositiveInt, ConfigWrapper::getMaxPasswordLength),
                 testString("max AI opponents", c -> c.maxAiOpponents = expectedString, ConfigWrapper::getMaxAiOpponents),
                 testTrue("save game activated", c -> c.saveGameActivated = true, ConfigWrapper::isSaveGameActivated),
-                testTrue("authentication activated", c -> c.authenticationActivated = true, ConfigWrapper::isAuthenticationActivated),
+                //testTrue("registration enabled", c -> c.registrationEnabled = true, ConfigWrapper::isRegistrationEnabled),
                 testString("google account", c -> c.googleAccount = expectedString, ConfigWrapper::getGoogleAccount),
                 testString("mailgun api key", c -> c.mailgunApiKey = expectedString, ConfigWrapper::getMailgunApiKey),
                 testString("mailgun domain", c -> c.mailgunDomain = expectedString, ConfigWrapper::getMailgunDomain),

--- a/Mage/src/main/java/mage/cards/repository/DatabaseUtils.java
+++ b/Mage/src/main/java/mage/cards/repository/DatabaseUtils.java
@@ -12,7 +12,7 @@ public class DatabaseUtils {
     // warning, do not change names or db format
     // h2
     public static final String DB_NAME_FEEDBACK = "feedback.h2";
-    public static final String DB_NAME_USERS = "authorized_user.h2";
+    public static final String DB_NAME_USERS = "authorized_users.db";
     public static final String DB_NAME_CARDS = "cards.h2";
     // sqlite (usage reason: h2 database works bad with 1GB+ files and can break it)
     public static final String DB_NAME_RECORDS = "table_record.db";


### PR DESCRIPTION
## What is this PR about?
As an xmage server owner I noticed that the current user management system allows *virtually anyone* to play, whether the registration is enabled (anyone can just create an account and play) or not (anyone can still login and play). I found myself in need of a more precise user control mechanism.

## What does this PR change?
- `authorizationEnabled` switch in the server config has been replaced with 2 others - `registrationEnabled` and `checkUsers`. The former controls whether any user is able to register, the latter controls whether the server has to check a user's credentials against the authorized_users.db upon logging in.
- `authorized_users.db`'s back-end has been changed to **sqlite**, instead of **H2**. This was done because it allows for simpler integration with 3rd-party tools, as there exist many more drivers for **sqlite**. **This will probably break all existing servers, as the `authorized_users.db` will have to be migrated to sqlite**. I can imagine, this change can be dropped if the xmage server is shipped with appropriate tools to modify an H2 database.

## Why is it useful?
It allows for server owners to prevent unwanted players from joining their servers as well as more precise control over existing players. 

**Thank you for your time!**