### PR TITLE
[DSC] Add Zimone's Hypothesis

### DIFF
--- a/Mage.Sets/src/mage/cards/z/ZimonesHypothesis.java
+++ b/Mage.Sets/src/mage/cards/z/ZimonesHypothesis.java
@@ -1,0 +1,90 @@
+package mage.cards.z;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.mageobject.PowerParityPredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * @author werhsdnas
+ */
+public final class ZimonesHypothesis extends CardImpl {
+
+    public ZimonesHypothesis(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}{U}");
+
+        // You may put a +1/+1 counter on a creature.
+        this.getSpellAbility().addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance()));
+        this.getSpellAbility().addTarget(new TargetCreaturePermanent(0, 1, StaticFilters.FILTER_PERMANENT_CREATURE, true));
+
+        //Then choose odd or even. Return each creature with power of the chosen quality to its owner’s hand.
+        this.getSpellAbility().addEffect(new ZimonesHypothesisBounceEffect());
+    }
+
+    private ZimonesHypothesis(final ZimonesHypothesis card) {
+        super(card);
+    }
+
+    @Override
+    public ZimonesHypothesis copy() {
+        return new ZimonesHypothesis(this);
+    }
+}
+
+class ZimonesHypothesisBounceEffect extends OneShotEffect {
+
+    private static final FilterPermanent evenFilter = new FilterCreaturePermanent();
+    private static final FilterPermanent oddFilter = new FilterCreaturePermanent();
+
+    static {
+        evenFilter.add(PowerParityPredicate.EVEN);
+        oddFilter.add(PowerParityPredicate.ODD);
+    }
+
+    ZimonesHypothesisBounceEffect() {
+        super(Outcome.Benefit);
+        staticText = "Choose odd or even. Return each creature with power of the chosen quality to its owner's hand. <i>(Zero is even.)</i>";
+    }
+
+    private ZimonesHypothesisBounceEffect(final ZimonesHypothesisBounceEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public ZimonesHypothesisBounceEffect copy() {
+        return new ZimonesHypothesisBounceEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        FilterPermanent filter = player.chooseUse(
+                outcome, "Odd or even?", null,
+                "Odd", "Even", source, game
+        ) ? oddFilter : evenFilter;
+
+        return player.moveCards(
+                game.getBattlefield().getActivePermanents(
+                        filter, source.getControllerId(), source, game
+                ).stream().collect(Collectors.toSet()), Zone.HAND, source, game
+        );
+    }
+}

--- a/Mage.Sets/src/mage/sets/DuskmournHouseOfHorrorCommander.java
+++ b/Mage.Sets/src/mage/sets/DuskmournHouseOfHorrorCommander.java
@@ -304,5 +304,6 @@ public final class DuskmournHouseOfHorrorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Yavimaya Elder", 208, Rarity.COMMON, mage.cards.y.YavimayaElder.class));
         cards.add(new SetCardInfo("Yedora, Grave Gardener", 209, Rarity.UNCOMMON, mage.cards.y.YedoraGraveGardener.class));
         cards.add(new SetCardInfo("Zimone, Mystery Unraveler", 8, Rarity.MYTHIC, mage.cards.z.ZimoneMysteryUnraveler.class));
+        cards.add(new SetCardInfo("Zimone's Hypothesis", 15, Rarity.RARE, mage.cards.z.ZimonesHypothesis.class));
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/mageobject/PowerParityPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/mageobject/PowerParityPredicate.java
@@ -1,0 +1,28 @@
+package mage.filter.predicate.mageobject;
+
+import mage.MageObject;
+import mage.filter.predicate.Predicate;
+import mage.game.Game;
+
+/**
+ * @author werhsdnas
+ */
+public enum PowerParityPredicate implements Predicate<MageObject> {
+    EVEN(0),
+    ODD(1);
+    private final int parity;
+
+    PowerParityPredicate(int parity) {
+        this.parity = parity;
+    }
+
+    @Override
+    public boolean apply(MageObject input, Game game) {
+        return input.getPower().getValue() % 2 == parity;
+    }
+
+    @Override
+    public String toString() {
+        return "PowerParity" + super.toString();
+    }
+}


### PR DESCRIPTION
Implements Zimone's Hypothesis. First time implementing a new card, but tested and it worked for me. Based most of the code off of the pre-existing Extinction Event Implementation. Additionally created new predicate for checking parity on creature power; currently only used on this card but generic enough that it could be useful in the future.