### PR TITLE
[DFT] Implement most remaining cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArmedAndArmored.java
+++ b/Mage.Sets/src/mage/cards/a/ArmedAndArmored.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.UUID;
 
 import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.VehiclesBecomeArtifactCreatureEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -25,7 +25,7 @@ public final class ArmedAndArmored extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{W}");
 
         // Vehicles you control become artifact creatures until end of turn.
-        this.getSpellAbility().addEffect(new ArmedAndArmoredEffect());
+        this.getSpellAbility().addEffect(new VehiclesBecomeArtifactCreatureEffect(Duration.EndOfTurn));
 
         // Choose a Dwarf you control. Attach any number of Equipment you control to it.
         this.getSpellAbility().addEffect(new ArmedAndArmoredEquipEffect());
@@ -38,41 +38,6 @@ public final class ArmedAndArmored extends CardImpl {
     @Override
     public ArmedAndArmored copy() {
         return new ArmedAndArmored(this);
-    }
-}
-
-class ArmedAndArmoredEffect extends ContinuousEffectImpl {
-
-    ArmedAndArmoredEffect() {
-        super(Duration.EndOfTurn, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.BecomeCreature);
-        staticText = "Vehicles you control become artifact creatures until end of turn";
-    }
-
-    private ArmedAndArmoredEffect(final ArmedAndArmoredEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ArmedAndArmoredEffect copy() {
-        return new ArmedAndArmoredEffect(this);
-    }
-
-    @Override
-    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
-        for (Permanent permanent : game.getBattlefield().getAllActivePermanents(source.getControllerId())) {
-            if (permanent != null && permanent.hasSubtype(SubType.VEHICLE, game)) {
-                if (sublayer == SubLayer.NA) {
-                    permanent.addCardType(game, CardType.ARTIFACT);
-                    permanent.addCardType(game, CardType.CREATURE);// TODO: Check if giving CREATURE Type is correct
-                }
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
     }
 }
 

--- a/Mage.Sets/src/mage/cards/b/BoneyardDesecrator.java
+++ b/Mage.Sets/src/mage/cards/b/BoneyardDesecrator.java
@@ -3,29 +3,22 @@ package mage.cards.b;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.Cost;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.MenaceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.predicate.mageobject.OutlawPredicate;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.TreasureToken;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -48,7 +41,10 @@ public final class BoneyardDesecrator extends CardImpl {
         Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance());
         Ability ability = new SimpleActivatedAbility(effect, new ManaCostsImpl<>("{1}{B}"));
         ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE));
-        ability.addEffect(new BoneyardDesecratorEffect());
+        ability.addEffect(new ConditionalOneShotEffect(
+                new CreateTokenEffect(new TreasureToken()),
+                new SacrificedPermanentCondition(StaticFilters.FILTER_ANOTHER_CREATURE, "an outlaw was sacrificed this way")
+        ));
         this.addAbility(ability);
     }
 
