### PR TITLE
[ACR] Implement Viewpoint Synchronization

### DIFF
--- a/Mage.Sets/src/mage/cards/c/Cultivate.java
+++ b/Mage.Sets/src/mage/cards/c/Cultivate.java
@@ -1,6 +1,6 @@
 package mage.cards.c;
 
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.cards.*;
 import mage.constants.CardType;
 import mage.filter.StaticFilters;
@@ -17,7 +17,7 @@ public final class Cultivate extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{G}");
 
         // Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(
+        this.getSpellAbility().addEffect(new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(
                 new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS)));
 
     }

--- a/Mage.Sets/src/mage/cards/f/FlareOfCultivation.java
+++ b/Mage.Sets/src/mage/cards/f/FlareOfCultivation.java
@@ -3,7 +3,7 @@ package mage.cards.f;
 import mage.ObjectColor;
 import mage.abilities.costs.AlternativeCostSourceAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -35,7 +35,7 @@ public final class FlareOfCultivation extends CardImpl {
         this.addAbility(new AlternativeCostSourceAbility(new SacrificeTargetCost(filter)).setRuleAtTheTop(true));
 
         // Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(
+        this.getSpellAbility().addEffect(new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(
                 new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS)
         ));
     }

--- a/Mage.Sets/src/mage/cards/f/FlourishingBloomKin.java
+++ b/Mage.Sets/src/mage/cards/f/FlourishingBloomKin.java
@@ -9,7 +9,7 @@ import mage.abilities.common.TurnedFaceUpSourceTriggeredAbility;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.abilities.hint.Hint;
 import mage.abilities.hint.ValueHint;
 import mage.constants.Duration;
@@ -56,7 +56,7 @@ public final class FlourishingBloomKin extends CardImpl {
         // When Flourishing Bloom-Kin is turned face up, search your library for up to two Forest cards and reveal them.
         // Put one of them onto the battlefield tapped and the other into your hand, then shuffle.
         this.addAbility(new TurnedFaceUpSourceTriggeredAbility(
-                new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(new TargetCardInLibrary(0, 2, filterForestCards))
+                new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(new TargetCardInLibrary(0, 2, filterForestCards))
                         .setText("search your library for up to two Forest cards and reveal them. Put one of them onto the battlefield tapped and the other into your hand, then shuffle")));
     }
 

--- a/Mage.Sets/src/mage/cards/k/KodamasReach.java
+++ b/Mage.Sets/src/mage/cards/k/KodamasReach.java
@@ -1,6 +1,6 @@
 package mage.cards.k;
 
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.SubType;
@@ -19,7 +19,7 @@ public final class KodamasReach extends CardImpl {
         this.subtype.add(SubType.ARCANE);
 
         // Search your library for up to two basic land cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(
+        this.getSpellAbility().addEffect(new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(
                 new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS)));
     }
 

--- a/Mage.Sets/src/mage/cards/n/NavigationOrb.java
+++ b/Mage.Sets/src/mage/cards/n/NavigationOrb.java
@@ -5,7 +5,7 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.cards.*;
 import mage.constants.*;
 import mage.filter.FilterCard;
@@ -32,7 +32,7 @@ public final class NavigationOrb extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // {2}, {T}, Sacrifice Navigation Orb: Search your library for up to two basic land cards and/or Gate cards, reveal those cards, put one onto the battlefield tapped and the other into your hand, then shuffle.
-        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(
+        Ability ability = new SimpleActivatedAbility(new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(
                 new TargetCardInLibrary(0, 2, filter)), new GenericManaCost(2));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/n/NissasPilgrimage.java
+++ b/Mage.Sets/src/mage/cards/n/NissasPilgrimage.java
@@ -4,7 +4,7 @@ package mage.cards.n;
 import java.util.UUID;
 import mage.abilities.condition.common.SpellMasteryCondition;
 import mage.abilities.decorator.ConditionalOneShotEffect;
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -32,8 +32,8 @@ public final class NissasPilgrimage extends CardImpl {
         // Search your library for up to two basic Forest cards, reveal those cards, and put one onto the battlefield tapped and the rest into your hand. Then shuffle.
         // <i>Spell Mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, search your library for up to three basic Forest cards instead of two.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(new TargetCardInLibrary(0, 3, filter)),
-                new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(new TargetCardInLibrary(0, 2, filter)),
+                new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(new TargetCardInLibrary(0, 3, filter)),
+                new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(new TargetCardInLibrary(0, 2, filter)),
                 SpellMasteryCondition.instance,
                 "Search your library for up to two basic Forest cards, reveal those cards, and put one onto the battlefield tapped and the rest into your hand. Then shuffle."
                         + "<br><i>Spell mastery</i> &mdash; If there are two or more instant and/or sorcery cards in your graveyard, search your library for up to three basic Forest cards instead of two."));

