### PR TITLE
refactor: add new simpler technique for intervening if conditions

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AngelOfTheDireHour.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfTheDireHour.java
@@ -1,11 +1,8 @@
-
 package mage.cards.a;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.CastFromHandSourcePermanentCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.ExileAllEffect;
 import mage.abilities.keyword.FlashAbility;
 import mage.abilities.keyword.FlyingAbility;
@@ -15,6 +12,8 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.watchers.common.CastFromHandWatcher;
+
+import java.util.UUID;
 
 /**
  *
@@ -34,10 +33,9 @@ public final class AngelOfTheDireHour extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // When Angel of the Dire Hour enters the battlefield, if you cast it from your hand, exile all attacking creatures.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new ExileAllEffect(StaticFilters.FILTER_ATTACKING_CREATURES), false),
-                CastFromHandSourcePermanentCondition.instance,
-                "When {this} enters, if you cast it from your hand, exile all attacking creatures."),
+        this.addAbility(new EntersBattlefieldTriggeredAbility(
+                new ExileAllEffect(StaticFilters.FILTER_ATTACKING_CREATURES), false)
+                        .withInterveningIf(CastFromHandSourcePermanentCondition.instance),
                 new CastFromHandWatcher());
     }
 

--- a/Mage.Sets/src/mage/cards/a/AnnieFlashTheVeteran.java
+++ b/Mage.Sets/src/mage/cards/a/AnnieFlashTheVeteran.java
@@ -5,7 +5,6 @@ import mage.abilities.Ability;
 import mage.abilities.common.BecomesTappedSourceTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.CastFromEverywhereSourceCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.ExileTopXMayPlayUntilEffect;
 import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
 import mage.abilities.keyword.FlashAbility;
@@ -43,12 +42,8 @@ public final class AnnieFlashTheVeteran extends CardImpl {
         this.addAbility(FlashAbility.getInstance());
 
         // When Annie Flash, the Veteran enters the battlefield, if you cast it, return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped.
-        Ability ability = new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new ReturnFromGraveyardToBattlefieldTargetEffect(true)),
-                CastFromEverywhereSourceCondition.instance,
-                "When {this} enters, if you cast it, "
-                        + "return target permanent card with mana value 3 or less from your graveyard to the battlefield tapped"
-        );
+        Ability ability = new EntersBattlefieldTriggeredAbility(new ReturnFromGraveyardToBattlefieldTargetEffect(true))
+                .withInterveningIf(CastFromEverywhereSourceCondition.instance);
         ability.addTarget(new TargetCardInYourGraveyard(filter));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/a/ArguelsBloodFast.java
+++ b/Mage.Sets/src/mage/cards/a/ArguelsBloodFast.java
@@ -1,7 +1,4 @@
-
 package mage.cards.a;
-
-import java.util.UUID;
 
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
@@ -9,7 +6,6 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.condition.common.FatefulHourCondition;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.TransformSourceEffect;
 import mage.abilities.keyword.TransformAbility;
@@ -19,6 +15,8 @@ import mage.constants.CardType;
 import mage.constants.SuperType;
 import mage.constants.TargetController;
 import mage.constants.Zone;
+
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -38,11 +36,8 @@ public final class ArguelsBloodFast extends CardImpl {
 
         // At the beginning of your upkeep, if you have 5 or less life, you may transform Arguel's Blood Fast.
         this.addAbility(new TransformAbility());
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new BeginningOfUpkeepTriggeredAbility(new TransformSourceEffect(), TargetController.YOU, true),
-                FatefulHourCondition.instance,
-                "At the beginning of your upkeep, if you have 5 or less life, you may transform {this}"
-        ));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new TransformSourceEffect(),
+                TargetController.YOU, true).withInterveningIf(FatefulHourCondition.instance));
     }
 
     private ArguelsBloodFast(final ArguelsBloodFast card) {

--- a/Mage.Sets/src/mage/cards/b/BlinkmothUrn.java
+++ b/Mage.Sets/src/mage/cards/b/BlinkmothUrn.java
@@ -1,11 +1,9 @@
 package mage.cards.b;
 
-import java.util.UUID;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.common.BeginningOfFirstMainTriggeredAbility;
 import mage.abilities.condition.common.SourceTappedCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -18,6 +16,8 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
+import java.util.UUID;
+
 /**
  *
  * @author nickmyers
@@ -28,10 +28,8 @@ public final class BlinkmothUrn extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{5}");
 
         // At the beginning of each player's precombat main phase, if Blinkmoth Urn is untapped, that player adds {C} for each artifact they control.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new BeginningOfFirstMainTriggeredAbility(new BlinkmothUrnEffect(), TargetController.ANY, false), SourceTappedCondition.UNTAPPED,
-                "At the beginning of each player's first main phase, if {this} is untapped, that player adds {C} for each artifact they control."
-        ));
+        this.addAbility(new BeginningOfFirstMainTriggeredAbility(new BlinkmothUrnEffect(), TargetController.ANY, false)
+                        .withInterveningIf(SourceTappedCondition.UNTAPPED));
     }
 
     private BlinkmothUrn(final BlinkmothUrn card) {

--- a/Mage.Sets/src/mage/cards/b/BubbleSnare.java
+++ b/Mage.Sets/src/mage/cards/b/BubbleSnare.java
@@ -4,7 +4,6 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.KickedCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.DontUntapInControllersUntapStepEnchantedEffect;
 import mage.abilities.effects.common.TapEnchantedEffect;
@@ -41,10 +40,7 @@ public final class BubbleSnare extends CardImpl {
         this.addAbility(ability);
 
         // When Bubble Snare enters the battlefield, if it was kicked, tap enchanted creature.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new TapEnchantedEffect()), KickedCondition.ONCE,
-                "When {this} enters, if it was kicked, tap enchanted creature."
-        ));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new TapEnchantedEffect()).withInterveningIf(KickedCondition.ONCE));
 
         // Enchanted creature doesn't untap during its controller's untap step.
         this.addAbility(new SimpleStaticAbility(new DontUntapInControllersUntapStepEnchantedEffect()));

--- a/Mage.Sets/src/mage/cards/d/DeadeyeTormentor.java
+++ b/Mage.Sets/src/mage/cards/d/DeadeyeTormentor.java
@@ -4,7 +4,6 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.RaidCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.discard.DiscardTargetEffect;
 import mage.abilities.hint.common.RaidHint;
 import mage.cards.CardImpl;
@@ -31,8 +30,8 @@ public final class DeadeyeTormentor extends CardImpl {
         this.toughness = new MageInt(2);
 
         // <i>Raid</i> &mdash; When Deadeye Tormentor enters the battlefield, if you attacked this turn, target opponent discards a card.
-        Ability ability = new ConditionalInterveningIfTriggeredAbility(new EntersBattlefieldTriggeredAbility(new DiscardTargetEffect(1)), RaidCondition.instance,
-                "When {this} enters, if you attacked this turn, target opponent discards a card.");
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DiscardTargetEffect(1))
+                .withInterveningIf(RaidCondition.instance);
         ability.addTarget(new TargetOpponent());
         ability.setAbilityWord(AbilityWord.RAID);
         ability.addHint(RaidHint.instance);

--- a/Mage.Sets/src/mage/cards/d/DeepSeaKraken.java
+++ b/Mage.Sets/src/mage/cards/d/DeepSeaKraken.java
@@ -1,39 +1,30 @@
-
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.common.SpellCastAllTriggeredAbility;
+import mage.abilities.common.SpellCastOpponentTriggeredAbility;
 import mage.abilities.condition.common.SuspendedCondition;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.counter.RemoveCounterSourceEffect;
 import mage.abilities.keyword.CantBeBlockedSourceAbility;
 import mage.abilities.keyword.SuspendAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.SetTargetPointer;
-import mage.constants.TargetController;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.FilterSpell;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class DeepSeaKraken extends CardImpl {
 
-    private static final FilterSpell filter = new FilterSpell("an opponent casts");
-
-    static {
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
-    }
-
     public DeepSeaKraken(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{7}{U}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{7}{U}{U}{U}");
         this.subtype.add(SubType.KRAKEN);
 
         this.power = new MageInt(6);
@@ -41,12 +32,16 @@ public final class DeepSeaKraken extends CardImpl {
 
         // Deep-Sea Kraken can't be blocked.
         this.addAbility(new CantBeBlockedSourceAbility());
+
         // Suspend 9-{2}{U}
         this.addAbility(new SuspendAbility(9, new ManaCostsImpl<>("{2}{U}"), this));
+
         // Whenever an opponent casts a spell, if Deep-Sea Kraken is suspended, remove a time counter from it.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new SpellCastAllTriggeredAbility(Zone.EXILED, new RemoveCounterSourceEffect(CounterType.TIME.createInstance()), filter, false, SetTargetPointer.NONE), SuspendedCondition.instance,
-                "Whenever an opponent casts a spell, if Deep-Sea Kraken is suspended, remove a time counter from it."));
+        this.addAbility(new SpellCastOpponentTriggeredAbility(Zone.EXILED,
+                new RemoveCounterSourceEffect(CounterType.TIME.createInstance())
+                        .setText("remove a time counter from it"),
+                StaticFilters.FILTER_SPELL_A, false, SetTargetPointer.NONE)
+                .withInterveningIf(SuspendedCondition.instance));
     }
 
     private DeepSeaKraken(final DeepSeaKraken card) {

--- a/Mage.Sets/src/mage/cards/f/FelidarSovereign.java
+++ b/Mage.Sets/src/mage/cards/f/FelidarSovereign.java
@@ -1,22 +1,19 @@
-
 package mage.cards.f;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
-import mage.abilities.TriggeredAbility;
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
-import mage.abilities.condition.Condition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.condition.common.LifeCompareCondition;
 import mage.abilities.effects.common.WinGameSourceControllerEffect;
 import mage.abilities.keyword.LifelinkAbility;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.ComparisonType;
 import mage.constants.SubType;
 import mage.constants.TargetController;
-import mage.game.Game;
+
+import java.util.UUID;
 
 /**
  *
@@ -34,10 +31,10 @@ public final class FelidarSovereign extends CardImpl {
 
         this.addAbility(VigilanceAbility.getInstance());
         this.addAbility(LifelinkAbility.getInstance());
-        // At the beginning of your upkeep, if you have 40 or more life, you win the game.
-        TriggeredAbility ability = new BeginningOfUpkeepTriggeredAbility(new WinGameSourceControllerEffect(), TargetController.YOU, false);
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, new FortyOrMoreLifeCondition(), "At the beginning of your upkeep, if you have 40 or more life, you win the game."));
 
+        // At the beginning of your upkeep, if you have 40 or more life, you win the game.
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new WinGameSourceControllerEffect(), TargetController.YOU, false)
+                .withInterveningIf(new LifeCompareCondition(TargetController.YOU, ComparisonType.OR_GREATER, 40)));
     }
 
     private FelidarSovereign(final FelidarSovereign card) {
@@ -47,13 +44,5 @@ public final class FelidarSovereign extends CardImpl {
     @Override
     public FelidarSovereign copy() {
         return new FelidarSovereign(this);
-    }
-}
-
-class FortyOrMoreLifeCondition implements Condition {
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return game.getPlayer(source.getControllerId()).getLife() >= 40;
     }
 }

--- a/Mage.Sets/src/mage/cards/k/KamiOfTerribleSecrets.java
+++ b/Mage.Sets/src/mage/cards/k/KamiOfTerribleSecrets.java
@@ -4,7 +4,6 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.ControlArtifactAndEnchantmentCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.GainLifeEffect;
 import mage.abilities.hint.common.ControlArtifactAndEnchantmentHint;
@@ -28,12 +27,9 @@ public final class KamiOfTerribleSecrets extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When Kami of Terrible Secrets enters the battlefield, if you control an artifact and an enchantment, you draw a card and you gain 1 life.
-        Ability ability = new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1)),
-                ControlArtifactAndEnchantmentCondition.instance, "When {this} enters, " +
-                "if you control an artifact and an enchantment, you draw a card and you gain 1 life."
-        );
-        ability.addEffect(new GainLifeEffect(1));
+        Ability ability =  new EntersBattlefieldTriggeredAbility(new DrawCardSourceControllerEffect(1, true))
+                .withInterveningIf(ControlArtifactAndEnchantmentCondition.instance);
+        ability.addEffect(new GainLifeEffect(1).concatBy("and"));
         this.addAbility(ability.addHint(ControlArtifactAndEnchantmentHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoldShambler.java
+++ b/Mage.Sets/src/mage/cards/m/MoldShambler.java
@@ -1,11 +1,8 @@
-
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.KickedCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.DestroyTargetEffect;
 import mage.abilities.keyword.KickerAbility;
 import mage.cards.CardImpl;
@@ -14,8 +11,9 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.predicate.Predicates;
-import mage.target.Target;
 import mage.target.TargetPermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -42,9 +40,8 @@ public final class MoldShambler extends CardImpl {
 
         // When Mold Shambler enters the battlefield, if it was kicked, destroy target noncreature permanent.
         EntersBattlefieldTriggeredAbility ability = new EntersBattlefieldTriggeredAbility(new DestroyTargetEffect(), false);
-        Target target = new TargetPermanent(filter);
-        ability.addTarget(target);
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(ability, KickedCondition.ONCE, "When {this} enters, if it was kicked, destroy target noncreature permanent."));
+        ability.addTarget(new TargetPermanent(filter));
+        this.addAbility(ability.withInterveningIf(KickedCondition.ONCE));
     }
 
     private MoldShambler(final MoldShambler card) {

--- a/Mage.Sets/src/mage/cards/n/NearDeathExperience.java
+++ b/Mage.Sets/src/mage/cards/n/NearDeathExperience.java
@@ -2,7 +2,6 @@ package mage.cards.n;
 
 import mage.abilities.common.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.condition.common.LifeCompareCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.WinGameSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -21,10 +20,8 @@ public final class NearDeathExperience extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{W}{W}{W}");
 
         // At the beginning of your upkeep, if you have exactly 1 life, you win the game.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new BeginningOfUpkeepTriggeredAbility(new WinGameSourceControllerEffect(), TargetController.YOU, false),
-                new LifeCompareCondition(TargetController.YOU, ComparisonType.EQUAL_TO, 1),
-                "At the beginning of your upkeep, if you have exactly 1 life, you win the game."));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new WinGameSourceControllerEffect(), TargetController.YOU, false)
+                        .withInterveningIf(new LifeCompareCondition(TargetController.YOU, ComparisonType.EQUAL_TO, 1)));
     }
 
     private NearDeathExperience(final NearDeathExperience card) {

--- a/Mage.Sets/src/mage/cards/p/PardicDragon.java
+++ b/Mage.Sets/src/mage/cards/p/PardicDragon.java
@@ -1,7 +1,5 @@
-
 package mage.cards.p;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -9,7 +7,6 @@ import mage.abilities.common.SpellCastOpponentTriggeredAbility;
 import mage.abilities.condition.common.SuspendedCondition;
 import mage.abilities.costs.mana.ColoredManaCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -22,6 +19,8 @@ import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
+
+import java.util.UUID;
 
 /**
  *
@@ -38,16 +37,17 @@ public final class PardicDragon extends CardImpl {
 
         // Flying
         this.addAbility(FlyingAbility.getInstance());
+
         // {R}: Pardic Dragon gets +1/+0 until end of turn.
         this.addAbility(new SimpleActivatedAbility(Zone.BATTLEFIELD, new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.R)));
+
         // Suspend 2-{R}{R}
         this.addAbility(new SuspendAbility(2, new ManaCostsImpl<>("{R}{R}"), this, true));
+
         // Whenever an opponent casts a spell, if Pardic Dragon is suspended, that player may put a time counter on Pardic Dragon.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new SpellCastOpponentTriggeredAbility(Zone.EXILED, new PardicDragonEffect(), StaticFilters.FILTER_SPELL, false, SetTargetPointer.PLAYER),
-                SuspendedCondition.instance,
-                "Whenever an opponent casts a spell, if {this} is suspended, that player may put a time counter on {this}."
-                ));
+        this.addAbility(new SpellCastOpponentTriggeredAbility(Zone.EXILED, new PardicDragonEffect(),
+                StaticFilters.FILTER_SPELL_A, false, SetTargetPointer.PLAYER)
+                .withInterveningIf(SuspendedCondition.instance));
 
     }
 
@@ -65,7 +65,7 @@ class PardicDragonEffect extends OneShotEffect {
 
     PardicDragonEffect() {
         super(Outcome.Benefit);
-        this.staticText = "that player may put a time counter on Pardic Dragon";
+        this.staticText = "that player may put a time counter on {this}";
     }
 
     private PardicDragonEffect(final PardicDragonEffect effect) {

--- a/Mage.Sets/src/mage/cards/s/SproutingGoblin.java
+++ b/Mage.Sets/src/mage/cards/s/SproutingGoblin.java
@@ -1,6 +1,5 @@
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
@@ -9,18 +8,19 @@ import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInHandEffect;
-import mage.constants.SubType;
 import mage.abilities.keyword.KickerAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterLandCard;
 import mage.filter.predicate.Predicates;
 import mage.target.common.TargetCardInLibrary;
+
+import java.util.UUID;
 
 /**
  *
@@ -52,11 +52,8 @@ public final class SproutingGoblin extends CardImpl {
         this.addAbility(new KickerAbility("{G}"));
 
         // When Sprouting Goblin enters the battlefield, if it was kicked, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(filter), true)),
-                KickedCondition.ONCE,
-                "When {this} enters, if it was kicked, search your library for a land card with a basic land type, reveal it, put it into your hand, then shuffle."
-        ));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new SearchLibraryPutInHandEffect(
+                new TargetCardInLibrary(filter), true)).withInterveningIf(KickedCondition.ONCE));
 
         // {R}, {T}, Sacrifice a land: Draw a card.
         Ability ability = new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new ManaCostsImpl<>("{R}"));

--- a/Mage.Sets/src/mage/cards/t/TajuruParagon.java
+++ b/Mage.Sets/src/mage/cards/t/TajuruParagon.java
@@ -5,7 +5,6 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.KickedCondition;
-import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.HasSubtypesSourceEffect;
 import mage.abilities.keyword.KickerAbility;
@@ -45,13 +44,8 @@ public final class TajuruParagon extends CardImpl {
         this.addAbility(new KickerAbility("{3}"));
 
         // When Tajuru Paragon enters the battlefield, if it was kicked, reveal the top six cards of your library. You may put a card that shares a creature type with it from among them into your hand. Put the rest on the bottom of your library in a random order.
-        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
-                new EntersBattlefieldTriggeredAbility(new TajuruParagonEffect()),
-                KickedCondition.ONCE, "When {this} enters, " +
-                "if it was kicked, reveal the top six cards of your library. " +
-                "You may put a card that shares a creature type with it from among them into your hand. " +
-                "Put the rest on the bottom of your library in a random order."
-        ));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new TajuruParagonEffect())
+                .withInterveningIf(KickedCondition.ONCE));
     }
 
     private TajuruParagon(final TajuruParagon card) {
@@ -68,6 +62,9 @@ class TajuruParagonEffect extends OneShotEffect {
 
     TajuruParagonEffect() {
         super(Outcome.Benefit);
+        this.staticText = "reveal the top six cards of your library. " +
+                "You may put a card that shares a creature type with it from among them into your hand. " +
+                "Put the rest on the bottom of your library in a random order";
     }
 
     private TajuruParagonEffect(final TajuruParagonEffect effect) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/xln/DeadeyeTormentorTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/xln/DeadeyeTormentorTest.java
@@ -1,0 +1,51 @@
+package org.mage.test.cards.single.xln;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class DeadeyeTormentorTest extends CardTestPlayerBase {
+
+    private static final String tormentor = "Deadeye Tormentor"; // 2B 2/2
+    // Raid — When Deadeye Tormentor enters, if you attacked this turn, target opponent discards a card.
+
+    @Test
+    public void testConditionFalse() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.HAND, playerA, tormentor);
+        addCard(Zone.HAND, playerB, "Ornithopter");
+
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, tormentor);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerB, "Ornithopter", 1);
+    }
+
+
+    @Test
+    public void testConditionTrue() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.HAND, playerA, tormentor);
+        addCard(Zone.HAND, playerB, "Ornithopter");
+        addCard(Zone.BATTLEFIELD, playerA, "Raging Goblin");
+
+        attack(1, playerA, "Raging Goblin", playerB);
+
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, tormentor);
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerB, "Ornithopter", 0);
+        assertGraveyardCount(playerB, "Ornithopter", 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/TriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/TriggeredAbility.java
@@ -1,6 +1,6 @@
-
 package mage.abilities;
 
+import mage.abilities.condition.Condition;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 
@@ -53,6 +53,8 @@ public interface TriggeredAbility extends Ability {
      * if true, replaces "{this}" with "it" in the effect text
      */
     TriggeredAbility withRuleTextReplacement(boolean replaceRuleText);
