### PR TITLE
Fix #13021: Allow Shifting Woodland to become a copy of a MDFC Permanent in the Graveyard

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShiftingWoodland.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftingWoodland.java
@@ -22,6 +22,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.PermanentCard;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 import mage.util.functions.EmptyCopyApplier;
 
 import java.util.UUID;
@@ -92,10 +93,7 @@ class ShiftingWoodlandCopyEffect extends OneShotEffect {
         if (copyFromCard == null) {
             return false;
         }
-        if (copyFromCard instanceof ModalDoubleFacedCard) {
-            copyFromCard = ((ModalDoubleFacedCard) copyFromCard).getLeftHalfCard();
-        }
-        Permanent blueprint = new PermanentCard(copyFromCard, source.getControllerId(), game);
+        Permanent blueprint = new PermanentCard(CardUtil.getDefaultCardSideForBattlefield(game, copyFromCard), source.getControllerId(), game);
         game.copyPermanent(Duration.EndOfTurn, blueprint, sourcePermanent.getId(), source, new EmptyCopyApplier());
         return true;
     }

--- a/Mage.Sets/src/mage/cards/s/ShiftingWoodland.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftingWoodland.java
@@ -12,6 +12,7 @@ import mage.abilities.mana.GreenManaAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.cards.ModalDoubleFacedCard;
 import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.FilterPermanent;
@@ -90,6 +91,9 @@ class ShiftingWoodlandCopyEffect extends OneShotEffect {
         Card copyFromCard = game.getCard(getTargetPointer().getFirst(game, source));
         if (copyFromCard == null) {
             return false;
+        }
+        if (copyFromCard instanceof ModalDoubleFacedCard) {
+            copyFromCard = ((ModalDoubleFacedCard) copyFromCard).getLeftHalfCard();
         }
         Permanent blueprint = new PermanentCard(copyFromCard, source.getControllerId(), game);
         game.copyPermanent(Duration.EndOfTurn, blueprint, sourcePermanent.getId(), source, new EmptyCopyApplier());

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/ShiftingWoodlandTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/ShiftingWoodlandTest.java
@@ -151,4 +151,24 @@ public class ShiftingWoodlandTest extends CardTestPlayerBase {
         assertLife(playerB, 20 - 3 - 1);
         assertGraveyardCount(playerA, woodland, 1);
     }
+
+    @Test
+    public void test_Copy_MDFC() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Yavimaya Coast", 4); // to be sure not to activate Woodland
+        addCard(Zone.BATTLEFIELD, playerA, woodland);
+        addCard(Zone.GRAVEYARD, playerA, "Drowner of Truth");
+        addCard(Zone.GRAVEYARD, playerA, "Plains");
+        addCard(Zone.GRAVEYARD, playerA, "Memnite");
+        addCard(Zone.GRAVEYARD, playerA, "Divination");
+
+        activateManaAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {G}. {this} deals 1 damage to you.", 4);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "<i>Delirium</i> &mdash; {2}{G}{G}:", "Drowner of Truth");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Drowner of Truth", 1);
+    }
 }


### PR DESCRIPTION
Permanent card explicitly forbids MDFCs, which makes sense. Use the front side since that's the side to use when an MDFC is in the graveyard.

Fixes #13021