### PR TITLE
Fix Awakened Skyclave & Grond, The Gatebreaker

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AwakenedSkyclave.java
+++ b/Mage.Sets/src/mage/cards/a/AwakenedSkyclave.java
@@ -35,7 +35,7 @@ public final class AwakenedSkyclave extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
 
         // As long as Awakened Skyclave is on the battlefield, it's a land in addition to its other types.
-        this.addAbility(new SimpleStaticAbility(new AddCardTypeSourceEffect(Duration.WhileOnBattlefield)
+        this.addAbility(new SimpleStaticAbility(new AddCardTypeSourceEffect(Duration.WhileOnBattlefield, CardType.LAND)
                 .setText("as long as {this} is on the battlefield, it's a land in addition to its other types")));
 
         // {T}: Add one mana of any color.

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCardTypeSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCardTypeSourceEffect.java
@@ -21,12 +21,17 @@ public class AddCardTypeSourceEffect extends ContinuousEffectImpl {
 
     public AddCardTypeSourceEffect(Duration duration, CardType... addedCardType) {
         super(duration, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
+        if (addedCardType.length == 0) {
+            throw new IllegalArgumentException("AddCardTypeSourceEffect should be called with at least one card type.");
+        }
         for (CardType cardType : addedCardType) {
             this.addedCardTypes.add(cardType);
             if (cardType == CardType.ENCHANTMENT) {
                 dependencyTypes.add(DependencyType.EnchantmentAddingRemoving);
             } else if (cardType == CardType.ARTIFACT) {
                 dependencyTypes.add(DependencyType.ArtifactAddingRemoving);
+            } else if (cardType == CardType.LAND) {
+                dependencyTypes.add(DependencyType.BecomeNonbasicLand);
             }
         }
     }
@@ -45,7 +50,8 @@ public class AddCardTypeSourceEffect extends ContinuousEffectImpl {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent != null && affectedObjectList.contains(new MageObjectReference(permanent, game))) {
+        if (permanent != null
+                && (affectedObjectList.contains(new MageObjectReference(permanent, game)) || !duration.isOnlyValidIfNoZoneChange())) {
             for (CardType cardType : addedCardTypes) {
                 permanent.addCardType(game, cardType);
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCardTypeSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCardTypeSourceEffect.java
@@ -51,7 +51,9 @@ public class AddCardTypeSourceEffect extends ContinuousEffectImpl {
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getSourceId());
         if (permanent != null
-                && (affectedObjectList.contains(new MageObjectReference(permanent, game)) || !duration.isOnlyValidIfNoZoneChange())) {
+                && (affectedObjectList.contains(new MageObjectReference(permanent, game))
+                // Workaround to support abilities like "As long as __, this permanent is a __ in addition to its other types."
+                || !duration.isOnlyValidIfNoZoneChange())) {
             for (CardType cardType : addedCardTypes) {
                 permanent.addCardType(game, cardType);
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCardTypeTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCardTypeTargetEffect.java
@@ -21,12 +21,17 @@ public class AddCardTypeTargetEffect extends ContinuousEffectImpl {
 
     public AddCardTypeTargetEffect(Duration duration, CardType... addedCardType) {
         super(duration, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
+        if (addedCardType.length == 0) {
+            throw new IllegalArgumentException("AddCardTypeTargetEffect should be called with at least one card type.");
+        }
         for (CardType cardType : addedCardType) {
             this.addedCardTypes.add(cardType);
             if (cardType == CardType.ENCHANTMENT) {
                 dependencyTypes.add(DependencyType.EnchantmentAddingRemoving);
             } else if (cardType == CardType.ARTIFACT) {
                 dependencyTypes.add(DependencyType.ArtifactAddingRemoving);
+            } else if (cardType == CardType.LAND) {
+                dependencyTypes.add(DependencyType.BecomeNonbasicLand);
             }
         }
 


### PR DESCRIPTION
At first glance, it looked like this would be a quick fix: just specify `CardType.LAND` as the card type to add in Awakened Skyclave. However, after doing so, it still did not become a land when on the battlefield.

It turned out that `AddCardTypeSourceEffect` was unnecessarily checking the affectedObjectList for durations where that was not needed. Adding a check to bypass this fixed the issue. I discovered that Grond, the Gatebreaker was also affected by this: if you controlled an Army during your turn, it would not continue being an artifact creature after zone changes.

I also added checks to ensure that `AddCardTypeSourceEffect` (and the similar `AddCardTypeTargetEffect`) require at least one card type to be supplied to them, and that dependencies with Blood Moon are handled properly when `CardType.LAND` is supplied.

Closes #13225.