### PR TITLE
Fix missing ProcessAction between the last mana being paid and the spell being cast.

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ncc/RainOfRichesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ncc/RainOfRichesTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.ncc;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -63,7 +62,6 @@ public class RainOfRichesTest extends CardTestPlayerBase {
     }
 
     @Test
-    @Ignore("Does not work until actions are processed between the last mana being paid and the spell being cast.")
     public void test_Cast_Two_Using_Treasures() {
         setStrictChooseMode(true);
         skipInitShuffling();
@@ -91,7 +89,6 @@ public class RainOfRichesTest extends CardTestPlayerBase {
     }
 
     @Test
-    @Ignore("Does not work until actions are processed between the last mana being paid and the spell being cast.")
     public void test_Cast_SomethingElse_Then_Cast_Using_Treasure() {
         setStrictChooseMode(true);
 

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1346,6 +1346,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                 castEvent.setZone(fromZone);
                 game.fireEvent(castEvent);
                 if (spell.activate(game, allowedIdentifiers, noMana)) {
+                    game.processAction();
                     GameEvent castedEvent = GameEvent.getEvent(GameEvent.EventType.SPELL_CAST,
                             ability.getId(), ability, playerId, approvingObject);
                     castedEvent.setZone(fromZone);


### PR DESCRIPTION
Fixes #9669 

This is necessary so that, among other things, the Rain of Riches watcher can see that the last mana of a spell was a Treasure before the spell is cast - at which point it needs to already have Cascade.

The spell casting sequence already contains many calls to processAction - processAction happens after each MANA_ADDED event, this adds one additional one after the final MANA_PAID event but before the ensuing SPELL_CAST event.
![image](https://github.com/user-attachments/assets/293c2df4-037f-4930-9441-85d7a96a48d0)
