### PR TITLE
Improve rules text for Decayed

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/DecayedAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/DecayedAbility.java
@@ -18,7 +18,7 @@ public class DecayedAbility extends StaticAbility {
         super(Zone.BATTLEFIELD, new CantBlockSourceEffect(Duration.WhileOnBattlefield));
         this.addSubAbility(new AttacksTriggeredAbility(new CreateDelayedTriggeredAbilityEffect(
                 new AtTheEndOfCombatDelayedTriggeredAbility(new SacrificeSourceEffect())
-        ).setText("sacrifice it at end of combat")).setTriggerPhrase("When {this} attacks, "));
+        ).setText("sacrifice it at end of combat")).setTriggerPhrase("When {this} attacks, ").setRuleVisible(false));
     }
 
     private DecayedAbility(final DecayedAbility ability) {
@@ -32,6 +32,6 @@ public class DecayedAbility extends StaticAbility {
 
     @Override
     public String getRule() {
-        return "decayed";
+        return "decayed <i>(This creature can’t block. When it attacks, sacrifice it at end of combat.)</i>";
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/DecayedAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/DecayedAbility.java
@@ -32,6 +32,6 @@ public class DecayedAbility extends StaticAbility {
 
     @Override
     public String getRule() {
-        return "decayed <i>(This creature can’t block. When it attacks, sacrifice it at end of combat.)</i>";
+        return "decayed <i>(This creature can't block. When it attacks, sacrifice it at end of combat.)</i>";
     }
 }


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e4b18403-be0f-462d-a624-b8aa603a1e30)

After:
![image](https://github.com/user-attachments/assets/92486069-9c40-4472-ace7-69803ad06659)

The previous rules text didn't mention that the creature can't block specifically because of decayed. This new rules text also bundles the "Sacrifice this on attack" text into the hint for the decayed ability instead of having it be formatted like a distinct ability. It's also more in line with how decayed looks on cards as they have reminder text.

<details><summary>Click to expand</summary>

![image](https://github.com/user-attachments/assets/01ce4b73-b795-4fcb-91ae-eed4df29db7c)
</details>