### PR TITLE
Implement ARB Collation

### DIFF
--- a/Mage.Sets/src/mage/sets/AlaraReborn.java
+++ b/Mage.Sets/src/mage/sets/AlaraReborn.java
@@ -2,8 +2,15 @@
 package mage.sets;
 
 import mage.cards.ExpansionSet;
+import mage.collation.BoosterCollator;
+import mage.collation.BoosterStructure;
+import mage.collation.CardRun;
+import mage.collation.RarityConfiguration;
 import mage.constants.Rarity;
 import mage.constants.SetType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *
@@ -20,7 +27,7 @@ public final class AlaraReborn extends ExpansionSet {
     private AlaraReborn() {
         super("Alara Reborn", "ARB", ExpansionSet.buildDate(2009, 3, 25), SetType.EXPANSION);
         this.blockName = "Shards of Alara";
-        this.parentSet = ShardsOfAlara.getInstance();
+        this.parentSet = AlaraReborn.getInstance();
         this.hasBasicLands = false;
         this.hasBoosters = true;
         this.numBoosterLands = 1;
@@ -174,6 +181,63 @@ public final class AlaraReborn extends ExpansionSet {
         cards.add(new SetCardInfo("Wildfield Borderpost", 80, Rarity.COMMON, mage.cards.w.WildfieldBorderpost.class));
         cards.add(new SetCardInfo("Winged Coatl", 105, Rarity.COMMON, mage.cards.w.WingedCoatl.class));
         cards.add(new SetCardInfo("Zealous Persecution", 85, Rarity.UNCOMMON, mage.cards.z.ZealousPersecution.class));
+    }
+
+    @Override
+    public BoosterCollator createCollator() {
+        return new AlaraRebornCollator();
+    }
+}
+
+// Booster collation info from https://vm1.substation33.com/tiera/t/lethe/arb.html
+// Using USA collation
+class AlaraRebornCollator implements BoosterCollator {
+    private final CardRun commonA = new CardRun(true, "51", "74", "122", "45", "52", "14", "134", "29", "75", "138", "43", "13", "59", "80", "135", "27", "7", "143", "46", "72", "96", "22", "134", "4", "80", "144", "17", "46", "96", "19", "7", "138", "105", "132", "95", "75", "51", "22", "4", "122", "56", "45", "143", "74", "29", "13", "48", "139", "56", "72", "17", "5", "144", "27", "43", "14", "139", "105", "52", "48", "132", "19", "59", "5", "135", "95");
+    private final CardRun commonB = new CardRun(true, "78", "131", "9", "55", "40", "107", "69", "18", "112", "61", "10", "40", "125", "79", "20", "107", "3", "55", "35", "116", "32", "79", "63", "112", "3", "66", "88", "142", "41", "32", "63", "141", "84", "54", "116", "66", "35", "20", "131", "38", "9", "54", "141", "78", "41", "84", "18", "142", "69", "61", "125", "10", "38", "88");
+    private final CardRun uncommonA = new CardRun(false, "1", "11", "23", "25", "34", "39", "62", "65", "68", "85", "89", "93", "99", "100", "101", "111", "120", "133", "136", "137", "140", "145");
+    private final CardRun uncommonB = new CardRun(false, "15", "16", "21", "26", "33", "44", "50", "57", "64", "76", "77", "83", "87", "94", "102", "108", "115", "127");
+    private final CardRun rare = new CardRun(false, "2", "2", "6", "6", "8", "8", "12", "12", "24", "24", "28", "28", "30", "30", "31", "31", "36", "36", "42", "42", "47", "47", "49", "49", "58", "58", "60", "60", "67", "67", "70", "70", "71", "71", "73", "73", "81", "81", "82", "82", "86", "86", "90", "90", "92", "92", "97", "97", "98", "98", "103", "103", "104", "104", "106", "106", "114", "114", "118", "118", "119", "119", "121", "121", "123", "123", "126", "126", "129", "129", "37", "53", "91", "109", "110", "113", "117", "124", "128", "130");
+    private final CardRun land = new CardRun(false, "ALA_230", "ALA_231", "ALA_232", "ALA_233", "ALA_234", "ALA_235", "ALA_236", "ALA_237", "ALA_238", "ALA_239", "ALA_240", "ALA_241", "ALA_242", "ALA_243", "ALA_244", "ALA_245", "ALA_246", "ALA_247", "ALA_248", "ALA_249");
+
+    private final BoosterStructure AAAAAABBBB = new BoosterStructure(
+            commonA, commonA, commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB
+    );
+    private final BoosterStructure AAAAABBBBB = new BoosterStructure(
+            commonA, commonA, commonA, commonA, commonA,
+            commonB, commonB, commonB, commonB, commonB
+    );
+    private final BoosterStructure AAB = new BoosterStructure(uncommonA, uncommonA, uncommonB);
+    private final BoosterStructure ABB = new BoosterStructure(uncommonA, uncommonB, uncommonB);
+    private final BoosterStructure R1 = new BoosterStructure(rare);
+    private final BoosterStructure L1 = new BoosterStructure(land);
+
+    // In order for equal numbers of each common to exist, the average booster must contain:
+    // 5.5 A commons (11 / 2)
+    // 4.5 B commons ( 9 / 2)
+    private final RarityConfiguration commonRuns = new RarityConfiguration(
+            AAAAAABBBB,
+            AAAAABBBBB
+    );
+    // In order for equal numbers of each uncommon to exist, the average booster must contain:
+    // 1.65 A uncommons (33 / 20)
+    // 1.35 B uncommons (27 / 20)
+    // These numbers are the same for all sets with 60 uncommons in asymmetrical A/B print runs
+    private final RarityConfiguration uncommonRuns = new RarityConfiguration(
+            AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB, AAB,
+            ABB, ABB, ABB, ABB, ABB, ABB, ABB
+    );
+    private final RarityConfiguration rareRuns = new RarityConfiguration(R1);
+    private final RarityConfiguration landRuns = new RarityConfiguration(L1);
+
+    @Override
+    public List<String> makeBooster() {
+        List<String> booster = new ArrayList<>();
+        booster.addAll(commonRuns.getNext().makeRun());
+        booster.addAll(uncommonRuns.getNext().makeRun());
+        booster.addAll(rareRuns.getNext().makeRun());
+        booster.addAll(landRuns.getNext().makeRun());
+        return booster;
     }
 
 }


### PR DESCRIPTION
Commons have print runs
Uncommons are split into A & B groups, but printruns unknown.

<details>
<summary>Stats generated from 10000 packs in the draftmancer version - using same logic</summary>
<code>
150000	Total Cards Opened			10000			
87.66%	8766	boosters missing mythic					
12.34%	1234	boosters missing rare					
100.00%	10000	boosters missing special					
100.00%	10000	boosters missing common colourless					
42.05%	4205	boosters missing common bant					
2.35%	235	boosters missing common esper					
4.92%	492	boosters missing common grixis					
4.30%	430	boosters missing common jund					
0.19%	19	boosters missing common naya					
45.25%	4525	boosters missing 1 common shard					
4.25%	425	boosters missing 2 common shards					
0.02%	2	boosters missing 3 common shards					
2041	.l	Mountain	515	506	496	524	[ala:242],[ala:243],[ala:245],[ala:244]
2022	.l	Swamp	529	491	500	502	[ala:241],[ala:238],[ala:240],[ala:239]
1991	.l	Island	512	481	524	474	[ala:235],[ala:234],[ala:236],[ala:237]
1982	.l	Plains	511	497	484	490	[ala:230],[ala:232],[ala:231],[ala:233]
1964	.l	Forest	512	504	465	483	[ala:249],[ala:247],[ala:246],[ala:248]
1732	c	Ethersworn Shieldmage	1732	[arb:4]			
1727	c	Jhessian Zombies	1727	[arb:22]			
1721	c	Gorger Wurm	1721	[arb:56]			
1721	c	Vedalken Ghoul	1721	[arb:32]			
1708	c	Offering to Asha	1708	[arb:9]			
1705	c	Magefire Wings	1705	[arb:88]			
1705	c	Mistvein Borderpost	1705	[arb:27]			
1705	c	Vectis Dominator	1705	[arb:84]			
1704	c	Arsenal Thresher	1704	[arb:131]			
1702	c	Jund Sojourners	1702	[arb:116]			
1694	c	Captured Sunlight	1694	[arb:66]			
1692	c	Architects of Will	1692	[plst:ARB-17]			
1692	c	Leonin Armorguard	1692	[arb:72]			
1692	c	Violent Outburst	1692	[j25:746]			
1688	c	Crystallization	1688	[arb:144]			
1688	c	Putrid Leech	1688	[arb:95]			
1688	c	Singe-Mind Ogre	1688	[arb:45]			
1687	c	Fieldmist Borderpost	1687	[arb:5]			
1683	c	Esper Stormblade	1683	[arb:132]			
1683	c	Sangrite Backlash	1683	[arb:139]			
1683	c	Soul Manipulation	1683	[mb1:1488]			
1683	c	Winged Coatl	1683	[2x2:295]			
1682	c	Veinfire Borderpost	1682	[arb:48]			
1679	c	Firewild Borderpost	1679	[arb:54]			
1678	c	Grixis Grimblade	1678	[arb:134]			
1677	c	Pale Recluse	1677	[arb:74]			
1676	c	Naya Hushblade	1676	[arb:141]			
1674	c	Bant Sureblade	1674	[arb:143]			
1673	c	Naya Sojourners	1673	[arb:122]			
1669	c	Demonic Dread	1669	[arb:38]			
1668	c	Esper Sojourners	1668	[arb:107]			
1665	c	Qasali Pridemage	1665	[2x2:267]			
1665	c	Rhox Brute	1665	[arb:59]			
1665	c	Stormcaller's Boon	1665	[arb:13]			
1661	c	Sigil of the Nayan Gods	1661	[arb:78]			
1660	c	Kathari Bomber	1660	[mm3:172]			
1659	c	Grixis Sojourners	1659	[arb:112]			
1655	c	Trace of Abundance	1655	[arb:142]			
1653	c	Sigiled Behemoth	1653	[arb:79]			
1653	c	Talon Trooper	1653	[mm3:192]			
1651	c	Deny Reality	1651	[plst:ARB-19]			
1651	c	Ethercaste Knight	1651	[arb:3]			
1649	c	Colossal Might	1649	[arb:51]			
1648	c	Etherium Abomination	1648	[arb:20]			
1643	c	Monstrous Carabid	1643	[arb:43]			
1640	c	Cerodon Yearling	1640	[arb:96]			
1640	c	Sanctum Plowbeast	1640	[arb:10]			
1639	c	Brainbite	1639	[arb:18]			
1639	c	Glassdust Hulk	1639	[2xm:199]			
1639	c	Igneous Pouncer	1639	[arb:40]			
1637	c	Breath of Malfegor	1637	[arb:35]			
1637	c	Jund Hackblade	1637	[arb:138]			
1624	c	Godtracker of Jund	1624	[arb:55]			
1623	c	Deadshot Minotaur	1623	[arb:52]			
1619	c	Sewn-Eye Drake	1619	[arb:135]			
1613	c	Terminate	1613	[acr:98]			
1611	c	Valley Rannet	1611	[arb:61]			
1611	c	Wildfield Borderpost	1611	[arb:80]			
1597	c	Grizzled Leotau	1597	[arb:69]			
1594	c	Bant Sojourners	1594	[arb:125]			
811	u	Giant Ambush Beetle	811	[arb:137]			
802	u	Mask of Riddles	802	[arb:25]			
797	u	Double Negative	797	[arb:87]			
797	u	Mage Slayer	797	[arb:57]			
794	u	Stun Sniper	794	[arb:100]			
786	u	Marisi's Twinclaws	786	[arb:140]			
782	u	Thopter Foundry	782	[arb:133]			
781	u	Wall of Denial	781	[arb:16]			
773	u	Nulltread Gargantuan	773	[arb:102]			
767	u	Messenger Falcons	767	[arb:145]			
762	u	Vithian Renegades	762	[arb:64]			
761	u	Ardent Plea	761	[arb:1]			
760	u	Anathemancer	760	[arb:33]			
758	u	Flurry of Wings	758	[arb:127]			
758	u	Sanity Gnawers	758	[arb:44]			
756	u	Skyclaw Thrash	756	[arb:89]			
756	u	Zealous Persecution	756	[arb:85]			
754	u	Gloryscale Viashino	754	[arb:120]			
753	u	Intimidation Bolt	753	[arb:99]			
753	u	Lorescale Coatl	753	[arb:101]			
752	u	Enlisted Wurm	752	[arb:68]			
749	u	Demonspine Whip	749	[arb:39]			
749	u	Tainted Sigil	749	[arb:83]			
746	u	Shield of the Righteous	746	[arb:11]			
745	u	Reborn Hope	745	[arb:76]			
742	u	Bituminous Blast	742	[arb:34]			
740	u	Dragon Appeasement	740	[arb:115]			
740	u	Slave of Bolas	740	[arb:136]			
739	u	Unbender Tine	739	[arb:15]			
736	u	Morbid Bloom	736	[arb:94]			
734	u	Marrow Chomper	734	[arb:93]			
732	u	Kathari Remnant	732	[arb:23]			
724	u	Bloodbraid Elf	724	[arb:50]			
723	u	Drastic Revelation	723	[arb:111]			
714	u	Mind Funeral	714	[arb:26]			
706	u	Behemoth Sledge	706	[arb:65]			
706	u	Vengeful Rebirth	706	[arb:62]			
699	u	Etherwrought Page	699	[arb:108]			
686	u	Sigil Captain	686	[arb:77]			
677	u	Illusory Demon	677	[arb:21]			
280	r	Meddling Mage	280	[arb:8]			
278	r	Knight of New Alara	278	[arb:70]			
278	r	Lavalanche	278	[arb:118]			
268	r	Maelstrom Pulse	268	[arb:92]			
268	r	Soulquake	268	[arb:30]			
267	r	Necromancer's Covenant	267	[arb:82]			
264	r	Nemesis of Reason	264	[arb:28]			
263	r	Sages of the Anima	263	[arb:103]			
263	r	Spellbound Dragon	263	[arb:90]			
262	r	Enigma Sphinx	262	[arb:106]			
262	r	Knotvine Paladin	262	[arb:71]			
262	r	Thought Hemorrhage	262	[arb:47]			
258	r	Glory of Warfare	258	[arb:98]			
258	r	Mycoid Shepherd	258	[arb:73]			
258	r	Time Sieve	258	[arb:31]			
258	r	Vedalken Heretic	258	[arb:104]			
256	r	Sovereigns of Lost Alara	256	[arb:12]			
254	r	Deathbringer Thoctar	254	[arb:36]			
250	r	Unscythe, Killer of Kings	250	[arb:114]			
248	r	Predatory Advantage	248	[arb:58]			
245	r	Finest Hour	245	[arb:126]			
244	r	Blitz Hellion	244	[arb:49]			
244	r	Retaliator Griffin	244	[arb:123]			
240	r	Lightning Reaver	240	[arb:42]			
240	r	Madrush Cyclops	240	[arb:119]			
239	r	Dauntless Escort	239	[arb:67]			
238	r	Spellbreaker Behemoth	238	[arb:60]			
237	r	Aven Mimeomancer	237	[arb:2]			
234	r	Identity Crisis	234	[arb:81]			
229	r	Fight to the Death	229	[arb:97]			
229	r	Wargate	229	[arb:129]			
228	r	Cloven Casting	228	[arb:86]			
223	r	Filigree Angel	223	[arb:6]			
222	r	Mayael's Aria	222	[arb:121]			
219	r	Lich Lord of Unx	219	[arb:24]			
143	m	Uril, the Miststalker	143	[arb:124]			
141	m	Maelstrom Nexus	141	[arb:130]			
134	m	Lord of Extinction	134	[arb:91]			
134	m	Sphinx of the Steel Wind	134	[arb:110]			
122	m	Defiler of Souls	122	[arb:37]			
122	m	Thraximundar	122	[arb:113]			
114	m	Sen Triplets	114	[arb:109]			
111	m	Jenara, Asura of War	111	[arb:128]			
109	m	Dragon Broodmother	109	[arb:53]			
104	m	Karrthus, Tyrant of Jund	104	[arb:117]		
</code>				
</details>