### PR TITLE
Fix profanity filter

### DIFF
--- a/Mage.Client/src/main/java/mage/client/chat/ChatPanelBasic.java
+++ b/Mage.Client/src/main/java/mage/client/chat/ChatPanelBasic.java
@@ -265,7 +265,7 @@ public class ChatPanelBasic extends javax.swing.JPanel {
         }
 
         String cachedProfanityFilterValue = PreferencesDialog.getCachedValue(PreferencesDialog.KEY_GAME_USE_PROFANITY_FILTER, "0");
-        boolean isContainsSwearing = !containsSwearing(messageToTest, cachedProfanityFilterValue);
+        boolean isContainsSwearing = containsSwearing(messageToTest, cachedProfanityFilterValue);
         boolean isUserInfoOrGameOrStatus = messageType == MessageType.USER_INFO || messageType == MessageType.GAME || messageType == MessageType.STATUS;
         if (isUserInfoOrGameOrStatus || cachedProfanityFilterValue.equals("0") || (!cachedProfanityFilterValue.equals("0") && !isContainsSwearing)) {
             if (username != null && !username.isEmpty()) {


### PR DESCRIPTION
Currently if you have a profanity filter of 1 basically everything is being written as if it contains profanity (small and black text).  This change converts it to print out small black text only if a message does contain profanity.