### PR TITLE
Fix Terra, Herald of Hope combat trigger

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TerraHeraldOfHope.java
+++ b/Mage.Sets/src/mage/cards/t/TerraHeraldOfHope.java
@@ -51,7 +51,7 @@ public final class TerraHeraldOfHope extends CardImpl {
         ReflexiveTriggeredAbility reflexiveAbility = new ReflexiveTriggeredAbility(
                 new ReturnFromGraveyardToBattlefieldTargetEffect(true), false
         );
-        ability.addTarget(new TargetCardInYourGraveyard(filter));
+        reflexiveAbility.addTarget(new TargetCardInYourGraveyard(filter));
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
                 new DoWhenCostPaid(reflexiveAbility, new GenericManaCost(2), "Pay {2}?")
         ));


### PR DESCRIPTION
This pull request fixes a bug with the reflexive triggered ability of Terra, Herald of Hope not triggering when the card does combat damage.

Tested it and it now correctly triggers on combat damage.