+
+    TriggeredAbility withInterveningIf(Condition condition);
 
     boolean checkInterveningIfClause(Game game);
 

--- a/Mage/src/main/java/mage/abilities/condition/common/FatefulHourCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/FatefulHourCondition.java
@@ -16,4 +16,9 @@ public enum FatefulHourCondition implements Condition {
         Player player = game.getPlayer(source.getControllerId());
         return player != null && player.getLife() <= 5;
     }
+
+    @Override
+    public String toString() {
+        return "you have 5 or less life";
+    }
 }

--- a/Mage/src/main/java/mage/abilities/condition/common/SuspendedCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/SuspendedCondition.java
@@ -1,5 +1,3 @@
-
-
 package mage.abilities.condition.common;
 
 import mage.constants.Zone;
@@ -42,4 +40,10 @@ public enum SuspendedCondition implements Condition {
         }
         return false;
     }
+
+    @Override
+    public String toString() {
+        return "{this} is suspended";
+    }
+
 }


### PR DESCRIPTION
The clunky and verbose wrapper class pattern of `ConditionalInterveningIfTriggeredAbility` has always bothered me. An intervening if condition can be present on any triggered ability and ought to be part of the base class. This way, text can be automatically generated rather than requiring a hardcoded rules text.

The new chaining method is `withInterveningIf(Condition interveningIfCondition)`.

There are way too many usages to fix all at once, plus some condition text needs updating, but this will give a cleaner option for new implementations. I will continue gradually making progress towards this direction. Many existing classes implement their own intervening if conditions which can be moved to this 

@theelk801 any concerns here? please keep in mind for new implementations.