### PR TITLE
[PIP] Add Curie, Emergent Intelligence

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CurieEmergentIntelligence.java
+++ b/Mage.Sets/src/mage/cards/c/CurieEmergentIntelligence.java
@@ -60,12 +60,12 @@ public final class CurieEmergentIntelligence extends CardImpl {
 
         // Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-            new DrawCardSourceControllerEffect(new CurieEmergentIntelligenceValue()).setText("draw cards equal to its base power"), false
+            new DrawCardSourceControllerEffect(CurieEmergentIntelligenceValue.NON_NEGATIVE).setText("draw cards equal to its base power"), false
         ));
 
         // {1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has 
         // "Whenever this creature deals combat damage to a player, draw cards equal to its base power."
-        Ability ability = new SimpleActivatedAbility(new CurieCopyEffect(), new ManaCostsImpl<>("{1}{U}"));
+        Ability ability = new SimpleActivatedAbility(new CurieEmergentIntelligenceCopyEffect(), new ManaCostsImpl<>("{1}{U}"));
         ability.addCost(new ExileTargetCost(new TargetControlledPermanent(filter)));
         this.addAbility(ability);
     }
@@ -80,7 +80,9 @@ public final class CurieEmergentIntelligence extends CardImpl {
     }
 }
 
-class CurieEmergentIntelligenceValue implements DynamicValue {
+enum CurieEmergentIntelligenceValue implements DynamicValue {
+    NON_NEGATIVE;
+
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
         Permanent sourcePermanent = sourceAbility.getSourcePermanentOrLKI(game);
@@ -108,30 +110,30 @@ class CurieEmergentIntelligenceValue implements DynamicValue {
     }
 }
 
-class CurieCopyEffect extends OneShotEffect {
+class CurieEmergentIntelligenceCopyEffect extends OneShotEffect {
 
     private static final CopyApplier applier = new CopyApplier() {
         @Override
         public boolean apply(Game game, MageObject blueprint, Ability source, UUID targetObjectId) {
             blueprint.getAbilities().add(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new DrawCardSourceControllerEffect(new CurieEmergentIntelligenceValue()).setText("draw cards equal to its base power"), false
+                new DrawCardSourceControllerEffect(CurieEmergentIntelligenceValue.NON_NEGATIVE).setText("draw cards equal to its base power"), false
             ));
             return true;
         }
     };
 
-    CurieCopyEffect() {
+    CurieEmergentIntelligenceCopyEffect() {
         super(Outcome.Benefit);
         this.setText("{this} becomes a copy of the exiled creature, except it has \"Whenever this creature deals combat damage to a player, draw cards equal to its base power.\"");
     }
 
-    private CurieCopyEffect(final CurieCopyEffect effect) {
+    private CurieEmergentIntelligenceCopyEffect(final CurieEmergentIntelligenceCopyEffect effect) {
         super(effect);
     }
 
     @Override
-    public CurieCopyEffect copy() {
-        return new CurieCopyEffect(this);
+    public CurieEmergentIntelligenceCopyEffect copy() {
+        return new CurieEmergentIntelligenceCopyEffect(this);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/c/CurieEmergentIntelligence.java
+++ b/Mage.Sets/src/mage/cards/c/CurieEmergentIntelligence.java
@@ -1,0 +1,133 @@
+package mage.cards.c;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.common.ExileTargetCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.dynamicvalue.common.SourcePermanentPowerValue;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.constants.Outcome;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.permanent.TokenPredicate;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.PermanentCard;
+import mage.MageInt;
+import mage.MageObject;
+import mage.target.common.TargetControlledPermanent;
+import mage.util.functions.CopyApplier;
+
+/**
+ *
+ * @author jam1garner
+ */
+public final class CurieEmergentIntelligence extends CardImpl {
+
+    private static final FilterControlledPermanent filter =
+            new FilterControlledPermanent("another nontoken artifact creature you control");
+
+    static {
+        filter.add(AnotherPredicate.instance);
+        filter.add(Predicates.and(
+            CardType.ARTIFACT.getPredicate(),
+            CardType.CREATURE.getPredicate()
+        ));
+        filter.add(TokenPredicate.FALSE);
+    }
+
+    public CurieEmergentIntelligence(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{1}{U}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ROBOT);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(3);
+
+        // Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
+            new DrawCardSourceControllerEffect(1).setText("draw cards equal to its base power"), false
+        ));
+
+        // {1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has 
+        // "Whenever this creature deals combat damage to a player, draw cards equal to its base power."
+        Ability ability = new SimpleActivatedAbility(new CurieCopyEffect(), new ManaCostsImpl<>("{1}{U}"));
+        ability.addCost(new ExileTargetCost(new TargetControlledPermanent(filter)));
+        this.addAbility(ability);
+    }
+
+    private CurieEmergentIntelligence(final CurieEmergentIntelligence card) {
+        super(card);
+    }
+
+    @Override
+    public CurieEmergentIntelligence copy() {
+        return new CurieEmergentIntelligence(this);
+    }
+}
+
+class CurieCopyEffect extends OneShotEffect {
+
+    private static final CopyApplier applier = new CopyApplier() {
+        @Override
+        public boolean apply(Game game, MageObject blueprint, Ability source, UUID targetObjectId) {
+            // Needed to account for Spinal Parasite
+            int basePower = Math.max(0, blueprint.getPower().getValue());
+
+            blueprint.getAbilities().add(new DealsCombatDamageToAPlayerTriggeredAbility(
+                new DrawCardSourceControllerEffect(basePower).setText("draw cards equal to its base power"), false
+            ));
+            return true;
+        }
+    };
+
+    CurieCopyEffect() {
+        super(Outcome.Benefit);
+        this.setText("{this} becomes a copy of the exiled creature, except it has \"Whenever this creature deals combat damage to a player, draw cards equal to its base power.\"");
+    }
+
+    private CurieCopyEffect(final CurieCopyEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public CurieCopyEffect copy() {
+        return new CurieCopyEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        for (Cost c : source.getCosts()) {
+            if (c.isPaid() && c instanceof ExileTargetCost) {
+                for (Permanent exiled : ((ExileTargetCost) c).getPermanents()) {
+                    if (exiled != null) {
+                        game.copyPermanent(
+                            Duration.WhileOnBattlefield,
+                            exiled,
+                            source.getSourceId(), source, applier
+                        );
+
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/c/CurieEmergentIntelligence.java
+++ b/Mage.Sets/src/mage/cards/c/CurieEmergentIntelligence.java
@@ -9,7 +9,8 @@ import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.ExileTargetCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.decorator.ConditionalOneShotEffect;
-import mage.abilities.dynamicvalue.common.SourcePermanentPowerValue;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
@@ -59,7 +60,7 @@ public final class CurieEmergentIntelligence extends CardImpl {
 
         // Whenever Curie, Emergent Intelligence deals combat damage to a player, draw cards equal to its base power.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-            new DrawCardSourceControllerEffect(1).setText("draw cards equal to its base power"), false
+            new DrawCardSourceControllerEffect(new CurieEmergentIntelligenceValue()).setText("draw cards equal to its base power"), false
         ));
 
         // {1}{U}, Exile another nontoken artifact creature you control: Curie becomes a copy of the exiled creature, except it has 
@@ -79,16 +80,41 @@ public final class CurieEmergentIntelligence extends CardImpl {
     }
 }
 
+class CurieEmergentIntelligenceValue implements DynamicValue {
+    @Override
+    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+        Permanent sourcePermanent = sourceAbility.getSourcePermanentOrLKI(game);
+        if (sourcePermanent == null) {
+            return 0;
+        }
+
+        // Minimum of 0 needed to account for Spinal Parasite
+        return Math.max(0, sourcePermanent.getPower().getModifiedBaseValue());
+    }
+
+    @Override
+    public CurieEmergentIntelligenceValue copy() {
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "X";
+    }
+
+    @Override
+    public String getMessage() {
+        return "{this}'s power";
+    }
+}
+
 class CurieCopyEffect extends OneShotEffect {
 
     private static final CopyApplier applier = new CopyApplier() {
         @Override
         public boolean apply(Game game, MageObject blueprint, Ability source, UUID targetObjectId) {
-            // Needed to account for Spinal Parasite
-            int basePower = Math.max(0, blueprint.getPower().getValue());
-
             blueprint.getAbilities().add(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new DrawCardSourceControllerEffect(basePower).setText("draw cards equal to its base power"), false
+                new DrawCardSourceControllerEffect(new CurieEmergentIntelligenceValue()).setText("draw cards equal to its base power"), false
             ));
             return true;
         }

--- a/Mage.Sets/src/mage/sets/Fallout.java
+++ b/Mage.Sets/src/mage/sets/Fallout.java
@@ -103,6 +103,7 @@ public final class Fallout extends ExpansionSet {
         cards.add(new SetCardInfo("Crucible of Worlds", 357, Rarity.MYTHIC, mage.cards.c.CrucibleOfWorlds.class));
         cards.add(new SetCardInfo("Crush Contraband", 158, Rarity.UNCOMMON, mage.cards.c.CrushContraband.class));
         cards.add(new SetCardInfo("Cultivate", 196, Rarity.UNCOMMON, mage.cards.c.Cultivate.class));
+        cards.add(new SetCardInfo("Curie, Emergent Intelligence", 30, Rarity.RARE, mage.cards.c.CurieEmergentIntelligence.class));
         cards.add(new SetCardInfo("Darkwater Catacombs", 260, Rarity.RARE, mage.cards.d.DarkwaterCatacombs.class));
         cards.add(new SetCardInfo("Deadly Dispute", 184, Rarity.COMMON, mage.cards.d.DeadlyDispute.class));
         cards.add(new SetCardInfo("Desdemona, Freedom's Edge", 101, Rarity.RARE, mage.cards.d.DesdemonaFreedomsEdge.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
Implements [Curie, Emergent Intelligence](https://scryfall.com/search?q=!curieemergentintelligence) for the Fallout Set (see #11324). Noticed this hadn't been implemented despite spending a while on "In Progress" in the checklist and since it has seen an uptick in popularity in Legacy due to some stiflenought pilots taking a liking to it I figured it would be nice to have. Hopefully not stepping on anyone's toes if it is actually in-progress.

Some assumptions the implementation makes that I could be wrong on:

- "another artifact creature you control" was too specific to be added to the common static filters 
- I'm unsure if this card draw is implemented exactly correctly


Have tested a lot of weird edge cases (the weirdest of which is using Curie with +1/+1 counters on it to exile a [Spinal Parasite](https://scryfall.com/card/5dn/155/spinal-parasite) in order to ensure it still triggers but draws 0 cards), but have also tested various combinations of copy/non-copy and no power modifications vs pump spells vs +1/+1 counters. Haven't tried much in terms of continuous effects, partially as I just don't know what the correct behavior of those would be, so I'm sure there's something I'm not considering. I'm guessing based on 208.4b this implementation is, in fact, incorrect (for example Curie copies Dreadnought, then an opponent plays Kudo, King Among Bears. I believe based on 208.4b this should result in 2 card getting drawn if the "Dreadnought" connects)

Point being, I'm assuming this implementation is not good enough but would appreciate guidance on how I should actually be determining the base power (and should I also be implementing an equivalent to `SourcePermanentPowerValue` for base power? I don't see one currently)