### PR TITLE
TargetAmount refactors

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbzanCharm.java
+++ b/Mage.Sets/src/mage/cards/a/AbzanCharm.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
-import mage.counters.CounterType;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
 import mage.target.common.TargetCreaturePermanent;
@@ -44,7 +43,7 @@ public final class AbzanCharm extends CardImpl {
 
         // *Distribute two +1/+1 counters among one or two target creatures.
         mode = new Mode(new DistributeCountersEffect(2, "one or two target creatures"));
-        mode.addTarget(new TargetCreaturePermanentAmount(2));
+        mode.addTarget(new TargetCreaturePermanentAmount(2, 1));
         this.getSpellAbility().addMode(mode);
 
     }

--- a/Mage.Sets/src/mage/cards/a/AbzanCharm.java
+++ b/Mage.Sets/src/mage/cards/a/AbzanCharm.java
@@ -42,7 +42,7 @@ public final class AbzanCharm extends CardImpl {
         this.getSpellAbility().addMode(mode);
 
         // *Distribute two +1/+1 counters among one or two target creatures.
-        mode = new Mode(new DistributeCountersEffect(2, "one or two target creatures"));
+        mode = new Mode(new DistributeCountersEffect());
         mode.addTarget(new TargetCreaturePermanentAmount(2, 1));
         this.getSpellAbility().addMode(mode);
 

--- a/Mage.Sets/src/mage/cards/a/AbzanCharm.java
+++ b/Mage.Sets/src/mage/cards/a/AbzanCharm.java
@@ -43,7 +43,7 @@ public final class AbzanCharm extends CardImpl {
 
         // *Distribute two +1/+1 counters among one or two target creatures.
         mode = new Mode(new DistributeCountersEffect());
-        mode.addTarget(new TargetCreaturePermanentAmount(2, 1));
+        mode.addTarget(new TargetCreaturePermanentAmount(2));
         this.getSpellAbility().addMode(mode);
 
     }

--- a/Mage.Sets/src/mage/cards/a/AerialVolley.java
+++ b/Mage.Sets/src/mage/cards/a/AerialVolley.java
@@ -27,7 +27,7 @@ public final class AerialVolley extends CardImpl {
 
         // Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, filter));
     }
 
     private AerialVolley(final AerialVolley card) {

--- a/Mage.Sets/src/mage/cards/a/AerialVolley.java
+++ b/Mage.Sets/src/mage/cards/a/AerialVolley.java
@@ -26,7 +26,7 @@ public final class AerialVolley extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{G}");
 
         // Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, filter));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AerialVolley.java
+++ b/Mage.Sets/src/mage/cards/a/AerialVolley.java
@@ -27,7 +27,7 @@ public final class AerialVolley extends CardImpl {
 
         // Aerial Volley deals 3 damage divided as you choose among one, two, or three target creatures with flying.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, filter));
     }
 
     private AerialVolley(final AerialVolley card) {

--- a/Mage.Sets/src/mage/cards/a/AjaniMentorOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniMentorOfHeroes.java
@@ -38,7 +38,7 @@ public final class AjaniMentorOfHeroes extends CardImpl {
 
         // +1: Distribute three +1/+1 counters among one, two, or three target creatures you control
         Ability ability = new LoyaltyAbility(new DistributeCountersEffect(), 1);
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
 
         // +1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card

--- a/Mage.Sets/src/mage/cards/a/AjaniMentorOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniMentorOfHeroes.java
@@ -9,7 +9,6 @@ import mage.abilities.effects.common.counter.DistributeCountersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.filter.predicate.Predicates;
@@ -39,7 +38,7 @@ public final class AjaniMentorOfHeroes extends CardImpl {
 
         // +1: Distribute three +1/+1 counters among one, two, or three target creatures you control
         Ability ability = new LoyaltyAbility(new DistributeCountersEffect(3, "one, two, or three target creatures you control"), 1);
-        ability.addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
 
         // +1: Look at the top four cards of your library. You may reveal an Aura, creature, or planeswalker card

--- a/Mage.Sets/src/mage/cards/a/AjaniMentorOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniMentorOfHeroes.java
@@ -37,7 +37,7 @@ public final class AjaniMentorOfHeroes extends CardImpl {
         this.setStartingLoyalty(4);
 
         // +1: Distribute three +1/+1 counters among one, two, or three target creatures you control
-        Ability ability = new LoyaltyAbility(new DistributeCountersEffect(3, "one, two, or three target creatures you control"), 1);
+        Ability ability = new LoyaltyAbility(new DistributeCountersEffect(), 1);
         ability.addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/a/AjaniSleeperAgent.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniSleeperAgent.java
@@ -15,11 +15,9 @@ import mage.constants.*;
 import mage.abilities.keyword.CompleatedAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.command.emblems.AjaniSleeperAgentEmblem;
 import mage.players.Player;
-import mage.target.Target;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
@@ -44,10 +42,7 @@ public final class AjaniSleeperAgent extends CardImpl {
         // −3: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.
         Ability ability = new LoyaltyAbility(new DistributeCountersEffect(3, "up to three target creatures"), -3);
         ability.addEffect(new GainAbilityTargetEffect(VigilanceAbility.getInstance()).setText("They gain vigilance until end of turn"));
-        Target target = new TargetCreaturePermanentAmount(3);
-        target.setMinNumberOfTargets(0);
-        target.setMaxNumberOfTargets(3);
-        ability.addTarget(target);
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         this.addAbility(ability);
 
         // −6: You get an emblem with "Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters."

--- a/Mage.Sets/src/mage/cards/a/AjaniSleeperAgent.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniSleeperAgent.java
@@ -40,7 +40,8 @@ public final class AjaniSleeperAgent extends CardImpl {
         this.addAbility(new LoyaltyAbility(new AjaniSleeperAgentEffect(), 1));
 
         // −3: Distribute three +1/+1 counters among up to three target creatures. They gain vigilance until end of turn.
-        Ability ability = new LoyaltyAbility(new DistributeCountersEffect(3, "up to three target creatures"), -3);
+        Ability ability = new LoyaltyAbility(new DistributeCountersEffect()
+                .setText("distribute three +1/+1 counters among up to three target creatures"), -3);
         ability.addEffect(new GainAbilityTargetEffect(VigilanceAbility.getInstance()).setText("They gain vigilance until end of turn"));
         ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/a/AjaniSleeperAgent.java
+++ b/Mage.Sets/src/mage/cards/a/AjaniSleeperAgent.java
@@ -43,7 +43,7 @@ public final class AjaniSleeperAgent extends CardImpl {
         Ability ability = new LoyaltyAbility(new DistributeCountersEffect()
                 .setText("distribute three +1/+1 counters among up to three target creatures"), -3);
         ability.addEffect(new GainAbilityTargetEffect(VigilanceAbility.getInstance()).setText("They gain vigilance until end of turn"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0, 3));
         this.addAbility(ability);
 
         // −6: You get an emblem with "Whenever you cast a creature or planeswalker spell, target opponent gets two poison counters."

--- a/Mage.Sets/src/mage/cards/a/AmethystDragon.java
+++ b/Mage.Sets/src/mage/cards/a/AmethystDragon.java
@@ -33,7 +33,7 @@ public final class AmethystDragon extends AdventureCard {
         // Explosive Crystal
         // Explosive Crystal deals 4 damage divided as you choose among any number of targets.
         this.getSpellCard().getSpellAbility().addEffect(new DamageMultiEffect(4));
-        this.getSpellCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
+        this.getSpellCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
         
         this.finalizeAdventure();
     }

--- a/Mage.Sets/src/mage/cards/a/AmethystDragon.java
+++ b/Mage.Sets/src/mage/cards/a/AmethystDragon.java
@@ -32,7 +32,7 @@ public final class AmethystDragon extends AdventureCard {
 
         // Explosive Crystal
         // Explosive Crystal deals 4 damage divided as you choose among any number of targets.
-        this.getSpellCard().getSpellAbility().addEffect(new DamageMultiEffect(4));
+        this.getSpellCard().getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
         
         this.finalizeAdventure();

--- a/Mage.Sets/src/mage/cards/a/AmethystDragon.java
+++ b/Mage.Sets/src/mage/cards/a/AmethystDragon.java
@@ -33,7 +33,7 @@ public final class AmethystDragon extends AdventureCard {
         // Explosive Crystal
         // Explosive Crystal deals 4 damage divided as you choose among any number of targets.
         this.getSpellCard().getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
+        this.getSpellCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
         
         this.finalizeAdventure();
     }

--- a/Mage.Sets/src/mage/cards/a/AngelOfSalvation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfSalvation.java
@@ -36,7 +36,7 @@ public final class AngelOfSalvation extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // When Angel of Salvation enters, prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.
         Ability ability = new EntersBattlefieldTriggeredAbility(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 5));
-        ability.addTarget(new TargetAnyTargetAmount(5, 0));
+        ability.addTarget(new TargetAnyTargetAmount(5));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AngelOfSalvation.java
+++ b/Mage.Sets/src/mage/cards/a/AngelOfSalvation.java
@@ -34,9 +34,9 @@ public final class AngelOfSalvation extends CardImpl {
         this.addAbility(new ConvokeAbility());
         // Flying
         this.addAbility(FlyingAbility.getInstance());
-        // When Angel of Salvation enters the battlefield, prevent the next 5 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.
+        // When Angel of Salvation enters, prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.
         Ability ability = new EntersBattlefieldTriggeredAbility(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 5));
-        ability.addTarget(new TargetAnyTargetAmount(5));
+        ability.addTarget(new TargetAnyTargetAmount(5, 0));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcLightning.java
+++ b/Mage.Sets/src/mage/cards/a/ArcLightning.java
@@ -18,7 +18,7 @@ public final class ArcLightning extends CardImpl {
 
         // Arc Lightning deals 3 damage divided as you choose among one, two, or three targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
     }
 
     private ArcLightning(final ArcLightning card) {

--- a/Mage.Sets/src/mage/cards/a/ArcLightning.java
+++ b/Mage.Sets/src/mage/cards/a/ArcLightning.java
@@ -17,7 +17,7 @@ public final class ArcLightning extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{R}");
 
         // Arc Lightning deals 3 damage divided as you choose among one, two, or three targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcLightning.java
+++ b/Mage.Sets/src/mage/cards/a/ArcLightning.java
@@ -18,7 +18,7 @@ public final class ArcLightning extends CardImpl {
 
         // Arc Lightning deals 3 damage divided as you choose among one, two, or three targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
     }
 
     private ArcLightning(final ArcLightning card) {

--- a/Mage.Sets/src/mage/cards/a/ArcMage.java
+++ b/Mage.Sets/src/mage/cards/a/ArcMage.java
@@ -28,7 +28,7 @@ public final class ArcMage extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {2}{R}, {tap}, Discard a card: Arc Mage deals 2 damage divided as you choose among one or two targets.
-        Ability ability = new SimpleActivatedAbility(new DamageMultiEffect(2), new ManaCostsImpl<>("{2}{R}"));
+        Ability ability = new SimpleActivatedAbility(new DamageMultiEffect(), new ManaCostsImpl<>("{2}{R}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());
         ability.addTarget(new TargetAnyTargetAmount(2, 1));

--- a/Mage.Sets/src/mage/cards/a/ArcMage.java
+++ b/Mage.Sets/src/mage/cards/a/ArcMage.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.target.common.TargetAnyTargetAmount;
 
 /**
@@ -32,7 +31,7 @@ public final class ArcMage extends CardImpl {
         Ability ability = new SimpleActivatedAbility(new DamageMultiEffect(2), new ManaCostsImpl<>("{2}{R}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());
-        ability.addTarget(new TargetAnyTargetAmount(2));
+        ability.addTarget(new TargetAnyTargetAmount(2, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcMage.java
+++ b/Mage.Sets/src/mage/cards/a/ArcMage.java
@@ -31,7 +31,7 @@ public final class ArcMage extends CardImpl {
         Ability ability = new SimpleActivatedAbility(new DamageMultiEffect(), new ManaCostsImpl<>("{2}{R}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());
-        ability.addTarget(new TargetAnyTargetAmount(2, 1));
+        ability.addTarget(new TargetAnyTargetAmount(2));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmamentCorps.java
+++ b/Mage.Sets/src/mage/cards/a/ArmamentCorps.java
@@ -9,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
 
@@ -29,7 +28,7 @@ public final class ArmamentCorps extends CardImpl {
 
         // When Armament Corps enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(2, "one or two target creatures you control"), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(2, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(2, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmamentCorps.java
+++ b/Mage.Sets/src/mage/cards/a/ArmamentCorps.java
@@ -28,7 +28,7 @@ public final class ArmamentCorps extends CardImpl {
 
         // When Armament Corps enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(2, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(2, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmamentCorps.java
+++ b/Mage.Sets/src/mage/cards/a/ArmamentCorps.java
@@ -27,7 +27,7 @@ public final class ArmamentCorps extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When Armament Corps enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(2, "one or two target creatures you control"), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(), false);
         ability.addTarget(new TargetCreaturePermanentAmount(2, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/a/ArrowVolleyTrap.java
+++ b/Mage.Sets/src/mage/cards/a/ArrowVolleyTrap.java
@@ -28,7 +28,7 @@ public final class ArrowVolleyTrap extends CardImpl {
 
         // Arrow Volley Trap deals 5 damage divided as you choose among any number of target attacking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(5));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, StaticFilters.FILTER_ATTACKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, 0, StaticFilters.FILTER_ATTACKING_CREATURES));
     }
 
     private ArrowVolleyTrap(final ArrowVolleyTrap card) {

--- a/Mage.Sets/src/mage/cards/a/ArrowVolleyTrap.java
+++ b/Mage.Sets/src/mage/cards/a/ArrowVolleyTrap.java
@@ -28,7 +28,7 @@ public final class ArrowVolleyTrap extends CardImpl {
 
         // Arrow Volley Trap deals 5 damage divided as you choose among any number of target attacking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, 0, StaticFilters.FILTER_ATTACKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, StaticFilters.FILTER_ATTACKING_CREATURES));
     }
 
     private ArrowVolleyTrap(final ArrowVolleyTrap card) {

--- a/Mage.Sets/src/mage/cards/a/ArrowVolleyTrap.java
+++ b/Mage.Sets/src/mage/cards/a/ArrowVolleyTrap.java
@@ -27,7 +27,7 @@ public final class ArrowVolleyTrap extends CardImpl {
         this.addAbility(new AlternativeCostSourceAbility(new ManaCostsImpl<>("{1}{W}"), ArrowVolleyTrapCondition.instance));
 
         // Arrow Volley Trap deals 5 damage divided as you choose among any number of target attacking creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(5));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, 0, StaticFilters.FILTER_ATTACKING_CREATURES));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AureliasFury.java
+++ b/Mage.Sets/src/mage/cards/a/AureliasFury.java
@@ -62,7 +62,7 @@ public final class AureliasFury extends CardImpl {
         // Aurelia's Fury deals X damage divided as you choose among any number of targets.
         // Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.
         DynamicValue xValue = GetXValue.instance;
-        this.getSpellAbility().addEffect(new DamageMultiEffect(xValue));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addEffect(new AureliasFuryEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(xValue));
         this.getSpellAbility().addWatcher(new AureliasFuryDamagedByWatcher());

--- a/Mage.Sets/src/mage/cards/a/AureliasFury.java
+++ b/Mage.Sets/src/mage/cards/a/AureliasFury.java
@@ -59,7 +59,7 @@ public final class AureliasFury extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{X}{R}{W}");
 
 
-        // Aurelia's Fury deals X damage divided as you choose among any number of target creatures and/or players.
+        // Aurelia's Fury deals X damage divided as you choose among any number of targets.
         // Tap each creature dealt damage this way. Players dealt damage this way can't cast noncreature spells this turn.
         DynamicValue xValue = GetXValue.instance;
         this.getSpellAbility().addEffect(new DamageMultiEffect(xValue));

--- a/Mage.Sets/src/mage/cards/a/AvacynsJudgment.java
+++ b/Mage.Sets/src/mage/cards/a/AvacynsJudgment.java
@@ -33,7 +33,7 @@ public final class AvacynsJudgment extends CardImpl {
 
         // Avacyn's Judgment deals 2 damage divided as you choose among any number of targets. If this spell's madness cost was paid, it deals X damage divided as you choose among those creatures and/or players instead.
         DynamicValue xValue = new AvacynsJudgmentManacostVariableValue();
-        Effect effect = new DamageMultiEffect(xValue);
+        Effect effect = new DamageMultiEffect();
         effect.setText("{this} deals 2 damage divided as you choose among any number of targets. If this spell's madness cost was paid, it deals X damage divided as you choose among those permanents and/or players instead.");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(xValue));

--- a/Mage.Sets/src/mage/cards/a/AvacynsJudgment.java
+++ b/Mage.Sets/src/mage/cards/a/AvacynsJudgment.java
@@ -31,7 +31,7 @@ public final class AvacynsJudgment extends CardImpl {
         ability.setRuleAtTheTop(true);
         this.addAbility(ability);
 
-        // Avacyn's Judgment deals 2 damage divided as you choose among any number of target creatures and/or players. If Avacyn's Judgment's madness cost was paid, it deals X damage divided as you choose among those creatures and/or players instead.
+        // Avacyn's Judgment deals 2 damage divided as you choose among any number of targets. If this spell's madness cost was paid, it deals X damage divided as you choose among those creatures and/or players instead.
         DynamicValue xValue = new AvacynsJudgmentManacostVariableValue();
         Effect effect = new DamageMultiEffect(xValue);
         effect.setText("{this} deals 2 damage divided as you choose among any number of targets. If this spell's madness cost was paid, it deals X damage divided as you choose among those permanents and/or players instead.");

--- a/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
@@ -114,7 +114,7 @@ class AwakenTheMaelstromEffect extends OneShotEffect {
         if (game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game) < 1) {
             return;
         }
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURE);
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURE);
         target.withNotTarget(true);
         target.withChooseHint("to distribute counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenTheMaelstrom.java
@@ -114,9 +114,7 @@ class AwakenTheMaelstromEffect extends OneShotEffect {
         if (game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game) < 1) {
             return;
         }
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURE);
-        target.setMinNumberOfTargets(1);
-        target.setMaxNumberOfTargets(3);
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURE);
         target.withNotTarget(true);
         target.withChooseHint("to distribute counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/b/BiogenicUpgrade.java
+++ b/Mage.Sets/src/mage/cards/b/BiogenicUpgrade.java
@@ -26,10 +26,7 @@ public final class BiogenicUpgrade extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}{G}");
 
         // Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(
-                3,
-                "one, two, or three target creatures"
-        ));
+        this.getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.getSpellAbility().addEffect(new BiogenicUpgradeEffect());
     }

--- a/Mage.Sets/src/mage/cards/b/BiogenicUpgrade.java
+++ b/Mage.Sets/src/mage/cards/b/BiogenicUpgrade.java
@@ -30,7 +30,7 @@ public final class BiogenicUpgrade extends CardImpl {
                 3,
                 "one, two, or three target creatures"
         ));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.getSpellAbility().addEffect(new BiogenicUpgradeEffect());
     }
 

--- a/Mage.Sets/src/mage/cards/b/BiogenicUpgrade.java
+++ b/Mage.Sets/src/mage/cards/b/BiogenicUpgrade.java
@@ -27,7 +27,7 @@ public final class BiogenicUpgrade extends CardImpl {
 
         // Distribute three +1/+1 counters among one, two, or three target creatures, then double the number of +1/+1 counters on each of those creatures.
         this.getSpellAbility().addEffect(new DistributeCountersEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3));
         this.getSpellAbility().addEffect(new BiogenicUpgradeEffect());
     }
 

--- a/Mage.Sets/src/mage/cards/b/BlasterHulk.java
+++ b/Mage.Sets/src/mage/cards/b/BlasterHulk.java
@@ -48,7 +48,7 @@ public final class BlasterHulk extends CardImpl {
         Ability ability = new AttacksTriggeredAbility(new GetEnergyCountersControllerEffect(2));
         ReflexiveTriggeredAbility reflexiveAbility = new ReflexiveTriggeredAbility(new DamageMultiEffect(8)
                 .setText("{this} deals 8 damage divided as you choose among up to eight targets"), false);
-        reflexiveAbility.addTarget(new TargetAnyTargetAmount(8));
+        reflexiveAbility.addTarget(new TargetAnyTargetAmount(8, 0));
         ability.addEffect(new DoWhenCostPaid(reflexiveAbility, new PayEnergyCost(8),
                 "Pay eight {E} to deal 8 damage divided as you choose among up to eight targets?"
         ).concatBy(", then"));

--- a/Mage.Sets/src/mage/cards/b/BlasterHulk.java
+++ b/Mage.Sets/src/mage/cards/b/BlasterHulk.java
@@ -46,7 +46,7 @@ public final class BlasterHulk extends CardImpl {
 
         // Whenever Blaster Hulk attacks, you get {E}{E}, then you may pay eight {E}. When you do, Blaster Hulk deals 8 damage divided as you choose among up to eight targets.
         Ability ability = new AttacksTriggeredAbility(new GetEnergyCountersControllerEffect(2));
-        ReflexiveTriggeredAbility reflexiveAbility = new ReflexiveTriggeredAbility(new DamageMultiEffect(8)
+        ReflexiveTriggeredAbility reflexiveAbility = new ReflexiveTriggeredAbility(new DamageMultiEffect()
                 .setText("{this} deals 8 damage divided as you choose among up to eight targets"), false);
         reflexiveAbility.addTarget(new TargetAnyTargetAmount(8, 0));
         ability.addEffect(new DoWhenCostPaid(reflexiveAbility, new PayEnergyCost(8),

--- a/Mage.Sets/src/mage/cards/b/BlasterHulk.java
+++ b/Mage.Sets/src/mage/cards/b/BlasterHulk.java
@@ -48,7 +48,7 @@ public final class BlasterHulk extends CardImpl {
         Ability ability = new AttacksTriggeredAbility(new GetEnergyCountersControllerEffect(2));
         ReflexiveTriggeredAbility reflexiveAbility = new ReflexiveTriggeredAbility(new DamageMultiEffect()
                 .setText("{this} deals 8 damage divided as you choose among up to eight targets"), false);
-        reflexiveAbility.addTarget(new TargetAnyTargetAmount(8, 0));
+        reflexiveAbility.addTarget(new TargetAnyTargetAmount(8));
         ability.addEffect(new DoWhenCostPaid(reflexiveAbility, new PayEnergyCost(8),
                 "Pay eight {E} to deal 8 damage divided as you choose among up to eight targets?"
         ).concatBy(", then"));

--- a/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
@@ -79,7 +79,7 @@ class BlessingOfFrostEffect extends OneShotEffect {
         int snow = ManaPaidSourceWatcher.getSnowPaid(source.getId(), game);
         int potentialTarget = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game);
         if (snow > 0 && potentialTarget > 0) {
-            TargetAmount target = new TargetCreaturePermanentAmount(snow, 0, StaticFilters.FILTER_CONTROLLED_CREATURE);
+            TargetAmount target = new TargetCreaturePermanentAmount(snow, 0, snow, StaticFilters.FILTER_CONTROLLED_CREATURE);
             target.withNotTarget(true);
             target.chooseTarget(outcome, player.getId(), source, game);
             for (UUID targetId : target.getTargets()) {

--- a/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingOfFrost.java
@@ -79,8 +79,7 @@ class BlessingOfFrostEffect extends OneShotEffect {
         int snow = ManaPaidSourceWatcher.getSnowPaid(source.getId(), game);
         int potentialTarget = game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game);
         if (snow > 0 && potentialTarget > 0) {
-            TargetAmount target = new TargetCreaturePermanentAmount(snow, StaticFilters.FILTER_CONTROLLED_CREATURE);
-            target.setMinNumberOfTargets(1);
+            TargetAmount target = new TargetCreaturePermanentAmount(snow, 0, StaticFilters.FILTER_CONTROLLED_CREATURE);
             target.withNotTarget(true);
             target.chooseTarget(outcome, player.getId(), source, game);
             for (UUID targetId : target.getTargets()) {

--- a/Mage.Sets/src/mage/cards/b/BlessingsOfNature.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingsOfNature.java
@@ -5,7 +5,6 @@ import mage.abilities.keyword.MiracleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 import java.util.UUID;
@@ -20,7 +19,7 @@ public final class BlessingsOfNature extends CardImpl {
 
         // Distribute four +1/+1 counters among any number of target creatures.
         this.getSpellAbility().addEffect(new DistributeCountersEffect(4, "any number of target creatures"));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0));
 
         this.addAbility(new MiracleAbility("{G}"));
     }

--- a/Mage.Sets/src/mage/cards/b/BlessingsOfNature.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingsOfNature.java
@@ -19,7 +19,7 @@ public final class BlessingsOfNature extends CardImpl {
 
         // Distribute four +1/+1 counters among any number of target creatures.
         this.getSpellAbility().addEffect(new DistributeCountersEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4));
 
         this.addAbility(new MiracleAbility("{G}"));
     }

--- a/Mage.Sets/src/mage/cards/b/BlessingsOfNature.java
+++ b/Mage.Sets/src/mage/cards/b/BlessingsOfNature.java
@@ -18,7 +18,7 @@ public final class BlessingsOfNature extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}");
 
         // Distribute four +1/+1 counters among any number of target creatures.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(4, "any number of target creatures"));
+        this.getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0));
 
         this.addAbility(new MiracleAbility("{G}"));

--- a/Mage.Sets/src/mage/cards/b/BogardanHellkite.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanHellkite.java
@@ -28,10 +28,15 @@ public final class BogardanHellkite extends CardImpl {
         this.power = new MageInt(5);
         this.toughness = new MageInt(5);
 
+        // Flash
         this.addAbility(FlashAbility.getInstance());
+
+        // Flying
         this.addAbility(FlyingAbility.getInstance());
+
+        // When Bogardan Hellkite enters, it deals 5 damage divided as you choose among any number of targets.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect(5, "it"), false);
-        ability.addTarget(new TargetAnyTargetAmount(5));
+        ability.addTarget(new TargetAnyTargetAmount(5, 0));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BogardanHellkite.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanHellkite.java
@@ -36,7 +36,7 @@ public final class BogardanHellkite extends CardImpl {
 
         // When Bogardan Hellkite enters, it deals 5 damage divided as you choose among any number of targets.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect("it"), false);
-        ability.addTarget(new TargetAnyTargetAmount(5, 0));
+        ability.addTarget(new TargetAnyTargetAmount(5));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/b/BogardanHellkite.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanHellkite.java
@@ -35,7 +35,7 @@ public final class BogardanHellkite extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // When Bogardan Hellkite enters, it deals 5 damage divided as you choose among any number of targets.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect(5, "it"), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect("it"), false);
         ability.addTarget(new TargetAnyTargetAmount(5, 0));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/b/Boulderfall.java
+++ b/Mage.Sets/src/mage/cards/b/Boulderfall.java
@@ -18,7 +18,7 @@ public final class Boulderfall extends CardImpl {
 
         // Boulderfall deals 5 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(5));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
     }
 
     private Boulderfall(final Boulderfall card) {

--- a/Mage.Sets/src/mage/cards/b/Boulderfall.java
+++ b/Mage.Sets/src/mage/cards/b/Boulderfall.java
@@ -18,7 +18,7 @@ public final class Boulderfall extends CardImpl {
 
         // Boulderfall deals 5 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5));
     }
 
     private Boulderfall(final Boulderfall card) {

--- a/Mage.Sets/src/mage/cards/b/Boulderfall.java
+++ b/Mage.Sets/src/mage/cards/b/Boulderfall.java
@@ -17,7 +17,7 @@ public final class Boulderfall extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{6}{R}{R}");
 
         // Boulderfall deals 5 damage divided as you choose among any number of targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(5));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BountyOfTheHunt.java
+++ b/Mage.Sets/src/mage/cards/b/BountyOfTheHunt.java
@@ -34,7 +34,7 @@ public final class BountyOfTheHunt extends CardImpl {
 
         // Distribute three +1/+1 counters among one, two, or three target creatures. For each +1/+1 counter you put on a creature this way, remove a +1/+1 counter from that creature at the beginning of the next cleanup step.
         this.getSpellAbility().addEffect(new DistributeCountersEffect().withRemoveAtEndOfTurn());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3));
     }
 
     private BountyOfTheHunt(final BountyOfTheHunt card) {

--- a/Mage.Sets/src/mage/cards/b/BountyOfTheHunt.java
+++ b/Mage.Sets/src/mage/cards/b/BountyOfTheHunt.java
@@ -33,10 +33,7 @@ public final class BountyOfTheHunt extends CardImpl {
         this.addAbility(new AlternativeCostSourceAbility(new ExileFromHandCost(new TargetCardInHand(filter))));
 
         // Distribute three +1/+1 counters among one, two, or three target creatures. For each +1/+1 counter you put on a creature this way, remove a +1/+1 counter from that creature at the beginning of the next cleanup step.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(
-                3,
-                "one, two, or three target creatures"
-        ).withRemoveAtEndOfTurn());
+        this.getSpellAbility().addEffect(new DistributeCountersEffect().withRemoveAtEndOfTurn());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BountyOfTheHunt.java
+++ b/Mage.Sets/src/mage/cards/b/BountyOfTheHunt.java
@@ -7,7 +7,6 @@ import mage.abilities.effects.common.counter.DistributeCountersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.filter.common.FilterOwnedCard;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.target.common.TargetCardInHand;
@@ -38,7 +37,7 @@ public final class BountyOfTheHunt extends CardImpl {
                 3,
                 "one, two, or three target creatures"
         ).withRemoveAtEndOfTurn());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
     }
 
     private BountyOfTheHunt(final BountyOfTheHunt card) {

--- a/Mage.Sets/src/mage/cards/b/Broodlord.java
+++ b/Mage.Sets/src/mage/cards/b/Broodlord.java
@@ -16,7 +16,7 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
-import mage.target.common.TargetPermanentAmount;
+import mage.target.common.TargetCreaturePermanentAmount;
 
 import java.util.UUID;
 
@@ -37,7 +37,7 @@ public final class Broodlord extends CardImpl {
 
         // Brood Telepathy -- When Broodlord enters the battlefield, distribute X +1/+1 counters among any number of other target creatures you control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new BroodlordEffect());
-        ability.addTarget(new TargetPermanentAmount(GetXValue.instance, StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
+        ability.addTarget(new TargetCreaturePermanentAmount(GetXValue.instance, StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
         this.addAbility(ability.withFlavorWord("Brood Telepathy"));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CaptainAmericaFirstAvenger.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainAmericaFirstAvenger.java
@@ -53,7 +53,7 @@ public final class CaptainAmericaFirstAvenger extends CardImpl {
 
         // Throw ... — {3}, Unattach an Equipment from Captain America: He deals damage equal to that Equipment’s mana value divided as you choose among one, two, or three targets.
         Ability ability = new SimpleActivatedAbility(
-                new DamageMultiEffect(CaptainAmericaFirstAvengerValue.instance).setText(
+                new DamageMultiEffect().setText(
                         "he deals damage equal to that Equipment's mana value divided as you choose among one, two, or three targets."),
                 new GenericManaCost(3));
         ability.addCost(new CaptainAmericaFirstAvengerUnattachCost());

--- a/Mage.Sets/src/mage/cards/c/CaptainAmericaFirstAvenger.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainAmericaFirstAvenger.java
@@ -57,7 +57,7 @@ public final class CaptainAmericaFirstAvenger extends CardImpl {
                         "he deals damage equal to that Equipment's mana value divided as you choose among one, two, or three targets."),
                 new GenericManaCost(3));
         ability.addCost(new CaptainAmericaFirstAvengerUnattachCost());
-        ability.addTarget(new TargetAnyTargetAmount(CaptainAmericaFirstAvengerValue.instance, 3));
+        ability.addTarget(new TargetAnyTargetAmount(CaptainAmericaFirstAvengerValue.instance, 1, 3));
         this.addAbility(ability.withFlavorWord("Throw ..."));
 
         // ... Catch — At the beginning of combat on your turn, attach up to one target Equipment you control to Captain America.

--- a/Mage.Sets/src/mage/cards/c/CaseOfTheTrampledGarden.java
+++ b/Mage.Sets/src/mage/cards/c/CaseOfTheTrampledGarden.java
@@ -41,7 +41,7 @@ public final class CaseOfTheTrampledGarden extends CardImpl {
 
         // When this Case enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
         Ability initialAbility = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect());
-        initialAbility.addTarget(new TargetCreaturePermanentAmount(2, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        initialAbility.addTarget(new TargetCreaturePermanentAmount(2, StaticFilters.FILTER_CONTROLLED_CREATURES));
         // To solve -- Creatures you control have total power 8 or greater.
         // Solved -- Whenever you attack, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.
         Ability solvedAbility = new ConditionalTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/c/CaseOfTheTrampledGarden.java
+++ b/Mage.Sets/src/mage/cards/c/CaseOfTheTrampledGarden.java
@@ -26,7 +26,7 @@ import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetAttackingCreature;
-import mage.target.common.TargetPermanentAmount;
+import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
  *
@@ -42,9 +42,7 @@ public final class CaseOfTheTrampledGarden extends CardImpl {
         // When this Case enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
         Ability initialAbility = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(2,
                 "one or two target creatures you control"));
-        TargetPermanentAmount target = new TargetPermanentAmount(2, StaticFilters.FILTER_CONTROLLED_CREATURES);
-        target.setMinNumberOfTargets(1);
-        initialAbility.addTarget(target);
+        initialAbility.addTarget(new TargetCreaturePermanentAmount(2, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         // To solve -- Creatures you control have total power 8 or greater.
         // Solved -- Whenever you attack, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.
         Ability solvedAbility = new ConditionalTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/c/CaseOfTheTrampledGarden.java
+++ b/Mage.Sets/src/mage/cards/c/CaseOfTheTrampledGarden.java
@@ -40,8 +40,7 @@ public final class CaseOfTheTrampledGarden extends CardImpl {
         this.subtype.add(SubType.CASE);
 
         // When this Case enters the battlefield, distribute two +1/+1 counters among one or two target creatures you control.
-        Ability initialAbility = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(2,
-                "one or two target creatures you control"));
+        Ability initialAbility = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect());
         initialAbility.addTarget(new TargetCreaturePermanentAmount(2, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         // To solve -- Creatures you control have total power 8 or greater.
         // Solved -- Whenever you attack, put a +1/+1 counter on target attacking creature. It gains trample until end of turn.

--- a/Mage.Sets/src/mage/cards/c/ChandraFlameshaper.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlameshaper.java
@@ -50,7 +50,7 @@ public final class ChandraFlameshaper extends CardImpl {
 
         // -4: Chandra deals 8 damage divided as you choose among any number of target creatures and/or planeswalkers.
         Ability minusFourAbility = new LoyaltyAbility(
-                new DamageMultiEffect(8, "{this}"), -4
+                new DamageMultiEffect(), -4
         );
         minusFourAbility.addTarget(new TargetCreatureOrPlaneswalkerAmount(8, 0));
         this.addAbility(minusFourAbility);

--- a/Mage.Sets/src/mage/cards/c/ChandraFlameshaper.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlameshaper.java
@@ -52,7 +52,7 @@ public final class ChandraFlameshaper extends CardImpl {
         Ability minusFourAbility = new LoyaltyAbility(
                 new DamageMultiEffect(), -4
         );
-        minusFourAbility.addTarget(new TargetCreatureOrPlaneswalkerAmount(8, 0));
+        minusFourAbility.addTarget(new TargetCreatureOrPlaneswalkerAmount(8));
         this.addAbility(minusFourAbility);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandraFlameshaper.java
+++ b/Mage.Sets/src/mage/cards/c/ChandraFlameshaper.java
@@ -52,7 +52,7 @@ public final class ChandraFlameshaper extends CardImpl {
         Ability minusFourAbility = new LoyaltyAbility(
                 new DamageMultiEffect(8, "{this}"), -4
         );
-        minusFourAbility.addTarget(new TargetCreatureOrPlaneswalkerAmount(8));
+        minusFourAbility.addTarget(new TargetCreatureOrPlaneswalkerAmount(8, 0));
         this.addAbility(minusFourAbility);
     }
 

--- a/Mage.Sets/src/mage/cards/c/ChandrasPyrohelix.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasPyrohelix.java
@@ -18,7 +18,7 @@ public final class ChandrasPyrohelix extends CardImpl {
 
         // Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(2));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
     }
 
     private ChandrasPyrohelix(final ChandrasPyrohelix card) {

--- a/Mage.Sets/src/mage/cards/c/ChandrasPyrohelix.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasPyrohelix.java
@@ -18,7 +18,7 @@ public final class ChandrasPyrohelix extends CardImpl {
 
         // Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
     }
 
     private ChandrasPyrohelix(final ChandrasPyrohelix card) {

--- a/Mage.Sets/src/mage/cards/c/ChandrasPyrohelix.java
+++ b/Mage.Sets/src/mage/cards/c/ChandrasPyrohelix.java
@@ -17,7 +17,7 @@ public final class ChandrasPyrohelix extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{R}");
 
         // Chandra's Pyrohelix deals 2 damage divided as you choose among one or two targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(2));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/c/Conflagrate.java
+++ b/Mage.Sets/src/mage/cards/c/Conflagrate.java
@@ -24,7 +24,7 @@ public final class Conflagrate extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{X}{R}");
 
         // Conflagrate deals X damage divided as you choose among any number of targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(GetXValue.instance));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(GetXValue.instance));
 
         // Flashback-{R}{R}, Discard X cards.

--- a/Mage.Sets/src/mage/cards/c/Contagion.java
+++ b/Mage.Sets/src/mage/cards/c/Contagion.java
@@ -38,10 +38,7 @@ public final class Contagion extends CardImpl {
 
         // Distribute two -2/-1 counters among one or two target creatures.
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(
-                CounterType.M2M1, 2,
-                "one or two target creatures"
-        ));
+        this.getSpellAbility().addEffect(new DistributeCountersEffect(CounterType.M2M1));
     }
 
     private Contagion(final Contagion card) {

--- a/Mage.Sets/src/mage/cards/c/Contagion.java
+++ b/Mage.Sets/src/mage/cards/c/Contagion.java
@@ -37,7 +37,7 @@ public final class Contagion extends CardImpl {
         this.addAbility(ability);
 
         // Distribute two -2/-1 counters among one or two target creatures.
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
         this.getSpellAbility().addEffect(new DistributeCountersEffect(CounterType.M2M1));
     }
 

--- a/Mage.Sets/src/mage/cards/c/Contagion.java
+++ b/Mage.Sets/src/mage/cards/c/Contagion.java
@@ -37,7 +37,7 @@ public final class Contagion extends CardImpl {
         this.addAbility(ability);
 
         // Distribute two -2/-1 counters among one or two target creatures.
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
         this.getSpellAbility().addEffect(new DistributeCountersEffect(
                 CounterType.M2M1, 2,
                 "one or two target creatures"

--- a/Mage.Sets/src/mage/cards/c/CourtOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/c/CourtOfGarenbrig.java
@@ -36,10 +36,7 @@ public final class CourtOfGarenbrig extends CardImpl {
                        2, "up to two target creatures"
                 )
         );
-        TargetCreaturePermanentAmount target = new TargetCreaturePermanentAmount(2);
-        target.setMinNumberOfTargets(0);
-        target.setMaxNumberOfTargets(2);
-        ability.addTarget(target);
+        ability.addTarget(new TargetCreaturePermanentAmount(2, 0));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DoubleCounterOnEachPermanentEffect(CounterType.P1P1, StaticFilters.FILTER_CONTROLLED_CREATURE),
                 MonarchIsSourceControllerCondition.instance

--- a/Mage.Sets/src/mage/cards/c/CourtOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/c/CourtOfGarenbrig.java
@@ -33,7 +33,7 @@ public final class CourtOfGarenbrig extends CardImpl {
         // At the beginning of your upkeep, distribute two +1/+1 counters among up to two target creatures. Then if you're the monarch, double the number of +1/+1 counters on each creature you control.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(new DistributeCountersEffect()
                 .setText("distribute two +1/+1 counters among up to two target creatures"));
-        ability.addTarget(new TargetCreaturePermanentAmount(2, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(2, 0, 2));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DoubleCounterOnEachPermanentEffect(CounterType.P1P1, StaticFilters.FILTER_CONTROLLED_CREATURE),
                 MonarchIsSourceControllerCondition.instance

--- a/Mage.Sets/src/mage/cards/c/CourtOfGarenbrig.java
+++ b/Mage.Sets/src/mage/cards/c/CourtOfGarenbrig.java
@@ -31,11 +31,8 @@ public final class CourtOfGarenbrig extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new BecomesMonarchSourceEffect()).addHint(MonarchHint.instance));
 
         // At the beginning of your upkeep, distribute two +1/+1 counters among up to two target creatures. Then if you're the monarch, double the number of +1/+1 counters on each creature you control.
-        Ability ability = new BeginningOfUpkeepTriggeredAbility(
-                new DistributeCountersEffect(
-                       2, "up to two target creatures"
-                )
-        );
+        Ability ability = new BeginningOfUpkeepTriggeredAbility(new DistributeCountersEffect()
+                .setText("distribute two +1/+1 counters among up to two target creatures"));
         ability.addTarget(new TargetCreaturePermanentAmount(2, 0));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DoubleCounterOnEachPermanentEffect(CounterType.P1P1, StaticFilters.FILTER_CONTROLLED_CREATURE),

--- a/Mage.Sets/src/mage/cards/d/DefendTheCelestus.java
+++ b/Mage.Sets/src/mage/cards/d/DefendTheCelestus.java
@@ -18,10 +18,7 @@ public final class DefendTheCelestus extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{G}{G}");
 
         // Distribute three +1/+1 counters among one, two, or three target creatures you control.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(
-                3,
-                "one, two, or three target creatures you control"
-        ));
+        this.getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(
                 3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES
         ));

--- a/Mage.Sets/src/mage/cards/d/DefendTheCelestus.java
+++ b/Mage.Sets/src/mage/cards/d/DefendTheCelestus.java
@@ -20,7 +20,7 @@ public final class DefendTheCelestus extends CardImpl {
         // Distribute three +1/+1 counters among one, two, or three target creatures you control.
         this.getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(
-                3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES
+                3, StaticFilters.FILTER_CONTROLLED_CREATURES
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DefendTheCelestus.java
+++ b/Mage.Sets/src/mage/cards/d/DefendTheCelestus.java
@@ -4,7 +4,6 @@ import mage.abilities.effects.common.counter.DistributeCountersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
 
@@ -24,7 +23,7 @@ public final class DefendTheCelestus extends CardImpl {
                 "one, two, or three target creatures you control"
         ));
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(
-                3, StaticFilters.FILTER_CONTROLLED_CREATURES
+                3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeftDismissal.java
+++ b/Mage.Sets/src/mage/cards/d/DeftDismissal.java
@@ -18,7 +18,7 @@ public final class DeftDismissal extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{W}");
 
         // Deft Dismissal deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DeftDismissal.java
+++ b/Mage.Sets/src/mage/cards/d/DeftDismissal.java
@@ -19,7 +19,7 @@ public final class DeftDismissal extends CardImpl {
 
         // Deft Dismissal deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 
     private DeftDismissal(final DeftDismissal card) {

--- a/Mage.Sets/src/mage/cards/d/DeftDismissal.java
+++ b/Mage.Sets/src/mage/cards/d/DeftDismissal.java
@@ -19,7 +19,7 @@ public final class DeftDismissal extends CardImpl {
 
         // Deft Dismissal deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 
     private DeftDismissal(final DeftDismissal card) {

--- a/Mage.Sets/src/mage/cards/d/DragonlordAtarka.java
+++ b/Mage.Sets/src/mage/cards/d/DragonlordAtarka.java
@@ -44,10 +44,7 @@ public final class DragonlordAtarka extends CardImpl {
 
         // When Dragonlord Atarka enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect(5, "it"), false);
-        TargetCreatureOrPlaneswalkerAmount target = new TargetCreatureOrPlaneswalkerAmount(5, filter);
-        target.setMinNumberOfTargets(1);
-        target.setMaxNumberOfTargets(5);
-        ability.addTarget(target);
+        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(5, 0, filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DragonlordAtarka.java
+++ b/Mage.Sets/src/mage/cards/d/DragonlordAtarka.java
@@ -43,7 +43,7 @@ public final class DragonlordAtarka extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // When Dragonlord Atarka enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect(5, "it"), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect("it"), false);
         ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(5, 0, filter));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/d/DragonlordAtarka.java
+++ b/Mage.Sets/src/mage/cards/d/DragonlordAtarka.java
@@ -44,7 +44,7 @@ public final class DragonlordAtarka extends CardImpl {
 
         // When Dragonlord Atarka enters the battlefield, it deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers your opponents control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect("it"), false);
-        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(5, 0, filter));
+        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(5, filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/e/Electrolyze.java
+++ b/Mage.Sets/src/mage/cards/e/Electrolyze.java
@@ -19,7 +19,7 @@ public final class Electrolyze extends CardImpl {
 
         // Electrolyze deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
         // Draw a card.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }

--- a/Mage.Sets/src/mage/cards/e/Electrolyze.java
+++ b/Mage.Sets/src/mage/cards/e/Electrolyze.java
@@ -18,7 +18,7 @@ public final class Electrolyze extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{U}{R}");
 
         // Electrolyze deals 2 damage divided as you choose among one or two targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(2));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
         // Draw a card.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));

--- a/Mage.Sets/src/mage/cards/e/Electrolyze.java
+++ b/Mage.Sets/src/mage/cards/e/Electrolyze.java
@@ -19,7 +19,7 @@ public final class Electrolyze extends CardImpl {
 
         // Electrolyze deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(2));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
         // Draw a card.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1).concatBy("<br>"));
     }

--- a/Mage.Sets/src/mage/cards/e/ElusiveOtter.java
+++ b/Mage.Sets/src/mage/cards/e/ElusiveOtter.java
@@ -12,7 +12,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.target.Target;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 import java.util.UUID;
@@ -41,10 +40,8 @@ public final class ElusiveOtter extends AdventureCard {
                 CounterType.P1P1, GetXValue.instance,
                 "any number of target creatures you control"
         ));
-        Target target = new TargetCreaturePermanentAmount(GetXValue.instance, StaticFilters.FILTER_CONTROLLED_CREATURES);
-        target.setMinNumberOfTargets(0);
-        target.setMaxNumberOfTargets(Integer.MAX_VALUE);
-        this.getSpellCard().getSpellAbility().addTarget(target);
+        this.getSpellCard().getSpellAbility().addTarget(
+                new TargetCreaturePermanentAmount(GetXValue.instance, StaticFilters.FILTER_CONTROLLED_CREATURES));
 
         this.finalizeAdventure();
     }

--- a/Mage.Sets/src/mage/cards/e/ElusiveOtter.java
+++ b/Mage.Sets/src/mage/cards/e/ElusiveOtter.java
@@ -10,7 +10,6 @@ import mage.cards.AdventureCard;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
 
@@ -36,10 +35,7 @@ public final class ElusiveOtter extends AdventureCard {
 
         // Grove's Bounty
         // Distribute X +1/+1 counters among any number of target creatures you control.
-        this.getSpellCard().getSpellAbility().addEffect(new DistributeCountersEffect(
-                CounterType.P1P1, GetXValue.instance,
-                "any number of target creatures you control"
-        ));
+        this.getSpellCard().getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellCard().getSpellAbility().addTarget(
                 new TargetCreaturePermanentAmount(GetXValue.instance, StaticFilters.FILTER_CONTROLLED_CREATURES));
 

--- a/Mage.Sets/src/mage/cards/e/ElvenRite.java
+++ b/Mage.Sets/src/mage/cards/e/ElvenRite.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.counter.DistributeCountersEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
@@ -20,7 +19,7 @@ public final class ElvenRite extends CardImpl {
 
         // Distribute two +1/+1 counters among one or two target creatures.
         this.getSpellAbility().addEffect(new DistributeCountersEffect(2, "one or two target creatures"));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
     }
 
     private ElvenRite(final ElvenRite card) {

--- a/Mage.Sets/src/mage/cards/e/ElvenRite.java
+++ b/Mage.Sets/src/mage/cards/e/ElvenRite.java
@@ -19,7 +19,7 @@ public final class ElvenRite extends CardImpl {
 
         // Distribute two +1/+1 counters among one or two target creatures.
         this.getSpellAbility().addEffect(new DistributeCountersEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
     }
 
     private ElvenRite(final ElvenRite card) {

--- a/Mage.Sets/src/mage/cards/e/ElvenRite.java
+++ b/Mage.Sets/src/mage/cards/e/ElvenRite.java
@@ -18,7 +18,7 @@ public final class ElvenRite extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{G}");
 
         // Distribute two +1/+1 counters among one or two target creatures.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(2, "one or two target creatures"));
+        this.getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/e/Embolden.java
+++ b/Mage.Sets/src/mage/cards/e/Embolden.java
@@ -9,7 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.TimingRule;
 import mage.target.common.TargetAnyTargetAmount;
 
 /**
@@ -21,9 +20,9 @@ public final class Embolden extends CardImpl {
     public Embolden(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{W}");
 
-        // Prevent the next 4 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.
+        // Prevent the next 4 damage that would be dealt this turn to any number of targets, divided as you choose.
         this.getSpellAbility().addEffect(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 4));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
 
         // Flashback {1}{W}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{1}{W}")));

--- a/Mage.Sets/src/mage/cards/e/Embolden.java
+++ b/Mage.Sets/src/mage/cards/e/Embolden.java
@@ -22,7 +22,7 @@ public final class Embolden extends CardImpl {
 
         // Prevent the next 4 damage that would be dealt this turn to any number of targets, divided as you choose.
         this.getSpellAbility().addEffect(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 4));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
 
         // Flashback {1}{W}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{1}{W}")));

--- a/Mage.Sets/src/mage/cards/f/FeastOfTheVictoriousDead.java
+++ b/Mage.Sets/src/mage/cards/f/FeastOfTheVictoriousDead.java
@@ -77,7 +77,7 @@ class FeastOfTheVictoriousDeadEffect extends OneShotEffect {
         if (player == null || game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game) < 1) {
             return false;
         }
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, 1, StaticFilters.FILTER_CONTROLLED_CREATURE);
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, 1, amount, StaticFilters.FILTER_CONTROLLED_CREATURE);
         target.withNotTarget(true);
         target.withChooseHint("to distribute " + amount + " counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/f/FeastOfTheVictoriousDead.java
+++ b/Mage.Sets/src/mage/cards/f/FeastOfTheVictoriousDead.java
@@ -77,8 +77,7 @@ class FeastOfTheVictoriousDeadEffect extends OneShotEffect {
         if (player == null || game.getBattlefield().count(StaticFilters.FILTER_CONTROLLED_CREATURE, player.getId(), source, game) < 1) {
             return false;
         }
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, StaticFilters.FILTER_CONTROLLED_CREATURE);
-        target.setMinNumberOfTargets(1);
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, 1, StaticFilters.FILTER_CONTROLLED_CREATURE);
         target.withNotTarget(true);
         target.withChooseHint("to distribute " + amount + " counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/f/FieryJustice.java
+++ b/Mage.Sets/src/mage/cards/f/FieryJustice.java
@@ -22,7 +22,7 @@ public final class FieryJustice extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{R}{G}{W}");
 
         // Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(5));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
         Effect effect = new GainLifeTargetEffect(5);
         effect.setTargetPointer(new SecondTargetPointer());

--- a/Mage.Sets/src/mage/cards/f/FieryJustice.java
+++ b/Mage.Sets/src/mage/cards/f/FieryJustice.java
@@ -23,7 +23,7 @@ public final class FieryJustice extends CardImpl {
 
         // Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5));
         Effect effect = new GainLifeTargetEffect(5);
         effect.setTargetPointer(new SecondTargetPointer());
         effect.setText("Target opponent gains 5 life");

--- a/Mage.Sets/src/mage/cards/f/FieryJustice.java
+++ b/Mage.Sets/src/mage/cards/f/FieryJustice.java
@@ -23,7 +23,7 @@ public final class FieryJustice extends CardImpl {
 
         // Fiery Justice deals 5 damage divided as you choose among any number of targets. Target opponent gains 5 life.
         this.getSpellAbility().addEffect(new DamageMultiEffect(5));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
         Effect effect = new GainLifeTargetEffect(5);
         effect.setTargetPointer(new SecondTargetPointer());
         effect.setText("Target opponent gains 5 life");

--- a/Mage.Sets/src/mage/cards/f/FightWithFire.java
+++ b/Mage.Sets/src/mage/cards/f/FightWithFire.java
@@ -38,7 +38,7 @@ public final class FightWithFire extends CardImpl {
         ));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetCreaturePermanent(), new TargetAnyTargetAmount(10)));
+                new TargetCreaturePermanent(), new TargetAnyTargetAmount(10, 0)));
     }
 
     private FightWithFire(final FightWithFire card) {

--- a/Mage.Sets/src/mage/cards/f/FightWithFire.java
+++ b/Mage.Sets/src/mage/cards/f/FightWithFire.java
@@ -38,7 +38,7 @@ public final class FightWithFire extends CardImpl {
         ));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetCreaturePermanent(), new TargetAnyTargetAmount(10, 0)));
+                new TargetCreaturePermanent(), new TargetAnyTargetAmount(10)));
     }
 
     private FightWithFire(final FightWithFire card) {

--- a/Mage.Sets/src/mage/cards/f/FightWithFire.java
+++ b/Mage.Sets/src/mage/cards/f/FightWithFire.java
@@ -29,7 +29,7 @@ public final class FightWithFire extends CardImpl {
 
         // Fight with Fire deals 5 damage to target creature. If this spell was kicked, it deals 10 damage divided as you choose among any number of targets instead.<i> (Those targets can include players and planeswalkers.)</i>
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageMultiEffect(10),
+                new DamageMultiEffect(),
                 new DamageTargetEffect(5),
                 KickedCondition.ONCE,
                 "{this} deals 5 damage to target creature. If this spell was kicked, "

--- a/Mage.Sets/src/mage/cards/f/FireAtWill.java
+++ b/Mage.Sets/src/mage/cards/f/FireAtWill.java
@@ -20,7 +20,7 @@ public final class FireAtWill extends CardImpl {
 
         // Fire at Will deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 
     private FireAtWill(final FireAtWill card) {

--- a/Mage.Sets/src/mage/cards/f/FireAtWill.java
+++ b/Mage.Sets/src/mage/cards/f/FireAtWill.java
@@ -20,7 +20,7 @@ public final class FireAtWill extends CardImpl {
 
         // Fire at Will deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 
     private FireAtWill(final FireAtWill card) {

--- a/Mage.Sets/src/mage/cards/f/FireAtWill.java
+++ b/Mage.Sets/src/mage/cards/f/FireAtWill.java
@@ -19,7 +19,7 @@ public final class FireAtWill extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R/W}{R/W}{R/W}");
 
         // Fire at Will deals 3 damage divided as you choose among one, two, or three target attacking or blocking creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FireCovenant.java
+++ b/Mage.Sets/src/mage/cards/f/FireCovenant.java
@@ -26,7 +26,7 @@ public final class FireCovenant extends CardImpl {
 
         // Fire Covenant deals X damage divided as you choose among any number of target creatures.
         DynamicValue xValue = GetXValue.instance;
-        this.getSpellAbility().addEffect(new DamageMultiEffect(xValue));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(xValue));
     }
 

--- a/Mage.Sets/src/mage/cards/f/FireIce.java
+++ b/Mage.Sets/src/mage/cards/f/FireIce.java
@@ -19,7 +19,7 @@ public final class FireIce extends SplitCard {
         // Fire
         // Fire deals 2 damage divided as you choose among one or two targets.
         getLeftHalfCard().getSpellAbility().addEffect(new DamageMultiEffect(2, "Fire"));
-        getLeftHalfCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
+        getLeftHalfCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
 
         // Ice
         // Tap target permanent.

--- a/Mage.Sets/src/mage/cards/f/FireIce.java
+++ b/Mage.Sets/src/mage/cards/f/FireIce.java
@@ -18,7 +18,7 @@ public final class FireIce extends SplitCard {
 
         // Fire
         // Fire deals 2 damage divided as you choose among one or two targets.
-        getLeftHalfCard().getSpellAbility().addEffect(new DamageMultiEffect(2, "Fire"));
+        getLeftHalfCard().getSpellAbility().addEffect(new DamageMultiEffect());
         getLeftHalfCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
 
         // Ice

--- a/Mage.Sets/src/mage/cards/f/FireIce.java
+++ b/Mage.Sets/src/mage/cards/f/FireIce.java
@@ -19,7 +19,7 @@ public final class FireIce extends SplitCard {
         // Fire
         // Fire deals 2 damage divided as you choose among one or two targets.
         getLeftHalfCard().getSpellAbility().addEffect(new DamageMultiEffect());
-        getLeftHalfCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
+        getLeftHalfCard().getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
 
         // Ice
         // Tap target permanent.

--- a/Mage.Sets/src/mage/cards/f/FlamesOfTheFirebrand.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfTheFirebrand.java
@@ -18,7 +18,7 @@ public final class FlamesOfTheFirebrand extends CardImpl {
 
         // Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
     }
 
     private FlamesOfTheFirebrand(final FlamesOfTheFirebrand card) {

--- a/Mage.Sets/src/mage/cards/f/FlamesOfTheFirebrand.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfTheFirebrand.java
@@ -18,7 +18,7 @@ public final class FlamesOfTheFirebrand extends CardImpl {
 
         // Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
     }
 
     private FlamesOfTheFirebrand(final FlamesOfTheFirebrand card) {

--- a/Mage.Sets/src/mage/cards/f/FlamesOfTheFirebrand.java
+++ b/Mage.Sets/src/mage/cards/f/FlamesOfTheFirebrand.java
@@ -17,7 +17,7 @@ public final class FlamesOfTheFirebrand extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{R}");
 
         // Flames of the Firebrand deals 3 damage divided as you choose among one, two, or three targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/f/Flameshot.java
+++ b/Mage.Sets/src/mage/cards/f/Flameshot.java
@@ -33,7 +33,7 @@ public final class Flameshot extends CardImpl {
         
         // Flameshot deals 3 damage divided as you choose among one, two, or three target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
     }
 
     private Flameshot(final Flameshot card) {

--- a/Mage.Sets/src/mage/cards/f/Flameshot.java
+++ b/Mage.Sets/src/mage/cards/f/Flameshot.java
@@ -33,7 +33,7 @@ public final class Flameshot extends CardImpl {
         
         // Flameshot deals 3 damage divided as you choose among one, two, or three target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3));
     }
 
     private Flameshot(final Flameshot card) {

--- a/Mage.Sets/src/mage/cards/f/Flameshot.java
+++ b/Mage.Sets/src/mage/cards/f/Flameshot.java
@@ -32,7 +32,7 @@ public final class Flameshot extends CardImpl {
         this.addAbility(new AlternativeCostSourceAbility(new DiscardTargetCost(new TargetCardInHand(filter))));
         
         // Flameshot deals 3 damage divided as you choose among one, two, or three target creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForkedBolt.java
+++ b/Mage.Sets/src/mage/cards/f/ForkedBolt.java
@@ -17,7 +17,7 @@ public final class ForkedBolt extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R}");
 
         // Forked Bolt deals 2 damage divided as you choose among one or two targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(2));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/f/ForkedBolt.java
+++ b/Mage.Sets/src/mage/cards/f/ForkedBolt.java
@@ -18,7 +18,7 @@ public final class ForkedBolt extends CardImpl {
 
         // Forked Bolt deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
     }
 
     private ForkedBolt(final ForkedBolt card) {

--- a/Mage.Sets/src/mage/cards/f/ForkedBolt.java
+++ b/Mage.Sets/src/mage/cards/f/ForkedBolt.java
@@ -18,7 +18,7 @@ public final class ForkedBolt extends CardImpl {
 
         // Forked Bolt deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(2));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
     }
 
     private ForkedBolt(final ForkedBolt card) {

--- a/Mage.Sets/src/mage/cards/f/ForkedLightning.java
+++ b/Mage.Sets/src/mage/cards/f/ForkedLightning.java
@@ -6,7 +6,6 @@ import mage.abilities.effects.common.DamageMultiEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.target.Target;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
@@ -21,7 +20,7 @@ public final class ForkedLightning extends CardImpl {
         // Forked Lightning deals 4 damage divided as you choose among one, two, or three target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(4)
                 .setText("{this} deals 4 damage divided as you choose among one, two, or three target creatures"));
-        Target target=new TargetCreaturePermanentAmount(4);target.setMaxNumberOfTargets(3);this.getSpellAbility().addTarget(target);
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 1, 3));
     }
 
     private ForkedLightning(final ForkedLightning card) {

--- a/Mage.Sets/src/mage/cards/f/ForkedLightning.java
+++ b/Mage.Sets/src/mage/cards/f/ForkedLightning.java
@@ -18,8 +18,7 @@ public final class ForkedLightning extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{R}");
 
         // Forked Lightning deals 4 damage divided as you choose among one, two, or three target creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(4)
-                .setText("{this} deals 4 damage divided as you choose among one, two, or three target creatures"));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 1, 3));
     }
 

--- a/Mage.Sets/src/mage/cards/f/Fury.java
+++ b/Mage.Sets/src/mage/cards/f/Fury.java
@@ -43,7 +43,7 @@ public final class Fury extends CardImpl {
 
         // When Fury enters the battlefield, it deals 4 damage divided as you choose among any number of target creatures and/or planeswalkers.
         Ability ability = new EntersBattlefieldTriggeredAbility(
-                new DamageMultiEffect(4, "it")
+                new DamageMultiEffect("it")
         );
         ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(4, 0));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/f/Fury.java
+++ b/Mage.Sets/src/mage/cards/f/Fury.java
@@ -45,7 +45,7 @@ public final class Fury extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(
                 new DamageMultiEffect("it")
         );
-        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(4, 0));
+        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(4));
         this.addAbility(ability);
 
         // Evoke—Exile a red card from your hand.

--- a/Mage.Sets/src/mage/cards/f/Fury.java
+++ b/Mage.Sets/src/mage/cards/f/Fury.java
@@ -45,7 +45,7 @@ public final class Fury extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(
                 new DamageMultiEffect(4, "it")
         );
-        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(4));
+        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(4, 0));
         this.addAbility(ability);
 
         // Evoke—Exile a red card from your hand.

--- a/Mage.Sets/src/mage/cards/g/GangOfDevils.java
+++ b/Mage.Sets/src/mage/cards/g/GangOfDevils.java
@@ -27,7 +27,7 @@ public final class GangOfDevils extends CardImpl {
 
         // When Gang of Devils dies, it deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new DiesSourceTriggeredAbility(new DamageMultiEffect("it"));
-        ability.addTarget(new TargetAnyTargetAmount(3, 1));
+        ability.addTarget(new TargetAnyTargetAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GangOfDevils.java
+++ b/Mage.Sets/src/mage/cards/g/GangOfDevils.java
@@ -26,7 +26,7 @@ public final class GangOfDevils extends CardImpl {
         this.toughness = new MageInt(3);
 
         // When Gang of Devils dies, it deals 3 damage divided as you choose among one, two, or three targets.
-        Ability ability = new DiesSourceTriggeredAbility(new DamageMultiEffect(3, "it"));
+        Ability ability = new DiesSourceTriggeredAbility(new DamageMultiEffect("it"));
         ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/g/GangOfDevils.java
+++ b/Mage.Sets/src/mage/cards/g/GangOfDevils.java
@@ -27,7 +27,7 @@ public final class GangOfDevils extends CardImpl {
 
         // When Gang of Devils dies, it deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new DiesSourceTriggeredAbility(new DamageMultiEffect(3, "it"));
-        ability.addTarget(new TargetAnyTargetAmount(3));
+        ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhiredsBelligerence.java
+++ b/Mage.Sets/src/mage/cards/g/GhiredsBelligerence.java
@@ -46,7 +46,7 @@ public final class GhiredsBelligerence extends CardImpl {
 
 class GhiredsBelligerenceEffect extends OneShotEffect {
 
-    private static final DamageMultiEffect effect = new DamageMultiEffect(GetXValue.instance);
+    private static final DamageMultiEffect effect = new DamageMultiEffect();
 
     GhiredsBelligerenceEffect() {
         super(Outcome.Benefit);

--- a/Mage.Sets/src/mage/cards/g/GlintWeaver.java
+++ b/Mage.Sets/src/mage/cards/g/GlintWeaver.java
@@ -31,9 +31,7 @@ public final class GlintWeaver extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
 
         // When Glint Weaver enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures, then you gain life equal to the greatest toughness among creatures you control.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(
-                3, "one, two, or three target creatures"
-        ));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect());
         ability.addEffect(new GainLifeEffect(GreatestToughnessAmongControlledCreaturesValue.instance)
                 .setText(", then you gain life equal to the greatest toughness among creatures you control"));
         ability.addTarget(new TargetCreaturePermanentAmount(3, 1));

--- a/Mage.Sets/src/mage/cards/g/GlintWeaver.java
+++ b/Mage.Sets/src/mage/cards/g/GlintWeaver.java
@@ -34,7 +34,7 @@ public final class GlintWeaver extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect());
         ability.addEffect(new GainLifeEffect(GreatestToughnessAmongControlledCreaturesValue.instance)
                 .setText(", then you gain life equal to the greatest toughness among creatures you control"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
+        ability.addTarget(new TargetCreaturePermanentAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/g/GlintWeaver.java
+++ b/Mage.Sets/src/mage/cards/g/GlintWeaver.java
@@ -11,7 +11,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 import java.util.UUID;
@@ -37,7 +36,7 @@ public final class GlintWeaver extends CardImpl {
         ));
         ability.addEffect(new GainLifeEffect(GreatestToughnessAmongControlledCreaturesValue.instance)
                 .setText(", then you gain life equal to the greatest toughness among creatures you control"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/h/HailOfArrows.java
+++ b/Mage.Sets/src/mage/cards/h/HailOfArrows.java
@@ -19,7 +19,7 @@ public final class HailOfArrows extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{X}{W}");
 
         // Hail of Arrows deals X damage divided as you choose among any number of target attacking creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(GetXValue.instance));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(GetXValue.instance, StaticFilters.FILTER_ATTACKING_CREATURES));
     }
 

--- a/Mage.Sets/src/mage/cards/i/IgniteDisorder.java
+++ b/Mage.Sets/src/mage/cards/i/IgniteDisorder.java
@@ -30,7 +30,7 @@ public final class IgniteDisorder extends CardImpl {
 
         // Ignite Disorder deals 3 damage divided as you choose among one, two, or three target white and/or blue creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, filter));
     }
 
     private IgniteDisorder(final IgniteDisorder card) {

--- a/Mage.Sets/src/mage/cards/i/IgniteDisorder.java
+++ b/Mage.Sets/src/mage/cards/i/IgniteDisorder.java
@@ -30,7 +30,7 @@ public final class IgniteDisorder extends CardImpl {
 
         // Ignite Disorder deals 3 damage divided as you choose among one, two, or three target white and/or blue creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, filter));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, filter));
     }
 
     private IgniteDisorder(final IgniteDisorder card) {

--- a/Mage.Sets/src/mage/cards/i/IgniteDisorder.java
+++ b/Mage.Sets/src/mage/cards/i/IgniteDisorder.java
@@ -29,7 +29,7 @@ public final class IgniteDisorder extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{R}");
 
         // Ignite Disorder deals 3 damage divided as you choose among one, two, or three target white and/or blue creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(3, 1, filter));
     }
 

--- a/Mage.Sets/src/mage/cards/i/ImpactResonance.java
+++ b/Mage.Sets/src/mage/cards/i/ImpactResonance.java
@@ -29,7 +29,7 @@ public final class ImpactResonance extends CardImpl {
 
         // Impact Resonance deals X damage divided as you choose among any number of target creatures, where X is the greatest amount of damage dealt by a source to a permanent or player this turn.
         DynamicValue xValue = GreatestAmountOfDamageDealtValue.instance;
-        Effect effect = new DamageMultiEffect(xValue);
+        Effect effect = new DamageMultiEffect();
         effect.setText("{this} deals X damage divided as you choose among any number of target creatures, where X is the greatest amount of damage dealt by a source to a permanent or player this turn");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(xValue));

--- a/Mage.Sets/src/mage/cards/i/InfernalHarvest.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalHarvest.java
@@ -37,7 +37,7 @@ public final class InfernalHarvest extends CardImpl {
         this.getSpellAbility().addCost(new InfernalHarvestAdditionalCost());
 
         // Infernal Harvest deals X damage divided as you choose among any number of target creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(GetXValue.instance));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(GetXValue.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfernoTitan.java
+++ b/Mage.Sets/src/mage/cards/i/InfernoTitan.java
@@ -30,7 +30,7 @@ public final class InfernoTitan extends CardImpl {
         this.addAbility(new SimpleActivatedAbility(new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ColoredManaCost(ColoredManaSymbol.R)));
 
         // Whenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.
-        Ability ability = new EntersBattlefieldOrAttacksSourceTriggeredAbility(new DamageMultiEffect(3, "it"));
+        Ability ability = new EntersBattlefieldOrAttacksSourceTriggeredAbility(new DamageMultiEffect("it"));
         ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/i/InfernoTitan.java
+++ b/Mage.Sets/src/mage/cards/i/InfernoTitan.java
@@ -31,7 +31,7 @@ public final class InfernoTitan extends CardImpl {
 
         // Whenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new EntersBattlefieldOrAttacksSourceTriggeredAbility(new DamageMultiEffect("it"));
-        ability.addTarget(new TargetAnyTargetAmount(3, 1));
+        ability.addTarget(new TargetAnyTargetAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InfernoTitan.java
+++ b/Mage.Sets/src/mage/cards/i/InfernoTitan.java
@@ -31,7 +31,7 @@ public final class InfernoTitan extends CardImpl {
 
         // Whenever Inferno Titan enters the battlefield or attacks, it deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new EntersBattlefieldOrAttacksSourceTriggeredAbility(new DamageMultiEffect(3, "it"));
-        ability.addTarget(new TargetAnyTargetAmount(3));
+        ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvokeJustice.java
+++ b/Mage.Sets/src/mage/cards/i/InvokeJustice.java
@@ -85,7 +85,7 @@ class InvokeJusticeEffect extends OneShotEffect {
         if (!game.getBattlefield().contains(filter, source, game, 1)) {
             return false;
         }
-        TargetPermanentAmount target = new TargetPermanentAmount(4, filter);
+        TargetPermanentAmount target = new TargetPermanentAmount(4, 0, filter);
         target.withNotTarget(true);
         target.chooseTarget(outcome, player.getId(), source, game);
         for (UUID targetId : target.getTargets()) {

--- a/Mage.Sets/src/mage/cards/j/JadeSeedstones.java
+++ b/Mage.Sets/src/mage/cards/j/JadeSeedstones.java
@@ -7,9 +7,8 @@ import mage.abilities.keyword.CraftAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.target.common.TargetPermanentAmount;
+import mage.target.common.TargetCreaturePermanentAmount;
 
 import java.util.UUID;
 
@@ -26,9 +25,7 @@ public final class JadeSeedstones extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(
                 3, "one, two, or three target creatures you control"
         ));
-        TargetPermanentAmount target = new TargetPermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURES);
-        target.setMinNumberOfTargets(1);
-        ability.addTarget(target);
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
 
         // Craft with creature {5}{G}{G}

--- a/Mage.Sets/src/mage/cards/j/JadeSeedstones.java
+++ b/Mage.Sets/src/mage/cards/j/JadeSeedstones.java
@@ -23,7 +23,7 @@ public final class JadeSeedstones extends CardImpl {
 
         // When Jade Seedstones enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures you control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect());
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
 
         // Craft with creature {5}{G}{G}

--- a/Mage.Sets/src/mage/cards/j/JadeSeedstones.java
+++ b/Mage.Sets/src/mage/cards/j/JadeSeedstones.java
@@ -22,9 +22,7 @@ public final class JadeSeedstones extends CardImpl {
         this.secondSideCardClazz = mage.cards.j.JadeheartAttendant.class;
 
         // When Jade Seedstones enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures you control.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(
-                3, "one, two, or three target creatures you control"
-        ));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect());
         ability.addTarget(new TargetCreaturePermanentAmount(3, 1, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/j/JawsOfStone.java
+++ b/Mage.Sets/src/mage/cards/j/JawsOfStone.java
@@ -30,7 +30,7 @@ public final class JawsOfStone extends CardImpl {
 
         // Jaws of Stone deals X damage divided as you choose among any number of targets, where X is the number of Mountains you control as you cast this spell.
         PermanentsOnBattlefieldCount mountains = new PermanentsOnBattlefieldCount(filter, null);
-        Effect effect = new DamageMultiEffect(mountains);
+        Effect effect = new DamageMultiEffect();
         effect.setText(rule);
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(mountains));

--- a/Mage.Sets/src/mage/cards/j/JuganTheRisingStar.java
+++ b/Mage.Sets/src/mage/cards/j/JuganTheRisingStar.java
@@ -32,7 +32,7 @@ public final class JuganTheRisingStar extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // When Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.
-        Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(5, "any number of target creatures"), true);
+        Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(), true);
         ability.addTarget(new TargetCreaturePermanentAmount(5, 0));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/j/JuganTheRisingStar.java
+++ b/Mage.Sets/src/mage/cards/j/JuganTheRisingStar.java
@@ -13,7 +13,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.counters.CounterType;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
@@ -34,7 +33,7 @@ public final class JuganTheRisingStar extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // When Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.
         Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(5, "any number of target creatures"), true);
-        ability.addTarget(new TargetCreaturePermanentAmount(5));
+        ability.addTarget(new TargetCreaturePermanentAmount(5, 0));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/j/JuganTheRisingStar.java
+++ b/Mage.Sets/src/mage/cards/j/JuganTheRisingStar.java
@@ -33,7 +33,7 @@ public final class JuganTheRisingStar extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // When Jugan, the Rising Star dies, you may distribute five +1/+1 counters among any number of target creatures.
         Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(), true);
-        ability.addTarget(new TargetCreaturePermanentAmount(5, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(5));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KuldothaFlamefiend.java
+++ b/Mage.Sets/src/mage/cards/k/KuldothaFlamefiend.java
@@ -28,7 +28,7 @@ public final class KuldothaFlamefiend extends CardImpl {
 
         // When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.
         EntersBattlefieldTriggeredAbility ability = 
-                new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(new DamageMultiEffect(4), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_AN)), false);
+                new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(new DamageMultiEffect(), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_AN)), false);
         ability.addTarget(new TargetAnyTargetAmount(4, 0));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/k/KuldothaFlamefiend.java
+++ b/Mage.Sets/src/mage/cards/k/KuldothaFlamefiend.java
@@ -11,7 +11,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
-import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetAnyTargetAmount;
 
 /**
@@ -30,7 +29,7 @@ public final class KuldothaFlamefiend extends CardImpl {
         // When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.
         EntersBattlefieldTriggeredAbility ability = 
                 new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(new DamageMultiEffect(4), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_AN)), false);
-        ability.addTarget(new TargetAnyTargetAmount(4));
+        ability.addTarget(new TargetAnyTargetAmount(4, 0));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/k/KuldothaFlamefiend.java
+++ b/Mage.Sets/src/mage/cards/k/KuldothaFlamefiend.java
@@ -29,7 +29,7 @@ public final class KuldothaFlamefiend extends CardImpl {
         // When Kuldotha Flamefiend enters the battlefield, you may sacrifice an artifact. If you do, Kuldotha Flamefiend deals 4 damage divided as you choose among any number of targets.
         EntersBattlefieldTriggeredAbility ability = 
                 new EntersBattlefieldTriggeredAbility(new DoIfCostPaid(new DamageMultiEffect(), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_AN)), false);
-        ability.addTarget(new TargetAnyTargetAmount(4, 0));
+        ability.addTarget(new TargetAnyTargetAmount(4));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/l/LathielTheBounteousDawn.java
+++ b/Mage.Sets/src/mage/cards/l/LathielTheBounteousDawn.java
@@ -15,10 +15,8 @@ import mage.abilities.keyword.LifelinkAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
-import mage.target.TargetAmount;
 import mage.target.common.TargetCreaturePermanentAmount;
 import mage.watchers.common.PlayerGainedLifeWatcher;
 
@@ -50,12 +48,9 @@ public final class LathielTheBounteousDawn extends CardImpl {
                 condition, "At the beginning of each end step, if you gained life this turn, " +
                 "distribute up to that many +1/+1 counters among any number of other target creatures."
         );
-        TargetAmount target = new TargetCreaturePermanentAmount(
+        ability.addTarget(new TargetCreaturePermanentAmount(
                 LathielTheBounteousDawnValue.instance,
-                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE
-        );
-        target.setMinNumberOfTargets(0);
-        ability.addTarget(target);
+                StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
         this.addAbility(ability.addHint(LathielTheBounteousDawnValue.getHint()), new PlayerGainedLifeWatcher());
     }
 

--- a/Mage.Sets/src/mage/cards/l/LathielTheBounteousDawn.java
+++ b/Mage.Sets/src/mage/cards/l/LathielTheBounteousDawn.java
@@ -42,9 +42,7 @@ public final class LathielTheBounteousDawn extends CardImpl {
 
         // At the beginning of each end step, if you gained life this turn, distribute up to that many +1/+1 counters among any number of other target creatures.
         Ability ability = new ConditionalInterveningIfTriggeredAbility(
-                new BeginningOfEndStepTriggeredAbility(TargetController.ANY, new DistributeCountersEffect(
-                       1, ""
-                ), false),
+                new BeginningOfEndStepTriggeredAbility(TargetController.ANY, new DistributeCountersEffect(), false),
                 condition, "At the beginning of each end step, if you gained life this turn, " +
                 "distribute up to that many +1/+1 counters among any number of other target creatures."
         );

--- a/Mage.Sets/src/mage/cards/l/LivingInferno.java
+++ b/Mage.Sets/src/mage/cards/l/LivingInferno.java
@@ -56,7 +56,8 @@ enum LivingInfernoAdjuster implements TargetAdjuster {
         Permanent sourcePermanent = game.getPermanentOrLKIBattlefield(ability.getSourceId());
         if (sourcePermanent != null) {
             ability.getTargets().clear();
-            ability.addTarget(new TargetCreaturePermanentAmount(sourcePermanent.getPower().getValue(), 0));
+            int power = sourcePermanent.getPower().getValue();
+            ability.addTarget(new TargetCreaturePermanentAmount(power, 0, power));
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LivingInferno.java
+++ b/Mage.Sets/src/mage/cards/l/LivingInferno.java
@@ -11,7 +11,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
@@ -57,7 +56,7 @@ enum LivingInfernoAdjuster implements TargetAdjuster {
         Permanent sourcePermanent = game.getPermanentOrLKIBattlefield(ability.getSourceId());
         if (sourcePermanent != null) {
             ability.getTargets().clear();
-            ability.addTarget(new TargetCreaturePermanentAmount(sourcePermanent.getPower().getValue()));
+            ability.addTarget(new TargetCreaturePermanentAmount(sourcePermanent.getPower().getValue(), 0));
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
@@ -135,9 +135,6 @@ enum LukkaBoundToRuinAdjuster implements TargetAdjuster {
         // Maximum targets is equal to the damage - as each target need to be assigned at least 1 damage
         ability.getTargets().clear();
         int xValue = GreatestPowerAmongControlledCreaturesValue.instance.calculate(game, ability, null);
-        TargetCreatureOrPlaneswalkerAmount targetCreatureOrPlaneswalkerAmount = new TargetCreatureOrPlaneswalkerAmount(xValue);
-        targetCreatureOrPlaneswalkerAmount.setMinNumberOfTargets(0);
-        targetCreatureOrPlaneswalkerAmount.setMaxNumberOfTargets(xValue);
-        ability.addTarget(targetCreatureOrPlaneswalkerAmount);
+        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(xValue, 0));
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
@@ -6,7 +6,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.condition.Condition;
-import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.GreatestPowerAmongControlledCreaturesValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
@@ -51,11 +50,10 @@ public class LukkaBoundToRuin extends CardImpl {
 
         // −4: Lukka deals X damage divided as you choose among any number of target creatures and/or planeswalkers,
         // where X is the greatest power among creatures you controlled as you activated this ability.
-        DynamicValue xValue = GreatestPowerAmongControlledCreaturesValue.instance;
-        DamageMultiEffect damageMultiEffect = new DamageMultiEffect(xValue);
+        DamageMultiEffect damageMultiEffect = new DamageMultiEffect();
         damageMultiEffect.setText("Lukka deals X damage divided as you choose " +
                 "among any number of target creatures and/or planeswalkers, " +
-                "where X is the greatest power among creatures you controlled as you activated this ability.");
+                "where X is the greatest power among creatures you control as you activate this ability.");
         ability = new LoyaltyAbility(damageMultiEffect, -4);
         ability.setTargetAdjuster(LukkaBoundToRuinAdjuster.instance);
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
+++ b/Mage.Sets/src/mage/cards/l/LukkaBoundToRuin.java
@@ -133,6 +133,6 @@ enum LukkaBoundToRuinAdjuster implements TargetAdjuster {
         // Maximum targets is equal to the damage - as each target need to be assigned at least 1 damage
         ability.getTargets().clear();
         int xValue = GreatestPowerAmongControlledCreaturesValue.instance.calculate(game, ability, null);
-        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(xValue, 0));
+        ability.addTarget(new TargetCreatureOrPlaneswalkerAmount(xValue, 0, xValue));
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MagicMissile.java
+++ b/Mage.Sets/src/mage/cards/m/MagicMissile.java
@@ -22,7 +22,7 @@ public final class MagicMissile extends CardImpl {
 
         // Magic Missile deals 3 damage divided as you choose among one, two, or three targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(3));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
     }
 
     private MagicMissile(final MagicMissile card) {

--- a/Mage.Sets/src/mage/cards/m/MagicMissile.java
+++ b/Mage.Sets/src/mage/cards/m/MagicMissile.java
@@ -21,7 +21,7 @@ public final class MagicMissile extends CardImpl {
         this.addAbility(new CantBeCounteredSourceAbility().setRuleAtTheTop(true));
 
         // Magic Missile deals 3 damage divided as you choose among one, two, or three targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(3));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MagicMissile.java
+++ b/Mage.Sets/src/mage/cards/m/MagicMissile.java
@@ -22,7 +22,7 @@ public final class MagicMissile extends CardImpl {
 
         // Magic Missile deals 3 damage divided as you choose among one, two, or three targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
     }
 
     private MagicMissile(final MagicMissile card) {

--- a/Mage.Sets/src/mage/cards/m/MagmaOpus.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaOpus.java
@@ -31,7 +31,7 @@ public final class MagmaOpus extends CardImpl {
 
         // Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0).withChooseHint("damage"));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4).withChooseHint("damage"));
         this.getSpellAbility().addEffect(new TapTargetEffect("tap two target permanents").setTargetPointer(new SecondTargetPointer()));
         this.getSpellAbility().addTarget(new TargetPermanent(2, StaticFilters.FILTER_PERMANENTS).withChooseHint("tap"));
         this.getSpellAbility().addEffect(new CreateTokenEffect(new Elemental44Token()));

--- a/Mage.Sets/src/mage/cards/m/MagmaOpus.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaOpus.java
@@ -30,7 +30,7 @@ public final class MagmaOpus extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{6}{U}{R}");
 
         // Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(4));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0).withChooseHint("damage"));
         this.getSpellAbility().addEffect(new TapTargetEffect("tap two target permanents").setTargetPointer(new SecondTargetPointer()));
         this.getSpellAbility().addTarget(new TargetPermanent(2, StaticFilters.FILTER_PERMANENTS).withChooseHint("tap"));

--- a/Mage.Sets/src/mage/cards/m/MagmaOpus.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaOpus.java
@@ -31,7 +31,7 @@ public final class MagmaOpus extends CardImpl {
 
         // Magma Opus deals 4 damage divided as you choose among any number of targets. Tap two target permanents. Create a 4/4 blue and red Elemental creature token. Draw two cards.
         this.getSpellAbility().addEffect(new DamageMultiEffect(4));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4).withChooseHint("damage"));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0).withChooseHint("damage"));
         this.getSpellAbility().addEffect(new TapTargetEffect("tap two target permanents").setTargetPointer(new SecondTargetPointer()));
         this.getSpellAbility().addTarget(new TargetPermanent(2, StaticFilters.FILTER_PERMANENTS).withChooseHint("tap"));
         this.getSpellAbility().addEffect(new CreateTokenEffect(new Elemental44Token()));

--- a/Mage.Sets/src/mage/cards/m/MagmaticCore.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaticCore.java
@@ -30,7 +30,7 @@ public final class MagmaticCore extends CardImpl {
         // At the beginning of your end step, Magmatic Core deals X damage divided as you choose among any number of target creatures, where X is the number of age counters on it.
         DynamicValue value = new CountersSourceCount(CounterType.AGE);
         Ability ability = new BeginningOfEndStepTriggeredAbility(
-                new DamageMultiEffect(value)
+                new DamageMultiEffect()
                         .setText("{this} deals X damage divided as you choose "
                                 + "among any number of target creatures,"
                                 + " where X is the number of age counters on it.")

--- a/Mage.Sets/src/mage/cards/m/MeteorShower.java
+++ b/Mage.Sets/src/mage/cards/m/MeteorShower.java
@@ -22,7 +22,8 @@ public final class MeteorShower extends CardImpl {
 
         // Meteor Shower deals X plus 1 damage divided as you choose among any number of targets.
         DynamicValue xValue = new IntPlusDynamicValue(1, GetXValue.instance);
-        this.getSpellAbility().addEffect(new DamageMultiEffect(xValue));
+        this.getSpellAbility().addEffect(new DamageMultiEffect()
+                .setText("{this} deals X plus 1 damage divided as you choose among any number of targets"));
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(xValue));
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeteorSwarm.java
+++ b/Mage.Sets/src/mage/cards/m/MeteorSwarm.java
@@ -23,7 +23,7 @@ public final class MeteorSwarm extends CardImpl {
                         setText("{this} deals 8 damage divided as you choose among X target creatures and/or planeswalkers.")
         );
         // Minimum number of targets will be overridden to X by the adjuster
-        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(8, 1));
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(8, 1, 8));
         this.getSpellAbility().setTargetAdjuster(new XTargetsCountAdjuster());
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeteorSwarm.java
+++ b/Mage.Sets/src/mage/cards/m/MeteorSwarm.java
@@ -22,7 +22,8 @@ public final class MeteorSwarm extends CardImpl {
                 new DamageMultiEffect(8).
                         setText("{this} deals 8 damage divided as you choose among X target creatures and/or planeswalkers.")
         );
-        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(8));
+        // Minimum number of targets will be overridden to X by the adjuster
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(8, 1));
         this.getSpellAbility().setTargetAdjuster(new XTargetsCountAdjuster());
     }
 

--- a/Mage.Sets/src/mage/cards/m/MeteorSwarm.java
+++ b/Mage.Sets/src/mage/cards/m/MeteorSwarm.java
@@ -19,7 +19,7 @@ public final class MeteorSwarm extends CardImpl {
 
         // Meteor Swarm deals 8 damage divided as you choose among X target creatures and/or planeswalkers.
         this.getSpellAbility().addEffect(
-                new DamageMultiEffect(8).
+                new DamageMultiEffect().
                         setText("{this} deals 8 damage divided as you choose among X target creatures and/or planeswalkers.")
         );
         // Minimum number of targets will be overridden to X by the adjuster

--- a/Mage.Sets/src/mage/cards/m/MoggMob.java
+++ b/Mage.Sets/src/mage/cards/m/MoggMob.java
@@ -29,7 +29,7 @@ public final class MoggMob extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new DamageMultiEffect("it"), new SacrificeSourceCost()
         );
-        ability.addTarget(new TargetAnyTargetAmount(3, 1));
+        ability.addTarget(new TargetAnyTargetAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoggMob.java
+++ b/Mage.Sets/src/mage/cards/m/MoggMob.java
@@ -29,7 +29,7 @@ public final class MoggMob extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new DamageMultiEffect(3, "it"), new SacrificeSourceCost()
         );
-        ability.addTarget(new TargetAnyTargetAmount(3));
+        ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MoggMob.java
+++ b/Mage.Sets/src/mage/cards/m/MoggMob.java
@@ -27,7 +27,7 @@ public final class MoggMob extends CardImpl {
 
         // Sacrifice Mogg Mob: It deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new SimpleActivatedAbility(
-                new DamageMultiEffect(3, "it"), new SacrificeSourceCost()
+                new DamageMultiEffect("it"), new SacrificeSourceCost()
         );
         ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/m/MonstrousOnslaught.java
+++ b/Mage.Sets/src/mage/cards/m/MonstrousOnslaught.java
@@ -22,7 +22,7 @@ public final class MonstrousOnslaught extends CardImpl {
 
         // Monstrous Onslaught deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast Monstrous Onslaught.
         DynamicValue xValue = GreatestPowerAmongControlledCreaturesValue.instance;
-        Effect effect = new DamageMultiEffect(xValue);
+        Effect effect = new DamageMultiEffect();
         effect.setText("{this} deals X damage divided as you choose among any number of target creatures, where X is the greatest power among creatures you control as you cast this spell");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(xValue));

--- a/Mage.Sets/src/mage/cards/m/MyojinOfToweringMight.java
+++ b/Mage.Sets/src/mage/cards/m/MyojinOfToweringMight.java
@@ -44,10 +44,8 @@ public final class MyojinOfToweringMight extends CardImpl {
         ), new CastFromHandWatcher());
 
         // Remove an indestructible counter from Myojin of Towering Might: Distribute eight +1/+1 counters among any number of target creatures you control. They gain trample until end of turn.
-        Ability ability = new SimpleActivatedAbility(new DistributeCountersEffect(
-                8,
-                "any number of target creatures you control"
-        ), new RemoveCountersSourceCost(CounterType.INDESTRUCTIBLE.createInstance()));
+        Ability ability = new SimpleActivatedAbility(new DistributeCountersEffect(),
+                new RemoveCountersSourceCost(CounterType.INDESTRUCTIBLE.createInstance()));
         ability.addEffect(new GainAbilityTargetEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn
         ).setText("They gain trample until end of turn"));

--- a/Mage.Sets/src/mage/cards/m/MyojinOfToweringMight.java
+++ b/Mage.Sets/src/mage/cards/m/MyojinOfToweringMight.java
@@ -51,7 +51,7 @@ public final class MyojinOfToweringMight extends CardImpl {
         ability.addEffect(new GainAbilityTargetEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn
         ).setText("They gain trample until end of turn"));
-        ability.addTarget(new TargetCreaturePermanentAmount(8, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(8, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MyojinOfToweringMight.java
+++ b/Mage.Sets/src/mage/cards/m/MyojinOfToweringMight.java
@@ -49,7 +49,7 @@ public final class MyojinOfToweringMight extends CardImpl {
         ability.addEffect(new GainAbilityTargetEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn
         ).setText("They gain trample until end of turn"));
-        ability.addTarget(new TargetCreaturePermanentAmount(8, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(8, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
+++ b/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
@@ -33,7 +33,7 @@ public final class MythosOfVadrok extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}{R}");
 
         // Mythos of Vadrok deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers. If {W}{U} was spent to cast this spell, until your next turn, those permanents can't attack or block and their activated abilities can't be activated.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(5));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(5, 0));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new MythosOfVadrokEffect(), condition, "If {W}{U} was spent to cast this spell, " +

--- a/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
+++ b/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
@@ -11,7 +11,6 @@ import mage.abilities.effects.common.DamageMultiEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.ColoredManaSymbol;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.game.Game;
@@ -35,7 +34,7 @@ public final class MythosOfVadrok extends CardImpl {
 
         // Mythos of Vadrok deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers. If {W}{U} was spent to cast this spell, until your next turn, those permanents can't attack or block and their activated abilities can't be activated.
         this.getSpellAbility().addEffect(new DamageMultiEffect(5));
-        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(5));
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(5, 0));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new MythosOfVadrokEffect(), condition, "If {W}{U} was spent to cast this spell, " +
                 "until your next turn, those permanents can't attack or block " +

--- a/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
+++ b/Mage.Sets/src/mage/cards/m/MythosOfVadrok.java
@@ -34,7 +34,7 @@ public final class MythosOfVadrok extends CardImpl {
 
         // Mythos of Vadrok deals 5 damage divided as you choose among any number of target creatures and/or planeswalkers. If {W}{U} was spent to cast this spell, until your next turn, those permanents can't attack or block and their activated abilities can't be activated.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(5, 0));
+        this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalkerAmount(5));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
                 new MythosOfVadrokEffect(), condition, "If {W}{U} was spent to cast this spell, " +
                 "until your next turn, those permanents can't attack or block " +

--- a/Mage.Sets/src/mage/cards/n/NahirisSacrifice.java
+++ b/Mage.Sets/src/mage/cards/n/NahirisSacrifice.java
@@ -41,7 +41,7 @@ public final class NahirisSacrifice extends CardImpl {
         this.getSpellAbility().addCost(new SacrificeXManaValueCost(filter,true));
 
         // Nahiri’s Sacrifice deals X damage divided as you choose among any number of target creatures.
-        Effect effect = new DamageMultiEffect(GetXValue.instance);
+        Effect effect = new DamageMultiEffect();
         effect.setText("{this} deals X damage divided as you choose among any number of target creatures.");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(GetXValue.instance));

--- a/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
+++ b/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
@@ -16,7 +16,7 @@ import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.players.Player;
-import mage.target.common.TargetCreaturePermanentAmount;
+import mage.target.common.TargetPermanentAmount;
 
 import java.util.UUID;
 
@@ -90,7 +90,7 @@ class NumaJoragaChieftainEffect extends OneShotEffect {
                 new DistributeCountersEffect(),
                 false, "distribute " + costX + " +1/+1 counters among any number of target Elves"
         );
-        ability.addTarget(new TargetCreaturePermanentAmount(costX, 0, costX, filter));
+        ability.addTarget(new TargetPermanentAmount(costX, 0, filter));
         game.fireReflexiveTriggeredAbility(ability, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
+++ b/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
@@ -90,7 +90,7 @@ class NumaJoragaChieftainEffect extends OneShotEffect {
                 new DistributeCountersEffect(),
                 false, "distribute " + costX + " +1/+1 counters among any number of target Elves"
         );
-        ability.addTarget(new TargetCreaturePermanentAmount(costX, 0, filter));
+        ability.addTarget(new TargetCreaturePermanentAmount(costX, 0, costX, filter));
         game.fireReflexiveTriggeredAbility(ability, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
+++ b/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
@@ -13,7 +13,6 @@ import mage.abilities.keyword.PartnerAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.players.Player;
@@ -91,7 +90,7 @@ class NumaJoragaChieftainEffect extends OneShotEffect {
                 new DistributeCountersEffect(costX, ""),
                 false, "distribute " + costX + " +1/+1 counters among any number of target Elves"
         );
-        ability.addTarget(new TargetCreaturePermanentAmount(costX, filter));
+        ability.addTarget(new TargetCreaturePermanentAmount(costX, 0, filter));
         game.fireReflexiveTriggeredAbility(ability, source);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
+++ b/Mage.Sets/src/mage/cards/n/NumaJoragaChieftain.java
@@ -87,7 +87,7 @@ class NumaJoragaChieftainEffect extends OneShotEffect {
             return false;
         }
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(
-                new DistributeCountersEffect(costX, ""),
+                new DistributeCountersEffect(),
                 false, "distribute " + costX + " +1/+1 counters among any number of target Elves"
         );
         ability.addTarget(new TargetCreaturePermanentAmount(costX, 0, filter));

--- a/Mage.Sets/src/mage/cards/o/OmnivorousFlytrap.java
+++ b/Mage.Sets/src/mage/cards/o/OmnivorousFlytrap.java
@@ -41,7 +41,7 @@ public final class OmnivorousFlytrap extends CardImpl {
                 new OmnivorousFlytrapEffect(),
                 new OmnivorousFlytrapCondition())
                 .concatBy("Then"));
-        ability.addTarget(new TargetCreaturePermanentAmount(2));
+        ability.addTarget(new TargetCreaturePermanentAmount(2, 1));
         ability.addHint(CardTypesInGraveyardHint.YOU);
         this.addAbility(ability.setAbilityWord(AbilityWord.DELIRIUM));
     }

--- a/Mage.Sets/src/mage/cards/o/OmnivorousFlytrap.java
+++ b/Mage.Sets/src/mage/cards/o/OmnivorousFlytrap.java
@@ -35,7 +35,7 @@ public final class OmnivorousFlytrap extends CardImpl {
 
         // Delirium -- Whenever Omnivorous Flytrap enters or attacks, if there are four or more card types among cards in your graveyard, distribute two +1/+1 counters among one or two target creatures. Then if there are six or more card types among cards in your graveyard, double the number of +1/+1 counters on those creatures.
         Ability ability = new EntersBattlefieldOrAttacksSourceTriggeredAbility(
-                new DistributeCountersEffect(CounterType.P1P1, 2, "one or two target creatures"))
+                new DistributeCountersEffect())
                 .withInterveningIf(DeliriumCondition.instance);
         ability.addEffect(new ConditionalOneShotEffect(
                 new OmnivorousFlytrapEffect(),

--- a/Mage.Sets/src/mage/cards/o/OmnivorousFlytrap.java
+++ b/Mage.Sets/src/mage/cards/o/OmnivorousFlytrap.java
@@ -41,7 +41,7 @@ public final class OmnivorousFlytrap extends CardImpl {
                 new OmnivorousFlytrapEffect(),
                 new OmnivorousFlytrapCondition())
                 .concatBy("Then"));
-        ability.addTarget(new TargetCreaturePermanentAmount(2, 1));
+        ability.addTarget(new TargetCreaturePermanentAmount(2));
         ability.addHint(CardTypesInGraveyardHint.YOU);
         this.addAbility(ability.setAbilityWord(AbilityWord.DELIRIUM));
     }

--- a/Mage.Sets/src/mage/cards/o/OnduKnotmaster.java
+++ b/Mage.Sets/src/mage/cards/o/OnduKnotmaster.java
@@ -50,12 +50,7 @@ public final class OnduKnotmaster extends AdventureCard {
 
         // Throw a Line
         // Distribute two +1/+1 counters among one or two target creatures.
-        this.getSpellCard().getSpellAbility().addEffect(
-                new DistributeCountersEffect(
-                       2,
-                        "one or two target creatures"
-                )
-        );
+        this.getSpellCard().getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellCard().getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
 
         this.finalizeAdventure();

--- a/Mage.Sets/src/mage/cards/o/OnduKnotmaster.java
+++ b/Mage.Sets/src/mage/cards/o/OnduKnotmaster.java
@@ -56,7 +56,7 @@ public final class OnduKnotmaster extends AdventureCard {
                         "one or two target creatures"
                 )
         );
-        this.getSpellCard().getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
+        this.getSpellCard().getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
 
         this.finalizeAdventure();
     }

--- a/Mage.Sets/src/mage/cards/o/OnduKnotmaster.java
+++ b/Mage.Sets/src/mage/cards/o/OnduKnotmaster.java
@@ -51,7 +51,7 @@ public final class OnduKnotmaster extends AdventureCard {
         // Throw a Line
         // Distribute two +1/+1 counters among one or two target creatures.
         this.getSpellCard().getSpellAbility().addEffect(new DistributeCountersEffect());
-        this.getSpellCard().getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
+        this.getSpellCard().getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
 
         this.finalizeAdventure();
     }

--- a/Mage.Sets/src/mage/cards/o/OrcaSiegeDemon.java
+++ b/Mage.Sets/src/mage/cards/o/OrcaSiegeDemon.java
@@ -38,7 +38,7 @@ public final class OrcaSiegeDemon extends CardImpl {
         this.addAbility(new DiesCreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, true));
 
         // When Orca dies, it deals damage equal to its power divided as you choose among any number of targets.
-        Ability ability = new DiesSourceTriggeredAbility(new DamageMultiEffect(SourcePermanentPowerValue.NOT_NEGATIVE)
+        Ability ability = new DiesSourceTriggeredAbility(new DamageMultiEffect()
                 .setText("it deals damage equal to its power divided as you choose among any number of targets."));
         ability.addTarget(new TargetAnyTargetAmount(SourcePermanentPowerValue.NOT_NEGATIVE));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/p/PicnicRuiner.java
+++ b/Mage.Sets/src/mage/cards/p/PicnicRuiner.java
@@ -41,7 +41,7 @@ public final class PicnicRuiner extends AdventureCard {
         // Distribute three +1/+1 counters among any number of target creatures you control.
         this.getSpellCard().getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellCard().getSpellAbility().addTarget(
-                new TargetCreaturePermanentAmount(3, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
+                new TargetCreaturePermanentAmount(3, 0, 3, StaticFilters.FILTER_CONTROLLED_CREATURES)
         );
 
         this.finalizeAdventure();

--- a/Mage.Sets/src/mage/cards/p/PicnicRuiner.java
+++ b/Mage.Sets/src/mage/cards/p/PicnicRuiner.java
@@ -39,12 +39,7 @@ public final class PicnicRuiner extends AdventureCard {
 
         // Stolen Goodies
         // Distribute three +1/+1 counters among any number of target creatures you control.
-        this.getSpellCard().getSpellAbility().addEffect(
-                new DistributeCountersEffect(
-                       3,
-                        "any number of target creatures you control"
-                )
-        );
+        this.getSpellCard().getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellCard().getSpellAbility().addTarget(
                 new TargetCreaturePermanentAmount(3, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
         );

--- a/Mage.Sets/src/mage/cards/p/PicnicRuiner.java
+++ b/Mage.Sets/src/mage/cards/p/PicnicRuiner.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
 
@@ -47,7 +46,7 @@ public final class PicnicRuiner extends AdventureCard {
                 )
         );
         this.getSpellCard().getSpellAbility().addTarget(
-                new TargetCreaturePermanentAmount(3, StaticFilters.FILTER_CONTROLLED_CREATURES)
+                new TargetCreaturePermanentAmount(3, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
         );
 
         this.finalizeAdventure();

--- a/Mage.Sets/src/mage/cards/p/PollenRemedy.java
+++ b/Mage.Sets/src/mage/cards/p/PollenRemedy.java
@@ -27,15 +27,15 @@ public final class PollenRemedy extends CardImpl {
         // Kicker-Sacrifice a land.
         this.addAbility(new KickerAbility(new SacrificeTargetCost(StaticFilters.FILTER_LAND)));
 
-        // Prevent the next 3 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.
+        // Prevent the next 3 damage that would be dealt this turn to any number of targets, divided as you choose.
         // If Pollen Remedy was kicked, prevent the next 6 damage this way instead.
         Effect effect = new ConditionalReplacementEffect(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 6),
                 KickedCondition.ONCE, new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 3));
         effect.setText("Prevent the next 3 damage that would be dealt this turn to any number of targets, divided as you choose. If this spell was kicked, prevent the next 6 damage this way instead.");
         this.getSpellAbility().addEffect(effect);
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 0));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetAnyTargetAmount(6)));
+                new TargetAnyTargetAmount(6, 0)));
     }
 
     private PollenRemedy(final PollenRemedy card) {

--- a/Mage.Sets/src/mage/cards/p/PollenRemedy.java
+++ b/Mage.Sets/src/mage/cards/p/PollenRemedy.java
@@ -33,9 +33,9 @@ public final class PollenRemedy extends CardImpl {
                 KickedCondition.ONCE, new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 3));
         effect.setText("Prevent the next 3 damage that would be dealt this turn to any number of targets, divided as you choose. If this spell was kicked, prevent the next 6 damage this way instead.");
         this.getSpellAbility().addEffect(effect);
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(3, 0, 3));
         this.getSpellAbility().setTargetAdjuster(new ConditionalTargetAdjuster(KickedCondition.ONCE,
-                new TargetAnyTargetAmount(6, 0)));
+                new TargetAnyTargetAmount(6)));
     }
 
     private PollenRemedy(final PollenRemedy card) {

--- a/Mage.Sets/src/mage/cards/p/PolukranosWorldEater.java
+++ b/Mage.Sets/src/mage/cards/p/PolukranosWorldEater.java
@@ -79,7 +79,7 @@ enum PolukranosWorldEaterAdjuster implements TargetAdjuster {
     public void adjustTargets(Ability ability, Game game) {
         int xValue = ((BecomesMonstrousSourceTriggeredAbility) ability).getMonstrosityValue();
         ability.getTargets().clear();
-        ability.addTarget(new TargetCreaturePermanentAmount(xValue, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
+        ability.addTarget(new TargetCreaturePermanentAmount(xValue, 0, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 }
 

--- a/Mage.Sets/src/mage/cards/p/PolukranosWorldEater.java
+++ b/Mage.Sets/src/mage/cards/p/PolukranosWorldEater.java
@@ -79,7 +79,7 @@ enum PolukranosWorldEaterAdjuster implements TargetAdjuster {
     public void adjustTargets(Ability ability, Game game) {
         int xValue = ((BecomesMonstrousSourceTriggeredAbility) ability).getMonstrosityValue();
         ability.getTargets().clear();
-        ability.addTarget(new TargetCreaturePermanentAmount(xValue, 0, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
+        ability.addTarget(new TargetCreaturePermanentAmount(xValue, 0, xValue, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
     }
 }
 

--- a/Mage.Sets/src/mage/cards/p/Pyrokinesis.java
+++ b/Mage.Sets/src/mage/cards/p/Pyrokinesis.java
@@ -34,7 +34,7 @@ public final class Pyrokinesis extends CardImpl {
 
         // Pyrokinesis deals 4 damage divided as you choose among any number of target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4));
     }
 
     private Pyrokinesis(final Pyrokinesis card) {

--- a/Mage.Sets/src/mage/cards/p/Pyrokinesis.java
+++ b/Mage.Sets/src/mage/cards/p/Pyrokinesis.java
@@ -34,7 +34,7 @@ public final class Pyrokinesis extends CardImpl {
 
         // Pyrokinesis deals 4 damage divided as you choose among any number of target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(4));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0));
     }
 
     private Pyrokinesis(final Pyrokinesis card) {

--- a/Mage.Sets/src/mage/cards/p/Pyrokinesis.java
+++ b/Mage.Sets/src/mage/cards/p/Pyrokinesis.java
@@ -33,7 +33,7 @@ public final class Pyrokinesis extends CardImpl {
         this.addAbility(new AlternativeCostSourceAbility(new ExileFromHandCost(new TargetCardInHand(filter))));
 
         // Pyrokinesis deals 4 damage divided as you choose among any number of target creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(4));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0));
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pyrotechnics.java
+++ b/Mage.Sets/src/mage/cards/p/Pyrotechnics.java
@@ -19,7 +19,7 @@ public final class Pyrotechnics extends CardImpl {
 
 
         // Pyrotechnics deals 4 damage divided as you choose among any number of targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(4));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pyrotechnics.java
+++ b/Mage.Sets/src/mage/cards/p/Pyrotechnics.java
@@ -20,7 +20,7 @@ public final class Pyrotechnics extends CardImpl {
 
         // Pyrotechnics deals 4 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
     }
 
     private Pyrotechnics(final Pyrotechnics card) {

--- a/Mage.Sets/src/mage/cards/p/Pyrotechnics.java
+++ b/Mage.Sets/src/mage/cards/p/Pyrotechnics.java
@@ -20,7 +20,7 @@ public final class Pyrotechnics extends CardImpl {
 
         // Pyrotechnics deals 4 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(4));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
     }
 
     private Pyrotechnics(final Pyrotechnics card) {

--- a/Mage.Sets/src/mage/cards/q/QuirionBeastcaller.java
+++ b/Mage.Sets/src/mage/cards/q/QuirionBeastcaller.java
@@ -14,7 +14,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.target.common.TargetPermanentAmount;
+import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
  *
@@ -42,7 +42,7 @@ public final class QuirionBeastcaller extends CardImpl {
                 // Amount here is only used for text generation.  Real amount is set in target.
                 1, "any number of target creatures you control"
         ).setText("distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on {this}"));
-        ability.addTarget(new TargetPermanentAmount(new CountersSourceCount(CounterType.P1P1), StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(new CountersSourceCount(CounterType.P1P1), StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuirionBeastcaller.java
+++ b/Mage.Sets/src/mage/cards/q/QuirionBeastcaller.java
@@ -39,8 +39,6 @@ public final class QuirionBeastcaller extends CardImpl {
 
         // When Quirion Beastcaller dies, distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on Quirion Beastcaller.
         Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(
-                // Amount here is only used for text generation.  Real amount is set in target.
-                1, "any number of target creatures you control"
         ).setText("distribute X +1/+1 counters among any number of target creatures you control, where X is the number of +1/+1 counters on {this}"));
         ability.addTarget(new TargetCreaturePermanentAmount(new CountersSourceCount(CounterType.P1P1), StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RalCallerOfStorms.java
+++ b/Mage.Sets/src/mage/cards/r/RalCallerOfStorms.java
@@ -40,7 +40,7 @@ public final class RalCallerOfStorms extends CardImpl {
         ));
 
         // -2: Ral, Caller of Storms deals 3 damage divided as you choose among one, two, or three targets.
-        Ability ability = new LoyaltyAbility(new DamageMultiEffect(3), -2);
+        Ability ability = new LoyaltyAbility(new DamageMultiEffect(), -2);
         ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/r/RalCallerOfStorms.java
+++ b/Mage.Sets/src/mage/cards/r/RalCallerOfStorms.java
@@ -41,7 +41,7 @@ public final class RalCallerOfStorms extends CardImpl {
 
         // -2: Ral, Caller of Storms deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new LoyaltyAbility(new DamageMultiEffect(3), -2);
-        ability.addTarget(new TargetAnyTargetAmount(3));
+        ability.addTarget(new TargetAnyTargetAmount(3, 1));
         this.addAbility(ability);
 
         // -7: Draw seven cards. Ral, Caller of Storms deals 7 damage to each creature your opponents control.

--- a/Mage.Sets/src/mage/cards/r/RalCallerOfStorms.java
+++ b/Mage.Sets/src/mage/cards/r/RalCallerOfStorms.java
@@ -41,7 +41,7 @@ public final class RalCallerOfStorms extends CardImpl {
 
         // -2: Ral, Caller of Storms deals 3 damage divided as you choose among one, two, or three targets.
         Ability ability = new LoyaltyAbility(new DamageMultiEffect(), -2);
-        ability.addTarget(new TargetAnyTargetAmount(3, 1));
+        ability.addTarget(new TargetAnyTargetAmount(3));
         this.addAbility(ability);
 
         // -7: Draw seven cards. Ral, Caller of Storms deals 7 damage to each creature your opponents control.

--- a/Mage.Sets/src/mage/cards/r/RalLeylineProdigy.java
+++ b/Mage.Sets/src/mage/cards/r/RalLeylineProdigy.java
@@ -76,7 +76,7 @@ public final class RalLeylineProdigy extends CardImpl {
 
         // -2: Ral deals 2 damage divided as you choose among one or two targets. Draw a card if you control a blue permanent other than Ral.
         Ability ability = new LoyaltyAbility(new DamageMultiEffect(2), -2);
-        ability.addTarget(new TargetAnyTargetAmount(2));
+        ability.addTarget(new TargetAnyTargetAmount(2, 1));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DrawCardSourceControllerEffect(1),
                 condition, "Draw a card if you control a blue permanent other than {this}"

--- a/Mage.Sets/src/mage/cards/r/RalLeylineProdigy.java
+++ b/Mage.Sets/src/mage/cards/r/RalLeylineProdigy.java
@@ -76,7 +76,7 @@ public final class RalLeylineProdigy extends CardImpl {
 
         // -2: Ral deals 2 damage divided as you choose among one or two targets. Draw a card if you control a blue permanent other than Ral.
         Ability ability = new LoyaltyAbility(new DamageMultiEffect(), -2);
-        ability.addTarget(new TargetAnyTargetAmount(2, 1));
+        ability.addTarget(new TargetAnyTargetAmount(2));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DrawCardSourceControllerEffect(1),
                 condition, "Draw a card if you control a blue permanent other than {this}"

--- a/Mage.Sets/src/mage/cards/r/RalLeylineProdigy.java
+++ b/Mage.Sets/src/mage/cards/r/RalLeylineProdigy.java
@@ -75,7 +75,7 @@ public final class RalLeylineProdigy extends CardImpl {
         this.addAbility(new LoyaltyAbility(new RalLeylineProdigyCostReductionEffect(), 1));
 
         // -2: Ral deals 2 damage divided as you choose among one or two targets. Draw a card if you control a blue permanent other than Ral.
-        Ability ability = new LoyaltyAbility(new DamageMultiEffect(2), -2);
+        Ability ability = new LoyaltyAbility(new DamageMultiEffect(), -2);
         ability.addTarget(new TargetAnyTargetAmount(2, 1));
         ability.addEffect(new ConditionalOneShotEffect(
                 new DrawCardSourceControllerEffect(1),

--- a/Mage.Sets/src/mage/cards/r/RavenousGigantotherium.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousGigantotherium.java
@@ -79,7 +79,7 @@ class RavenousGigantotheriumAbility extends EntersBattlefieldTriggeredAbility {
         if (power < 1) {
             return true;
         }
-        this.addTarget(new TargetCreaturePermanentAmount(power));
+        this.addTarget(new TargetCreaturePermanentAmount(power, 0));
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/r/RavenousGigantotherium.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousGigantotherium.java
@@ -73,7 +73,7 @@ class RavenousGigantotheriumAbility extends EntersBattlefieldTriggeredAbility {
         }
         int power = Math.max(permanent.getPower().getValue(), 0);
         this.getEffects().clear();
-        this.addEffect(new DamageMultiEffect(power));
+        this.addEffect(new DamageMultiEffect());
         this.addEffect(new RavenousGigantotheriumEffect());
         this.getTargets().clear();
         if (power < 1) {

--- a/Mage.Sets/src/mage/cards/r/RavenousGigantotherium.java
+++ b/Mage.Sets/src/mage/cards/r/RavenousGigantotherium.java
@@ -79,7 +79,7 @@ class RavenousGigantotheriumAbility extends EntersBattlefieldTriggeredAbility {
         if (power < 1) {
             return true;
         }
-        this.addTarget(new TargetCreaturePermanentAmount(power, 0));
+        this.addTarget(new TargetCreaturePermanentAmount(power, 0, power));
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/r/Remedy.java
+++ b/Mage.Sets/src/mage/cards/r/Remedy.java
@@ -21,7 +21,7 @@ public final class Remedy extends CardImpl {
 
         // Prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.
         this.getSpellAbility().addEffect(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 5));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5));
     }
 
     private Remedy(final Remedy card) {

--- a/Mage.Sets/src/mage/cards/r/Remedy.java
+++ b/Mage.Sets/src/mage/cards/r/Remedy.java
@@ -19,9 +19,9 @@ public final class Remedy extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{W}");
 
 
-        // Prevent the next 5 damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose.
+        // Prevent the next 5 damage that would be dealt this turn to any number of targets, divided as you choose.
         this.getSpellAbility().addEffect(new PreventDamageToTargetMultiAmountEffect(Duration.EndOfTurn, 5));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(5, 0));
     }
 
     private Remedy(final Remedy card) {

--- a/Mage.Sets/src/mage/cards/r/RockSlide.java
+++ b/Mage.Sets/src/mage/cards/r/RockSlide.java
@@ -30,7 +30,7 @@ public final class RockSlide extends CardImpl {
 
         // Rock Slide deals X damage divided as you choose among any number of target attacking or blocking creatures without flying.
         DynamicValue xValue = GetXValue.instance;
-        this.getSpellAbility().addEffect(new DamageMultiEffect(xValue));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(xValue, filter));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoilsRetribution.java
+++ b/Mage.Sets/src/mage/cards/r/RoilsRetribution.java
@@ -19,7 +19,7 @@ public final class RoilsRetribution extends CardImpl {
 
         // Roil's Retribution deals 5 damage divided as you choose among any number of target attacking or blocking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(5));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, 0, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 
     private RoilsRetribution(final RoilsRetribution card) {

--- a/Mage.Sets/src/mage/cards/r/RoilsRetribution.java
+++ b/Mage.Sets/src/mage/cards/r/RoilsRetribution.java
@@ -18,7 +18,7 @@ public final class RoilsRetribution extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{W}{W}");
 
         // Roil's Retribution deals 5 damage divided as you choose among any number of target attacking or blocking creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(5));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, 0, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RoilsRetribution.java
+++ b/Mage.Sets/src/mage/cards/r/RoilsRetribution.java
@@ -19,7 +19,7 @@ public final class RoilsRetribution extends CardImpl {
 
         // Roil's Retribution deals 5 damage divided as you choose among any number of target attacking or blocking creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, 0, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(5, StaticFilters.FILTER_ATTACKING_OR_BLOCKING_CREATURES));
     }
 
     private RoilsRetribution(final RoilsRetribution card) {

--- a/Mage.Sets/src/mage/cards/r/RollingThunder.java
+++ b/Mage.Sets/src/mage/cards/r/RollingThunder.java
@@ -20,7 +20,7 @@ public final class RollingThunder extends CardImpl {
 
         // Rolling Thunder deals X damage divided as you choose among any number of targets.
         DynamicValue xValue = GetXValue.instance;
-        this.getSpellAbility().addEffect(new DamageMultiEffect(xValue));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(xValue));  
     }
 

--- a/Mage.Sets/src/mage/cards/s/SamutTheTested.java
+++ b/Mage.Sets/src/mage/cards/s/SamutTheTested.java
@@ -45,7 +45,7 @@ public final class SamutTheTested extends CardImpl {
         this.addAbility(ability);
 
         // -2: Samut, the Tested deals 2 damage divided as you choose among one or two targets.
-        effect = new DamageMultiEffect(2);
+        effect = new DamageMultiEffect();
         ability = new LoyaltyAbility(effect, -2);
         ability.addTarget(new TargetAnyTargetAmount(2, 1));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SamutTheTested.java
+++ b/Mage.Sets/src/mage/cards/s/SamutTheTested.java
@@ -47,7 +47,7 @@ public final class SamutTheTested extends CardImpl {
         // -2: Samut, the Tested deals 2 damage divided as you choose among one or two targets.
         effect = new DamageMultiEffect(2);
         ability = new LoyaltyAbility(effect, -2);
-        ability.addTarget(new TargetAnyTargetAmount(2));
+        ability.addTarget(new TargetAnyTargetAmount(2, 1));
         this.addAbility(ability);
 
         // -7: Search your library for up to two creature and/or planeswalker cards, put them onto the battlefield, then shuffle your library.

--- a/Mage.Sets/src/mage/cards/s/SamutTheTested.java
+++ b/Mage.Sets/src/mage/cards/s/SamutTheTested.java
@@ -47,7 +47,7 @@ public final class SamutTheTested extends CardImpl {
         // -2: Samut, the Tested deals 2 damage divided as you choose among one or two targets.
         effect = new DamageMultiEffect();
         ability = new LoyaltyAbility(effect, -2);
-        ability.addTarget(new TargetAnyTargetAmount(2, 1));
+        ability.addTarget(new TargetAnyTargetAmount(2));
         this.addAbility(ability);
 
         // -7: Search your library for up to two creature and/or planeswalker cards, put them onto the battlefield, then shuffle your library.

--- a/Mage.Sets/src/mage/cards/s/SerrasHymn.java
+++ b/Mage.Sets/src/mage/cards/s/SerrasHymn.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.target.common.TargetAnyTargetAmount;
 
@@ -22,7 +21,7 @@ import mage.target.common.TargetAnyTargetAmount;
  */
 public final class SerrasHymn extends CardImpl {
 
-    private static final String rule = "Prevent the next X damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose, where X is the number of verse counters on {this}.";
+    private static final String rule = "Prevent the next X damage that would be dealt this turn to any number of targets, divided as you choose, where X is the number of verse counters on {this}.";
 
     public SerrasHymn(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{W}");
@@ -31,7 +30,7 @@ public final class SerrasHymn extends CardImpl {
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
                 new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
 
-        // Sacrifice Serra's Hymn: Prevent the next X damage that would be dealt this turn to any number of target creatures and/or players, divided as you choose, where X is the number of verse counters on Serra's Hymn.
+        // Sacrifice Serra's Hymn: Prevent the next X damage that would be dealt this turn to any number of targets, divided as you choose, where X is the number of verse counters on Serra's Hymn.
         Ability ability = new SimpleActivatedAbility(
                 new PreventDamageToTargetMultiAmountEffect(
                         Duration.EndOfTurn,

--- a/Mage.Sets/src/mage/cards/s/ShamblingSwarm.java
+++ b/Mage.Sets/src/mage/cards/s/ShamblingSwarm.java
@@ -27,7 +27,7 @@ public final class ShamblingSwarm extends CardImpl {
 
         // When Shambling Swarm dies, distribute three -1/-1 counters among one, two, or three target creatures. For each -1/-1 counter you put on a creature this way, remove a -1/-1 counter from that creature at the beginning of the next end step.
         Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(
-                CounterType.M1M1, 3, "one, two, or three target creatures"
+                CounterType.M1M1
         ).withRemoveAtEndOfTurn(), false);
         ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/ShamblingSwarm.java
+++ b/Mage.Sets/src/mage/cards/s/ShamblingSwarm.java
@@ -29,7 +29,7 @@ public final class ShamblingSwarm extends CardImpl {
         Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(
                 CounterType.M1M1, 3, "one, two, or three target creatures"
         ).withRemoveAtEndOfTurn(), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShamblingSwarm.java
+++ b/Mage.Sets/src/mage/cards/s/ShamblingSwarm.java
@@ -29,7 +29,7 @@ public final class ShamblingSwarm extends CardImpl {
         Ability ability = new DiesSourceTriggeredAbility(new DistributeCountersEffect(
                 CounterType.M1M1
         ).withRemoveAtEndOfTurn(), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
+        ability.addTarget(new TargetCreaturePermanentAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/ShatterskullSmashing.java
+++ b/Mage.Sets/src/mage/cards/s/ShatterskullSmashing.java
@@ -90,12 +90,10 @@ enum ShatterskullSmashingAdjuster implements TargetAdjuster {
         ability.getTargets().clear();
         TargetAmount target;
         if (CardUtil.getSourceCostsTag(game, ability, "X", 0) >= 6) {
-            target = new TargetCreatureOrPlaneswalkerAmount(2 * CardUtil.getSourceCostsTag(game, ability, "X", 0));
+            target = new TargetCreatureOrPlaneswalkerAmount(2 * CardUtil.getSourceCostsTag(game, ability, "X", 0), 0, 2);
         } else {
-            target = new TargetCreatureOrPlaneswalkerAmount(CardUtil.getSourceCostsTag(game, ability, "X", 0));
+            target = new TargetCreatureOrPlaneswalkerAmount(CardUtil.getSourceCostsTag(game, ability, "X", 0), 0, 2);
         }
-        target.setMinNumberOfTargets(0);
-        target.setMaxNumberOfTargets(2);
         ability.addTarget(target);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/ShatterskullSmashing.java
+++ b/Mage.Sets/src/mage/cards/s/ShatterskullSmashing.java
@@ -5,9 +5,6 @@ import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.decorator.ConditionalOneShotEffect;
-import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.MultipliedValue;
-import mage.abilities.dynamicvalue.common.GetXValue;
 import mage.abilities.effects.common.DamageMultiEffect;
 import mage.abilities.effects.common.TapSourceUnlessPaysEffect;
 import mage.abilities.mana.RedManaAbility;
@@ -28,8 +25,6 @@ import java.util.UUID;
  */
 public final class ShatterskullSmashing extends ModalDoubleFacedCard {
 
-    private static final DynamicValue xValue = new MultipliedValue(GetXValue.instance, 2);
-
     public ShatterskullSmashing(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo,
                 new CardType[]{CardType.SORCERY}, new SubType[]{}, "{X}{R}{R}",
@@ -42,7 +37,7 @@ public final class ShatterskullSmashing extends ModalDoubleFacedCard {
 
         // Shatterskull Smashing deals X damage divided as you choose among up to two target creatures and/or planeswalkers. If X is 6 or more, Shatterskull Smashing deals twice X damage divided as you choose among them instead.
         this.getLeftHalfCard().getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageMultiEffect(xValue), new DamageMultiEffect(GetXValue.instance),
+                new DamageMultiEffect(), new DamageMultiEffect(),
                 ShatterskullSmashingCondition.instance, "{this} deals X damage divided as you choose " +
                 "among up to two target creatures and/or planeswalkers. If X is 6 or more, " +
                 "{this} deals twice X damage divided as you choose among them instead."

--- a/Mage.Sets/src/mage/cards/s/SkarrganHellkite.java
+++ b/Mage.Sets/src/mage/cards/s/SkarrganHellkite.java
@@ -43,7 +43,7 @@ public final class SkarrganHellkite extends CardImpl {
                 "{3}{R}: {this} deals 2 damage divided as you choose among one or two targets. " +
                         "Activate only if {this} has a +1/+1 counter on it."
         );
-        ability.addTarget(new TargetAnyTargetAmount(2));
+        ability.addTarget(new TargetAnyTargetAmount(2, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkarrganHellkite.java
+++ b/Mage.Sets/src/mage/cards/s/SkarrganHellkite.java
@@ -43,7 +43,7 @@ public final class SkarrganHellkite extends CardImpl {
                 "{3}{R}: {this} deals 2 damage divided as you choose among one or two targets. " +
                         "Activate only if {this} has a +1/+1 counter on it."
         );
-        ability.addTarget(new TargetAnyTargetAmount(2, 1));
+        ability.addTarget(new TargetAnyTargetAmount(2));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkarrganHellkite.java
+++ b/Mage.Sets/src/mage/cards/s/SkarrganHellkite.java
@@ -38,7 +38,7 @@ public final class SkarrganHellkite extends CardImpl {
 
         // {3}{R}: Skarrgan Hellkite deals 2 damage divided as you choose among one or two targets. Activate this ability only if Skarrgan Hellkite has a +1/+1 counter on it.
         Ability ability = new ConditionalActivatedAbility(
-                Zone.BATTLEFIELD, new DamageMultiEffect(2),
+                Zone.BATTLEFIELD, new DamageMultiEffect(),
                 new ManaCostsImpl<>("{3}{R}"), new SourceHasCounterCondition(CounterType.P1P1),
                 "{3}{R}: {this} deals 2 damage divided as you choose among one or two targets. " +
                         "Activate only if {this} has a +1/+1 counter on it."

--- a/Mage.Sets/src/mage/cards/s/SkirkVolcanist.java
+++ b/Mage.Sets/src/mage/cards/s/SkirkVolcanist.java
@@ -37,7 +37,7 @@ public final class SkirkVolcanist extends CardImpl {
         
         // When Skirk Volcanist is turned face up, it deals 3 damage divided as you choose among one, two, or three target creatures.
         Ability ability = new TurnedFaceUpSourceTriggeredAbility(new DamageMultiEffect("it"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
+        ability.addTarget(new TargetCreaturePermanentAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkirkVolcanist.java
+++ b/Mage.Sets/src/mage/cards/s/SkirkVolcanist.java
@@ -12,9 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledLandPermanent;
-import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreaturePermanentAmount;
-import mage.target.common.TargetSacrifice;
 
 /**
  *
@@ -39,7 +37,7 @@ public final class SkirkVolcanist extends CardImpl {
         
         // When Skirk Volcanist is turned face up, it deals 3 damage divided as you choose among one, two, or three target creatures.
         Ability ability = new TurnedFaceUpSourceTriggeredAbility(new DamageMultiEffect(3, "it"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkirkVolcanist.java
+++ b/Mage.Sets/src/mage/cards/s/SkirkVolcanist.java
@@ -36,7 +36,7 @@ public final class SkirkVolcanist extends CardImpl {
         this.addAbility(new MorphAbility(this, new SacrificeTargetCost(2, filter)));
         
         // When Skirk Volcanist is turned face up, it deals 3 damage divided as you choose among one, two, or three target creatures.
-        Ability ability = new TurnedFaceUpSourceTriggeredAbility(new DamageMultiEffect(3, "it"));
+        Ability ability = new TurnedFaceUpSourceTriggeredAbility(new DamageMultiEffect("it"));
         ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/s/SplendidAgony.java
+++ b/Mage.Sets/src/mage/cards/s/SplendidAgony.java
@@ -20,7 +20,7 @@ public final class SplendidAgony extends CardImpl {
 
         // Distribute two -1/-1 counters among one or two target creatures.
         getSpellAbility().addEffect(new DistributeCountersEffect(CounterType.M1M1, 2, "one or two target creatures"));
-        getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
+        getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
 
     }
 

--- a/Mage.Sets/src/mage/cards/s/SplendidAgony.java
+++ b/Mage.Sets/src/mage/cards/s/SplendidAgony.java
@@ -19,7 +19,7 @@ public final class SplendidAgony extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{B}");
 
         // Distribute two -1/-1 counters among one or two target creatures.
-        getSpellAbility().addEffect(new DistributeCountersEffect(CounterType.M1M1, 2, "one or two target creatures"));
+        getSpellAbility().addEffect(new DistributeCountersEffect(CounterType.M1M1));
         getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
 
     }

--- a/Mage.Sets/src/mage/cards/s/SplendidAgony.java
+++ b/Mage.Sets/src/mage/cards/s/SplendidAgony.java
@@ -20,7 +20,7 @@ public final class SplendidAgony extends CardImpl {
 
         // Distribute two -1/-1 counters among one or two target creatures.
         getSpellAbility().addEffect(new DistributeCountersEffect(CounterType.M1M1));
-        getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2, 1));
+        getSpellAbility().addTarget(new TargetCreaturePermanentAmount(2));
 
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpreadingFlames.java
+++ b/Mage.Sets/src/mage/cards/s/SpreadingFlames.java
@@ -18,7 +18,7 @@ public final class SpreadingFlames extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{6}{R}");
 
         // Spreading Flames deals 6 damage divided as you choose among any number of target creatures.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(6));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(6, 0));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpreadingFlames.java
+++ b/Mage.Sets/src/mage/cards/s/SpreadingFlames.java
@@ -19,7 +19,7 @@ public final class SpreadingFlames extends CardImpl {
 
         // Spreading Flames deals 6 damage divided as you choose among any number of target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(6, 0));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(6));
     }
 
     private SpreadingFlames(final SpreadingFlames card) {

--- a/Mage.Sets/src/mage/cards/s/SpreadingFlames.java
+++ b/Mage.Sets/src/mage/cards/s/SpreadingFlames.java
@@ -19,7 +19,7 @@ public final class SpreadingFlames extends CardImpl {
 
         // Spreading Flames deals 6 damage divided as you choose among any number of target creatures.
         this.getSpellAbility().addEffect(new DamageMultiEffect(6));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(6));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(6, 0));
     }
 
     private SpreadingFlames(final SpreadingFlames card) {

--- a/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
+++ b/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
@@ -22,10 +22,7 @@ public final class StormTheSeedcore extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}{G}");
 
         // Distribute four +1/+1 counter among up to four target creatures you control. Creatures you control gain vigilance and trample until end of turn.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(
-                4,
-                "up to four target creatures you control"
-        ));
+        this.getSpellAbility().addEffect(new DistributeCountersEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.getSpellAbility().addEffect(new GainAbilityControlledEffect(
                 VigilanceAbility.getInstance(), Duration.EndOfTurn,

--- a/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
+++ b/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
@@ -8,10 +8,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
-import mage.target.common.TargetPermanentAmount;
 
 import java.util.UUID;
 
@@ -28,10 +26,7 @@ public final class StormTheSeedcore extends CardImpl {
                 4,
                 "up to four target creatures you control"
         ));
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(4, StaticFilters.FILTER_CONTROLLED_CREATURES);
-        target.setMinNumberOfTargets(0);
-        target.setMaxNumberOfTargets(4);
-        this.getSpellAbility().addTarget(target);
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.getSpellAbility().addEffect(new GainAbilityControlledEffect(
                 VigilanceAbility.getInstance(), Duration.EndOfTurn,
                 StaticFilters.FILTER_CONTROLLED_CREATURES

--- a/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
+++ b/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
@@ -24,7 +24,7 @@ public final class StormTheSeedcore extends CardImpl {
         // Distribute four +1/+1 counters among up to four target creatures you control. Creatures you control gain vigilance and trample until end of turn.
         this.getSpellAbility().addEffect(new DistributeCountersEffect()
                 .setText("distribute four +1/+1 counters among up to four target creatures you control"));
-        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.getSpellAbility().addEffect(new GainAbilityControlledEffect(
                 VigilanceAbility.getInstance(), Duration.EndOfTurn,
                 StaticFilters.FILTER_CONTROLLED_CREATURES

--- a/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
+++ b/Mage.Sets/src/mage/cards/s/StormTheSeedcore.java
@@ -21,8 +21,9 @@ public final class StormTheSeedcore extends CardImpl {
     public StormTheSeedcore(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}{G}");
 
-        // Distribute four +1/+1 counter among up to four target creatures you control. Creatures you control gain vigilance and trample until end of turn.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect());
+        // Distribute four +1/+1 counters among up to four target creatures you control. Creatures you control gain vigilance and trample until end of turn.
+        this.getSpellAbility().addEffect(new DistributeCountersEffect()
+                .setText("distribute four +1/+1 counters among up to four target creatures you control"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.getSpellAbility().addEffect(new GainAbilityControlledEffect(
                 VigilanceAbility.getInstance(), Duration.EndOfTurn,

--- a/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
+++ b/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
@@ -20,7 +20,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetAmount;
-import mage.target.common.TargetCreatureOrPlaneswalkerAmount;
+import mage.target.common.TargetPermanentAmount;
 
 import java.util.UUID;
 
@@ -96,7 +96,7 @@ class StumpsquallHydraEffect extends OneShotEffect {
             return false;
         }
 
-        TargetAmount targetAmount = new TargetCreatureOrPlaneswalkerAmount(xValue, 1, xValue, filter);
+        TargetAmount targetAmount = new TargetPermanentAmount(xValue, 1, filter);
         targetAmount.withNotTarget(true);
         targetAmount.chooseTarget(outcome, player.getId(), source, game);
         for (UUID targetId : targetAmount.getTargets()) {

--- a/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
+++ b/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
@@ -96,8 +96,7 @@ class StumpsquallHydraEffect extends OneShotEffect {
             return false;
         }
 
-        TargetAmount targetAmount = new TargetCreatureOrPlaneswalkerAmount(xValue, filter);
-        targetAmount.setMinNumberOfTargets(1);
+        TargetAmount targetAmount = new TargetCreatureOrPlaneswalkerAmount(xValue, 1, filter);
         targetAmount.withNotTarget(true);
         targetAmount.chooseTarget(outcome, player.getId(), source, game);
         for (UUID targetId : targetAmount.getTargets()) {

--- a/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
+++ b/Mage.Sets/src/mage/cards/s/StumpsquallHydra.java
@@ -96,7 +96,7 @@ class StumpsquallHydraEffect extends OneShotEffect {
             return false;
         }
 
-        TargetAmount targetAmount = new TargetCreatureOrPlaneswalkerAmount(xValue, 1, filter);
+        TargetAmount targetAmount = new TargetCreatureOrPlaneswalkerAmount(xValue, 1, xValue, filter);
         targetAmount.withNotTarget(true);
         targetAmount.chooseTarget(outcome, player.getId(), source, game);
         for (UUID targetId : targetAmount.getTargets()) {

--- a/Mage.Sets/src/mage/cards/s/SunderingStroke.java
+++ b/Mage.Sets/src/mage/cards/s/SunderingStroke.java
@@ -30,7 +30,7 @@ public final class SunderingStroke extends CardImpl {
                         "If at least seven red mana was spent to cast this spell, " +
                         "instead {this} deals 7 damage to each of those permanents and/or players"
         ));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(7, 3));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(7, 1, 3));
         this.getSpellAbility().addHint(new StaticHint(
                 "(You have to choose how 7 damage is divided even if you spend seven red mana.)"
         ));

--- a/Mage.Sets/src/mage/cards/s/SunderingStroke.java
+++ b/Mage.Sets/src/mage/cards/s/SunderingStroke.java
@@ -25,7 +25,7 @@ public final class SunderingStroke extends CardImpl {
 
         // Sundering Stroke deals 7 damage divided as you choose among one, two, or three targets. If at least seven red mana was spent to cast this spell, instead Sundering Stroke deals 7 damage to each of those permanents and/or players.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new DamageTargetEffect(7), new DamageMultiEffect(7), SunderingStrokeCondtition.instance,
+                new DamageTargetEffect(7), new DamageMultiEffect(), SunderingStrokeCondtition.instance,
                 "{this} deals 7 damage divided as you choose among one, two, or three targets. " +
                         "If at least seven red mana was spent to cast this spell, " +
                         "instead {this} deals 7 damage to each of those permanents and/or players"

--- a/Mage.Sets/src/mage/cards/t/TheGrandEvolution.java
+++ b/Mage.Sets/src/mage/cards/t/TheGrandEvolution.java
@@ -44,10 +44,8 @@ public final class TheGrandEvolution extends CardImpl {
         // II -- Distribute seven +1/+1 counters among any number of target creatures you control.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_II, SagaChapter.CHAPTER_II,
-                new DistributeCountersEffect(
-                       7,
-                        "any number of target creatures you control"
-                ), new TargetCreaturePermanentAmount(7, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
+                new DistributeCountersEffect(),
+                new TargetCreaturePermanentAmount(7, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
         );
 
         // III -- Until end of turn, creatures you control gain "{1}: This creature fights target creature you don't control." Exile The Grand Evolution, then return it to the battlefield.

--- a/Mage.Sets/src/mage/cards/t/TheGrandEvolution.java
+++ b/Mage.Sets/src/mage/cards/t/TheGrandEvolution.java
@@ -45,7 +45,7 @@ public final class TheGrandEvolution extends CardImpl {
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_II, SagaChapter.CHAPTER_II,
                 new DistributeCountersEffect(),
-                new TargetCreaturePermanentAmount(7, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
+                new TargetCreaturePermanentAmount(7, StaticFilters.FILTER_CONTROLLED_CREATURES)
         );
 
         // III -- Until end of turn, creatures you control gain "{1}: This creature fights target creature you don't control." Exile The Grand Evolution, then return it to the battlefield.

--- a/Mage.Sets/src/mage/cards/t/TheGrandEvolution.java
+++ b/Mage.Sets/src/mage/cards/t/TheGrandEvolution.java
@@ -14,13 +14,12 @@ import mage.cards.CardSetInfo;
 import mage.cards.Cards;
 import mage.cards.CardsImpl;
 import mage.constants.*;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.TargetPermanent;
-import mage.target.common.TargetPermanentAmount;
+import mage.target.common.TargetCreaturePermanentAmount;
 
 import java.util.UUID;
 
@@ -48,7 +47,7 @@ public final class TheGrandEvolution extends CardImpl {
                 new DistributeCountersEffect(
                        7,
                         "any number of target creatures you control"
-                ), new TargetPermanentAmount(7, StaticFilters.FILTER_CONTROLLED_CREATURES)
+                ), new TargetCreaturePermanentAmount(7, 0, StaticFilters.FILTER_CONTROLLED_CREATURES)
         );
 
         // III -- Until end of turn, creatures you control gain "{1}: This creature fights target creature you don't control." Exile The Grand Evolution, then return it to the battlefield.

--- a/Mage.Sets/src/mage/cards/t/TwinBolt.java
+++ b/Mage.Sets/src/mage/cards/t/TwinBolt.java
@@ -18,7 +18,7 @@ public final class TwinBolt extends CardImpl {
 
         // Twin Bolt deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(2));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
     }
 
     private TwinBolt(final TwinBolt card) {

--- a/Mage.Sets/src/mage/cards/t/TwinBolt.java
+++ b/Mage.Sets/src/mage/cards/t/TwinBolt.java
@@ -17,7 +17,7 @@ public final class TwinBolt extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{R}");
 
         // Twin Bolt deals 2 damage divided as you choose among one or two targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(2));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
     }
 

--- a/Mage.Sets/src/mage/cards/t/TwinBolt.java
+++ b/Mage.Sets/src/mage/cards/t/TwinBolt.java
@@ -18,7 +18,7 @@ public final class TwinBolt extends CardImpl {
 
         // Twin Bolt deals 2 damage divided as you choose among one or two targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2, 1));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(2));
     }
 
     private TwinBolt(final TwinBolt card) {

--- a/Mage.Sets/src/mage/cards/u/UndercityUpheaval.java
+++ b/Mage.Sets/src/mage/cards/u/UndercityUpheaval.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.AbilityWord;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
 
@@ -30,7 +29,7 @@ public final class UndercityUpheaval extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{G}{G}");
 
         // Undergrowth -- Distribute X +1/+1 counters among any number of target creatures you control, where X is the number of creature cards in your graveyard as you cast this spell. Creatures you control gain vigilance until end of turn.
-        this.getSpellAbility().addEffect(new DistributeCountersEffect(1, "")
+        this.getSpellAbility().addEffect(new DistributeCountersEffect()
                 .setText("distribute X +1/+1 counters among any number of target creatures you control, " +
                         "where X is the number of creature cards in your graveyard as you cast this spell"));
         this.getSpellAbility().addEffect(new GainAbilityControlledEffect(

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -145,7 +145,7 @@ class UrzaAcademyHeadmasterRandomEffect extends OneShotEffect {
                             case 2: // AJANI MENTOR OF HEROES 1
                                 sb.append("Distribute three +1/+1 counters among one, two, or three target creatures you control.");
                                 effects.add(new DistributeCountersEffect());
-                                target = new TargetCreaturePermanentAmount(3, 1, filter1);
+                                target = new TargetCreaturePermanentAmount(3, filter1);
                                 break;
                             case 3: // NICOL BOLAS PLANESWALKER 1
                                 sb.append("Destroy target noncreature permanent.");

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -145,7 +145,7 @@ class UrzaAcademyHeadmasterRandomEffect extends OneShotEffect {
                             case 2: // AJANI MENTOR OF HEROES 1
                                 sb.append("Distribute three +1/+1 counters among one, two, or three target creatures you control.");
                                 effects.add(new DistributeCountersEffect(3, "one, two, or three target creatures you control"));
-                                target = new TargetCreaturePermanentAmount(3, filter1);
+                                target = new TargetCreaturePermanentAmount(3, 1, filter1);
                                 break;
                             case 3: // NICOL BOLAS PLANESWALKER 1
                                 sb.append("Destroy target noncreature permanent.");

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -144,7 +144,7 @@ class UrzaAcademyHeadmasterRandomEffect extends OneShotEffect {
                                 break;
                             case 2: // AJANI MENTOR OF HEROES 1
                                 sb.append("Distribute three +1/+1 counters among one, two, or three target creatures you control.");
-                                effects.add(new DistributeCountersEffect(3, "one, two, or three target creatures you control"));
+                                effects.add(new DistributeCountersEffect());
                                 target = new TargetCreaturePermanentAmount(3, 1, filter1);
                                 break;
                             case 3: // NICOL BOLAS PLANESWALKER 1

--- a/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
@@ -88,7 +88,7 @@ class VastwoodHydraDistributeEffect extends OneShotEffect {
             return false;
         }
 
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, 0, StaticFilters.FILTER_CONTROLLED_CREATURE);
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, 0, amount, StaticFilters.FILTER_CONTROLLED_CREATURE);
         target.withNotTarget(true);
         target.withChooseHint("to distribute " + amount + " counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodHydra.java
@@ -88,8 +88,7 @@ class VastwoodHydraDistributeEffect extends OneShotEffect {
             return false;
         }
 
-        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, StaticFilters.FILTER_CONTROLLED_CREATURE);
-        target.setMinNumberOfTargets(1);
+        TargetPermanentAmount target = new TargetCreaturePermanentAmount(amount, 0, StaticFilters.FILTER_CONTROLLED_CREATURE);
         target.withNotTarget(true);
         target.withChooseHint("to distribute " + amount + " counters");
         target.chooseTarget(outcome, player.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/v/VerdurousGearhulk.java
+++ b/Mage.Sets/src/mage/cards/v/VerdurousGearhulk.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCreaturePermanentAmount;
 
@@ -32,7 +31,7 @@ public final class VerdurousGearhulk extends CardImpl {
 
         // When Verdurous Gearhulk enters the battlefield, distribute four +1/+1 counters among any number of target creatures you control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(4, "any number of target creatures you control"), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(4, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VerdurousGearhulk.java
+++ b/Mage.Sets/src/mage/cards/v/VerdurousGearhulk.java
@@ -31,7 +31,7 @@ public final class VerdurousGearhulk extends CardImpl {
 
         // When Verdurous Gearhulk enters the battlefield, distribute four +1/+1 counters among any number of target creatures you control.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
+        ability.addTarget(new TargetCreaturePermanentAmount(4, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/v/VerdurousGearhulk.java
+++ b/Mage.Sets/src/mage/cards/v/VerdurousGearhulk.java
@@ -30,7 +30,7 @@ public final class VerdurousGearhulk extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // When Verdurous Gearhulk enters the battlefield, distribute four +1/+1 counters among any number of target creatures you control.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(4, "any number of target creatures you control"), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(), false);
         ability.addTarget(new TargetCreaturePermanentAmount(4, 0, StaticFilters.FILTER_CONTROLLED_CREATURES));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/v/ViolentEruption.java
+++ b/Mage.Sets/src/mage/cards/v/ViolentEruption.java
@@ -20,7 +20,7 @@ public final class ViolentEruption extends CardImpl {
 
         // Violent Eruption deals 4 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(4));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
 
         // Madness {1}{R}{R}
         this.addAbility(new MadnessAbility(new ManaCostsImpl<>("{1}{R}{R}")));

--- a/Mage.Sets/src/mage/cards/v/ViolentEruption.java
+++ b/Mage.Sets/src/mage/cards/v/ViolentEruption.java
@@ -19,7 +19,7 @@ public final class ViolentEruption extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{R}{R}{R}");
 
         // Violent Eruption deals 4 damage divided as you choose among any number of targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(4));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
 
         // Madness {1}{R}{R}

--- a/Mage.Sets/src/mage/cards/v/ViolentEruption.java
+++ b/Mage.Sets/src/mage/cards/v/ViolentEruption.java
@@ -20,7 +20,7 @@ public final class ViolentEruption extends CardImpl {
 
         // Violent Eruption deals 4 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(4));
 
         // Madness {1}{R}{R}
         this.addAbility(new MadnessAbility(new ManaCostsImpl<>("{1}{R}{R}")));

--- a/Mage.Sets/src/mage/cards/v/VivienArkbowRanger.java
+++ b/Mage.Sets/src/mage/cards/v/VivienArkbowRanger.java
@@ -14,7 +14,6 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetCreatureOrPlaneswalker;
@@ -41,10 +40,7 @@ public final class VivienArkbowRanger extends CardImpl {
                 TrampleAbility.getInstance(), Duration.EndOfTurn,
                 "They gain trample until end of turn"
         ));
-        TargetCreaturePermanentAmount target = new TargetCreaturePermanentAmount(2);
-        target.setMinNumberOfTargets(0);
-        target.setMaxNumberOfTargets(2);
-        ability.addTarget(target);
+        ability.addTarget(new TargetCreaturePermanentAmount(2, 0));
         this.addAbility(ability);
 
         // −3: Target creature you control deals damage equal to its power to target creature or planeswalker.

--- a/Mage.Sets/src/mage/cards/v/VivienArkbowRanger.java
+++ b/Mage.Sets/src/mage/cards/v/VivienArkbowRanger.java
@@ -34,8 +34,8 @@ public final class VivienArkbowRanger extends CardImpl {
         this.setStartingLoyalty(4);
 
         // +1: Distribute two +1/+1 counters among up to two target creatures. They gain trample until end of turn.
-        Ability ability = new LoyaltyAbility(new DistributeCountersEffect(
-                2, "up to two target creatures"), 1);
+        Ability ability = new LoyaltyAbility(new DistributeCountersEffect()
+                .setText("distribute two +1/+1 counters among up to two target creatures"), 1);
         ability.addEffect(new GainAbilityTargetEffect(
                 TrampleAbility.getInstance(), Duration.EndOfTurn,
                 "They gain trample until end of turn"

--- a/Mage.Sets/src/mage/cards/v/VivienArkbowRanger.java
+++ b/Mage.Sets/src/mage/cards/v/VivienArkbowRanger.java
@@ -40,7 +40,7 @@ public final class VivienArkbowRanger extends CardImpl {
                 TrampleAbility.getInstance(), Duration.EndOfTurn,
                 "They gain trample until end of turn"
         ));
-        ability.addTarget(new TargetCreaturePermanentAmount(2, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(2, 0, 2));
         this.addAbility(ability);
 
         // −3: Target creature you control deals damage equal to its power to target creature or planeswalker.

--- a/Mage.Sets/src/mage/cards/v/VolcanicWind.java
+++ b/Mage.Sets/src/mage/cards/v/VolcanicWind.java
@@ -25,7 +25,7 @@ public final class VolcanicWind extends CardImpl {
 
         // Volcanic Wind deals X damage divided as you choose among any number of target creatures, where X is the number of creatures as you cast Volcanic Wind.
         PermanentsOnBattlefieldCount creatures = new PermanentsOnBattlefieldCount(filter, null);
-        Effect effect = new DamageMultiEffect(creatures);
+        Effect effect = new DamageMultiEffect();
         effect.setText(rule);
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanentAmount(creatures));

--- a/Mage.Sets/src/mage/cards/v/VolleyOfBoulders.java
+++ b/Mage.Sets/src/mage/cards/v/VolleyOfBoulders.java
@@ -20,7 +20,7 @@ public final class VolleyOfBoulders extends CardImpl {
 
         // Volley of Boulders deals 6 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect());
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(6, 0));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(6));
         // Flashback {R}{R}{R}{R}{R}{R}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{R}{R}{R}{R}{R}{R}")));
     }

--- a/Mage.Sets/src/mage/cards/v/VolleyOfBoulders.java
+++ b/Mage.Sets/src/mage/cards/v/VolleyOfBoulders.java
@@ -19,7 +19,7 @@ public final class VolleyOfBoulders extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{8}{R}");
 
         // Volley of Boulders deals 6 damage divided as you choose among any number of targets.
-        this.getSpellAbility().addEffect(new DamageMultiEffect(6));
+        this.getSpellAbility().addEffect(new DamageMultiEffect());
         this.getSpellAbility().addTarget(new TargetAnyTargetAmount(6, 0));
         // Flashback {R}{R}{R}{R}{R}{R}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{R}{R}{R}{R}{R}{R}")));

--- a/Mage.Sets/src/mage/cards/v/VolleyOfBoulders.java
+++ b/Mage.Sets/src/mage/cards/v/VolleyOfBoulders.java
@@ -7,7 +7,6 @@ import mage.abilities.keyword.FlashbackAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.TimingRule;
 import mage.target.common.TargetAnyTargetAmount;
 
 /**
@@ -21,7 +20,7 @@ public final class VolleyOfBoulders extends CardImpl {
 
         // Volley of Boulders deals 6 damage divided as you choose among any number of targets.
         this.getSpellAbility().addEffect(new DamageMultiEffect(6));
-        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(6));
+        this.getSpellAbility().addTarget(new TargetAnyTargetAmount(6, 0));
         // Flashback {R}{R}{R}{R}{R}{R}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{R}{R}{R}{R}{R}{R}")));
     }

--- a/Mage.Sets/src/mage/cards/w/WurmskinForger.java
+++ b/Mage.Sets/src/mage/cards/w/WurmskinForger.java
@@ -26,7 +26,7 @@ public final class WurmskinForger extends CardImpl {
         this.toughness = new MageInt(2);
 
         // When Wurmskin Forger enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(3, "one, two, or three target creatures"), false);
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(), false);
         ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/w/WurmskinForger.java
+++ b/Mage.Sets/src/mage/cards/w/WurmskinForger.java
@@ -10,7 +10,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.counters.CounterType;
 import mage.target.common.TargetCreaturePermanentAmount;
 
 /**
@@ -28,7 +27,7 @@ public final class WurmskinForger extends CardImpl {
 
         // When Wurmskin Forger enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(3, "one, two, or three target creatures"), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/w/WurmskinForger.java
+++ b/Mage.Sets/src/mage/cards/w/WurmskinForger.java
@@ -27,7 +27,7 @@ public final class WurmskinForger extends CardImpl {
 
         // When Wurmskin Forger enters the battlefield, distribute three +1/+1 counters among one, two, or three target creatures.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DistributeCountersEffect(), false);
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 1));
+        ability.addTarget(new TargetCreaturePermanentAmount(3));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/y/YannikScavengingSentinel.java
+++ b/Mage.Sets/src/mage/cards/y/YannikScavengingSentinel.java
@@ -98,7 +98,7 @@ class YannikScavengingSentinelEffect extends OneShotEffect {
         game.addDelayedTriggeredAbility(new OnLeaveReturnExiledAbility(), source);
         if (game.getState().getZone(permanent.getId()) != Zone.BATTLEFIELD) {
             ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(
-                    new DistributeCountersEffect(power, ""), false,
+                    new DistributeCountersEffect(), false,
                     "distribute X +1/+1 counters among any number of target creatures, " +
                     "where X is the exiled creature's power"
             );

--- a/Mage.Sets/src/mage/cards/y/YannikScavengingSentinel.java
+++ b/Mage.Sets/src/mage/cards/y/YannikScavengingSentinel.java
@@ -13,7 +13,6 @@ import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -103,7 +102,7 @@ class YannikScavengingSentinelEffect extends OneShotEffect {
                     "distribute X +1/+1 counters among any number of target creatures, " +
                     "where X is the exiled creature's power"
             );
-            ability.addTarget(new TargetCreaturePermanentAmount(power));
+            ability.addTarget(new TargetCreaturePermanentAmount(power, 0));
             game.fireReflexiveTriggeredAbility(ability, source);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/y/YannikScavengingSentinel.java
+++ b/Mage.Sets/src/mage/cards/y/YannikScavengingSentinel.java
@@ -102,7 +102,7 @@ class YannikScavengingSentinelEffect extends OneShotEffect {
                     "distribute X +1/+1 counters among any number of target creatures, " +
                     "where X is the exiled creature's power"
             );
-            ability.addTarget(new TargetCreaturePermanentAmount(power, 0));
+            ability.addTarget(new TargetCreaturePermanentAmount(power, 0, power));
             game.fireReflexiveTriggeredAbility(ability, source);
         }
         return true;

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
@@ -224,7 +224,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
     @Test
     public void test_targetAmount_NormalCase() {
         Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(3), new ManaCostsImpl<>("{R}"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         addCustomCardWithAbility("damage 3", playerA, ability);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
         //
@@ -251,7 +251,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
         // choose targets as enters battlefield (e.g. can't be canceled)
         SpellAbility spell = new SpellAbility(new ManaCostsImpl<>("{R}"), "damage 3", Zone.HAND);
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect(3));
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         addCustomCardWithSpell(playerA, spell, ability, CardType.ENCHANTMENT);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
         //
@@ -284,7 +284,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
         int cardsMultiplier = 3;
 
         Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(3), new ManaCostsImpl<>("{R}"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         addCustomCardWithAbility("damage 3", playerA, ability);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
         //

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
@@ -223,7 +223,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
 
     @Test
     public void test_targetAmount_NormalCase() {
-        Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(3), new ManaCostsImpl<>("{R}"));
+        Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(), new ManaCostsImpl<>("{R}"));
         ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         addCustomCardWithAbility("damage 3", playerA, ability);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
@@ -250,7 +250,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
     public void test_targetAmount_BadCase() {
         // choose targets as enters battlefield (e.g. can't be canceled)
         SpellAbility spell = new SpellAbility(new ManaCostsImpl<>("{R}"), "damage 3", Zone.HAND);
-        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect(3));
+        Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect());
         ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         addCustomCardWithSpell(playerA, spell, ability, CardType.ENCHANTMENT);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
@@ -283,7 +283,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
     public void test_targetAmount_Performance() {
         int cardsMultiplier = 3;
 
-        Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(3), new ManaCostsImpl<>("{R}"));
+        Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(), new ManaCostsImpl<>("{R}"));
         ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
         addCustomCardWithAbility("damage 3", playerA, ability);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetPriorityTest.java
@@ -224,7 +224,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
     @Test
     public void test_targetAmount_NormalCase() {
         Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(), new ManaCostsImpl<>("{R}"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0, 3));
         addCustomCardWithAbility("damage 3", playerA, ability);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
         //
@@ -251,7 +251,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
         // choose targets as enters battlefield (e.g. can't be canceled)
         SpellAbility spell = new SpellAbility(new ManaCostsImpl<>("{R}"), "damage 3", Zone.HAND);
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageMultiEffect());
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0, 3));
         addCustomCardWithSpell(playerA, spell, ability, CardType.ENCHANTMENT);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
         //
@@ -284,7 +284,7 @@ public class TargetPriorityTest extends CardTestPlayerBaseAI {
         int cardsMultiplier = 3;
 
         Ability ability = new SimpleActivatedAbility(Zone.ALL, new DamageMultiEffect(), new ManaCostsImpl<>("{R}"));
-        ability.addTarget(new TargetCreaturePermanentAmount(3, 0));
+        ability.addTarget(new TargetCreaturePermanentAmount(3, 0, 3));
         addCustomCardWithAbility("damage 3", playerA, ability);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
         //

--- a/Mage.Tests/src/test/java/org/mage/test/cards/enchantments/AnimateDeadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/enchantments/AnimateDeadTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.enchantments;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -192,6 +193,7 @@ public class AnimateDeadTest extends CardTestPlayerBase {
         addCard(Zone.GRAVEYARD, playerB, "Dragonlord Atarka", 1);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Animate Dead", "Dragonlord Atarka");
+        addTarget(playerA, TestPlayer.TARGET_SKIP);
 
         setStopAt(2, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage/src/main/java/mage/abilities/effects/common/DamageMultiEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DamageMultiEffect.java
@@ -4,13 +4,13 @@ import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.Mode;
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
+import mage.target.TargetAmount;
 
 import java.util.*;
 
@@ -19,32 +19,21 @@ import java.util.*;
  */
 public class DamageMultiEffect extends OneShotEffect {
 
-    protected DynamicValue amount;
     private String sourceName = "{this}";
     private final Set<MageObjectReference> damagedSet = new HashSet<>();
 
-    public DamageMultiEffect(int amount) {
-        this(StaticValue.get(amount));
-    }
-
-    public DamageMultiEffect(int amount, String whoDealDamageName) {
-        this(StaticValue.get(amount), whoDealDamageName);
-    }
-
-    public DamageMultiEffect(DynamicValue amount, String whoDealDamageName) {
-        this(amount);
-        this.sourceName = whoDealDamageName;
-    }
-
-    public DamageMultiEffect(DynamicValue amount) {
+    public DamageMultiEffect() {
         super(Outcome.Damage);
-        this.amount = amount;
+    }
+
+    public DamageMultiEffect(String whoDealDamageName) {
+        super(Outcome.Damage);
+        this.sourceName = whoDealDamageName;
     }
 
     protected DamageMultiEffect(final DamageMultiEffect effect) {
         super(effect);
         this.damagedSet.addAll(effect.damagedSet);
-        this.amount = effect.amount;
         this.sourceName = effect.sourceName;
     }
 
@@ -84,16 +73,15 @@ public class DamageMultiEffect extends OneShotEffect {
         StringBuilder sb = new StringBuilder(sourceName);
         sb.append(" deals ");
 
-        String amountString = amount.toString();
-        sb.append(amountString);
-        sb.append(" damage divided as you choose among ");
-        sb.append(amountString.equals("2") ? "one or two " : amountString.equals("3") ? "one, two, or three " : "any number of ");
-
-        String targetName = mode.getTargets().get(0).getTargetName();
-        if (!targetName.contains("target")) {
-            sb.append("target ");
+        TargetAmount target = (TargetAmount) mode.getTargets().get(0);
+        if (target == null) {
+            throw new IllegalStateException("Must use TargetAmount");
         }
-        sb.append(targetName);
+
+        DynamicValue amount = target.getAmount();
+        sb.append(amount.toString());
+        sb.append(" damage divided as you choose among ");
+        sb.append(target.getDescription());
 
         return sb.toString();
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/DamageMultiEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/DamageMultiEffect.java
@@ -73,15 +73,16 @@ public class DamageMultiEffect extends OneShotEffect {
         StringBuilder sb = new StringBuilder(sourceName);
         sb.append(" deals ");
 
-        TargetAmount target = (TargetAmount) mode.getTargets().get(0);
-        if (target == null) {
+        Target target = mode.getTargets().get(0);
+        if (!(target instanceof TargetAmount)) {
             throw new IllegalStateException("Must use TargetAmount");
         }
+        TargetAmount targetAmount = (TargetAmount) target;
 
-        DynamicValue amount = target.getAmount();
+        DynamicValue amount = targetAmount.getAmount();
         sb.append(amount.toString());
         sb.append(" damage divided as you choose among ");
-        sb.append(target.getDescription());
+        sb.append(targetAmount.getDescription());
 
         return sb.toString();
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/DistributeCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/DistributeCountersEffect.java
@@ -81,15 +81,16 @@ public class DistributeCountersEffect extends OneShotEffect {
         if (staticText != null && !staticText.isEmpty()) {
             return staticText;
         }
-        TargetAmount target = (TargetAmount) mode.getTargets().get(0);
-        if (target == null) {
+        Target target = mode.getTargets().get(0);
+        if (!(target instanceof TargetAmount)) {
             throw new IllegalStateException("Must use TargetAmount");
         }
-        DynamicValue amount = target.getAmount();
+        TargetAmount targetAmount = (TargetAmount) target;
+        DynamicValue amount = targetAmount.getAmount();
 
         String name = counterType.getName();
         String number = (amount instanceof StaticValue) ? CardUtil.numberToText(((StaticValue) amount).getValue()) : amount.toString();
-        String text = "distribute " + number + ' ' + name + " counters among " + target.getDescription();
+        String text = "distribute " + number + ' ' + name + " counters among " + targetAmount.getDescription();
         if (removeAtEndOfTurn) {
             text += ". For each " + name + " counter you put on a creature this way, remove a "
                     + name + " counter from that creature at the beginning of the next cleanup step.";

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/DistributeCountersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/DistributeCountersEffect.java
@@ -12,6 +12,7 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.Target;
+import mage.target.TargetAmount;
 import mage.util.CardUtil;
 
 import java.util.UUID;
@@ -22,34 +23,24 @@ import java.util.UUID;
 public class DistributeCountersEffect extends OneShotEffect {
 
     private final CounterType counterType;
-    private final DynamicValue amount;
     private boolean removeAtEndOfTurn = false;
-    private final String targetDescription;
 
     /**
      * Distribute +1/+1 counters among targets
      */
-    public DistributeCountersEffect(int amount, String targetDescription) {
-        this(CounterType.P1P1, StaticValue.get(amount), targetDescription);
+    public DistributeCountersEffect() {
+        this(CounterType.P1P1);
     }
 
-    public DistributeCountersEffect(CounterType counterType, int amount, String targetDescription) {
-        this(counterType, StaticValue.get(amount), targetDescription);
-    }
-
-    public DistributeCountersEffect(CounterType counterType, DynamicValue amount, String targetDescription) {
+    public DistributeCountersEffect(CounterType counterType) {
         super(Outcome.BoostCreature);
         this.counterType = counterType;
-        this.amount = amount;
-        this.targetDescription = targetDescription;
     }
 
     protected DistributeCountersEffect(final DistributeCountersEffect effect) {
         super(effect);
         this.counterType = effect.counterType;
-        this.amount = effect.amount;
         this.removeAtEndOfTurn = effect.removeAtEndOfTurn;
-        this.targetDescription = effect.targetDescription;
     }
 
     @Override
@@ -90,9 +81,15 @@ public class DistributeCountersEffect extends OneShotEffect {
         if (staticText != null && !staticText.isEmpty()) {
             return staticText;
         }
+        TargetAmount target = (TargetAmount) mode.getTargets().get(0);
+        if (target == null) {
+            throw new IllegalStateException("Must use TargetAmount");
+        }
+        DynamicValue amount = target.getAmount();
+
         String name = counterType.getName();
         String number = (amount instanceof StaticValue) ? CardUtil.numberToText(((StaticValue) amount).getValue()) : amount.toString();
-        String text = "distribute " + number + ' ' + name + " counters among " + targetDescription;
+        String text = "distribute " + number + ' ' + name + " counters among " + target.getDescription();
         if (removeAtEndOfTurn) {
             text += ". For each " + name + " counter you put on a creature this way, remove a "
                     + name + " counter from that creature at the beginning of the next cleanup step.";

--- a/Mage/src/main/java/mage/target/TargetAmount.java
+++ b/Mage/src/main/java/mage/target/TargetAmount.java
@@ -67,6 +67,10 @@ public abstract class TargetAmount extends TargetImpl {
         amountWasSet = true;
     }
 
+    public DynamicValue getAmount() {
+        return amount;
+    }
+
     public int getAmountTotal(Game game, Ability source) {
         return amount.calculate(game, source, null);
     }

--- a/Mage/src/main/java/mage/target/TargetAmount.java
+++ b/Mage/src/main/java/mage/target/TargetAmount.java
@@ -195,12 +195,12 @@ public abstract class TargetAmount extends TargetImpl {
             return true;
         }
         // For a TargetAmount with a min of 0:
-        // A max of 0, or a max that equals the amount when the amount is a StaticValue,
+        // A max that equals the amount, when the amount is a StaticValue,
         // usually represents "any number of target __s", since you can't target more than the amount.
         //
         // 601.2d. If the spell requires the player to divide or distribute an effect
         // (such as damage or counters) among one or more targets, the player announces the division.
         // Each of these targets must receive at least one of whatever is being divided.
-        return max == 0 || (amount instanceof StaticValue && max == ((StaticValue) amount).getValue());
+        return amount instanceof StaticValue && max == ((StaticValue) amount).getValue();
     }
 }

--- a/Mage/src/main/java/mage/target/TargetAmount.java
+++ b/Mage/src/main/java/mage/target/TargetAmount.java
@@ -2,6 +2,7 @@ package mage.target;
 
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.constants.Outcome;
 import mage.game.Game;
 import mage.players.Player;
@@ -181,5 +182,25 @@ public abstract class TargetAmount extends TargetImpl {
         }
         remainingAmount -= (amount - this.getTargetAmount(targetId));
         this.setTargetAmount(targetId, amount, game);
+    }
+
+    @Override
+    protected boolean getUseAnyNumber() {
+        int min = getMinNumberOfTargets();
+        int max = getMaxNumberOfTargets();
+        if (min != 0) {
+            return false;
+        }
+        if (max == Integer.MAX_VALUE) {
+            return true;
+        }
+        // For a TargetAmount with a min of 0:
+        // A max of 0, or a max that equals the amount when the amount is a StaticValue,
+        // usually represents "any number of target __s", since you can't target more than the amount.
+        //
+        // 601.2d. If the spell requires the player to divide or distribute an effect
+        // (such as damage or counters) among one or more targets, the player announces the division.
+        // Each of these targets must receive at least one of whatever is being divided.
+        return max == 0 || (amount instanceof StaticValue && max == ((StaticValue) amount).getValue());
     }
 }

--- a/Mage/src/main/java/mage/target/TargetAmount.java
+++ b/Mage/src/main/java/mage/target/TargetAmount.java
@@ -18,8 +18,10 @@ public abstract class TargetAmount extends TargetImpl {
     DynamicValue amount;
     int remainingAmount;
 
-    protected TargetAmount(DynamicValue amount) {
+    protected TargetAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets) {
         this.amount = amount;
+        setMinNumberOfTargets(minNumberOfTargets);
+        setMaxNumberOfTargets(maxNumberOfTargets);
     }
 
     protected TargetAmount(final TargetAmount target) {

--- a/Mage/src/main/java/mage/target/TargetImpl.java
+++ b/Mage/src/main/java/mage/target/TargetImpl.java
@@ -150,6 +150,9 @@ public abstract class TargetImpl implements Target {
         return sb.toString();
     }
 
+    /**
+     * Used for generating text description. Needed so that subclasses may override.
+     */
     protected boolean getUseAnyNumber() {
         int min = getMinNumberOfTargets();
         int max = getMaxNumberOfTargets();

--- a/Mage/src/main/java/mage/target/TargetImpl.java
+++ b/Mage/src/main/java/mage/target/TargetImpl.java
@@ -2,8 +2,6 @@ package mage.target;
 
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.cards.Card;
 import mage.constants.AbilityType;
 import mage.constants.Outcome;
@@ -112,28 +110,7 @@ public abstract class TargetImpl implements Target {
         } else if (!targetName.startsWith("X ") && (min != 1 || max != 1)) {
             targetName = targetName.replace("another", "other"); //If non-singular, use "other" instead of "another"
 
-            boolean useAnyNumber = false;
-            if (min == 0 && max == Integer.MAX_VALUE) {
-                useAnyNumber = true;
-            } else if (min == 0 && this instanceof TargetAmount) {
-                // For a TargetAmount with a min of 0:
-                // A max of 0, or a max that equals the amount when the amount is a StaticValue,
-                // usually represents "any number of target __s", since you can't target more than the amount.
-                //
-                // 601.2d. If the spell requires the player to divide or distribute an effect
-                // (such as damage or counters) among one or more targets, the player announces the division.
-                // Each of these targets must receive at least one of whatever is being divided.
-                if (max == 0) {
-                    useAnyNumber = true;
-                } else {
-                    DynamicValue amount = ((TargetAmount) this).getAmount();
-                    if ((amount instanceof StaticValue && max == ((StaticValue) amount).getValue())) {
-                        useAnyNumber = true;
-                    }
-                }
-            }
-
-            if (useAnyNumber) {
+            if (getUseAnyNumber()) {
                 sb.append(("any number of "));
             } else {
                 if (min < max && max != Integer.MAX_VALUE) {
@@ -171,6 +148,12 @@ public abstract class TargetImpl implements Target {
             sb.append(targetName);
         }
         return sb.toString();
+    }
+
+    protected boolean getUseAnyNumber() {
+        int min = getMinNumberOfTargets();
+        int max = getMaxNumberOfTargets();
+        return min == 0 && max == Integer.MAX_VALUE;
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetAnyTargetAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetAnyTargetAmount.java
@@ -23,7 +23,7 @@ public class TargetAnyTargetAmount extends TargetPermanentOrPlayerAmount {
     }
 
     public TargetAnyTargetAmount(DynamicValue amount) {
-        this(amount, 0, 0);
+        this(amount, 0, Integer.MAX_VALUE);
     }
 
     public TargetAnyTargetAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets) {

--- a/Mage/src/main/java/mage/target/common/TargetAnyTargetAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetAnyTargetAmount.java
@@ -14,25 +14,20 @@ public class TargetAnyTargetAmount extends TargetPermanentOrPlayerAmount {
     private static final FilterPermanentOrPlayer defaultFilter
             = new FilterAnyTarget("targets");
 
-    public TargetAnyTargetAmount(int amount) {
-        this(amount, 0);
+    public TargetAnyTargetAmount(int amount, int minNumberOfTargets) {
+        this(amount, minNumberOfTargets, amount);
     }
 
-    public TargetAnyTargetAmount(int amount, int maxNumberOfTargets) {
-        // 107.1c If a rule or ability instructs a player to choose “any number,” that player may choose
-        // any positive number or zero, unless something (such as damage or counters) is being divided
-        // or distributed among “any number” of players and/or objects. In that case, a nonzero number
-        // of players and/or objects must be chosen if possible.
-        this(StaticValue.get(amount), maxNumberOfTargets);
-        this.minNumberOfTargets = 1;
+    public TargetAnyTargetAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        this(StaticValue.get(amount), minNumberOfTargets, maxNumberOfTargets);
     }
 
     public TargetAnyTargetAmount(DynamicValue amount) {
-        this(amount, 0);
+        this(amount, 0, 0);
     }
 
-    public TargetAnyTargetAmount(DynamicValue amount, int maxNumberOfTargets) {
-        super(amount, maxNumberOfTargets);
+    public TargetAnyTargetAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets);
         this.zone = Zone.ALL;
         this.filter = defaultFilter;
         this.targetName = filter.getMessage();

--- a/Mage/src/main/java/mage/target/common/TargetAnyTargetAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetAnyTargetAmount.java
@@ -14,18 +14,43 @@ public class TargetAnyTargetAmount extends TargetPermanentOrPlayerAmount {
     private static final FilterPermanentOrPlayer defaultFilter
             = new FilterAnyTarget("targets");
 
-    public TargetAnyTargetAmount(int amount, int minNumberOfTargets) {
-        this(amount, minNumberOfTargets, amount);
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!<br>
+     * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
+     * {@code maxNumberOfTargets} defaults to {@code amount}.
+     *
+     * @see TargetAnyTargetAmount#TargetAnyTargetAmount(int, int, int)
+     */
+    public TargetAnyTargetAmount(int amount) {
+        this(amount, amount > 3 ? 0 : 1, amount);
     }
 
+    /**
+     * @param amount             Amount of stuff (e.g. damage) to distribute.
+     * @param minNumberOfTargets Minimum number of targets.
+     * @param maxNumberOfTargets Maximum number of targets. Should be set to {@code amount} if no lower max is needed.
+     */
     public TargetAnyTargetAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
         this(StaticValue.get(amount), minNumberOfTargets, maxNumberOfTargets);
     }
 
+    /**
+     * {@code minNumberOfTargets} defaults to zero.<br>
+     * {@code maxNumberOfTargets} defaults to Integer.MAX_VALUE.
+     *
+     * @see TargetAnyTargetAmount#TargetAnyTargetAmount(DynamicValue, int, int)
+     */
     public TargetAnyTargetAmount(DynamicValue amount) {
         this(amount, 0, Integer.MAX_VALUE);
     }
 
+    /**
+     * @param amount             Amount of stuff (e.g. damage) to distribute.
+     * @param minNumberOfTargets Minimum number of targets.
+     * @param maxNumberOfTargets Maximum number of targets. Since {@code amount} is dynamic,
+     *                           should be set to Integer.MAX_VALUE if no lower max is needed.
+     *                           (Game will always prevent choosing more than {@code amount} targets.)
+     */
     public TargetAnyTargetAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets) {
         super(amount, minNumberOfTargets, maxNumberOfTargets);
         this.zone = Zone.ALL;

--- a/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
@@ -16,7 +16,7 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
     }
 
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
-        this(amount, minNumberOfTargets, 0, filter);
+        this(amount, minNumberOfTargets, amount, filter);
     }
 
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {

--- a/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
@@ -11,12 +11,16 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
     private static final FilterCreatureOrPlaneswalkerPermanent defaultFilter
             = new FilterCreatureOrPlaneswalkerPermanent("target creatures and/or planeswalkers");
 
-    public TargetCreatureOrPlaneswalkerAmount(int amount) {
-        super(amount, defaultFilter);
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets) {
+        super(amount, minNumberOfTargets, defaultFilter);
     }
 
-    public TargetCreatureOrPlaneswalkerAmount(int amount, FilterPermanent filter) {
-        super(amount, filter);
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
+    }
+
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
+        super(amount, minNumberOfTargets, filter);
     }
 
     private TargetCreatureOrPlaneswalkerAmount(final TargetCreatureOrPlaneswalkerAmount target) {

--- a/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
@@ -11,18 +11,44 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
     private static final FilterCreatureOrPlaneswalkerPermanent defaultFilter
             = new FilterCreatureOrPlaneswalkerPermanent("target creatures and/or planeswalkers");
 
-    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets) {
-        this(amount, minNumberOfTargets, defaultFilter);
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!<br>
+     * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
+     * {@code maxNumberOfTargets} defaults to {@code amount}.<br>
+     * {@code filter} defaults to all creature and planeswalker permanents. ("target creatures and/or planeswalkers")
+     *
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterPermanent)
+     */
+    public TargetCreatureOrPlaneswalkerAmount(int amount) {
+        this(amount, defaultFilter);
     }
 
-    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
-        this(amount, minNumberOfTargets, amount, filter);
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!<br>
+     * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
+     * {@code maxNumberOfTargets} defaults to {@code amount}.
+     *
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterPermanent)
+     */
+    public TargetCreatureOrPlaneswalkerAmount(int amount, FilterPermanent filter) {
+        this(amount, amount > 3 ? 0 : 1, amount, filter);
     }
 
+    /**
+     * {@code filter} defaults to all creature and planeswalker permanents. ("target creatures and/or planeswalkers")
+     *
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterPermanent)
+     */
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
         this(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
     }
 
+    /**
+     * @param amount             Amount of stuff (e.g. damage, counters) to distribute.
+     * @param minNumberOfTargets Minimum number of targets.
+     * @param maxNumberOfTargets Maximum number of targets. If no lower max is needed, set to {@code amount}.
+     * @param filter             Filter for creatures and/or planeswalkers that something will be distributed amongst.
+     */
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
         super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
     }

--- a/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
@@ -1,6 +1,6 @@
 package mage.target.common;
 
-import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledCreatureOrPlaneswalkerPermanent;
 import mage.filter.common.FilterCreatureOrPlaneswalkerPermanent;
 
 /**
@@ -17,7 +17,7 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
      * {@code maxNumberOfTargets} defaults to {@code amount}.<br>
      * {@code filter} defaults to all creature and planeswalker permanents. ("target creatures and/or planeswalkers")
      *
-     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterPermanent)
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterCreatureOrPlaneswalkerPermanent)
      */
     public TargetCreatureOrPlaneswalkerAmount(int amount) {
         this(amount, defaultFilter);
@@ -28,16 +28,16 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
      * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
      * {@code maxNumberOfTargets} defaults to {@code amount}.
      *
-     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterPermanent)
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterCreatureOrPlaneswalkerPermanent)
      */
-    public TargetCreatureOrPlaneswalkerAmount(int amount, FilterPermanent filter) {
+    public TargetCreatureOrPlaneswalkerAmount(int amount, FilterCreatureOrPlaneswalkerPermanent filter) {
         this(amount, amount > 3 ? 0 : 1, amount, filter);
     }
 
     /**
      * {@code filter} defaults to all creature and planeswalker permanents. ("target creatures and/or planeswalkers")
      *
-     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterPermanent)
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterCreatureOrPlaneswalkerPermanent)
      */
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
         this(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
@@ -49,7 +49,23 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
      * @param maxNumberOfTargets Maximum number of targets. If no lower max is needed, set to {@code amount}.
      * @param filter             Filter for creatures and/or planeswalkers that something will be distributed amongst.
      */
-    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterCreatureOrPlaneswalkerPermanent filter) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
+    }
+
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!
+     *
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, FilterCreatureOrPlaneswalkerPermanent)
+     */
+    public TargetCreatureOrPlaneswalkerAmount(int amount, FilterControlledCreatureOrPlaneswalkerPermanent filter) {
+        this(amount, amount > 3 ? 0 : 1, amount, filter);
+    }
+
+    /**
+     * @see TargetCreatureOrPlaneswalkerAmount#TargetCreatureOrPlaneswalkerAmount(int, int, int, FilterCreatureOrPlaneswalkerPermanent)
+     */
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterControlledCreatureOrPlaneswalkerPermanent filter) {
         super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
     }
 

--- a/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreatureOrPlaneswalkerAmount.java
@@ -12,15 +12,19 @@ public class TargetCreatureOrPlaneswalkerAmount extends TargetPermanentAmount {
             = new FilterCreatureOrPlaneswalkerPermanent("target creatures and/or planeswalkers");
 
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets) {
-        super(amount, minNumberOfTargets, defaultFilter);
-    }
-
-    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
-        super(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
+        this(amount, minNumberOfTargets, defaultFilter);
     }
 
     public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
-        super(amount, minNumberOfTargets, filter);
+        this(amount, minNumberOfTargets, 0, filter);
+    }
+
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        this(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
+    }
+
+    public TargetCreatureOrPlaneswalkerAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
     }
 
     private TargetCreatureOrPlaneswalkerAmount(final TargetCreatureOrPlaneswalkerAmount target) {

--- a/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
@@ -11,26 +11,63 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
 
     private static final FilterCreaturePermanent defaultFilter = new FilterCreaturePermanent("target creatures");
 
-    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets) {
-        this(amount, minNumberOfTargets, defaultFilter);
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!<br>
+     * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
+     * {@code maxNumberOfTargets} defaults to {@code amount}.<br>
+     * {@code filter} defaults to all creature permanents. ("target creatures")
+     *
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterPermanent)
+     */
+    public TargetCreaturePermanentAmount(int amount) {
+        this(amount, defaultFilter);
     }
 
-    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
-        this(amount, minNumberOfTargets, amount, filter);
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!<br>
+     * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
+     * {@code maxNumberOfTargets} defaults to {@code amount}.
+     *
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterPermanent)
+     */
+    public TargetCreaturePermanentAmount(int amount, FilterPermanent filter) {
+        this(amount, amount > 3 ? 0 : 1, amount, filter);
     }
 
+    /**
+     * {@code filter} defaults to all creature permanents. ("target creatures")
+     *
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterPermanent)
+     */
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
         this(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
     }
 
+    /**
+     * @param amount             Amount of stuff (e.g. damage, counters) to distribute.
+     * @param minNumberOfTargets Minimum number of targets.
+     * @param maxNumberOfTargets Maximum number of targets. If no lower max is needed, set to {@code amount}.
+     * @param filter             Filter for creatures that something will be distributed amongst.
+     */
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
         super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
     }
 
+    /**
+     * {@code filter} defaults to all creature permanents. ("target creatures")
+     *
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(DynamicValue, FilterPermanent)
+     */
     public TargetCreaturePermanentAmount(DynamicValue amount) {
         this(amount, defaultFilter);
     }
 
+    /**
+     * Minimum number of targets will be zero, and max will be set to Integer.MAX_VALUE.
+     *
+     * @param amount Amount of stuff (e.g. damage, counters) to distribute.
+     * @param filter Filter for creatures that something will be distributed amongst.
+     */
     public TargetCreaturePermanentAmount(DynamicValue amount, FilterPermanent filter) {
         super(amount, 0, filter);
     }

--- a/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
@@ -1,7 +1,7 @@
 package mage.target.common;
 
 import mage.abilities.dynamicvalue.DynamicValue;
-import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
 
 /**
@@ -17,7 +17,7 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
      * {@code maxNumberOfTargets} defaults to {@code amount}.<br>
      * {@code filter} defaults to all creature permanents. ("target creatures")
      *
-     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterPermanent)
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterCreaturePermanent)
      */
     public TargetCreaturePermanentAmount(int amount) {
         this(amount, defaultFilter);
@@ -28,16 +28,16 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
      * {@code minNumberOfTargets} defaults to zero for {@code amount} > 3, otherwise to one, in line with typical templating.<br>
      * {@code maxNumberOfTargets} defaults to {@code amount}.
      *
-     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterPermanent)
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterCreaturePermanent)
      */
-    public TargetCreaturePermanentAmount(int amount, FilterPermanent filter) {
+    public TargetCreaturePermanentAmount(int amount, FilterCreaturePermanent filter) {
         this(amount, amount > 3 ? 0 : 1, amount, filter);
     }
 
     /**
      * {@code filter} defaults to all creature permanents. ("target creatures")
      *
-     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterPermanent)
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterCreaturePermanent)
      */
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
         this(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
@@ -49,14 +49,14 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
      * @param maxNumberOfTargets Maximum number of targets. If no lower max is needed, set to {@code amount}.
      * @param filter             Filter for creatures that something will be distributed amongst.
      */
-    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterCreaturePermanent filter) {
         super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
     }
 
     /**
      * {@code filter} defaults to all creature permanents. ("target creatures")
      *
-     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(DynamicValue, FilterPermanent)
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(DynamicValue, FilterCreaturePermanent)
      */
     public TargetCreaturePermanentAmount(DynamicValue amount) {
         this(amount, defaultFilter);
@@ -68,7 +68,30 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
      * @param amount Amount of stuff (e.g. damage, counters) to distribute.
      * @param filter Filter for creatures that something will be distributed amongst.
      */
-    public TargetCreaturePermanentAmount(DynamicValue amount, FilterPermanent filter) {
+    public TargetCreaturePermanentAmount(DynamicValue amount, FilterCreaturePermanent filter) {
+        super(amount, 0, filter);
+    }
+
+    /**
+     * <b>IMPORTANT</b>: Use more specific constructor if {@code amount} is not always the same number!
+     *
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, FilterCreaturePermanent)
+     */
+    public TargetCreaturePermanentAmount(int amount, FilterControlledCreaturePermanent filter) {
+        this(amount, amount > 3 ? 0 : 1, amount, filter);
+    }
+
+    /**
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(int, int, int, FilterCreaturePermanent)
+     */
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterControlledCreaturePermanent filter) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
+    }
+
+    /**
+     * @see TargetCreaturePermanentAmount#TargetCreaturePermanentAmount(DynamicValue, FilterCreaturePermanent)
+     */
+    public TargetCreaturePermanentAmount(DynamicValue amount, FilterControlledCreaturePermanent filter) {
         super(amount, 0, filter);
     }
 

--- a/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
@@ -11,20 +11,24 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
 
     private static final FilterCreaturePermanent defaultFilter = new FilterCreaturePermanent("target creatures");
 
-    public TargetCreaturePermanentAmount(int amount) {
-        super(amount, defaultFilter);
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets) {
+        super(amount, minNumberOfTargets, defaultFilter);
+    }
+
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
     }
 
     public TargetCreaturePermanentAmount(DynamicValue amount) {
-        this(amount, defaultFilter);
+        super(amount, 0, defaultFilter);
     }
 
-    public TargetCreaturePermanentAmount(int amount, FilterPermanent filter) {
-        super(amount, filter);
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
+        super(amount, minNumberOfTargets, filter);
     }
 
     public TargetCreaturePermanentAmount(DynamicValue amount, FilterPermanent filter) {
-        super(amount, filter);
+        super(amount, 0, filter);
     }
 
     private TargetCreaturePermanentAmount(final TargetCreaturePermanentAmount target) {

--- a/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
@@ -16,7 +16,7 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
     }
 
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
-        this(amount, minNumberOfTargets, 0, filter);
+        this(amount, minNumberOfTargets, amount, filter);
     }
 
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {

--- a/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreaturePermanentAmount.java
@@ -12,19 +12,23 @@ public class TargetCreaturePermanentAmount extends TargetPermanentAmount {
     private static final FilterCreaturePermanent defaultFilter = new FilterCreaturePermanent("target creatures");
 
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets) {
-        super(amount, minNumberOfTargets, defaultFilter);
-    }
-
-    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
-        super(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
-    }
-
-    public TargetCreaturePermanentAmount(DynamicValue amount) {
-        super(amount, 0, defaultFilter);
+        this(amount, minNumberOfTargets, defaultFilter);
     }
 
     public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
-        super(amount, minNumberOfTargets, filter);
+        this(amount, minNumberOfTargets, 0, filter);
+    }
+
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        this(amount, minNumberOfTargets, maxNumberOfTargets, defaultFilter);
+    }
+
+    public TargetCreaturePermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets, filter);
+    }
+
+    public TargetCreaturePermanentAmount(DynamicValue amount) {
+        this(amount, defaultFilter);
     }
 
     public TargetCreaturePermanentAmount(DynamicValue amount, FilterPermanent filter) {

--- a/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
@@ -28,7 +28,7 @@ public class TargetPermanentAmount extends TargetAmount {
     }
 
     public TargetPermanentAmount(DynamicValue amount, int minNumberOfTargets, FilterPermanent filter) {
-        this(amount, minNumberOfTargets, 0, filter);
+        this(amount, minNumberOfTargets, Integer.MAX_VALUE, filter);
     }
 
     public TargetPermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {

--- a/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
@@ -23,16 +23,20 @@ public class TargetPermanentAmount extends TargetAmount {
 
     protected final FilterPermanent filter;
 
-    public TargetPermanentAmount(int amount, FilterPermanent filter) {
-        // 107.1c If a rule or ability instructs a player to choose “any number,” that player may choose
-        // any positive number or zero, unless something (such as damage or counters) is being divided
-        // or distributed among “any number” of players and/or objects. In that case, a nonzero number
-        // of players and/or objects must be chosen if possible.
-        this(StaticValue.get(amount), filter);
+    public TargetPermanentAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
+        this(amount, minNumberOfTargets, amount, filter);
     }
 
-    public TargetPermanentAmount(DynamicValue amount, FilterPermanent filter) {
-        super(amount);
+    public TargetPermanentAmount(DynamicValue amount, int minNumberOfTargets, FilterPermanent filter) {
+        this(amount, minNumberOfTargets, 0, filter);
+    }
+
+    public TargetPermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
+        this(StaticValue.get(amount), minNumberOfTargets, maxNumberOfTargets, filter);
+    }
+
+    public TargetPermanentAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets);
         this.zone = Zone.ALL;
         this.filter = filter;
         this.targetName = filter.getMessage();

--- a/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
@@ -23,18 +23,39 @@ public class TargetPermanentAmount extends TargetAmount {
 
     protected final FilterPermanent filter;
 
+    /**
+     * {@code maxNumberOfTargets} defaults to {@code amount}.
+     *
+     * @see TargetPermanentAmount#TargetPermanentAmount(DynamicValue, int, int, FilterPermanent)
+     */
     public TargetPermanentAmount(int amount, int minNumberOfTargets, FilterPermanent filter) {
         this(amount, minNumberOfTargets, amount, filter);
     }
 
+    /**
+     * {@code maxNumberOfTargets} defaults to Integer.MAX_VALUE.
+     *
+     * @see TargetPermanentAmount#TargetPermanentAmount(DynamicValue, int, int, FilterPermanent)
+     */
     public TargetPermanentAmount(DynamicValue amount, int minNumberOfTargets, FilterPermanent filter) {
         this(amount, minNumberOfTargets, Integer.MAX_VALUE, filter);
     }
 
+    /**
+     * @see TargetPermanentAmount#TargetPermanentAmount(DynamicValue, int, int, FilterPermanent)
+     */
     public TargetPermanentAmount(int amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
         this(StaticValue.get(amount), minNumberOfTargets, maxNumberOfTargets, filter);
     }
 
+    /**
+     * @param amount             Amount of stuff (e.g. damage, counters) to distribute.
+     * @param minNumberOfTargets Minimum number of targets.
+     * @param maxNumberOfTargets Maximum number of targets. If no lower max is needed:
+     *                           set to {@code amount} if amount is static; otherwise, set to Integer.MAX_VALUE.
+     *                           (Game will always prevent distributing among more than {@code amount} permanents.)
+     * @param filter             Filter for permanents that something will be distributed amongst.
+     */
     public TargetPermanentAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets, FilterPermanent filter) {
         super(amount, minNumberOfTargets, maxNumberOfTargets);
         this.zone = Zone.ALL;

--- a/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentAmount.java
@@ -5,7 +5,6 @@ import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.constants.Zone;
-import mage.filter.Filter;
 import mage.filter.FilterPermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -74,7 +73,7 @@ public class TargetPermanentAmount extends TargetAmount {
     }
 
     @Override
-    public Filter getFilter() {
+    public FilterPermanent getFilter() {
         return this.filter;
     }
 

--- a/Mage/src/main/java/mage/target/common/TargetPermanentOrPlayerAmount.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentOrPlayerAmount.java
@@ -22,9 +22,8 @@ public abstract class TargetPermanentOrPlayerAmount extends TargetAmount {
 
     protected FilterPermanentOrPlayer filter;
 
-    TargetPermanentOrPlayerAmount(DynamicValue amount, int maxNumberOfTargets) {
-        super(amount);
-        this.maxNumberOfTargets = maxNumberOfTargets;
+    TargetPermanentOrPlayerAmount(DynamicValue amount, int minNumberOfTargets, int maxNumberOfTargets) {
+        super(amount, minNumberOfTargets, maxNumberOfTargets);
     }
 
     TargetPermanentOrPlayerAmount(final TargetPermanentOrPlayerAmount target) {


### PR DESCRIPTION
With this, minimum target counts must be specified for `TargetAmount`. Maximum target counts can also be set. By default, it'll use `amount` for the maximum when the amount is static, which is nicer in the GUI since it'll stop highlighting other cards to pick for targets once you've hit the max. Otherwise, setting it to zero by default seems to have no ill effects, but please let me know if there's something I've overlooked there.

I also refactored `DistributeCountersEffect` and `DamageMultiEffect` so that they don't need parameters to generate their rules text anymore, with some new code in `TargetImpl.getDescription()`. There is also the much less used `PreventDamageToTargetMultiAmountEffect`, which at a quick glance looks a bit more complex to refactor similarly, but it likely could be done? For now I've left it alone.

I believe I checked every affected card and verified that the rules text is still correct (or slightly corrected, in a few cases). That said, let me know if there are any mistakes, or potentially better approaches.

Closes #9457.