### PR TITLE
Fix for disconnect causing instant loss

### DIFF
--- a/Mage.Server/src/main/java/mage/server/Main.java
+++ b/Mage.Server/src/main/java/mage/server/Main.java
@@ -370,7 +370,7 @@ public final class Main {
                 // no need to keep session
                 logger.info("CLIENT DISCONNECTED - " + sessionInfo);
                 logger.debug("- cause: client called disconnect command");
-                managerFactory.sessionManager().disconnect(client.getSessionId(), DisconnectReason.DisconnectedByUser, true);
+                managerFactory.sessionManager().disconnect(client.getSessionId(), DisconnectReason.LostConnection, true);
             } else if (throwable == null) {
                 // lease timeout (ping), so server lost connection with a client
                 // must keep tables


### PR DESCRIPTION
For the past several months, users with somewhat spotty connections have sometimes experienced disconnects causing instant concessions with no chance to reconnect. Upon examination of server logs, it is seemingly entirely due to `CLIENT DISCONNECTED`.

I'm unsure as to _why_ this is occurring, as the jboss documentation suggests that that the `ClientDisconnectedException` should only happen if the client does a normal client termination, but it has been consistent enough that I think it's worth putting this fix in.