### PR TITLE
fix a bug in Sharae of Numbing Depths

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
+++ b/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
@@ -83,7 +83,6 @@ class SharaeOfNumbingDepthsTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         Permanent permanent = game.getPermanent(event.getTargetId());
         return permanent != null
-                && StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE.match(permanent,event.getPlayerId(),this,game);
-//                && isControlledBy(event.getPlayerId());
+                && StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE.match(permanent, event.getPlayerId(), this, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
+++ b/Mage.Sets/src/mage/cards/s/SharaeOfNumbingDepths.java
@@ -83,7 +83,7 @@ class SharaeOfNumbingDepthsTriggeredAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         Permanent permanent = game.getPermanent(event.getTargetId());
         return permanent != null
-                && StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE.match(permanent, game)
-                && isControlledBy(event.getPlayerId());
+                && StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE.match(permanent,event.getPlayerId(),this,game);
+//                && isControlledBy(event.getPlayerId());
     }
 }


### PR DESCRIPTION
The bug caused Sharae's ability to trigger even when her owner's permanents got tapped.