### PR TITLE
Fix second ability of Mu Yanling, Wind Rider

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MuYanlingWindRider.java
+++ b/Mage.Sets/src/mage/cards/m/MuYanlingWindRider.java
@@ -31,10 +31,6 @@ public final class MuYanlingWindRider extends CardImpl {
     private static final FilterCreaturePermanent filter2
             = new FilterCreaturePermanent("creatures you control with flying");
 
-    static {
-        filter.add(new AbilityPredicate(FlyingAbility.class));
-    }
-
     public MuYanlingWindRider(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{U}");
 

--- a/Mage.Sets/src/mage/cards/m/MuYanlingWindRider.java
+++ b/Mage.Sets/src/mage/cards/m/MuYanlingWindRider.java
@@ -31,6 +31,10 @@ public final class MuYanlingWindRider extends CardImpl {
     private static final FilterCreaturePermanent filter2
             = new FilterCreaturePermanent("creatures you control with flying");
 
+    static {
+        filter2.add(new AbilityPredicate(FlyingAbility.class));
+    }
+
     public MuYanlingWindRider(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{U}");
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dft/MuYanlingWindRiderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dft/MuYanlingWindRiderTest.java
@@ -38,6 +38,7 @@ public class MuYanlingWindRiderTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
         addCard(Zone.HAND, playerA, muyanling);
         addCard(Zone.HAND, playerA, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerA, "Ankle Biter");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, muyanling, true);
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Memnite", true);
@@ -47,6 +48,7 @@ public class MuYanlingWindRiderTest extends CardTestPlayerBase {
 
         attack(3, playerA, "Vehicle Token", playerB);
         attack(3, playerA, muyanling, playerB);
+        attack(3, playerA, "Ankle Biter", playerB);
 
         setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/dft/MuYanlingWindRiderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/dft/MuYanlingWindRiderTest.java
@@ -1,0 +1,61 @@
+package org.mage.test.cards.single.dft;
+
+import mage.abilities.keyword.FlyingAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author jimga150
+ */
+public class MuYanlingWindRiderTest extends CardTestPlayerBase {
+
+    // When this creature enters, create a 3/2 colorless Vehicle artifact token with crew 1.
+    // Vehicles you control have flying.
+    // Whenever one or more creatures you control with flying deal combat damage to a player, draw a card.
+    private final String muyanling = "Mu Yanling, Wind Rider";
+
+    @Test
+    public void testToken() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.HAND, playerA, muyanling);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, muyanling, true);
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA, muyanling, 1);
+        assertPermanentCount(playerA, "Vehicle Token", 1);
+        assertAbility(playerA, "Vehicle Token", FlyingAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testDraw() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.HAND, playerA, muyanling);
+        addCard(Zone.HAND, playerA, "Memnite");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, muyanling, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Memnite", true);
+
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Crew 1");
+        setChoice(playerA, "Memnite");
+
+        attack(3, playerA, "Vehicle Token", playerB);
+        attack(3, playerA, muyanling, playerB);
+
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA, muyanling, 1);
+        assertPermanentCount(playerA, "Vehicle Token", 1);
+        assertAbility(playerA, "Vehicle Token", FlyingAbility.getInstance(), true);
+        assertHandCount(playerA,  2); // 1 for turn plus 1 for attack
+    }
+
+}


### PR DESCRIPTION
[[Mu Yanling, Wind Rider]]

Implementation was set to only grant vehicles flying if they already had flying.