### PR TITLE
[DFT] Implement Wickerfolk Indomitable

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
+++ b/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
@@ -1,0 +1,80 @@
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.MayCastFromGraveyardSourceAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class WickerfolkIndomitable extends CardImpl {
+
+    public WickerfolkIndomitable(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{3}{B}");
+        
+        this.subtype.add(SubType.SCARECROW);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.
+        Ability ability = new SimpleStaticAbility(Zone.GRAVEYARD, new WickerfolkIndomitableGraveyardEffect());
+        ability.addCost(new PayLifeCost(2).setText(""));
+        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE)
+                .setText(""));
+
+        this.addAbility(ability);
+    }
+
+    private WickerfolkIndomitable(final WickerfolkIndomitable card) {
+        super(card);
+    }
+
+    @Override
+    public WickerfolkIndomitable copy() {
+        return new WickerfolkIndomitable(this);
+    }
+}
+
+class WickerfolkIndomitableGraveyardEffect extends AsThoughEffectImpl {
+
+    WickerfolkIndomitableGraveyardEffect() {
+        super(AsThoughEffectType.CAST_FROM_NOT_OWN_HAND_ZONE, Duration.EndOfGame, Outcome.PutCreatureInPlay);
+        this.staticText = "You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.";
+    }
+
+    private WickerfolkIndomitableGraveyardEffect(final WickerfolkIndomitableGraveyardEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public WickerfolkIndomitableGraveyardEffect copy() {
+        return new WickerfolkIndomitableGraveyardEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+
+    @Override
+    public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
+        if (!objectId.equals(source.getSourceId()) || !source.isControlledBy(affectedControllerId)) {
+            return false;
+        }
+        Card card = game.getCard(source.getSourceId());
+        return card != null && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
+++ b/Mage.Sets/src/mage/cards/w/WickerfolkIndomitable.java
@@ -1,12 +1,18 @@
 package mage.cards.w;
 
 import java.util.UUID;
+
+import mage.MageIdentifier;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.MayCastFromGraveyardSourceAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.Costs;
+import mage.abilities.costs.CostsImpl;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -15,6 +21,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.filter.StaticFilters;
 import mage.game.Game;
+import mage.players.Player;
 
 /**
  *
@@ -30,10 +37,8 @@ public final class WickerfolkIndomitable extends CardImpl {
         this.toughness = new MageInt(3);
 
         // You may cast this card from your graveyard by paying 2 life and sacrificing an artifact or creature in addition to paying its other costs.
-        Ability ability = new SimpleStaticAbility(Zone.GRAVEYARD, new WickerfolkIndomitableGraveyardEffect());
-        ability.addCost(new PayLifeCost(2).setText(""));
-        ability.addCost(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE)
-                .setText(""));
+        Ability ability = new SimpleStaticAbility(Zone.GRAVEYARD, new WickerfolkIndomitableGraveyardEffect())
+                .setIdentifier(MageIdentifier.WickerfolkIndomitableAlternateCast);
 
         this.addAbility(ability);
     }
@@ -71,10 +76,19 @@ class WickerfolkIndomitableGraveyardEffect extends AsThoughEffectImpl {
 
     @Override
     public boolean applies(UUID objectId, Ability source, UUID affectedControllerId, Game game) {
-        if (!objectId.equals(source.getSourceId()) || !source.isControlledBy(affectedControllerId)) {
+        if (!objectId.equals(source.getSourceId()) || !source.isControlledBy(affectedControllerId)
+        || game.getState().getZone(source.getSourceId()) != Zone.GRAVEYARD) {
             return false;
         }
-        Card card = game.getCard(source.getSourceId());
-        return card != null && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD;
+        Player controller = game.getPlayer(affectedControllerId);
+        if (controller != null) {
+            Costs<Cost> costs = new CostsImpl<>();
+            costs.add(new PayLifeCost(2));
+            costs.add(new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT_OR_CREATURE));
+            controller.setCastSourceIdWithAlternateMana(objectId, new ManaCostsImpl<>("{3}{B}"), costs,
+                    MageIdentifier.WickerfolkIndomitableAlternateCast);
+            return true;
+        }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -276,6 +276,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Wastewood Verge", 268, Rarity.RARE, mage.cards.w.WastewoodVerge.class));
         cards.add(new SetCardInfo("Waxen Shapethief", 74, Rarity.RARE, mage.cards.w.WaxenShapethief.class));
         cards.add(new SetCardInfo("Webstrike Elite", 186, Rarity.RARE, mage.cards.w.WebstrikeElite.class));
+        cards.add(new SetCardInfo("Wickerfolk Indomitable", 109, Rarity.UNCOMMON, mage.cards.w.WickerfolkIndomitable.class));
         cards.add(new SetCardInfo("Wild Roads", 269, Rarity.UNCOMMON, mage.cards.w.WildRoads.class));
         cards.add(new SetCardInfo("Willowrush Verge", 270, Rarity.RARE, mage.cards.w.WillowrushVerge.class));
         cards.add(new SetCardInfo("Wind-Scarred Crag", 271, Rarity.COMMON, mage.cards.w.WindScarredCrag.class));

--- a/Mage/src/main/java/mage/MageIdentifier.java
+++ b/Mage/src/main/java/mage/MageIdentifier.java
@@ -76,7 +76,8 @@ public enum MageIdentifier {
     TheRuinousPowersAlternateCast,
     FiresOfMountDoomAlternateCast,
     PrimalPrayersAlternateCast,
-    QuilledGreatwurmAlternateCast;
+    QuilledGreatwurmAlternateCast,
+    WickerfolkIndomitableAlternateCast;
 
     /**
      * Additional text if there is need to differentiate two very similar effects


### PR DESCRIPTION
Part of #13033

This card uses a MageIdentifier for the alternate graveyard cast. This was done following the example of the card [[Demilich]].