### PR TITLE
[DRC] implement Hashaton, Scarab's Fist

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
+++ b/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
@@ -1,12 +1,33 @@
 package mage.cards.h;
 
+import java.util.Optional;
 import java.util.UUID;
+
 import mage.MageInt;
+import mage.MageObject;
+import mage.ObjectColor;
+import mage.abilities.Ability;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
+import mage.abilities.effects.common.DiscardCardControllerTriggeredAbility;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.FlyingAbility;
+import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreatureCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+import mage.watchers.common.DiscardedCardWatcher;
 
 /**
  * @author sobiech
@@ -15,7 +36,7 @@ public final class HashatonScarabsFist extends CardImpl {
 
     public HashatonScarabsFist(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{W}{B}");
-        
+
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.ZOMBIE);
         this.subtype.add(SubType.WIZARD);
@@ -23,6 +44,10 @@ public final class HashatonScarabsFist extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever you discard a creature card, you may pay {2}{U}. If you do, create a tapped token that's a copy of that card, except it's a 4/4 black Zombie.
+        final Ability ability = new DiscardCardControllerTriggeredAbility(
+                new DoIfCostPaid(new HashatonScarabsFistEffect(), new ManaCostsImpl<>("{2}{U}")), false, StaticFilters.FILTER_CARD_CREATURE_A
+        );
+        this.addAbility(ability);
     }
 
     private HashatonScarabsFist(final HashatonScarabsFist card) {
@@ -32,5 +57,43 @@ public final class HashatonScarabsFist extends CardImpl {
     @Override
     public HashatonScarabsFist copy() {
         return new HashatonScarabsFist(this);
+    }
+}
+
+class HashatonScarabsFistEffect extends OneShotEffect {
+
+    HashatonScarabsFistEffect() {
+        super(Outcome.PutCreatureInPlay);
+        this.staticText = "create a tapped token that`s a copy of that card, except it`s a 4/4 black Zombie";
+    }
+
+    private HashatonScarabsFistEffect(OneShotEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+
+        return Optional.ofNullable(this.values.get("discardedCard"))
+                .map(CardImpl.class::cast)
+                .filter(CardImpl::isCreature)
+                //create a tapped token that's a copy of that card, except it's a 4/4 black Zombie.
+                .map(card -> new CreateTokenCopyTargetEffect(null, null, false, 1,
+                                true, false, null, 4, 4, false)
+                                .setOnlyColor(ObjectColor.BLACK)
+                                .setOnlySubType(SubType.ZOMBIE)
+                                .setTargetPointer(new FixedTarget(card, game))
+                                .apply(game, source)
+                )
+                .orElse(false);
+    }
+
+    @Override
+    public HashatonScarabsFistEffect copy() {
+        return new HashatonScarabsFistEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
+++ b/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
@@ -1,0 +1,36 @@
+package mage.cards.h;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ * @author sobiech
+ */
+public final class HashatonScarabsFist extends CardImpl {
+
+    public HashatonScarabsFist(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{W}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ZOMBIE);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(3);
+
+        // Whenever you discard a creature card, you may pay {2}{U}. If you do, create a tapped token that's a copy of that card, except it's a 4/4 black Zombie.
+    }
+
+    private HashatonScarabsFist(final HashatonScarabsFist card) {
+        super(card);
+    }
+
+    @Override
+    public HashatonScarabsFist copy() {
+        return new HashatonScarabsFist(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
+++ b/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -12,22 +11,16 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.abilities.effects.common.DiscardCardControllerTriggeredAbility;
 import mage.abilities.effects.common.DoIfCostPaid;
-import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.effects.common.counter.AddCountersSourceEffect;
-import mage.abilities.keyword.FlyingAbility;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreatureCard;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
-import mage.watchers.common.DiscardedCardWatcher;
 
 /**
  * @author sobiech

--- a/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
+++ b/Mage.Sets/src/mage/cards/h/HashatonScarabsFist.java
@@ -7,10 +7,13 @@ import mage.MageInt;
 import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.abilities.effects.common.DiscardCardControllerTriggeredAbility;
 import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.hint.StaticHint;
+import mage.cards.Card;
 import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.constants.SuperType;
@@ -38,7 +41,9 @@ public final class HashatonScarabsFist extends CardImpl {
 
         // Whenever you discard a creature card, you may pay {2}{U}. If you do, create a tapped token that's a copy of that card, except it's a 4/4 black Zombie.
         final Ability ability = new DiscardCardControllerTriggeredAbility(
-                new DoIfCostPaid(new HashatonScarabsFistEffect(), new ManaCostsImpl<>("{2}{U}")), false, StaticFilters.FILTER_CARD_CREATURE_A
+                new DoIfCostPaid(new HashatonScarabsFistEffect(), new ManaCostsImpl<>("{2}{U}"))
+                        .withChooseHint(new HashatonScarabsFistHint()),
+                false, StaticFilters.FILTER_CARD_CREATURE_A
         );
         this.addAbility(ability);
     }
@@ -50,6 +55,27 @@ public final class HashatonScarabsFist extends CardImpl {
     @Override
     public HashatonScarabsFist copy() {
         return new HashatonScarabsFist(this);
+    }
+}
+
+class HashatonScarabsFistHint extends StaticHint {
+
+    public HashatonScarabsFistHint() {
+        super("");
+    }
+
+    @Override
+    public String getText(Game game, Ability source) {
+        if (source.getEffects().isEmpty()) {
+            return "";
+        }
+        for (Effect effect : source.getEffects()) {
+            Card discardedCard = (Card) effect.getValue("discardedCard");
+            if (discardedCard != null) {
+                return "Discarded card: " + discardedCard.getName();
+            }
+        }
+        return "";
     }
 }
 

--- a/Mage.Sets/src/mage/sets/AetherdriftCommander.java
+++ b/Mage.Sets/src/mage/sets/AetherdriftCommander.java
@@ -95,6 +95,7 @@ public final class AetherdriftCommander extends ExpansionSet {
         cards.add(new SetCardInfo("God-Pharaoh's Gift", 131, Rarity.RARE, mage.cards.g.GodPharaohsGift.class));
         cards.add(new SetCardInfo("Grave Titan", 42, Rarity.MYTHIC, mage.cards.g.GraveTitan.class));
         cards.add(new SetCardInfo("Gravecrawler", 43, Rarity.RARE, mage.cards.g.Gravecrawler.class));
+        cards.add(new SetCardInfo("Hashaton, Scarab's Fist", 1, Rarity.MYTHIC, mage.cards.h.HashatonScarabsFist.class));
         cards.add(new SetCardInfo("Hinterland Harbor", 160, Rarity.RARE, mage.cards.h.HinterlandHarbor.class));
         cards.add(new SetCardInfo("Irrigated Farmland", 161, Rarity.RARE, mage.cards.i.IrrigatedFarmland.class));
         cards.add(new SetCardInfo("Isolated Chapel", 162, Rarity.RARE, mage.cards.i.IsolatedChapel.class));


### PR DESCRIPTION

![Zrzut ekranu 2025-02-10 121503](https://github.com/user-attachments/assets/bd6e0407-3be3-4999-ae89-ce3eec1c7fcf)
When discarding more then one card at once its unclear of which the copy would be created. Is there an option to alter text displayed in the popup choice menu without altering static text of card?
Part of #13252
