### PR TITLE
Fix 15 card booster generation

### DIFF
--- a/Mage/src/main/java/mage/cards/ExpansionSet.java
+++ b/Mage/src/main/java/mage/cards/ExpansionSet.java
@@ -145,6 +145,7 @@ public abstract class ExpansionSet implements Serializable {
     protected boolean hasAlternateBoosterPrintings = true; // not counting basic lands; e.g. Fallen Empires true, but Tenth Edition false
 
     protected int maxCardNumberInBooster; // used to omit cards with collector numbers beyond the regular cards in a set for boosters
+    protected int maxCardNumberBasePrint; // used to omit limit boosters to only contain cards with a base printing
 
     protected final EnumMap<Rarity, List<CardInfo>> savedCards = new EnumMap<>(Rarity.class);
     protected final EnumMap<Rarity, List<CardInfo>> savedSpecialCards = new EnumMap<>(Rarity.class);
@@ -220,8 +221,14 @@ public abstract class ExpansionSet implements Serializable {
             }
         }
 
-        while (theBooster.size() > 15) {
+        // removing positional cards from collated boosters is going to mess with balancing and as-fan
+        // also for sets with common lands in the land slot, this may eliminate the majority of fixing from a pack
+        // instead removing a random card that is not in the last four (where rare and uncommons usually are - though some uncommons may be displayed by cards with special collation - eg DFC or bonus sheet).
+        if (this.Booster.size() > 15 && this.Booster.get(0).getRarity() == Rarity.LAND) {
             theBooster.remove(0);
+        }
+        while (theBooster.size() > 15) {
+            theBooster.remove(RandomUtil.nextInt(theBooster.size() - 4));
         }
 
         return theBooster;


### PR DESCRIPTION
I noticed the code for reducing boosters to 15 cards and realised it wouldn't work well with collated boosters, or with boosters with fixing in the first slot.