@@ -59,46 +55,5 @@ public final class BoneyardDesecrator extends CardImpl {
     @Override
     public BoneyardDesecrator copy() {
         return new BoneyardDesecrator(this);
-    }
-}
-
-// Inspired by Thallid Omnivore
-class BoneyardDesecratorEffect extends OneShotEffect {
-
-    private static final FilterPermanent filter = new FilterPermanent("an outlaw");
-
-    static {
-        filter.add(OutlawPredicate.instance);
-    }
-
-    BoneyardDesecratorEffect() {
-        super(Outcome.GainLife);
-        this.staticText = "If an outlaw was sacrificed this way, create a Treasure token";
-    }
-
-    private BoneyardDesecratorEffect(final BoneyardDesecratorEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public BoneyardDesecratorEffect copy() {
-        return new BoneyardDesecratorEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Cost cost : source.getCosts()) {
-            if (cost instanceof SacrificeTargetCost) {
-                SacrificeTargetCost sacrificeCost = (SacrificeTargetCost) cost;
-                List<Permanent> permanents = sacrificeCost.getPermanents();
-                for (Permanent permanent : permanents) {
-                    if (!filter.match(permanent, source.getControllerId(), source, game)) {
-                        continue;
-                    }
-                    return new CreateTokenEffect(new TreasureToken()).apply(game, source);
-                }
-            }
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EbonPraetor.java
+++ b/Mage.Sets/src/mage/cards/e/EbonPraetor.java
@@ -4,12 +4,12 @@ package mage.cards.e;
 import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.LimitedTimesPerTurnActivatedAbility;
 import mage.abilities.condition.common.IsStepCondition;
-import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.SacrificeTargetCost;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.effects.common.counter.RemoveCounterSourceEffect;
 import mage.abilities.keyword.FirstStrikeAbility;
@@ -19,8 +19,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
+import mage.filter.common.FilterCreaturePermanent;
 
 /**
  *
@@ -47,7 +46,9 @@ public final class EbonPraetor extends CardImpl {
         // Sacrifice a creature: Remove a -2/-2 counter from Ebon Praetor. If the sacrificed creature was a Thrull, put a +1/+0 counter on Ebon Praetor. Activate this ability only during your upkeep and only once each turn.
         Ability ability = new LimitedTimesPerTurnActivatedAbility(Zone.BATTLEFIELD, new RemoveCounterSourceEffect(CounterType.M2M2.createInstance()),
                 new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE), 1, new IsStepCondition(PhaseStep.UPKEEP));
-        ability.addEffect(new EbonPraetorEffect());
+        ability.addEffect(new ConditionalOneShotEffect(new AddCountersSourceEffect(CounterType.P1P0.createInstance()),
+                new SacrificedPermanentCondition(new FilterCreaturePermanent(SubType.THRULL, "a Thrull"), "If the sacrificed creature was a Thrull")
+        ));
         this.addAbility(ability);
     }
 
@@ -58,37 +59,5 @@ public final class EbonPraetor extends CardImpl {
     @Override
     public EbonPraetor copy() {
         return new EbonPraetor(this);
-    }
-}
-
-class EbonPraetorEffect extends OneShotEffect {
-
-    EbonPraetorEffect() {
-        super(Outcome.BoostCreature);
-        this.staticText = "If the sacrificed creature was a Thrull, put a +1/+0 counter on {this}";
-    }
-
-    private EbonPraetorEffect(final EbonPraetorEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public EbonPraetorEffect copy() {
-        return new EbonPraetorEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Cost cost : source.getCosts()) {
-            if (cost instanceof SacrificeTargetCost) {
-                Permanent sacrificedCreature = ((SacrificeTargetCost) cost).getPermanents().get(0);
-                Permanent sourceCreature = game.getPermanent(source.getSourceId());
-                if (sacrificedCreature.hasSubtype(SubType.THRULL, game) && sourceCreature != null) {
-                    sourceCreature.addCounters(CounterType.P1P0.createInstance(), source.getControllerId(), source, game);
-                    return true;
-                }
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EverethViceroyOfPlunder.java
+++ b/Mage.Sets/src/mage/cards/e/EverethViceroyOfPlunder.java
@@ -6,8 +6,7 @@ import mage.abilities.Ability;
 import mage.abilities.common.ActivateAsSorceryActivatedAbility;
 import mage.abilities.common.DiesSourceTriggeredAbility;
 import mage.abilities.common.delayed.ReflexiveTriggeredAbility;
-import mage.abilities.condition.Condition;
-import mage.abilities.costs.Cost;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.decorator.ConditionalContinuousEffect;
@@ -24,14 +23,18 @@ import mage.cards.CardSetInfo;
 import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 
 /**
  *
  * @author Grath
  */
 public final class EverethViceroyOfPlunder extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("a treasure");
+
+    static {
+        filter.add(SubType.TREASURE.getPredicate());
+    }
 
     public EverethViceroyOfPlunder(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{B}");
@@ -51,7 +54,7 @@ public final class EverethViceroyOfPlunder extends CardImpl {
                 new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE_OR_ARTIFACT)
         );
         ability.addEffect(new ConditionalContinuousEffect(new GainAbilitySourceEffect(LifelinkAbility.getInstance(), Duration.EndOfTurn),
-                EverethViceroyOfPlunderCondition.instance,
+                new SacrificedPermanentCondition(filter),
                 "If the sacrificed permanent was a Treasure, Evereth gains lifelink until end of turn."
         ));
         this.addAbility(ability);
@@ -72,34 +75,5 @@ public final class EverethViceroyOfPlunder extends CardImpl {
     @Override
     public EverethViceroyOfPlunder copy() {
         return new EverethViceroyOfPlunder(this);
-    }
-}
-
-enum EverethViceroyOfPlunderCondition implements Condition {
-    instance;
-
-    private static final FilterPermanent filter = new FilterPermanent("a treasure");
-
-    static {
-        filter.add(SubType.TREASURE.getPredicate());
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Cost cost : source.getCosts()) {
-            if (cost instanceof SacrificeTargetCost) {
-                for (Permanent permanent : ((SacrificeTargetCost) cost).getPermanents()) {
-                    if (filter.match(permanent, source.getControllerId(), source, game)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        return "the sacrificed permanent was a Treasure";
     }
 }

--- a/Mage.Sets/src/mage/cards/e/ExplosiveGetaway.java
+++ b/Mage.Sets/src/mage/cards/e/ExplosiveGetaway.java
@@ -1,0 +1,51 @@
+package mage.cards.e;
+
+import java.util.UUID;
+import java.util.function.Predicate;
+
+import mage.abilities.Ability;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.effects.common.DamageAllEffect;
+import mage.abilities.effects.common.ExileReturnBattlefieldNextEndStepTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.predicate.Predicates;
+import mage.target.TargetPermanent;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class ExplosiveGetaway extends CardImpl {
+    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
+
+    static {
+        filter.add(Predicates.or(
+                CardType.ARTIFACT.getPredicate(),
+                CardType.CREATURE.getPredicate()
+        ));
+    }
+
+    public ExplosiveGetaway(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{R}{W}");
+        
+
+        // Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.
+        this.getSpellAbility().addEffect(new ExileReturnBattlefieldNextEndStepTargetEffect().withTextThatCard(false));
+        this.getSpellAbility().addTarget(new TargetPermanent(0, 1, filter));
+        // Explosive Getaway deals 4 damage to each creature.
+        this.getSpellAbility().addEffect(new DamageAllEffect(4, StaticFilters.FILTER_PERMANENT_ALL_CREATURES).concatBy("<br>"));
+    }
+
+    private ExplosiveGetaway(final ExplosiveGetaway card) {
+        super(card);
+    }
+
+    @Override
+    public ExplosiveGetaway copy() {
+        return new ExplosiveGetaway(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathAristocrat.java
@@ -1,12 +1,12 @@
 package mage.cards.f;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.Cost;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
 import mage.abilities.costs.common.SacrificeTargetCost;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.IndestructibleAbility;
@@ -14,9 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.target.common.TargetControlledCreaturePermanent;
+import mage.filter.common.FilterCreaturePermanent;
 
 import java.util.UUID;
 
@@ -41,7 +39,9 @@ public final class FalkenrathAristocrat extends CardImpl {
         SimpleActivatedAbility ability = new SimpleActivatedAbility(
                 new GainAbilitySourceEffect(IndestructibleAbility.getInstance(), Duration.EndOfTurn),
                 new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
-        ability.addEffect(new FalkenrathAristocratEffect());
+        ability.addEffect(new ConditionalOneShotEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
+                new SacrificedPermanentCondition(new FilterCreaturePermanent(SubType.HUMAN, "a Human")))
+                .setText("If the sacrificed creature was a Human, put a +1/+1 counter on {this}"));
         this.addAbility(ability);
     }
 
@@ -52,37 +52,5 @@ public final class FalkenrathAristocrat extends CardImpl {
     @Override
     public FalkenrathAristocrat copy() {
         return new FalkenrathAristocrat(this);
-    }
-}
-
-class FalkenrathAristocratEffect extends OneShotEffect {
-
-    FalkenrathAristocratEffect() {
-        super(Outcome.BoostCreature);
-        this.staticText = "If the sacrificed creature was a Human, put a +1/+1 counter on {this}";
-    }
-
-    private FalkenrathAristocratEffect(final FalkenrathAristocratEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public FalkenrathAristocratEffect copy() {
-        return new FalkenrathAristocratEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Cost cost : source.getCosts()) {
-            if (cost instanceof SacrificeTargetCost) {
-                Permanent sacrificedCreature = ((SacrificeTargetCost) cost).getPermanents().get(0);
-                Permanent sourceCreature = game.getPermanent(source.getSourceId());
-                if (sacrificedCreature.hasSubtype(SubType.HUMAN, game) && sourceCreature != null) {
-                    sourceCreature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                    break;
-                }
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
+++ b/Mage.Sets/src/mage/cards/f/FalkenrathTorturer.java
@@ -3,21 +3,19 @@ package mage.cards.f;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.Cost;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
 import mage.abilities.costs.common.SacrificeTargetCost;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.continuous.GainAbilitySourceEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.target.common.TargetControlledCreaturePermanent;
+import mage.filter.common.FilterCreaturePermanent;
 
 /**
  *
@@ -37,7 +35,9 @@ public final class FalkenrathTorturer extends CardImpl {
         SimpleActivatedAbility ability = new SimpleActivatedAbility(
                 new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.EndOfTurn),
                 new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE));
-        ability.addEffect(new FalkenrathAristocratEffect());
+        ability.addEffect(new ConditionalOneShotEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance()),
+                new SacrificedPermanentCondition(new FilterCreaturePermanent(SubType.HUMAN, "a Human")))
+                .setText("If the sacrificed creature was a Human, put a +1/+1 counter on {this}"));
         this.addAbility(ability);
     }
 
@@ -48,37 +48,5 @@ public final class FalkenrathTorturer extends CardImpl {
     @Override
     public FalkenrathTorturer copy() {
         return new FalkenrathTorturer(this);
-    }
-}
-
-class FalkenrathTorturerEffect extends OneShotEffect {
-
-    FalkenrathTorturerEffect() {
-        super(Outcome.DrawCard);
-        this.staticText = "If the sacrificed creature was a Human, put a +1/+1 counter on {this}";
-    }
-
-    private FalkenrathTorturerEffect(final FalkenrathTorturerEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public FalkenrathTorturerEffect copy() {
-        return new FalkenrathTorturerEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Cost cost : source.getCosts()) {
-            if (cost instanceof SacrificeTargetCost) {
-                Permanent sacrificedCreature = ((SacrificeTargetCost) cost).getPermanents().get(0);
-                Permanent sourceCreature = game.getPermanent(source.getSourceId());
-                if (sacrificedCreature.hasSubtype(SubType.HUMAN, game) && sourceCreature != null) {
-                    sourceCreature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FangDruidSummoner.java
+++ b/Mage.Sets/src/mage/cards/f/FangDruidSummoner.java
@@ -1,0 +1,51 @@
+package mage.cards.f;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.common.search.SearchLibraryGraveyardPutInHandEffect;
+import mage.constants.SubType;
+import mage.abilities.keyword.ReachAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreatureCard;
+import mage.filter.predicate.mageobject.NoAbilityPredicate;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class FangDruidSummoner extends CardImpl {
+    private static final FilterCreatureCard filter = new FilterCreatureCard("a creature card with no abilities");
+
+    static {
+        filter.add(NoAbilityPredicate.instance);
+    }
+    public FangDruidSummoner(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
+        
+        this.subtype.add(SubType.APE);
+        this.subtype.add(SubType.DRUID);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Reach
+        this.addAbility(ReachAbility.getInstance());
+
+        // When this creature enters, you may search your library and/or graveyard for a creature card with no abilities, reveal it, and put it into your hand. If you search your library this way, shuffle.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(
+                new SearchLibraryGraveyardPutInHandEffect(filter, false, true)
+        ));
+    }
+
+    private FangDruidSummoner(final FangDruidSummoner card) {
+        super(card);
+    }
+
+    @Override
+    public FangDruidSummoner copy() {
+        return new FangDruidSummoner(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FoundryHelix.java
+++ b/Mage.Sets/src/mage/cards/f/FoundryHelix.java
@@ -1,8 +1,6 @@
 package mage.cards.f;
 
-import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
-import mage.abilities.costs.Cost;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
@@ -11,10 +9,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetAnyTarget;
-import mage.target.common.TargetControlledPermanent;
 
 import java.util.UUID;
 
@@ -31,7 +26,8 @@ public final class FoundryHelix extends CardImpl {
 
         // Foundry Helix deals 4 damage to any target. If the sacrificed permanent was an artifact, you gain 4 life.
         this.getSpellAbility().addEffect(new DamageTargetEffect(4));
-        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(new GainLifeEffect(4), FoundryHelixCondition.instance));
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(new GainLifeEffect(4),
+                new SacrificedPermanentCondition(StaticFilters.FILTER_PERMANENT_ARTIFACT_AN)));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
     }
 
@@ -42,28 +38,5 @@ public final class FoundryHelix extends CardImpl {
     @Override
     public FoundryHelix copy() {
         return new FoundryHelix(this);
-    }
-}
-
-enum FoundryHelixCondition implements Condition {
-    instance;
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        for (Cost cost : source.getCosts()) {
-            if (cost instanceof SacrificeTargetCost) {
-                for (Permanent permanent : ((SacrificeTargetCost) cost).getPermanents()) {
-                    if (permanent.isArtifact(game)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        return "the sacrificed permanent was an artifact";
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FullThrottle.java
+++ b/Mage.Sets/src/mage/cards/f/FullThrottle.java
@@ -1,0 +1,74 @@
+package mage.cards.f;
+
+import java.util.UUID;
+
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.condition.OrCondition;
+import mage.abilities.condition.common.IsPhaseCondition;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.common.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.turn.Turn;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class FullThrottle extends CardImpl {
+
+    public FullThrottle(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{R}{R}");
+
+
+        // After this main phase, there are two additional combat phases.
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new AdditionalCombatPhaseEffect(2, TargetController.ANY),
+                new OrCondition(new IsPhaseCondition(TurnPhase.PRECOMBAT_MAIN), new IsPhaseCondition(TurnPhase.POSTCOMBAT_MAIN)),
+                "After this main phase, there are two additional combat phases."
+        ));
+        // At the beginning of each combat this turn, untap all creatures that attacked this turn.
+        DelayedTriggeredAbility ability = new FullThrottleTriggeredAbility();
+        this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(ability).concatBy("<br>"));
+    }
+
+    private FullThrottle(final FullThrottle card) {
+        super(card);
+    }
+
+    @Override
+    public FullThrottle copy() {
+        return new FullThrottle(this);
+    }
+}
+
+class FullThrottleTriggeredAbility extends DelayedTriggeredAbility {
+
+    public FullThrottleTriggeredAbility() {
+        super(new UntapAllThatAttackedEffect(), Duration.EndOfTurn, false);
+        setTriggerPhrase("At the beginning of each combat this turn, ");
+    }
+
+    private FullThrottleTriggeredAbility(final FullThrottleTriggeredAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public FullThrottleTriggeredAbility copy() {
+        return new FullThrottleTriggeredAbility(this);
+    }
+
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.COMBAT_PHASE_PRE;
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+        Turn turn = game.getState().getTurn();
+        return turn.getPhase().getType() == TurnPhase.COMBAT;
+    }
+}

--- a/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
+++ b/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
@@ -1,0 +1,83 @@
+package mage.cards.g;
+
+import java.util.UUID;
+
+import mage.ConditionalMana;
+import mage.MageInt;
+import mage.MageObject;
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.mana.ConditionalColoredManaAbility;
+import mage.abilities.mana.builder.ConditionalManaBuilder;
+import mage.abilities.mana.conditional.ManaCondition;
+import mage.constants.SubType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.game.Game;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class GuidelightOptimizer extends CardImpl {
+
+    public GuidelightOptimizer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{1}{U}");
+        
+        this.subtype.add(SubType.ROBOT);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability.
+        this.addAbility(new ConditionalColoredManaAbility(Mana.BlueMana(1), new ArtifactOrActivatedManaBuilder()));
+    }
+
+    private GuidelightOptimizer(final GuidelightOptimizer card) {
+        super(card);
+    }
+
+    @Override
+    public GuidelightOptimizer copy() {
+        return new GuidelightOptimizer(this);
+    }
+}
+
+class ArtifactOrActivatedManaBuilder extends ConditionalManaBuilder {
+
+    @Override
+    public ConditionalMana build(Object... options) {
+        return new ArtifactOrActivatedConditionalMana(this.mana);
+    }
+
+    @Override
+    public String getRule() {
+        return "Spend this mana only to cast artifact spells or activate abilities of artifacts";
+    }
+}
+
+class ArtifactOrActivatedConditionalMana extends ConditionalMana {
+
+    public ArtifactOrActivatedConditionalMana(Mana mana) {
+        super(mana);
+        staticText = "Spend this mana only to cast artifact spells or activate abilities of artifacts";
+        addCondition(new ArtifactOrActivatedManaCondition());
+    }
+}
+
+class ArtifactOrActivatedManaCondition extends ManaCondition implements Condition {
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        MageObject sourceObject = game.getObject(source);
+        return source != null
+                && (source.isActivatedAbility() && !source.isActivated())
+                || (sourceObject != null && sourceObject.isArtifact());
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, UUID originalId, mage.abilities.costs.Cost costsToPay) {
+        return apply(game, source);
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HellishSideswipe.java
+++ b/Mage.Sets/src/mage/cards/h/HellishSideswipe.java
@@ -17,14 +17,25 @@ import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
+import mage.target.TargetPermanent;
 
 /**
  *
  * @author Jmlundeen
  */
 public final class HellishSideswipe extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("creature or Vehicle");
+
+    static {
+        filter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
 
     public HellishSideswipe(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
@@ -38,6 +49,7 @@ public final class HellishSideswipe extends CardImpl {
                 new DrawCardSourceControllerEffect(1),
                 new SacrificedPermanentCondition(new FilterPermanent(SubType.VEHICLE, "a Vehicle"))
         ));
+        this.getSpellAbility().addTarget(new TargetPermanent(filter));
     }
 
     private HellishSideswipe(final HellishSideswipe card) {

--- a/Mage.Sets/src/mage/cards/h/HellishSideswipe.java
+++ b/Mage.Sets/src/mage/cards/h/HellishSideswipe.java
@@ -1,0 +1,51 @@
+package mage.cards.h;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.condition.common.SacrificedPermanentCondition;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.decorator.ConditionalOneShotEffect;
+import mage.abilities.effects.common.DestroyTargetEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledPermanent;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class HellishSideswipe extends CardImpl {
+
+    public HellishSideswipe(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
+        
+
+        // As an additional cost to cast this spell, sacrifice an artifact or creature.
+        this.getSpellAbility().addEffect(new DestroyTargetEffect("Destroy target creature or Vehicle"));
+        this.getSpellAbility().addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE));
+        // Destroy target creature or Vehicle. If the sacrificed permanent was a Vehicle, draw a card.
+        this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
+                new DrawCardSourceControllerEffect(1),
+                new SacrificedPermanentCondition(new FilterPermanent(SubType.VEHICLE, "a Vehicle"))
+        ));
+    }
+
+    private HellishSideswipe(final HellishSideswipe card) {
+        super(card);
+    }
+
+    @Override
+    public HellishSideswipe copy() {
+        return new HellishSideswipe(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
+++ b/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
@@ -1,0 +1,66 @@
+package mage.cards.l;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.mana.AddManaOfAnyColorEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.keyword.DoubleStrikeAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class LootThePathfinder extends CardImpl {
+
+    public LootThePathfinder(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{U}{R}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.BEAST);
+        this.subtype.add(SubType.NOBLE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Double strike
+        this.addAbility(DoubleStrikeAbility.getInstance());
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Exhaust -- {G}, {T}: Add three mana of any one color.
+        this.addAbility(new ExhaustAbility(new AddManaOfAnyColorEffect(3),
+                new CompositeCost(new ManaCostsImpl<>("{G}"), new TapSourceCost(), "{G}, {T}")));
+        // Exhaust -- {U}, {T}: Draw three cards.
+        this.addAbility(new ExhaustAbility(new DrawCardSourceControllerEffect(3),
+                new CompositeCost(new ManaCostsImpl<>("{U}"), new TapSourceCost(), "{U}, {T}"))
+                .withReminderText(false));
+        // Exhaust -- {R}, {T}: Loot deals 3 damage to any target.
+        this.addAbility(new ExhaustAbility(new DamageTargetEffect(3),
+                new CompositeCost(new ManaCostsImpl<>("{R}"), new TapSourceCost(), "{R}, {T}"))
+                .withReminderText(false));
+    }
+
+    private LootThePathfinder(final LootThePathfinder card) {
+        super(card);
+    }
+
+    @Override
+    public LootThePathfinder copy() {
+        return new LootThePathfinder(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MarchOfTheWorldOoze.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfTheWorldOoze.java
@@ -1,0 +1,58 @@
+package mage.cards.m;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.SpellCastOpponentNoManaSpentTriggeredAbility;
+import mage.abilities.common.SpellCastOpponentTriggeredAbility;
+import mage.abilities.condition.common.OnOpponentsTurnCondition;
+import mage.abilities.effects.common.CastSourceTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenAllEffect;
+import mage.abilities.effects.common.CreateTokenControllerTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.continuous.AddCardSubtypeAllEffect;
+import mage.abilities.effects.common.continuous.SetBasePowerToughnessAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterSpell;
+import mage.filter.StaticFilters;
+import mage.game.permanent.token.ElephantToken;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class MarchOfTheWorldOoze extends CardImpl {
+    public static final FilterSpell filter = new FilterSpell("a spell, if it's not their turn");
+
+    static {
+        filter.add(TargetController.INACTIVE.getControllerPredicate());
+    }
+    public MarchOfTheWorldOoze(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{G}{G}{G}");
+        
+
+        // Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.
+        Ability ability = new SimpleStaticAbility(new SetBasePowerToughnessAllEffect(
+                6, 6, Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURE));
+        ability.addEffect(new AddCardSubtypeAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE, SubType.OOZE, null)
+                        .concatBy("and"));
+        this.addAbility(ability);
+        // Whenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.
+        Ability ability2 = new SpellCastOpponentTriggeredAbility(new CreateTokenEffect(new ElephantToken())
+                .setText("you create a 3/3 green Elephant creature token"),
+                filter, false);
+        this.addAbility(ability2);
+    }
+
+    private MarchOfTheWorldOoze(final MarchOfTheWorldOoze card) {
+        super(card);
+    }
+
+    @Override
+    public MarchOfTheWorldOoze copy() {
+        return new MarchOfTheWorldOoze(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MomentumBreaker.java
+++ b/Mage.Sets/src/mage/cards/m/MomentumBreaker.java
@@ -1,0 +1,103 @@
+package mage.cards.m;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SacrificeSourceTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.common.SacrificeSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.ControllerSpeedCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.effects.common.SacrificeEffect;
+import mage.abilities.keyword.StartYourEnginesAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class MomentumBreaker extends CardImpl {
+
+    public MomentumBreaker(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
+        
+
+        // Start your engines!
+        this.addAbility(new StartYourEnginesAbility());
+
+        // When this enchantment enters, each opponent sacrifices a creature or Vehicle of their choice. Each opponent who can't discards a card.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new MomentumBreakerEffect()));
+        // {2}, Sacrifice this enchantment: You gain life equal to your speed.
+        Effect gainLifeEffect = new GainLifeEffect(ControllerSpeedCount.instance).setText("You gain life equal to your speed");
+        Ability ability = (new SimpleActivatedAbility(gainLifeEffect,
+                new CompositeCost(new ManaCostsImpl<>("{2}"), new SacrificeSourceCost(), "{2}, Sacrifice this enchantment")
+                ));
+        this.addAbility(ability);
+    }
+
+    private MomentumBreaker(final MomentumBreaker card) {
+        super(card);
+    }
+
+    @Override
+    public MomentumBreaker copy() {
+        return new MomentumBreaker(this);
+    }
+}
+
+class MomentumBreakerEffect extends OneShotEffect {
+
+    MomentumBreakerEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "each opponent sacrifices a creature or Vehicle of their choice. " +
+                "Each opponent who can't discards a card.";
+    }
+
+    private MomentumBreakerEffect(final MomentumBreakerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MomentumBreakerEffect copy() {
+        return new MomentumBreakerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        game.getOpponents(source.getControllerId()).forEach(opponent -> {
+            Player player = game.getPlayer(opponent);
+            if (player != null) {
+                FilterPermanent filter = new FilterPermanent("creature or Vehicle");
+                filter.add(Predicates.or(
+                        CardType.CREATURE.getPredicate(),
+                        SubType.VEHICLE.getPredicate()
+                ));
+                filter.add(new ControllerIdPredicate(opponent));
+                if (game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game).isEmpty()) {
+                    player.discard(1, false, false, source, game);
+                } else {
+                    Effect effect = new SacrificeEffect(filter, 1, null);
+                    effect.setTargetPointer(new FixedTarget(player.getId(), game));
+                    effect.apply(game, source);
+                }
+            }
+        });
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -1,0 +1,95 @@
+package mage.cards.o;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawDiscardTargetEffect;
+import mage.abilities.effects.common.LookAtTargetPlayerHandEffect;
+import mage.abilities.effects.common.discard.DiscardAndDrawThatManyEffect;
+import mage.cards.Card;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.abilities.keyword.LifelinkAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.keyword.WardAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetCardInHand;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class OildeepGearhulk extends CardImpl {
+
+    public OildeepGearhulk(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{U}{U}{B}{B}");
+        
+        this.subtype.add(SubType.CONSTRUCT);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Lifelink
+        this.addAbility(LifelinkAbility.getInstance());
+
+        // Ward {1}
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{1}")));
+
+        // When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.
+        Ability ability = new EntersBattlefieldTriggeredAbility(new LookAtTargetPlayerHandEffect());
+        ability.addEffect(new OildeepGearhulkEffect());
+        this.addAbility(ability);
+    }
+
+    private OildeepGearhulk(final OildeepGearhulk card) {
+        super(card);
+    }
+
+    @Override
+    public OildeepGearhulk copy() {
+        return new OildeepGearhulk(this);
+    }
+}
+
+class OildeepGearhulkEffect extends OneShotEffect {
+
+    public OildeepGearhulkEffect() {
+        super(Outcome.Benefit);
+        staticText = "look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card";
+    }
+
+    public OildeepGearhulkEffect(final OildeepGearhulkEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public OildeepGearhulkEffect copy() {
+        return new OildeepGearhulkEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Player targetPlayer = game.getPlayer(source.getFirstTarget());
+        if (controller == null || targetPlayer == null) {
+            return false;
+        }
+
+        controller.lookAtCards(targetPlayer.getName() + " Hand", targetPlayer.getHand(), game);
+        TargetCard chosenCard = new TargetCardInHand(0, 1, new FilterCard("card to discard"));
+        if (controller.choose(outcome, targetPlayer.getHand(), chosenCard, source, game)) {
+            Card card = game.getCard(chosenCard.getFirstTarget());
+            targetPlayer.discard(card, false, source, game);
+            targetPlayer.drawCards(1, source, game);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -18,9 +18,11 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
+import mage.target.TargetPlayer;
 import mage.target.common.TargetCardInHand;
 
 /**
@@ -45,6 +47,7 @@ public final class OildeepGearhulk extends CardImpl {
         // When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.
         Ability ability = new EntersBattlefieldTriggeredAbility(new LookAtTargetPlayerHandEffect());
         ability.addEffect(new OildeepGearhulkEffect());
+        ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -45,8 +45,7 @@ public final class OildeepGearhulk extends CardImpl {
         this.addAbility(new WardAbility(new ManaCostsImpl<>("{1}")));
 
         // When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new LookAtTargetPlayerHandEffect());
-        ability.addEffect(new OildeepGearhulkEffect());
+        Ability ability = new EntersBattlefieldTriggeredAbility(new OildeepGearhulkEffect());
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/p/PushTheLimit.java
+++ b/Mage.Sets/src/mage/cards/p/PushTheLimit.java
@@ -1,0 +1,138 @@
+package mage.cards.p;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import mage.abilities.Ability;
+import mage.abilities.DelayedTriggeredAbility;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ReturnFromYourGraveyardToBattlefieldAllEffect;
+import mage.abilities.effects.common.SacrificeAllEffect;
+import mage.abilities.effects.common.SacrificeEffect;
+import mage.abilities.effects.common.SacrificeTargetEffect;
+import mage.abilities.effects.common.continuous.BecomesSubtypeAllEffect;
+import mage.abilities.effects.common.continuous.CreaturesBecomeOtherTypeEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.effects.common.continuous.VehiclesBecomeArtifactCreatureEffect;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.cards.Cards;
+import mage.constants.*;
+import mage.filter.FilterCard;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class PushTheLimit extends CardImpl {
+    private static final FilterPermanent filterCreatures = new FilterControlledPermanent("Creatures you control");
+
+    public PushTheLimit(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{R}{R}");
+        
+
+        // Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at the beginning of the next end step.
+        this.getSpellAbility().addEffect(new PushTheLimitEffect());
+        // Vehicles you control become artifact creatures until end of turn. Creatures you control gain haste until end of turn.
+        this.getSpellAbility().addEffect(new VehiclesBecomeArtifactCreatureEffect(Duration.EndOfTurn)
+                .concatBy("<br>"));
+        this.getSpellAbility().addEffect(new GainAbilityAllEffect(HasteAbility.getInstance(), Duration.EndOfTurn, filterCreatures));
+    }
+
+    private PushTheLimit(final PushTheLimit card) {
+        super(card);
+    }
+
+    @Override
+    public PushTheLimit copy() {
+        return new PushTheLimit(this);
+    }
+}
+
+class PushTheLimitSacrificeEffect extends OneShotEffect {
+
+    private final Set<Card> cards;
+
+    public PushTheLimitSacrificeEffect(Set<Card> cards) {
+        super(Outcome.Sacrifice);
+        this.cards = cards;
+    }
+
+    public PushTheLimitSacrificeEffect(final PushTheLimitSacrificeEffect effect) {
+        super(effect);
+        this.cards = effect.cards;
+    }
+
+    @Override
+    public PushTheLimitSacrificeEffect copy() {
+        return new PushTheLimitSacrificeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Set<Permanent> permanents = cards.stream()
+                .map(Card::getId)
+                .map(game::getPermanent)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (permanents.isEmpty()) {
+            return false;
+        }
+        permanents.forEach(permanent -> {
+            permanent.sacrifice(source, game);
+        });
+        return true;
+    }
+}
+
+class PushTheLimitEffect extends ReturnFromYourGraveyardToBattlefieldAllEffect {
+    private static final FilterCard filter = new FilterCard("Mount and Vehicle cards");
+    static {
+        filter.add(Predicates.or(
+                SubType.MOUNT.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+    public PushTheLimitEffect() {
+        super(filter);
+        staticText += ". Sacrifice them at the beginning of the next end step.";
+    }
+
+    public PushTheLimitEffect(final PushTheLimitEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public PushTheLimitEffect copy() {
+        return new PushTheLimitEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+        Set<Card> cards = controller.getGraveyard().getCards(filter, source.getControllerId(), source, game);
+        boolean result = controller.moveCards(controller.getGraveyard().getCards(filter, source.getControllerId(), source, game),
+                Zone.BATTLEFIELD, source, game, false, false, false, null);
+        if (result) {
+
+            Effect sacrificeEffect = new PushTheLimitSacrificeEffect(cards);
+            game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(sacrificeEffect), source);
+        }
+        return result;
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RadiantLotus.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantLotus.java
@@ -1,0 +1,88 @@
+package mage.cards.r;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.costs.common.SacrificeXTargetCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.choices.ChoiceColor;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledArtifactPermanent;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class RadiantLotus extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterControlledArtifactPermanent("artifacts");
+    public RadiantLotus(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{6}");
+        
+
+        // {T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.
+        Ability ability = new SimpleActivatedAbility(new RadiantLotusEffect(), new TapSourceCost());
+        ability.addCost(new SacrificeXTargetCost(filter, true, 1).setText("Sacrifice one or more artifacts"));
+        ability.addTarget(new TargetPlayer());
+        this.addAbility(ability);
+    }
+
+    private RadiantLotus(final RadiantLotus card) {
+        super(card);
+    }
+
+    @Override
+    public RadiantLotus copy() {
+        return new RadiantLotus(this);
+    }
+}
+
+
+class RadiantLotusEffect extends OneShotEffect {
+
+    public RadiantLotusEffect() {
+        super(Outcome.Benefit);
+        staticText = "Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way";
+    }
+
+    public RadiantLotusEffect(final RadiantLotusEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RadiantLotusEffect copy() {
+        return new RadiantLotusEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        int manaCount = source.getCosts().stream()
+            .filter(SacrificeTargetCost.class::isInstance)
+            .mapToInt(cost -> ((SacrificeTargetCost) cost).getPermanents().size() * 3)
+            .sum();
+
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            String mes = String.format("Select a color of mana to add %d of it", manaCount);
+            ChoiceColor choice = new ChoiceColor(true, mes, game.getObject(source));
+            if (controller.choose(outcome, choice, game)) {
+                Player player = game.getPlayer(source.getFirstTarget());
+                if (choice.getColor() != null && player != null) {
+                    player.getManaPool().addMana(choice.getMana(manaCount), game, source);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RiptideGearhulk.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideGearhulk.java
@@ -1,0 +1,61 @@
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.PutIntoLibraryNFromTopTargetEffect;
+import mage.constants.SubType;
+import mage.abilities.keyword.DoubleStrikeAbility;
+import mage.abilities.keyword.ProwessAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterNonlandCard;
+import mage.filter.predicate.mageobject.PermanentPredicate;
+import mage.target.common.TargetCardInGraveyard;
+import mage.target.common.TargetNonlandPermanent;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
+import mage.target.targetpointer.EachTargetPointer;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class RiptideGearhulk extends CardImpl {
+    public RiptideGearhulk(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{1}{W}{W}{U}{U}");
+        
+        this.subtype.add(SubType.CONSTRUCT);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(5);
+
+        // Double strike
+        this.addAbility(DoubleStrikeAbility.getInstance());
+
+        // Prowess
+        this.addAbility(new ProwessAbility());
+
+        // When this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.
+        Effect effect = new PutIntoLibraryNFromTopTargetEffect(3)
+                .setText("put up to one target nonland permanent that player controls into its owner's library third from the top")
+                .setTargetPointer(new EachTargetPointer());
+        Ability ability = new EntersBattlefieldTriggeredAbility(effect)
+                .setTriggerPhrase("When {this} creature enters, for each opponent, ");
+        ability.addTarget(new TargetNonlandPermanent(0, 1));
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
+        this.addAbility(ability);
+    }
+
+    private RiptideGearhulk(final RiptideGearhulk card) {
+        super(card);
+    }
+
+    @Override
+    public RiptideGearhulk copy() {
+        return new RiptideGearhulk(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RiverchurnMonument.java
+++ b/Mage.Sets/src/mage/cards/r/RiverchurnMonument.java
@@ -1,0 +1,55 @@
+package mage.cards.r;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.CardsInTargetPlayersGraveyardCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.MillCardsTargetEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.target.TargetPlayer;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class RiverchurnMonument extends CardImpl {
+
+    public RiverchurnMonument(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{U}");
+        
+
+        // {1}, {T}: Any number of target players each mill two cards.
+        Effect effect = new MillCardsTargetEffect(2);
+        effect.setText("Any number of target players each mill two cards. " +
+                "(Each of them puts the top two cards of their library into their graveyard.)");
+        Cost cost = new CompositeCost(new TapSourceCost(), new ManaCostsImpl<>("{1}"), "{1}, {T}");
+        Ability ability = new SimpleActivatedAbility(effect, cost);
+        ability.addTarget(new TargetPlayer(0, Integer.MAX_VALUE, false));
+        this.addAbility(ability);
+        // Exhaust -- {2}{U}{U}, {T}: Any number of target players each mill cards equal to the number of cards in their graveyard.
+        Cost exhaustCost = new CompositeCost(new TapSourceCost(), new ManaCostsImpl<>("{2}{U}{U}"), "{2}{U}{U}, {T}");
+        Effect exhaustEffect = new MillCardsTargetEffect(new CardsInTargetPlayersGraveyardCount());
+        exhaustEffect.setText("Any number of target players each mill cards equal to the number of cards in their graveyard.");
+        Ability exhaustAbility = new ExhaustAbility(exhaustEffect, exhaustCost);
+        exhaustAbility.addTarget(new TargetPlayer(0, Integer.MAX_VALUE, false));
+        this.addAbility(exhaustAbility);
+    }
+
+    private RiverchurnMonument(final RiverchurnMonument card) {
+        super(card);
+    }
+
+    @Override
+    public RiverchurnMonument copy() {
+        return new RiverchurnMonument(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SitaVarmaMaskedRacer.java
+++ b/Mage.Sets/src/mage/cards/s/SitaVarmaMaskedRacer.java
@@ -1,0 +1,87 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.dynamicvalue.common.SourcePermanentPowerValue;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.SetBasePowerToughnessAllEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SitaVarmaMaskedRacer extends CardImpl {
+
+    public SitaVarmaMaskedRacer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{U}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.ROGUE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(3);
+
+        // Exhaust -- {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.
+        Cost cost = new ManaCostsImpl<>("{X}{G}{G}{U}");
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(), GetXValue.instance);
+        Ability ability = new ExhaustAbility(effect, cost);
+        ability.addEffect(new SitaVarmaMaskedRacerMayEffect());
+        this.addAbility(ability);
+    }
+
+    private SitaVarmaMaskedRacer(final SitaVarmaMaskedRacer card) {
+        super(card);
+    }
+
+    @Override
+    public SitaVarmaMaskedRacer copy() {
+        return new SitaVarmaMaskedRacer(this);
+    }
+}
+
+class SitaVarmaMaskedRacerMayEffect extends OneShotEffect {
+    private static final String choiceText = "Have the base power and toughness of each other creature you control" +
+            " become equal to Sita Varma's power until end of turn?";
+
+    public SitaVarmaMaskedRacerMayEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.";
+    }
+
+    public SitaVarmaMaskedRacerMayEffect(final SitaVarmaMaskedRacerMayEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SitaVarmaMaskedRacerMayEffect copy() {
+        return new SitaVarmaMaskedRacerMayEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null || !controller.chooseUse(outcome, choiceText, source, game)) {
+            return false;
+        }
+        ContinuousEffect setBasePowerToughnessEffect = new SetBasePowerToughnessAllEffect(SourcePermanentPowerValue.ALLOW_NEGATIVE,
+                SourcePermanentPowerValue.ALLOW_NEGATIVE, Duration.EndOfTurn,
+                StaticFilters.FILTER_OTHER_CONTROLLED_CREATURES);
+        game.addEffect(setBasePowerToughnessEffect, source);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
+++ b/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
@@ -1,0 +1,89 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.ChooseACardNameEffect;
+import mage.abilities.effects.common.cost.CostModificationEffectImpl;
+import mage.abilities.effects.common.cost.SpellsCostIncreasingAllEffect;
+import mage.constants.*;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.game.Game;
+import mage.util.CardUtil;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SkyseersChariot extends CardImpl {
+
+    public SkyseersChariot(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{W}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // As this Vehicle enters, choose a nonland card name.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseACardNameEffect(ChooseACardNameEffect.TypeOfName.NON_LAND_NAME)));
+        // Activated abilities of sources with the chosen name cost {2} more to activate.
+        this.addAbility(new SimpleStaticAbility(new SkyseersChariotEffect()));
+
+        // Crew 2
+        this.addAbility(new CrewAbility(2));
+
+    }
+
+    private SkyseersChariot(final SkyseersChariot card) {
+        super(card);
+    }
+
+    @Override
+    public SkyseersChariot copy() {
+        return new SkyseersChariot(this);
+    }
+}
+
+class SkyseersChariotEffect extends CostModificationEffectImpl {
+
+    SkyseersChariotEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Detriment, CostModificationType.INCREASE_COST);
+        staticText = "Activated abilities of sources with the chosen name cost {2} more to activate";
+    }
+
+    private SkyseersChariotEffect(final SkyseersChariotEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SkyseersChariotEffect copy() {
+        return new SkyseersChariotEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, Ability abilityToModify) {
+        CardUtil.increaseCost(abilityToModify, 2);
+        return true;
+    }
+
+    @Override
+    public boolean applies(Ability abilityToModify, Ability source, Game game) {
+        MageObject activatedSource = game.getObject(abilityToModify.getSourceId());
+        if (activatedSource == null) {
+            return false;
+        }
+        String chosenName = (String) game.getState().getValue(
+                source.getSourceId().toString() + ChooseACardNameEffect.INFO_KEY
+        );
+        return CardUtil.haveSameNames(activatedSource, chosenName, game);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
+++ b/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
@@ -84,6 +84,7 @@ class SkyseersChariotEffect extends CostModificationEffectImpl {
         String chosenName = (String) game.getState().getValue(
                 source.getSourceId().toString() + ChooseACardNameEffect.INFO_KEY
         );
-        return CardUtil.haveSameNames(activatedSource, chosenName, game);
+        return CardUtil.haveSameNames(activatedSource, chosenName, game)
+                && abilityToModify.isActivatedAbility();
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SkyserpentSeeker.java
+++ b/Mage.Sets/src/mage/cards/s/SkyserpentSeeker.java
@@ -1,0 +1,95 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.RevealCardsFromLibraryUntilEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.cards.*;
+import mage.constants.*;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.DeathtouchAbility;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SkyserpentSeeker extends CardImpl {
+
+    public SkyserpentSeeker(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{U}");
+        
+        this.subtype.add(SubType.SNAKE);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Deathtouch
+        this.addAbility(DeathtouchAbility.getInstance());
+
+        // Exhaust -- {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature.
+        Ability ability = (new ExhaustAbility(new SkyserpentSeekerEffect(), new ManaCostsImpl<>("{4}")));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), StaticValue.get(1)));
+        this.addAbility(ability);
+    }
+
+    private SkyserpentSeeker(final SkyserpentSeeker card) {
+        super(card);
+    }
+
+    @Override
+    public SkyserpentSeeker copy() {
+        return new SkyserpentSeeker(this);
+    }
+
+}
+class SkyserpentSeekerEffect extends OneShotEffect {
+
+    SkyserpentSeekerEffect() {
+        super(Outcome.PutLandInPlay);
+        this.staticText = "Reveal cards from the top of your library until you reveal two land cards. " +
+                "Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order";
+    }
+
+    private SkyserpentSeekerEffect(final SkyserpentSeekerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SkyserpentSeekerEffect copy() {
+        return new SkyserpentSeekerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+        Cards revealedCards = new CardsImpl();
+        Cards lands = new CardsImpl();
+        for (Card card : controller.getLibrary().getCards(game)) {
+            if (card.isLand()) {
+                lands.add(card);
+                if (lands.size() == 2) {
+                    break;
+                }
+            }
+            revealedCards.add(card);
+        }
+        controller.revealCards(source, revealedCards, game);
+        PutCards.BATTLEFIELD_TAPPED.moveCards(controller, lands, source, game);
+        PutCards.BOTTOM_RANDOM.moveCards(controller, revealedCards, source, game);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SpectacularPileup.java
+++ b/Mage.Sets/src/mage/cards/s/SpectacularPileup.java
@@ -1,0 +1,55 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.abilities.effects.common.continuous.LoseAbilityAllEffect;
+import mage.abilities.keyword.CyclingAbility;
+import mage.abilities.keyword.IndestructibleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SpectacularPileup extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("creatures and Vehicles");
+
+    static {
+        filter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+
+    public SpectacularPileup(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{W}{W}");
+        
+
+        // All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.
+        this.getSpellAbility().addEffect(new LoseAbilityAllEffect(
+                IndestructibleAbility.getInstance(), Duration.EndOfTurn, filter)
+                .setText("All creatures and Vehicles lose indestructible until end of turn")
+        );
+        this.getSpellAbility().addEffect(new DestroyAllEffect(filter).concatBy(", then"));
+        // Cycling {2}
+        this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
+
+    }
+
+    private SpectacularPileup(final SpectacularPileup card) {
+        super(card);
+    }
+
+    @Override
+    public SpectacularPileup copy() {
+        return new SpectacularPileup(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
+++ b/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
@@ -1,0 +1,75 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.costs.common.TapTargetCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.continuous.AddCardTypeSourceEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.counters.CounterType;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.permanent.TappedPredicate;
+import mage.target.common.TargetControlledPermanent;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SpireMechcycle extends CardImpl {
+
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("another untapped Mount or Vehicle you control");
+    private static final DynamicValue mountAndVehicleCount = new PermanentsOnBattlefieldCount(filter);
+
+    static {
+        filter.add(AnotherPredicate.instance);
+        filter.add(TappedPredicate.UNTAPPED);
+        filter.add(Predicates.or(
+                SubType.MOUNT.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+
+    public SpireMechcycle(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}{R}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(4);
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Exhaust -- Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle.
+        Effect effect = new AddCardTypeSourceEffect(Duration.WhileOnBattlefield, CardType.ARTIFACT, CardType.CREATURE)
+                .setText("This Vehicle becomes an artifact creature");
+        Ability ability = new ExhaustAbility(effect, new TapTargetCost(new TargetControlledPermanent(filter)));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), mountAndVehicleCount)
+                .setText("Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle"));
+        this.addAbility(ability);
+        // Crew 2
+        this.addAbility(new CrewAbility(2));
+
+    }
+
+    private SpireMechcycle(final SpireMechcycle card) {
+        super(card);
+    }
+
+    @Override
+    public SpireMechcycle copy() {
+        return new SpireMechcycle(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
+++ b/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
@@ -31,12 +31,18 @@ import mage.target.common.TargetControlledPermanent;
 public final class SpireMechcycle extends CardImpl {
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("another untapped Mount or Vehicle you control");
-    private static final DynamicValue mountAndVehicleCount = new PermanentsOnBattlefieldCount(filter);
+    private static final FilterControlledPermanent mountAndVehicleFilter = new FilterControlledPermanent("Mount and/or Vehicle you control other than this Vehicle");
+    private static final DynamicValue mountAndVehicleCount = new PermanentsOnBattlefieldCount(mountAndVehicleFilter);
 
     static {
         filter.add(AnotherPredicate.instance);
         filter.add(TappedPredicate.UNTAPPED);
         filter.add(Predicates.or(
+                SubType.MOUNT.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+        mountAndVehicleFilter.add(AnotherPredicate.instance);
+        mountAndVehicleFilter.add(Predicates.or(
                 SubType.MOUNT.getPredicate(),
                 SubType.VEHICLE.getPredicate()
         ));

--- a/Mage.Sets/src/mage/cards/s/StartYourEngines.java
+++ b/Mage.Sets/src/mage/cards/s/StartYourEngines.java
@@ -6,6 +6,7 @@ import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
+import mage.abilities.effects.common.continuous.VehiclesBecomeArtifactCreatureEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -22,7 +23,7 @@ public final class StartYourEngines extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{R}");
 
         // Vehicles you control becomes artifact creatures until end of turn.
-        Effect effect = new StartYourEnginesEffect();
+        Effect effect = new VehiclesBecomeArtifactCreatureEffect(Duration.EndOfTurn);
         this.getSpellAbility().addEffect(effect);
 
         // Creatures you control get +2/+0 until end of turn.
@@ -37,40 +38,4 @@ public final class StartYourEngines extends CardImpl {
     public StartYourEngines copy() {
         return new StartYourEngines(this);
     }
-}
-
-class StartYourEnginesEffect extends ContinuousEffectImpl {
-
-    StartYourEnginesEffect() {
-        super(Duration.EndOfTurn, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.BecomeCreature);
-        staticText = "Vehicles you control become artifact creatures until end of turn";
-    }
-
-    private StartYourEnginesEffect(final StartYourEnginesEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public StartYourEnginesEffect copy() {
-        return new StartYourEnginesEffect(this);
-    }
-
-    @Override
-    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
-        for (Permanent permanent : game.getBattlefield().getAllActivePermanents(source.getControllerId())) {
-            if (permanent != null && permanent.hasSubtype(SubType.VEHICLE, game)) {
-                if (sublayer == SubLayer.NA) {
-                    permanent.addCardType(game, CardType.ARTIFACT);
-                    permanent.addCardType(game, CardType.CREATURE);// TODO: Check if giving CREATURE Type is correct
-                }
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return false;
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/t/ThunderousVelocipede.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderousVelocipede.java
@@ -1,0 +1,71 @@
+package mage.cards.t;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.EntersWithCountersControlledEffect;
+import mage.constants.ComparisonType;
+import mage.constants.SubType;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.counters.CounterType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class ThunderousVelocipede extends CardImpl {
+
+    private static final FilterPermanent fourOrLessFilter = new FilterPermanent("other Vehicle and creature you control with mana value 4 or less");
+    private static final FilterPermanent greaterThanFourFilter = new FilterPermanent("other Vehicle and creature you control with mana value greater than 4");
+
+    static {
+        fourOrLessFilter.add(new ManaValuePredicate(ComparisonType.OR_LESS, 4));
+        fourOrLessFilter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+        greaterThanFourFilter.add(new ManaValuePredicate(ComparisonType.MORE_THAN, 4));
+        greaterThanFourFilter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+
+    public ThunderousVelocipede(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{G}{G}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.
+        Ability ability = new SimpleStaticAbility(new EntersWithCountersControlledEffect(fourOrLessFilter, CounterType.P1P1.createInstance(1), true)
+                .setText("Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less."));
+        ability.addEffect(new EntersWithCountersControlledEffect(greaterThanFourFilter, CounterType.P1P1.createInstance(3), true)
+                .setText("otherwise, it enters with three additional +1/+1 counters on it."));
+        this.addAbility(ability);
+        // Crew 3
+        this.addAbility(new CrewAbility(3));
+
+    }
+
+    private ThunderousVelocipede(final ThunderousVelocipede card) {
+        super(card);
+    }
+
+    @Override
+    public ThunderousVelocipede copy() {
+        return new ThunderousVelocipede(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/t/TuneUp.java
+++ b/Mage.Sets/src/mage/cards/t/TuneUp.java
@@ -1,0 +1,70 @@
+package mage.cards.t;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
+import mage.abilities.effects.common.ReturnFromYourGraveyardToBattlefieldAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetCardInYourGraveyard;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class TuneUp extends CardImpl {
+
+    public TuneUp(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{W}");
+        
+
+        // Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.
+        this.getSpellAbility().addEffect(new ReturnFromGraveyardToBattlefieldTargetEffect());
+        this.getSpellAbility().addEffect(new TuneUpEffect());
+        this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_ARTIFACT_FROM_YOUR_GRAVEYARD));
+    }
+
+    private TuneUp(final TuneUp card) {
+        super(card);
+    }
+
+    @Override
+    public TuneUp copy() {
+        return new TuneUp(this);
+    }
+}
+
+class TuneUpEffect extends OneShotEffect {
+
+    TuneUpEffect() {
+        super(Outcome.BecomeCreature);
+        this.staticText = "If it's a Vehicle, it becomes an artifact creature";
+    }
+
+    private TuneUpEffect(final TuneUpEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public TuneUpEffect copy() {
+        return new TuneUpEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getFirstTarget());
+        if (permanent != null && permanent.hasSubtype(SubType.VEHICLE, game)) {
+            permanent.addCardType(CardType.CREATURE);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
+++ b/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
@@ -1,0 +1,80 @@
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.MayCastFromGraveyardSourceAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class WickerfolkIndomitable extends CardImpl {
+
+    public WickerfolkIndomitable(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{3}{B}");
+        
+        this.subtype.add(SubType.SCARECROW);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.
+        Ability ability = new SimpleStaticAbility(Zone.GRAVEYARD, new WickerfolkIndomitableGraveyardEffect());
+        ability.addCost(new PayLifeCost(2).setText(""));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE)
+                .setText(""));
+
+        this.addAbility(ability);
+    }
+
+    private WickerfolkIndomitable(final WickerfolkIndomitable card) {
+        super(card);
+    }
+
+    @Override
+    public WickerfolkIndomitable copy() {
+        return new WickerfolkIndomitable(this);
+    }
+}
+
+class WickerfolkIndomitableGraveyardEffect extends AsThoughEffectImpl {
+
+    WickerfolkIndomitableGraveyardEffect() {
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.PutCreatureInPlay);
+        this.staticText = "You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.";
+    }
+
+    private WickerfolkIndomitableGraveyardEffect(final WickerfolkIndomitableGraveyardEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public WickerfolkIndomitableGraveyardEffect copy() {
+        return new WickerfolkIndomitableGraveyardEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        if (!objectId.equals(source.getSourceId()) || !source.isControlledBy(affectedControllerId)) {
+            return false;
+        }
+        Card card = game.getCard(source.getSourceId());
+        return card != null && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
+++ b/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
@@ -1,12 +1,18 @@
 package mage.cards.w;
 
 import java.util.UUID;
+
+import mage.MageIdentifier;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.MayCastFromGraveyardSourceAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.Costs;
+import mage.abilities.costs.CostsImpl;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -15,6 +21,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.filter.StaticFilters;
 import mage.game.Game;
+import mage.players.Player;
 
 /**
  *
@@ -30,10 +37,8 @@ public final class WickerfolkIndomitable extends CardImpl {
         this.toughness = new MageInt(3);
 
         // You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.
-        Ability ability = new SimpleStaticAbility(Zone.GRAVEYARD, new WickerfolkIndomitableGraveyardEffect());
-        ability.addCost(new PayLifeCost(2).setText(""));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE)
-                .setText(""));
+        Ability ability = new SimpleStaticAbility(Zone.GRAVEYARD, new WickerfolkIndomitableGraveyardEffect())
+                .setIdentifier(MageIdentifier.WickerfolkIndomitableAlternateCast);
 
         this.addAbility(ability);
     }
@@ -71,10 +76,19 @@ class WickerfolkIndomitableGraveyardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!objectId.equals(source.getSourceId()) || !source.isControlledBy(affectedControllerId)) {
+        if (!objectId.equals(source.getSourceId()) || !source.isControlledBy(affectedControllerId)
+        || game.getState().getZone(source.getSourceId()) != Zone.GRAVEYARD) {
             return false;
         }
-        Card card = game.getCard(source.getSourceId());
-        return card != null && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+        Player controller = game.getPlayer(affectedControllerId);
+        if (controller != null) {
+            Costs<Cost> costs = new CostsImpl<>();
+            costs.add(new PayLifeCost(2));
+            costs.add(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE));
+            controller.setCastSourceIdWithAlternateMana(objectId, new ManaCostsImpl<>("{3}{B}"), costs,
+                    MageIdentifier.WickerfolkIndomitableAlternateCast);
+            return true;
+        }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WinterCursedRider.java
+++ b/Mage.Sets/src/mage/cards/w/WinterCursedRider.java
@@ -1,0 +1,78 @@
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.common.ExileXFromYourGraveCost;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
+import mage.abilities.effects.common.continuous.BoostAllEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.keyword.WardAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class WinterCursedRider extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Each other nonartifact creature");
+    private static final DynamicValue xValue = new SignInversionDynamicValue(GetXValue.instance);
+
+    static {
+        filter.add(Predicates.not(CardType.ARTIFACT.getPredicate()));
+    }
+
+    public WinterCursedRider(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{U}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WARLOCK);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(2);
+
+        // Ward--Pay 2 life.
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("")));
+
+        // Artifacts you control have "Ward--Pay 2 life."
+        WardAbility wardAbility = new WardAbility(new PayLifeCost(2));
+        this.addAbility(new SimpleStaticAbility(
+                new GainAbilityAllEffect(wardAbility, Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACTS)
+                        .setText("Artifacts you control have " + "\"" + wardAbility.getRuleWithoutHint() + "\"")
+        ));
+        // Exhaust -- {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.
+        Ability ability = new ExhaustAbility(new BoostAllEffect(xValue, xValue, Duration.EndOfTurn, filter, true),
+                new ManaCostsImpl<>("{2}{U}{B}"));
+        ability.addCost(new TapSourceCost());
+        ability.addCost(new ExileXFromYourGraveCost(StaticFilters.FILTER_CARD_ARTIFACTS)
+                .setText("Exile X artifact cards from your graveyard"));
+        this.addAbility(ability);
+    }
+
+    private WinterCursedRider(final WinterCursedRider card) {
+        super(card);
+    }
+
+    @Override
+    public WinterCursedRider copy() {
+        return new WinterCursedRider(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -111,6 +111,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Endrider Catalyzer", 124, Rarity.COMMON, mage.cards.e.EndriderCatalyzer.class));
         cards.add(new SetCardInfo("Endrider Spikespitter", 125, Rarity.UNCOMMON, mage.cards.e.EndriderSpikespitter.class));
         cards.add(new SetCardInfo("Engine Rat", 84, Rarity.COMMON, mage.cards.e.EngineRat.class));
+        cards.add(new SetCardInfo("Explosive Getaway", 202, Rarity.RARE, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 390, Rarity.RARE, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 403, Rarity.MYTHIC, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 413, Rarity.MYTHIC, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 479, Rarity.RARE, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Fang Guardian", 162, Rarity.UNCOMMON, mage.cards.f.FangGuardian.class));
         cards.add(new SetCardInfo("Fang-Druid Summoner", 163, Rarity.UNCOMMON, mage.cards.f.FangDruidSummoner.class));
         cards.add(new SetCardInfo("Far Fortune, End Boss", 203, Rarity.RARE, mage.cards.f.FarFortuneEndBoss.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -303,6 +303,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Thornwood Falls", 266, Rarity.COMMON, mage.cards.t.ThornwoodFalls.class));
         cards.add(new SetCardInfo("Thunderhead Gunner", 148, Rarity.COMMON, mage.cards.t.ThunderheadGunner.class));
         cards.add(new SetCardInfo("Thundering Broodwagon", 225, Rarity.UNCOMMON, mage.cards.t.ThunderingBroodwagon.class));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 183, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 317, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 471, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 529, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Ticket Tortoise", 245, Rarity.COMMON, mage.cards.t.TicketTortoise.class));
         cards.add(new SetCardInfo("Trade the Helm", 69, Rarity.UNCOMMON, mage.cards.t.TradeTheHelm.class));
         cards.add(new SetCardInfo("Tranquil Cove", 267, Rarity.COMMON, mage.cards.t.TranquilCove.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -272,6 +272,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Skyserpent Seeker", 420, Rarity.UNCOMMON, mage.cards.s.SkyserpentSeeker.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));
         cards.add(new SetCardInfo("Slick Imitator", 62, Rarity.UNCOMMON, mage.cards.s.SlickImitator.class));
+        cards.add(new SetCardInfo("Spectacular Pileup", 29, Rarity.RARE, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 378, Rarity.RARE, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 398, Rarity.MYTHIC, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 408, Rarity.MYTHIC, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 433, Rarity.RARE, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Spectral Interference", 63, Rarity.COMMON, mage.cards.s.SpectralInterference.class));
         cards.add(new SetCardInfo("Spell Pierce", 64, Rarity.UNCOMMON, mage.cards.s.SpellPierce.class));
         cards.add(new SetCardInfo("Spikeshell Harrier", 65, Rarity.UNCOMMON, mage.cards.s.SpikeshellHarrier.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -185,6 +185,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Migrating Ketradon", 170, Rarity.COMMON, mage.cards.m.MigratingKetradon.class));
         cards.add(new SetCardInfo("Mindspring Merfolk", 51, Rarity.RARE, mage.cards.m.MindspringMerfolk.class));
         cards.add(new SetCardInfo("Molt Tender", 171, Rarity.UNCOMMON, mage.cards.m.MoltTender.class));
+        cards.add(new SetCardInfo("Momentum Breaker", 97, Rarity.UNCOMMON, mage.cards.m.MomentumBreaker.class));
         cards.add(new SetCardInfo("Monument to Endurance", 237, Rarity.RARE, mage.cards.m.MonumentToEndurance.class));
         cards.add(new SetCardInfo("Mountain", 286, Rarity.LAND, mage.cards.basiclands.Mountain.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Mu Yanling, Wind Rider", 52, Rarity.MYTHIC, mage.cards.m.MuYanlingWindRider.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -212,6 +212,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Pothole Mole", 176, Rarity.COMMON, mage.cards.p.PotholeMole.class));
         cards.add(new SetCardInfo("Pride of the Road", 24, Rarity.UNCOMMON, mage.cards.p.PrideOfTheRoad.class));
         cards.add(new SetCardInfo("Prowcatcher Specialist", 142, Rarity.COMMON, mage.cards.p.ProwcatcherSpecialist.class));
+        cards.add(new SetCardInfo("Push the Limit", 143, Rarity.UNCOMMON, mage.cards.p.PushTheLimit.class));
         cards.add(new SetCardInfo("Pyrewood Gearhulk", 216, Rarity.MYTHIC, mage.cards.p.PyrewoodGearhulk.class));
         cards.add(new SetCardInfo("Quag Feast", 100, Rarity.RARE, mage.cards.q.QuagFeast.class));
         cards.add(new SetCardInfo("Racers' Scoreboard", 239, Rarity.UNCOMMON, mage.cards.r.RacersScoreboard.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -238,6 +238,9 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Rise from the Wreck", 178, Rarity.UNCOMMON, mage.cards.r.RiseFromTheWreck.class));
         cards.add(new SetCardInfo("Risen Necroregent", 102, Rarity.UNCOMMON, mage.cards.r.RisenNecroregent.class));
         cards.add(new SetCardInfo("Risky Shortcut", 103, Rarity.COMMON, mage.cards.r.RiskyShortcut.class));
+        cards.add(new SetCardInfo("Riverchurn Monument", 57, Rarity.RARE, mage.cards.r.RiverchurnMonument.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riverchurn Monument", 381, Rarity.RARE, mage.cards.r.RiverchurnMonument.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riverchurn Monument", 440, Rarity.RARE, mage.cards.r.RiverchurnMonument.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Riverpyre Verge", 260, Rarity.RARE, mage.cards.r.RiverpyreVerge.class));
         cards.add(new SetCardInfo("Road Rage", 145, Rarity.UNCOMMON, mage.cards.r.RoadRage.class));
         cards.add(new SetCardInfo("Roadside Assistance", 26, Rarity.UNCOMMON, mage.cards.r.RoadsideAssistance.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -329,6 +329,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Wastewood Verge", 268, Rarity.RARE, mage.cards.w.WastewoodVerge.class));
         cards.add(new SetCardInfo("Waxen Shapethief", 74, Rarity.RARE, mage.cards.w.WaxenShapethief.class));
         cards.add(new SetCardInfo("Webstrike Elite", 186, Rarity.RARE, mage.cards.w.WebstrikeElite.class));
+        cards.add(new SetCardInfo("Wickerfolk Indomitable", 109, Rarity.UNCOMMON, mage.cards.w.WickerfolkIndomitable.class));
         cards.add(new SetCardInfo("Wild Roads", 269, Rarity.UNCOMMON, mage.cards.w.WildRoads.class));
         cards.add(new SetCardInfo("Willowrush Verge", 270, Rarity.RARE, mage.cards.w.WillowrushVerge.class));
         cards.add(new SetCardInfo("Wind-Scarred Crag", 271, Rarity.COMMON, mage.cards.w.WindScarredCrag.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -172,6 +172,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Lumbering Worldwagon", 168, Rarity.RARE, mage.cards.l.LumberingWorldwagon.class));
         cards.add(new SetCardInfo("Magmakin Artillerist", 137, Rarity.COMMON, mage.cards.m.MagmakinArtillerist.class));
         cards.add(new SetCardInfo("Marauding Mako", 138, Rarity.UNCOMMON, mage.cards.m.MaraudingMako.class));
+        cards.add(new SetCardInfo("March of the World Ooze", 169, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 388, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 402, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 412, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 468, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Marketback Walker", 235, Rarity.RARE, mage.cards.m.MarketbackWalker.class));
         cards.add(new SetCardInfo("Marshals' Pathcruiser", 236, Rarity.UNCOMMON, mage.cards.m.MarshalsPathcruiser.class));
         cards.add(new SetCardInfo("Maximum Overdrive", 96, Rarity.COMMON, mage.cards.m.MaximumOverdrive.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -160,6 +160,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Lightshield Parry", 19, Rarity.COMMON, mage.cards.l.LightshieldParry.class));
         cards.add(new SetCardInfo("Lightwheel Enhancements", 20, Rarity.COMMON, mage.cards.l.LightwheelEnhancements.class));
         cards.add(new SetCardInfo("Locust Spray", 95, Rarity.UNCOMMON, mage.cards.l.LocustSpray.class));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 212, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 391, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 404, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 414, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 484, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Lotusguard Disciple", 21, Rarity.COMMON, mage.cards.l.LotusguardDisciple.class));
         cards.add(new SetCardInfo("Loxodon Surveyor", 167, Rarity.COMMON, mage.cards.l.LoxodonSurveyor.class));
         cards.add(new SetCardInfo("Lumbering Worldwagon", 168, Rarity.RARE, mage.cards.l.LumberingWorldwagon.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -193,6 +193,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Nesting Bot", 22, Rarity.UNCOMMON, mage.cards.n.NestingBot.class));
         cards.add(new SetCardInfo("Night Market", 258, Rarity.COMMON, mage.cards.n.NightMarket.class));
         cards.add(new SetCardInfo("Nimble Thopterist", 53, Rarity.COMMON, mage.cards.n.NimbleThopterist.class));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 215, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 351, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 487, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 550, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Ooze Patrol", 172, Rarity.UNCOMMON, mage.cards.o.OozePatrol.class));
         cards.add(new SetCardInfo("Outpace Oblivion", 139, Rarity.UNCOMMON, mage.cards.o.OutpaceOblivion.class));
         cards.add(new SetCardInfo("Oviya, Automech Artisan", 173, Rarity.RARE, mage.cards.o.OviyaAutomechArtisan.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -142,6 +142,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Haunted Hellride", 208, Rarity.UNCOMMON, mage.cards.h.HauntedHellride.class));
         cards.add(new SetCardInfo("Hazard of the Dunes", 165, Rarity.COMMON, mage.cards.h.HazardOfTheDunes.class));
         cards.add(new SetCardInfo("Hazoret, Godseeker", 133, Rarity.MYTHIC, mage.cards.h.HazoretGodseeker.class));
+        cards.add(new SetCardInfo("Hellish Sideswipe", 90, Rarity.UNCOMMON, mage.cards.h.HellishSideswipe.class));
         cards.add(new SetCardInfo("Hour of Victory", 91, Rarity.UNCOMMON, mage.cards.h.HourOfVictory.class));
         cards.add(new SetCardInfo("Howler's Heavy", 46, Rarity.COMMON, mage.cards.h.HowlersHeavy.class));
         cards.add(new SetCardInfo("Howlsquad Heavy", 134, Rarity.RARE, mage.cards.h.HowlsquadHeavy.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -333,6 +333,9 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Wild Roads", 269, Rarity.UNCOMMON, mage.cards.w.WildRoads.class));
         cards.add(new SetCardInfo("Willowrush Verge", 270, Rarity.RARE, mage.cards.w.WillowrushVerge.class));
         cards.add(new SetCardInfo("Wind-Scarred Crag", 271, Rarity.COMMON, mage.cards.w.WindScarredCrag.class));
+        cards.add(new SetCardInfo("Winter, Cursed Rider", 228, Rarity.RARE, mage.cards.w.WinterCursedRider.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Winter, Cursed Rider", 369, Rarity.RARE, mage.cards.w.WinterCursedRider.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Winter, Cursed Rider", 494, Rarity.RARE, mage.cards.w.WinterCursedRider.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Wreck Remover", 247, Rarity.COMMON, mage.cards.w.WreckRemover.class));
         cards.add(new SetCardInfo("Wreckage Wickerfolk", 110, Rarity.COMMON, mage.cards.w.WreckageWickerfolk.class));
         cards.add(new SetCardInfo("Wretched Doll", 111, Rarity.UNCOMMON, mage.cards.w.WretchedDoll.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -112,6 +112,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Endrider Spikespitter", 125, Rarity.UNCOMMON, mage.cards.e.EndriderSpikespitter.class));
         cards.add(new SetCardInfo("Engine Rat", 84, Rarity.COMMON, mage.cards.e.EngineRat.class));
         cards.add(new SetCardInfo("Fang Guardian", 162, Rarity.UNCOMMON, mage.cards.f.FangGuardian.class));
+        cards.add(new SetCardInfo("Fang-Druid Summoner", 163, Rarity.UNCOMMON, mage.cards.f.FangDruidSummoner.class));
         cards.add(new SetCardInfo("Far Fortune, End Boss", 203, Rarity.RARE, mage.cards.f.FarFortuneEndBoss.class));
         cards.add(new SetCardInfo("Fearless Swashbuckler", 204, Rarity.RARE, mage.cards.f.FearlessSwashbuckler.class));
         cards.add(new SetCardInfo("Flood the Engine", 42, Rarity.COMMON, mage.cards.f.FloodTheEngine.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -259,6 +259,9 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Scrounging Skyray", 60, Rarity.UNCOMMON, mage.cards.s.ScroungingSkyray.class));
         cards.add(new SetCardInfo("Shefet Archfiend", 104, Rarity.UNCOMMON, mage.cards.s.ShefetArchfiend.class));
         cards.add(new SetCardInfo("Silken Strength", 180, Rarity.COMMON, mage.cards.s.SilkenStrength.class));
+        cards.add(new SetCardInfo("Sita Varma, Masked Racer", 223, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sita Varma, Masked Racer", 368, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sita Varma, Masked Racer", 493, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skybox Ferry", 243, Rarity.COMMON, mage.cards.s.SkyboxFerry.class));
         cards.add(new SetCardInfo("Skycrash", 146, Rarity.UNCOMMON, mage.cards.s.Skycrash.class));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -231,6 +231,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Repurposing Bay", 56, Rarity.RARE, mage.cards.r.RepurposingBay.class));
         cards.add(new SetCardInfo("Ride's End", 25, Rarity.COMMON, mage.cards.r.RidesEnd.class));
         cards.add(new SetCardInfo("Ripclaw Wrangler", 101, Rarity.COMMON, mage.cards.r.RipclawWrangler.class));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 219, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 353, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 490, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 552, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Rise from the Wreck", 178, Rarity.UNCOMMON, mage.cards.r.RiseFromTheWreck.class));
         cards.add(new SetCardInfo("Risen Necroregent", 102, Rarity.UNCOMMON, mage.cards.r.RisenNecroregent.class));
         cards.add(new SetCardInfo("Risky Shortcut", 103, Rarity.COMMON, mage.cards.r.RiskyShortcut.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -268,6 +268,8 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Skyseer's Chariot", 296, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skyseer's Chariot", 432, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skyseer's Chariot", 518, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyserpent Seeker", 224, Rarity.UNCOMMON, mage.cards.s.SkyserpentSeeker.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyserpent Seeker", 420, Rarity.UNCOMMON, mage.cards.s.SkyserpentSeeker.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));
         cards.add(new SetCardInfo("Slick Imitator", 62, Rarity.UNCOMMON, mage.cards.s.SlickImitator.class));
         cards.add(new SetCardInfo("Spectral Interference", 63, Rarity.COMMON, mage.cards.s.SpectralInterference.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -264,6 +264,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Sita Varma, Masked Racer", 493, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skybox Ferry", 243, Rarity.COMMON, mage.cards.s.SkyboxFerry.class));
         cards.add(new SetCardInfo("Skycrash", 146, Rarity.UNCOMMON, mage.cards.s.Skycrash.class));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 28, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 296, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 432, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 518, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));
         cards.add(new SetCardInfo("Slick Imitator", 62, Rarity.UNCOMMON, mage.cards.s.SlickImitator.class));
         cards.add(new SetCardInfo("Spectral Interference", 63, Rarity.COMMON, mage.cards.s.SpectralInterference.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -119,6 +119,9 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Forest", 289, Rarity.LAND, mage.cards.basiclands.Forest.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Foul Roads", 255, Rarity.UNCOMMON, mage.cards.f.FoulRoads.class));
         cards.add(new SetCardInfo("Fuel the Flames", 126, Rarity.UNCOMMON, mage.cards.f.FuelTheFlames.class));
+        cards.add(new SetCardInfo("Full Throttle", 127, Rarity.RARE, mage.cards.f.FullThrottle.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Full Throttle", 386, Rarity.RARE, mage.cards.f.FullThrottle.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Full Throttle", 460, Rarity.RARE, mage.cards.f.FullThrottle.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Gallant Strike", 13, Rarity.UNCOMMON, mage.cards.g.GallantStrike.class));
         cards.add(new SetCardInfo("Gas Guzzler", 85, Rarity.RARE, mage.cards.g.GasGuzzler.class));
         cards.add(new SetCardInfo("Gastal Blockbuster", 128, Rarity.COMMON, mage.cards.g.GastalBlockbuster.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -135,6 +135,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Grim Bauble", 88, Rarity.COMMON, mage.cards.g.GrimBauble.class));
         cards.add(new SetCardInfo("Grim Javelineer", 89, Rarity.COMMON, mage.cards.g.GrimJavelineer.class));
         cards.add(new SetCardInfo("Guardian Sunmare", 15, Rarity.RARE, mage.cards.g.GuardianSunmare.class));
+        cards.add(new SetCardInfo("Guidelight Optimizer", 45, Rarity.COMMON, mage.cards.g.GuidelightOptimizer.class));
         cards.add(new SetCardInfo("Guidelight Pathmaker", 206, Rarity.UNCOMMON, mage.cards.g.GuidelightPathmaker.class));
         cards.add(new SetCardInfo("Guidelight Synergist", 16, Rarity.UNCOMMON, mage.cards.g.GuidelightSynergist.class));
         cards.add(new SetCardInfo("Haunt the Network", 207, Rarity.UNCOMMON, mage.cards.h.HauntTheNetwork.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -211,6 +211,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Pyrewood Gearhulk", 216, Rarity.MYTHIC, mage.cards.p.PyrewoodGearhulk.class));
         cards.add(new SetCardInfo("Quag Feast", 100, Rarity.RARE, mage.cards.q.QuagFeast.class));
         cards.add(new SetCardInfo("Racers' Scoreboard", 239, Rarity.UNCOMMON, mage.cards.r.RacersScoreboard.class));
+        cards.add(new SetCardInfo("Radiant Lotus", 240, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 395, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 406, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 416, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 500, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Rangers' Aetherhive", 217, Rarity.UNCOMMON, mage.cards.r.RangersAetherhive.class));
         cards.add(new SetCardInfo("Rangers' Refueler", 55, Rarity.UNCOMMON, mage.cards.r.RangersRefueler.class));
         cards.add(new SetCardInfo("Reckless Velocitaur", 144, Rarity.UNCOMMON, mage.cards.r.RecklessVelocitaur.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -312,6 +312,8 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Tranquil Cove", 267, Rarity.COMMON, mage.cards.t.TranquilCove.class));
         cards.add(new SetCardInfo("Transit Mage", 70, Rarity.UNCOMMON, mage.cards.t.TransitMage.class));
         cards.add(new SetCardInfo("Trip Up", 71, Rarity.COMMON, mage.cards.t.TripUp.class));
+        cards.add(new SetCardInfo("Tune Up", 33, Rarity.UNCOMMON, mage.cards.t.TuneUp.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Tune Up", 417, Rarity.UNCOMMON, mage.cards.t.TuneUp.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Tyrox, Saurid Tyrant", 149, Rarity.UNCOMMON, mage.cards.t.TyroxSauridTyrant.class));
         cards.add(new SetCardInfo("Unstoppable Plan", 72, Rarity.RARE, mage.cards.u.UnstoppablePlan.class));
         cards.add(new SetCardInfo("Unswerving Sloth", 34, Rarity.UNCOMMON, mage.cards.u.UnswervingSloth.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -281,6 +281,8 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Spell Pierce", 64, Rarity.UNCOMMON, mage.cards.s.SpellPierce.class));
         cards.add(new SetCardInfo("Spikeshell Harrier", 65, Rarity.UNCOMMON, mage.cards.s.SpikeshellHarrier.class));
         cards.add(new SetCardInfo("Spin Out", 106, Rarity.COMMON, mage.cards.s.SpinOut.class));
+        cards.add(new SetCardInfo("Spire Mechcycle", 147, Rarity.UNCOMMON, mage.cards.s.SpireMechcycle.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spire Mechcycle", 314, Rarity.UNCOMMON, mage.cards.s.SpireMechcycle.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Spotcycle Scouter", 30, Rarity.COMMON, mage.cards.s.SpotcycleScouter.class));
         cards.add(new SetCardInfo("Stall Out", 66, Rarity.COMMON, mage.cards.s.StallOut.class));
         cards.add(new SetCardInfo("Stampeding Scurryfoot", 181, Rarity.COMMON, mage.cards.s.StampedingScurryfoot.class));

--- a/Mage/src/main/java/mage/MageIdentifier.java
+++ b/Mage/src/main/java/mage/MageIdentifier.java
@@ -76,7 +76,8 @@ public enum MageIdentifier {
     TheRuinousPowersAlternateCast,
     FiresOfMountDoomAlternateCast,
     PrimalPrayersAlternateCast,
-    QuilledGreatwurmAlternateCast;
+    QuilledGreatwurmAlternateCast,
+    WickerfolkIndomitableAlternateCast;
 
     /**
      * Additional text if there is need to differentiate two very similar effects

--- a/Mage/src/main/java/mage/abilities/condition/common/SacrificedPermanentCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/SacrificedPermanentCondition.java
@@ -1,0 +1,44 @@
+package mage.abilities.condition.common;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.filter.FilterPermanent;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+public class SacrificedPermanentCondition implements Condition {
+
+    private final FilterPermanent filter;
+    private final String staticText;
+
+    public SacrificedPermanentCondition(FilterPermanent filter) {
+        this.filter = filter;
+        this.staticText = "the sacrificed permanent was " + filter.getMessage();
+    }
+
+    public SacrificedPermanentCondition(FilterPermanent filter, String staticText) {
+        this.filter = filter;
+        this.staticText = staticText;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        for (Cost cost : source.getCosts()) {
+            if (cost instanceof SacrificeTargetCost) {
+                for (Permanent permanent : ((SacrificeTargetCost) cost).getPermanents()) {
+                    if (filter.match(permanent, source.getControllerId(), source, game)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return staticText;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/AdditionalCombatPhaseEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/AdditionalCombatPhaseEffect.java
@@ -3,19 +3,45 @@ package mage.abilities.effects.common;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.constants.Outcome;
+import mage.constants.TargetController;
 import mage.constants.TurnPhase;
 import mage.game.Game;
 import mage.game.turn.TurnMod;
 
+import java.util.UUID;
+
 public class AdditionalCombatPhaseEffect extends OneShotEffect {
+
+    private final int additionalPhases;
+    private final TargetController targetController;
 
     public AdditionalCombatPhaseEffect() {
         super(Outcome.Benefit);
+        this.additionalPhases = 1;
+        this.targetController = TargetController.YOU;
         staticText = "after this phase, there is an additional combat phase";
+    }
+
+    public AdditionalCombatPhaseEffect(int additionalPhases) {
+        this(additionalPhases, TargetController.YOU);
+    }
+
+    public AdditionalCombatPhaseEffect(int additionalPhases, TargetController targetController) {
+        super(Outcome.Benefit);
+        if (additionalPhases <= 1) {
+            this.additionalPhases = 1;
+            staticText = "after this phase, there is an additional combat phase";
+        } else {
+            this.additionalPhases = additionalPhases;
+            staticText = "after this phase, there are " + additionalPhases + " additional combat phases";
+        }
+        this.targetController = targetController;
     }
 
     protected AdditionalCombatPhaseEffect(final AdditionalCombatPhaseEffect effect) {
         super(effect);
+        this.additionalPhases = effect.additionalPhases;
+        this.targetController = effect.targetController;
     }
 
     @Override
@@ -25,7 +51,21 @@ public class AdditionalCombatPhaseEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        game.getState().getTurnMods().add(new TurnMod(game.getState().getActivePlayerId()).withExtraPhase(TurnPhase.COMBAT));
+        UUID controllerId;
+        switch (targetController) {
+            case YOU:
+                controllerId = source.getControllerId();
+                break;
+            case ANY:
+                controllerId = game.getActivePlayerId();
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported TargetController in AdditionalCombatPhaseEffect: " + targetController);
+        }
+        for (int i = 0; i < additionalPhases; i++) {
+            TurnMod combat = new TurnMod(controllerId).withExtraPhase(TurnPhase.COMBAT);
+            game.getState().getTurnMods().add(combat);
+        }
         return true;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/MillCardsTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/MillCardsTargetEffect.java
@@ -10,6 +10,8 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.util.CardUtil;
 
+import java.util.UUID;
+
 /**
  * @author LevelX2
  */
@@ -38,12 +40,13 @@ public class MillCardsTargetEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
-        if (player != null) {
-            player.millCards(numberCards.calculate(game, source, this), source, game);
-            return true;
+        for (UUID playerId : getTargetPointer().getTargets(game, source)) {
+            Player player = game.getPlayer(playerId);
+            if (player != null) {
+                player.millCards(numberCards.calculate(game, source, this), source, game);
+            }
         }
-        return false;
+        return true;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/VehiclesBecomeArtifactCreatureEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/VehiclesBecomeArtifactCreatureEffect.java
@@ -1,0 +1,42 @@
+package mage.abilities.effects.common.continuous;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+public class VehiclesBecomeArtifactCreatureEffect extends ContinuousEffectImpl {
+
+    public VehiclesBecomeArtifactCreatureEffect(Duration duration) {
+        super(duration, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.BecomeCreature);
+        staticText = "Vehicles you control become artifact creatures until end of turn";
+    }
+
+    private VehiclesBecomeArtifactCreatureEffect(final VehiclesBecomeArtifactCreatureEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public VehiclesBecomeArtifactCreatureEffect copy() {
+        return new VehiclesBecomeArtifactCreatureEffect(this);
+    }
+
+    @Override
+    public boolean apply(Layer layer, SubLayer sublayer, Ability source, Game game) {
+        for (Permanent permanent : game.getBattlefield().getAllActivePermanents(source.getControllerId())) {
+            if (permanent != null && permanent.hasSubtype(SubType.VEHICLE, game)) {
+                if (sublayer == SubLayer.NA) {
+                    permanent.addCardType(game, CardType.ARTIFACT);
+                    permanent.addCardType(game, CardType.CREATURE);// TODO: Check if giving CREATURE Type is correct
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return false;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/ExhaustAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ExhaustAbility.java
@@ -10,13 +10,27 @@ import mage.constants.Zone;
  */
 public class ExhaustAbility extends ActivatedAbilityImpl {
 
+    private boolean withReminderText = true;
+
     public ExhaustAbility(Effect effect, Cost cost) {
         super(Zone.BATTLEFIELD, effect, cost);
+    }
+
+    public ExhaustAbility(Effect effect, Cost cost, boolean withReminderText) {
+        super(Zone.BATTLEFIELD, effect, cost);
+        this.setRuleVisible(false);
+        this.withReminderText = withReminderText;
     }
 
     private ExhaustAbility(final ExhaustAbility ability) {
         super(ability);
         this.maxActivationsPerGame = 1;
+        this.withReminderText = ability.withReminderText;
+    }
+
+    public ExhaustAbility withReminderText(boolean withReminderText) {
+        this.withReminderText = withReminderText;
+        return this;
     }
 
     @Override
@@ -26,6 +40,7 @@ public class ExhaustAbility extends ActivatedAbilityImpl {
 
     @Override
     public String getRule() {
-        return "Exhaust &mdash; " + super.getRule() + " <i>(Activate each exhaust ability only once.)</i>";
+        return "Exhaust &mdash; " + super.getRule() +
+                (withReminderText ? " <i>(Activate each exhaust ability only once.)</i>" : "");
     }
 }


### PR DESCRIPTION
part of #13033

Cards have been built and tested manually. I can split this into smaller batches if necessary.
Cards Implemented:
- Winter, Cursed Rider
- Wickerfolk Indomitable
- Tune Up
- Thunderous Velocipede
- Spire Mechcycle
- Spectacular Pileup
- Skyserpent Seeker
- SkySeers Chariot
- Sita Varma, Masked Racer
- Riverchurn Monument
- Riptide Gearhulk
- Momentum Breaker
- Push the Limit
- Oildeep Gearhulk
- Radiant Lotus
- March of the World Ooze
- Hellish Sideswipe
- Guidelight Optimizer
- Loot, the Pathfinder
- Explosive Getaway
- Full Throttle
- Fang-Druid Summoner