### PR TITLE
Fix user registration not using provided password

### DIFF
--- a/Mage.Server/src/main/java/mage/server/Session.java
+++ b/Mage.Server/src/main/java/mage/server/Session.java
@@ -99,12 +99,14 @@ public class Session {
             }
 
             // auto-generated password
-            RandomString randomString = new RandomString(10);
-            password = randomString.nextString();
-            returnMessage = validatePassword(password, userName);
-            if (returnMessage != null) {
-                sendErrorMessageToClient("Auto-generated password fail, try again: " + returnMessage);
-                return returnMessage;
+            if (password.isEmpty()) {
+                RandomString randomString = new RandomString(10);
+                password = randomString.nextString();
+                returnMessage = validatePassword(password, userName);
+                if (returnMessage != null) {
+                    sendErrorMessageToClient("Auto-generated password fail, try again: " + returnMessage);
+                    return returnMessage;
+                }
             }
 
             // email


### PR DESCRIPTION
While going over the user registration code, I noticed that the provided by user password is simply being discarded in favor of a randomly generated one. I assume this is not the intended behavior. 