### PR TITLE
Delete empty tooltips

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.form
@@ -180,7 +180,6 @@
     </Component>
     <Component class="javax.swing.JLabel" name="lblForestIcon">
       <Properties>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[22, 20]"/>
         </Property>

--- a/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/AddLandDialog.java
@@ -271,7 +271,6 @@ public class AddLandDialog extends MageDialog {
 
         spnForest.setModel(new javax.swing.SpinnerNumberModel(0, 0, null, 1));
 
-        lblForestIcon.setToolTipText("");
         lblForestIcon.setMaximumSize(new java.awt.Dimension(22, 20));
         lblForestIcon.setMinimumSize(new java.awt.Dimension(22, 20));
         lblForestIcon.setPreferredSize(new java.awt.Dimension(22, 20));

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.form
@@ -35,7 +35,6 @@
         <MenuItem class="javax.swing.JMenuItem" name="menuLoadSettingsLast">
           <Properties>
             <Property name="text" type="java.lang.String" value="Load from last time"/>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="menuLoadSettingsLastActionPerformed"/>
@@ -46,7 +45,6 @@
         <MenuItem class="javax.swing.JMenuItem" name="menuLoadSettings1">
           <Properties>
             <Property name="text" type="java.lang.String" value="Load from config 1"/>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="menuLoadSettings1ActionPerformed"/>
@@ -65,7 +63,6 @@
         <MenuItem class="javax.swing.JMenuItem" name="menuLoadSettingsDefault">
           <Properties>
             <Property name="text" type="java.lang.String" value="Load default settings"/>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="menuLoadSettingsDefaultActionPerformed"/>
@@ -391,7 +388,6 @@
     <Component class="javax.swing.JLabel" name="lblSkillLevel">
       <Properties>
         <Property name="text" type="java.lang.String" value="Skill Level:"/>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
     </Component>
     <Component class="javax.swing.JComboBox" name="cbSkillLevel">

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTableDialog.java
@@ -150,7 +150,6 @@ public class NewTableDialog extends MageDialog {
         popupSaveSettings.add(menuSaveSettings2);
 
         menuLoadSettingsLast.setText("Load from last time");
-        menuLoadSettingsLast.setToolTipText("");
         menuLoadSettingsLast.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 menuLoadSettingsLastActionPerformed(evt);
@@ -160,7 +159,6 @@ public class NewTableDialog extends MageDialog {
         popupLoadSettings.add(separator1);
 
         menuLoadSettings1.setText("Load from config 1");
-        menuLoadSettings1.setToolTipText("");
         menuLoadSettings1.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 menuLoadSettings1ActionPerformed(evt);
@@ -178,7 +176,6 @@ public class NewTableDialog extends MageDialog {
         popupLoadSettings.add(separator2);
 
         menuLoadSettingsDefault.setText("Load default settings");
-        menuLoadSettingsDefault.setToolTipText("");
         menuLoadSettingsDefault.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 menuLoadSettingsDefaultActionPerformed(evt);
@@ -228,7 +225,6 @@ public class NewTableDialog extends MageDialog {
         });
 
         lblSkillLevel.setText("Skill Level:");
-        lblSkillLevel.setToolTipText("");
 
         cbSkillLevel.setToolTipText("<HTML>This option can be used to make it easier to find matches<br>\nwith opponents of the appropriate skill level.");
 

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.form
@@ -35,7 +35,6 @@
         <MenuItem class="javax.swing.JMenuItem" name="menuLoadSettingsLast">
           <Properties>
             <Property name="text" type="java.lang.String" value="Load from last time"/>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="menuLoadSettingsLastActionPerformed"/>
@@ -46,7 +45,6 @@
         <MenuItem class="javax.swing.JMenuItem" name="menuLoadSettings1">
           <Properties>
             <Property name="text" type="java.lang.String" value="Load from config 1"/>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="menuLoadSettings1ActionPerformed"/>
@@ -65,7 +63,6 @@
         <MenuItem class="javax.swing.JMenuItem" name="menuLoadSettingsDefault">
           <Properties>
             <Property name="text" type="java.lang.String" value="Load default settings"/>
-            <Property name="toolTipText" type="java.lang.String" value=""/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="menuLoadSettingsDefaultActionPerformed"/>
@@ -663,7 +660,6 @@
             <EtchetBorder/>
           </Border>
         </Property>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
@@ -677,7 +673,6 @@
     </Component>
     <Component class="javax.swing.JSpinner" name="spnQuitRatio">
       <Properties>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
     </Component>
     <Component class="javax.swing.JLabel" name="lblMinimumRating">

--- a/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/NewTournamentDialog.java
@@ -203,7 +203,6 @@ public class NewTournamentDialog extends MageDialog {
         popupSaveSettings.add(menuSaveSettings2);
 
         menuLoadSettingsLast.setText("Load from last time");
-        menuLoadSettingsLast.setToolTipText("");
         menuLoadSettingsLast.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 menuLoadSettingsLastActionPerformed(evt);
@@ -213,7 +212,6 @@ public class NewTournamentDialog extends MageDialog {
         popupLoadSettings.add(separator1);
 
         menuLoadSettings1.setText("Load from config 1");
-        menuLoadSettings1.setToolTipText("");
         menuLoadSettings1.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 menuLoadSettings1ActionPerformed(evt);
@@ -231,7 +229,6 @@ public class NewTournamentDialog extends MageDialog {
         popupLoadSettings.add(separator2);
 
         menuLoadSettingsDefault.setText("Load default settings");
-        menuLoadSettingsDefault.setToolTipText("");
         menuLoadSettingsDefault.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 menuLoadSettingsDefaultActionPerformed(evt);
@@ -411,12 +408,9 @@ public class NewTournamentDialog extends MageDialog {
         });
 
         pnlRandomPacks.setBorder(javax.swing.BorderFactory.createEtchedBorder());
-        pnlRandomPacks.setToolTipText("");
         pnlRandomPacks.setLayout(new javax.swing.BoxLayout(pnlRandomPacks, javax.swing.BoxLayout.Y_AXIS));
 
         lblQuitRatio.setText("Allowed quit %");
-
-        spnQuitRatio.setToolTipText("");
 
         lblMinimumRating.setText("Minimum rating:");
         lblMinimumRating.setToolTipText("Players with rating less than this value can't join this table");

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
@@ -2010,7 +2010,6 @@
                   <Properties>
                     <Property name="horizontalAlignment" type="int" value="2"/>
                     <Property name="text" type="java.lang.String" value="GUI color style:"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="horizontalTextPosition" type="int" value="10"/>
                     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
                       <Dimension value="[110, 16]"/>
@@ -2616,7 +2615,6 @@
                   <Properties>
                     <Property name="selected" type="boolean" value="true"/>
                     <Property name="text" type="java.lang.String" value="STOP skips on declare attackers if attackers are available"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
@@ -2624,21 +2622,18 @@
                   <Properties>
                     <Property name="selected" type="boolean" value="true"/>
                     <Property name="text" type="java.lang.String" value="STOP skips on declare blockers if ANY blockers are available"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="cbStopBlockWithZero">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="STOP skips on declare blockers if ZERO blockers are available"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="cbStopOnNewStackObjects">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Skip to STACK resolved (F10): stop on new objects added (on) or stop until empty (off)"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
                       <Dimension value="[300, 25]"/>
@@ -2648,14 +2643,12 @@
                 <Component class="javax.swing.JCheckBox" name="cbStopOnAllMain">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Skip to MAIN step (F7): stop on any main steps (on) or stop on your main step (off)"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="cbStopOnAllEnd">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Skip to END step (F5): stop on any end steps (on) or stop on opponents end step (off)"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
                       <Dimension value="[300, 25]"/>
@@ -3128,7 +3121,6 @@
                 <Component class="javax.swing.JLabel" name="jLabel16">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Playing from folder:"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JTextField" name="txtBattlefieldIBGMPath">

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -2108,7 +2108,6 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
         lbSelectLabel.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
         lbSelectLabel.setText("GUI color style:");
-        lbSelectLabel.setToolTipText("");
         lbSelectLabel.setHorizontalTextPosition(javax.swing.SwingConstants.LEADING);
         lbSelectLabel.setPreferredSize(new java.awt.Dimension(110, 16));
         lbSelectLabel.setVerticalTextPosition(javax.swing.SwingConstants.TOP);
@@ -2391,34 +2390,28 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
         cbStopAttack.setSelected(true);
         cbStopAttack.setText("STOP skips on declare attackers if attackers are available");
-        cbStopAttack.setToolTipText("");
         cbStopAttack.setActionCommand("");
         phases_stopSettings.add(cbStopAttack);
 
         cbStopBlockWithAny.setSelected(true);
         cbStopBlockWithAny.setText("STOP skips on declare blockers if ANY blockers are available");
-        cbStopBlockWithAny.setToolTipText("");
         cbStopBlockWithAny.setActionCommand("");
         phases_stopSettings.add(cbStopBlockWithAny);
 
         cbStopBlockWithZero.setText("STOP skips on declare blockers if ZERO blockers are available");
-        cbStopBlockWithZero.setToolTipText("");
         cbStopBlockWithZero.setActionCommand("");
         phases_stopSettings.add(cbStopBlockWithZero);
 
         cbStopOnNewStackObjects.setText("Skip to STACK resolved (F10): stop on new objects added (on) or stop until empty (off)");
-        cbStopOnNewStackObjects.setToolTipText("");
         cbStopOnNewStackObjects.setActionCommand("");
         cbStopOnNewStackObjects.setPreferredSize(new java.awt.Dimension(300, 25));
         phases_stopSettings.add(cbStopOnNewStackObjects);
 
         cbStopOnAllMain.setText("Skip to MAIN step (F7): stop on any main steps (on) or stop on your main step (off)");
-        cbStopOnAllMain.setToolTipText("");
         cbStopOnAllMain.setActionCommand("");
         phases_stopSettings.add(cbStopOnAllMain);
 
         cbStopOnAllEnd.setText("Skip to END step (F5): stop on any end steps (on) or stop on opponents end step (off)");
-        cbStopOnAllEnd.setToolTipText("");
         cbStopOnAllEnd.setActionCommand("");
         cbStopOnAllEnd.setPreferredSize(new java.awt.Dimension(300, 25));
         phases_stopSettings.add(cbStopOnAllEnd);
@@ -2743,7 +2736,6 @@ public class PreferencesDialog extends javax.swing.JDialog {
         });
 
         jLabel16.setText("Playing from folder:");
-        jLabel16.setToolTipText("");
 
         btnBattlefieldBGMBrowse.setText("Browse...");
         btnBattlefieldBGMBrowse.addActionListener(new java.awt.event.ActionListener() {

--- a/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.form
@@ -165,7 +165,6 @@
     </Component>
     <Component class="javax.swing.JLabel" name="lblStatus">
       <Properties>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="txtServer">
@@ -212,7 +211,6 @@
           <ComponentRef name="txtEmail"/>
         </Property>
         <Property name="text" type="java.lang.String" value="(used for password reset)"/>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
     </Component>
   </SubComponents>

--- a/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/RegisterUserDialog.java
@@ -87,8 +87,6 @@ public class RegisterUserDialog extends MageDialog {
         btnCancel.setText("Cancel");
         btnCancel.addActionListener(evt -> btnCancelActionPerformed(evt));
 
-        lblStatus.setToolTipText("");
-
         lblPasswordConfirmation.setLabelFor(txtPasswordConfirmation);
         lblPasswordConfirmation.setText("Password:");
 
@@ -102,7 +100,6 @@ public class RegisterUserDialog extends MageDialog {
         lblEmailReasoning.setFont(new java.awt.Font("Lucida Grande", 0, 10)); // NOI18N
         lblEmailReasoning.setLabelFor(txtEmail);
         lblEmailReasoning.setText("(used for password reset and sending initial password)");
-        lblEmailReasoning.setToolTipText("");
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.form
@@ -94,7 +94,6 @@
         <Property name="dividerLocation" type="int" value="300"/>
         <Property name="dividerSize" type="int" value="3"/>
         <Property name="resizeWeight" type="double" value="1.0"/>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>

--- a/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TableWaitingDialog.java
@@ -207,7 +207,6 @@ public class TableWaitingDialog extends MageDialog {
         jSplitPane1.setDividerLocation(300);
         jSplitPane1.setDividerSize(3);
         jSplitPane1.setResizeWeight(1.0);
-        jSplitPane1.setToolTipText("");
 
         jTableSeats.setModel(tableWaitModel);
         jTableSeats.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);

--- a/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.form
@@ -300,7 +300,6 @@
             <StringItem index="0" value="loading..."/>
           </StringArray>
         </Property>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
       <Events>
         <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="comboCardColorItemStateChanged"/>
@@ -382,7 +381,6 @@
                         <StringItem index="2" value="Dead"/>
                       </StringArray>
                     </Property>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="alignmentX" type="float" value="0.0"/>
                   </Properties>
                   <Events>

--- a/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
@@ -736,7 +736,6 @@ public class TestCardRenderDialog extends MageDialog {
         labelCardColor.setText("Card color:");
 
         comboCardColor.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "loading..." }));
-        comboCardColor.setToolTipText("");
         comboCardColor.addItemListener(new java.awt.event.ItemListener() {
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 comboCardColorItemStateChanged(evt);
@@ -774,7 +773,6 @@ public class TestCardRenderDialog extends MageDialog {
         playerOptions.add(checkPlayerSmallMode);
 
         comboPlayerStatus.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Active", "Inactive", "Dead" }));
-        comboPlayerStatus.setToolTipText("");
         comboPlayerStatus.setAlignmentX(0.0F);
         comboPlayerStatus.addItemListener(new java.awt.event.ItemListener() {
             public void itemStateChanged(java.awt.event.ItemEvent evt) {

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.form
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.form
@@ -343,7 +343,6 @@
                     </Property>
                     <Property name="horizontalAlignment" type="int" value="4"/>
                     <Property name="text" type="java.lang.String" value="player 2"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="alignmentX" type="float" value="1.0"/>
                     <Property name="alignmentY" type="float" value="0.0"/>
                     <Property name="focusable" type="boolean" value="false"/>
@@ -523,7 +522,6 @@
                     </Property>
                     <Property name="horizontalAlignment" type="int" value="2"/>
                     <Property name="text" type="java.lang.String" value="player 12"/>
-                    <Property name="toolTipText" type="java.lang.String" value=""/>
                     <Property name="focusable" type="boolean" value="false"/>
                     <Property name="requestFocusEnabled" type="boolean" value="false"/>
                     <Property name="verifyInputWhenFocusTarget" type="boolean" value="false"/>

--- a/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
+++ b/Mage.Client/src/main/java/mage/client/draft/DraftPanel.java
@@ -773,7 +773,6 @@
         labelPlayer02.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         labelPlayer02.setHorizontalAlignment(javax.swing.SwingConstants.RIGHT);
         labelPlayer02.setText("player 2");
-        labelPlayer02.setToolTipText("");
         labelPlayer02.setAlignmentX(1.0F);
         labelPlayer02.setAlignmentY(0.0F);
         labelPlayer02.setFocusable(false);
@@ -887,7 +886,6 @@
         labelPlayer12.setFont(new java.awt.Font("Tahoma", 0, 10)); // NOI18N
         labelPlayer12.setHorizontalAlignment(javax.swing.SwingConstants.LEFT);
         labelPlayer12.setText("player 12");
-        labelPlayer12.setToolTipText("");
         labelPlayer12.setFocusable(false);
         labelPlayer12.setRequestFocusEnabled(false);
         labelPlayer12.setVerifyInputWhenFocusTarget(false);

--- a/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.form
+++ b/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.form
@@ -273,7 +273,6 @@
     <Container class="javax.swing.JSplitPane" name="jSplitPane2">
       <Properties>
         <Property name="resizeWeight" type="double" value="1.0"/>
-        <Property name="toolTipText" type="java.lang.String" value=""/>
       </Properties>
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JSplitPaneSupportLayout"/>

--- a/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.java
+++ b/Mage.Client/src/main/java/mage/client/tournament/TournamentPanel.java
@@ -444,7 +444,6 @@ public class TournamentPanel extends javax.swing.JPanel {
         );
 
         jSplitPane2.setResizeWeight(1.0);
-        jSplitPane2.setToolTipText("");
 
         jSplitPane1.setDividerLocation(230);
         jSplitPane1.setOrientation(javax.swing.JSplitPane.VERTICAL_SPLIT);


### PR DESCRIPTION
XMage is littered with redundant, empty tooltips that randomly display when mousing over some buttons / words, with no consistency at all. E.g., "Load from config 1" had an empty tooltip, but "Load from config 2" didn't... this PR removes those tooltips.

Before:
![image](https://github.com/user-attachments/assets/ab841547-25d7-4542-bd06-e8c8730711e0)
![image](https://github.com/user-attachments/assets/81284273-c403-489f-a088-0bd9b690a86e)

After:
![image](https://github.com/user-attachments/assets/b5f1e7c1-a102-439e-a2a9-8e9b308e023a)
![image](https://github.com/user-attachments/assets/b11542f8-1c68-4148-9563-ced9334198b5)