--- a/Mage.Sets/src/mage/cards/p/Peregrination.java
+++ b/Mage.Sets/src/mage/cards/p/Peregrination.java
@@ -1,7 +1,7 @@
 package mage.cards.p;
 
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.search.SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
 import mage.abilities.effects.keyword.ScryEffect;
 import mage.cards.*;
 import mage.constants.CardType;
@@ -19,7 +19,7 @@ public final class Peregrination extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{G}");
 
         // Search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle, then scry 1.
-        this.getSpellAbility().addEffect(new SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect(
+        this.getSpellAbility().addEffect(new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(
                 new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS))
                 .setText("search your library for up to two basic land cards, reveal those cards, and put one onto the battlefield tapped and the other into your hand. Shuffle"));
         Effect effect = new ScryEffect(1);

--- a/Mage.Sets/src/mage/cards/v/ViewpointSynchronization.java
+++ b/Mage.Sets/src/mage/cards/v/ViewpointSynchronization.java
@@ -1,0 +1,32 @@
+package mage.cards.v;
+
+import mage.abilities.effects.common.search.SearchLibraryPutOntoBattlefieldTappedRestInHandEffect;
+import mage.abilities.keyword.FreerunningAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.StaticFilters;
+import mage.target.common.TargetCardInLibrary;
+
+import java.util.UUID;
+
+public class ViewpointSynchronization extends CardImpl {
+    public ViewpointSynchronization(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}");
+
+        this.addAbility(new FreerunningAbility("{2}{G}"));
+
+        // Search your library for up to three basic land cards and reveal them. Put two of them onto the battlefield tapped and the other in your hand, then shuffle.
+        this.getSpellAbility().addEffect(new SearchLibraryPutOntoBattlefieldTappedRestInHandEffect(
+                new TargetCardInLibrary(0, 3, StaticFilters.FILTER_CARD_BASIC_LANDS), 2));
+    }
+
+    public ViewpointSynchronization(ViewpointSynchronization card) {
+        super(card);
+    }
+
+    @Override
+    public ViewpointSynchronization copy() {
+        return new ViewpointSynchronization(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/AssassinsCreed.java
+++ b/Mage.Sets/src/mage/sets/AssassinsCreed.java
@@ -321,8 +321,8 @@ public final class AssassinsCreed extends ExpansionSet {
         cards.add(new SetCardInfo("Towering Viewpoint", 263, Rarity.UNCOMMON, mage.cards.t.ToweringViewpoint.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Towering Viewpoint", 77, Rarity.UNCOMMON, mage.cards.t.ToweringViewpoint.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Tranquilize", 284, Rarity.COMMON, mage.cards.t.Tranquilize.class));
-        //cards.add(new SetCardInfo("Viewpoint Synchronization", 223, Rarity.UNCOMMON, mage.cards.v.ViewpointSynchronization.class, NON_FULL_USE_VARIOUS));
-        //cards.add(new SetCardInfo("Viewpoint Synchronization", 43, Rarity.UNCOMMON, mage.cards.v.ViewpointSynchronization.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Viewpoint Synchronization", 223, Rarity.UNCOMMON, mage.cards.v.ViewpointSynchronization.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Viewpoint Synchronization", 43, Rarity.UNCOMMON, mage.cards.v.ViewpointSynchronization.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Waterlogged Grove", 116, Rarity.RARE, mage.cards.w.WaterloggedGrove.class));
         //cards.add(new SetCardInfo("What Must Be Done", 11, Rarity.RARE, mage.cards.w.WhatMustBeDone.class, NON_FULL_USE_VARIOUS));
         //cards.add(new SetCardInfo("What Must Be Done", 157, Rarity.RARE, mage.cards.w.WhatMustBeDone.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
Card functions as expected and unit tests pass.

SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect had to be refactored to handle multiple cards and was renamed to reflect it's new functionality (SearchLibraryPutOneOntoBattlefieldTappedRestInHandEffect -> SearchLibraryPutOntoBattlefieldTappedRestInHandEffect). Other cards that use similar effects still seem to be working.

part of #11854