### PR TITLE
[FIC] Implement Y'shtola, Night's Blessed

### DIFF
--- a/Mage.Sets/src/mage/cards/y/YshtolaNightsBlessed.java
+++ b/Mage.Sets/src/mage/cards/y/YshtolaNightsBlessed.java
@@ -1,0 +1,94 @@
+package mage.cards.y;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.condition.Condition;
+import mage.abilities.decorator.ConditionalInterveningIfTriggeredAbility;
+import mage.abilities.effects.common.DamagePlayersEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.hint.ConditionHint;
+import mage.abilities.triggers.BeginningOfEndStepTriggeredAbility;
+import mage.constants.*;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.FilterSpell;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.game.Game;
+import mage.watchers.common.PlayerLostLifeWatcher;
+
+/**
+ *
+ * @author inuenc
+ */
+public final class YshtolaNightsBlessed extends CardImpl {
+
+    private static final FilterSpell filter = new FilterSpell("a noncreature spell with mana value 3 or greater");
+
+    static {
+        filter.add(Predicates.not(CardType.CREATURE.getPredicate()));
+        filter.add(new ManaValuePredicate(ComparisonType.MORE_THAN, 2));
+    }
+
+    public YshtolaNightsBlessed(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}{U}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.CAT);
+        this.subtype.add(SubType.WARLOCK);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // At the beginning of each end step, if a player lost 4 or more life this turn, you draw a card.
+        this.addAbility(new ConditionalInterveningIfTriggeredAbility(
+                new BeginningOfEndStepTriggeredAbility(
+                        TargetController.ANY,
+                        new DrawCardSourceControllerEffect(1),
+                        false
+                ), YshtolaNightsBlessedCondition.instance, "At the beginning of each end step, " +
+                "if a player lost 4 or more life this turn, you draw a card."
+        ).addHint(new ConditionHint(YshtolaNightsBlessedCondition.instance, "A player lost 4 or more life this turn")));
+
+        // Whenever you cast a noncreature spell with mana value 3 or greater, Y'shtola deals 2 damage to each opponent and you gain 2 life.
+        Ability ability = new SpellCastControllerTriggeredAbility(
+                new DamagePlayersEffect(
+                2, TargetController.OPPONENT, "Y'shtola"),
+                filter, false
+        );
+        ability.addEffect(new GainLifeEffect(2).setText("and you gain 2 life"));
+        this.addAbility(ability);
+    }
+
+    private YshtolaNightsBlessed(final YshtolaNightsBlessed card) {
+        super(card);
+    }
+
+    @Override
+    public YshtolaNightsBlessed copy() {
+        return new YshtolaNightsBlessed(this);
+    }
+}
+
+enum YshtolaNightsBlessedCondition implements Condition {
+    instance;
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        PlayerLostLifeWatcher watcher = game.getState().getWatcher(PlayerLostLifeWatcher.class);
+        if (watcher == null) {
+            return false;
+        }
+        return game
+                .getState()
+                .getPlayersInRange(source.getControllerId(), game)
+                .stream()
+                .anyMatch(uuid -> watcher.getLifeLost(uuid) > 3);
+    }
+}

--- a/Mage.Sets/src/mage/sets/FinalFantasyCommander.java
+++ b/Mage.Sets/src/mage/sets/FinalFantasyCommander.java
@@ -20,5 +20,9 @@ public final class FinalFantasyCommander extends ExpansionSet {
         this.hasBasicLands = false;
 
         cards.add(new SetCardInfo("Terra, Herald of Hope", 4, Rarity.MYTHIC, mage.cards.t.TerraHeraldOfHope.class));
+        cards.add(new SetCardInfo("Y'shtola, Night's Blessed", 7, Rarity.MYTHIC, mage.cards.y.YshtolaNightsBlessed.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Y'shtola, Night's Blessed", 191, Rarity.MYTHIC, mage.cards.y.YshtolaNightsBlessed.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Y'shtola, Night's Blessed", 215, Rarity.MYTHIC, mage.cards.y.YshtolaNightsBlessed.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Y'shtola, Night's Blessed", 226, Rarity.MYTHIC, mage.cards.y.YshtolaNightsBlessed.class, NON_FULL_USE_VARIOUS));
     }
 }


### PR DESCRIPTION
[[Y'shtola, Night's Blessed]] implemented.
Tested with JUnit and abilities in-game, seemed to work fine:

![image](https://github.com/user-attachments/assets/05593c41-89ef-4f7c-9b1e-6f28adc79c76)

I used code from [[Knight of the Ebon Legion]], [[Sygg, River Cutthroat]] (ability 1) and [[Jin-Gitaxias]], [[Grasping Thrull]] (ability 2).

part of #13362