### PR TITLE
[DFT] Implement Simple Cards

### DIFF
--- a/Mage.Sets/src/mage/cards/e/ExplosiveGetaway.java
+++ b/Mage.Sets/src/mage/cards/e/ExplosiveGetaway.java
@@ -1,0 +1,51 @@
+package mage.cards.e;
+
+import java.util.UUID;
+import java.util.function.Predicate;
+
+import mage.abilities.Ability;
+import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
+import mage.abilities.effects.common.DamageAllEffect;
+import mage.abilities.effects.common.ExileReturnBattlefieldNextEndStepTargetEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.predicate.Predicates;
+import mage.target.TargetPermanent;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class ExplosiveGetaway extends CardImpl {
+    private static final FilterPermanent filter = new FilterPermanent("artifact or creature");
+
+    static {
+        filter.add(Predicates.or(
+                CardType.ARTIFACT.getPredicate(),
+                CardType.CREATURE.getPredicate()
+        ));
+    }
+
+    public ExplosiveGetaway(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{R}{W}");
+        
+
+        // Exile up to one target artifact or creature. Return it to the battlefield under its owner's control at the beginning of the next end step.
+        this.getSpellAbility().addEffect(new ExileReturnBattlefieldNextEndStepTargetEffect().withTextThatCard(false));
+        this.getSpellAbility().addTarget(new TargetPermanent(0, 1, filter));
+        // Explosive Getaway deals 4 damage to each creature.
+        this.getSpellAbility().addEffect(new DamageAllEffect(4, StaticFilters.FILTER_PERMANENT_ALL_CREATURES).concatBy("<br>"));
+    }
+
+    private ExplosiveGetaway(final ExplosiveGetaway card) {
+        super(card);
+    }
+
+    @Override
+    public ExplosiveGetaway copy() {
+        return new ExplosiveGetaway(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/f/FangDruidSummoner.java
+++ b/Mage.Sets/src/mage/cards/f/FangDruidSummoner.java
@@ -1,0 +1,51 @@
+package mage.cards.f;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.common.search.SearchLibraryGraveyardPutInHandEffect;
+import mage.constants.SubType;
+import mage.abilities.keyword.ReachAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreatureCard;
+import mage.filter.predicate.mageobject.NoAbilityPredicate;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class FangDruidSummoner extends CardImpl {
+    private static final FilterCreatureCard filter = new FilterCreatureCard("a creature card with no abilities");
+
+    static {
+        filter.add(NoAbilityPredicate.instance);
+    }
+    public FangDruidSummoner(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{G}");
+        
+        this.subtype.add(SubType.APE);
+        this.subtype.add(SubType.DRUID);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Reach
+        this.addAbility(ReachAbility.getInstance());
+
+        // When this creature enters, you may search your library and/or graveyard for a creature card with no abilities, reveal it, and put it into your hand. If you search your library this way, shuffle.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(
+                new SearchLibraryGraveyardPutInHandEffect(filter, false, true)
+        ));
+    }
+
+    private FangDruidSummoner(final FangDruidSummoner card) {
+        super(card);
+    }
+
+    @Override
+    public FangDruidSummoner copy() {
+        return new FangDruidSummoner(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MarchOfTheWorldOoze.java
+++ b/Mage.Sets/src/mage/cards/m/MarchOfTheWorldOoze.java
@@ -1,0 +1,58 @@
+package mage.cards.m;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.SpellCastOpponentNoManaSpentTriggeredAbility;
+import mage.abilities.common.SpellCastOpponentTriggeredAbility;
+import mage.abilities.condition.common.OnOpponentsTurnCondition;
+import mage.abilities.effects.common.CastSourceTriggeredAbility;
+import mage.abilities.effects.common.CreateTokenAllEffect;
+import mage.abilities.effects.common.CreateTokenControllerTargetEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.abilities.effects.common.continuous.AddCardSubtypeAllEffect;
+import mage.abilities.effects.common.continuous.SetBasePowerToughnessAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.FilterSpell;
+import mage.filter.StaticFilters;
+import mage.game.permanent.token.ElephantToken;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class MarchOfTheWorldOoze extends CardImpl {
+    public static final FilterSpell filter = new FilterSpell("a spell, if it's not their turn");
+
+    static {
+        filter.add(TargetController.INACTIVE.getControllerPredicate());
+    }
+    public MarchOfTheWorldOoze(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{G}{G}{G}");
+        
+
+        // Creatures you control have base power and toughness 6/6 and are Oozes in addition to their other types.
+        Ability ability = new SimpleStaticAbility(new SetBasePowerToughnessAllEffect(
+                6, 6, Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_CREATURE));
+        ability.addEffect(new AddCardSubtypeAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE, SubType.OOZE, null)
+                        .concatBy("and"));
+        this.addAbility(ability);
+        // Whenever an opponent casts a spell, if it's not their turn, you create a 3/3 green Elephant creature token.
+        Ability ability2 = new SpellCastOpponentTriggeredAbility(new CreateTokenEffect(new ElephantToken())
+                .setText("you create a 3/3 green Elephant creature token"),
+                filter, false);
+        this.addAbility(ability2);
+    }
+
+    private MarchOfTheWorldOoze(final MarchOfTheWorldOoze card) {
+        super(card);
+    }
+
+    @Override
+    public MarchOfTheWorldOoze copy() {
+        return new MarchOfTheWorldOoze(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RiptideGearhulk.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideGearhulk.java
@@ -1,0 +1,61 @@
+package mage.cards.r;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.PutIntoLibraryNFromTopTargetEffect;
+import mage.constants.SubType;
+import mage.abilities.keyword.DoubleStrikeAbility;
+import mage.abilities.keyword.ProwessAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterNonlandCard;
+import mage.filter.predicate.mageobject.PermanentPredicate;
+import mage.target.common.TargetCardInGraveyard;
+import mage.target.common.TargetNonlandPermanent;
+import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
+import mage.target.targetpointer.EachTargetPointer;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class RiptideGearhulk extends CardImpl {
+    public RiptideGearhulk(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{1}{W}{W}{U}{U}");
+        
+        this.subtype.add(SubType.CONSTRUCT);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(5);
+
+        // Double strike
+        this.addAbility(DoubleStrikeAbility.getInstance());
+
+        // Prowess
+        this.addAbility(new ProwessAbility());
+
+        // When this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.
+        Effect effect = new PutIntoLibraryNFromTopTargetEffect(3)
+                .setText("put up to one target nonland permanent that player controls into its owner's library third from the top")
+                .setTargetPointer(new EachTargetPointer());
+        Ability ability = new EntersBattlefieldTriggeredAbility(effect)
+                .setTriggerPhrase("When {this} creature enters, for each opponent, ");
+        ability.addTarget(new TargetNonlandPermanent(0, 1));
+        ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
+        this.addAbility(ability);
+    }
+
+    private RiptideGearhulk(final RiptideGearhulk card) {
+        super(card);
+    }
+
+    @Override
+    public RiptideGearhulk copy() {
+        return new RiptideGearhulk(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/r/RiptideGearhulk.java
+++ b/Mage.Sets/src/mage/cards/r/RiptideGearhulk.java
@@ -12,11 +12,6 @@ import mage.abilities.keyword.ProwessAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterCard;
-import mage.filter.StaticFilters;
-import mage.filter.common.FilterNonlandCard;
-import mage.filter.predicate.mageobject.PermanentPredicate;
-import mage.target.common.TargetCardInGraveyard;
 import mage.target.common.TargetNonlandPermanent;
 import mage.target.targetadjustment.ForEachOpponentTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
@@ -41,10 +36,9 @@ public final class RiptideGearhulk extends CardImpl {
 
         // When this creature enters, for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top.
         Effect effect = new PutIntoLibraryNFromTopTargetEffect(3)
-                .setText("put up to one target nonland permanent that player controls into its owner's library third from the top")
+                .setText("for each opponent, put up to one target nonland permanent that player controls into its owner's library third from the top")
                 .setTargetPointer(new EachTargetPointer());
-        Ability ability = new EntersBattlefieldTriggeredAbility(effect)
-                .setTriggerPhrase("When {this} creature enters, for each opponent, ");
+        Ability ability = new EntersBattlefieldTriggeredAbility(effect);
         ability.addTarget(new TargetNonlandPermanent(0, 1));
         ability.setTargetAdjuster(new ForEachOpponentTargetsAdjuster());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SpectacularPileup.java
+++ b/Mage.Sets/src/mage/cards/s/SpectacularPileup.java
@@ -1,0 +1,55 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.abilities.effects.common.continuous.LoseAbilityAllEffect;
+import mage.abilities.keyword.CyclingAbility;
+import mage.abilities.keyword.IndestructibleAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SpectacularPileup extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterPermanent("creatures and Vehicles");
+
+    static {
+        filter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+
+    public SpectacularPileup(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{W}{W}");
+        
+
+        // All creatures and Vehicles lose indestructible until end of turn, then destroy all creatures and Vehicles.
+        this.getSpellAbility().addEffect(new LoseAbilityAllEffect(
+                IndestructibleAbility.getInstance(), Duration.EndOfTurn, filter)
+                .setText("All creatures and Vehicles lose indestructible until end of turn")
+        );
+        this.getSpellAbility().addEffect(new DestroyAllEffect(filter).concatBy(", then"));
+        // Cycling {2}
+        this.addAbility(new CyclingAbility(new ManaCostsImpl<>("{2}")));
+
+    }
+
+    private SpectacularPileup(final SpectacularPileup card) {
+        super(card);
+    }
+
+    @Override
+    public SpectacularPileup copy() {
+        return new SpectacularPileup(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
+++ b/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
@@ -1,0 +1,75 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.costs.common.TapTargetCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsOnBattlefieldCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.common.continuous.AddCardTypeSourceEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.counters.CounterType;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.permanent.TappedPredicate;
+import mage.target.common.TargetControlledPermanent;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SpireMechcycle extends CardImpl {
+
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("another untapped Mount or Vehicle you control");
+    private static final DynamicValue mountAndVehicleCount = new PermanentsOnBattlefieldCount(filter);
+
+    static {
+        filter.add(AnotherPredicate.instance);
+        filter.add(TappedPredicate.UNTAPPED);
+        filter.add(Predicates.or(
+                SubType.MOUNT.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+
+    public SpireMechcycle(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}{R}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(4);
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Exhaust -- Tap another untapped Mount or Vehicle you control: This Vehicle becomes an artifact creature. Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle.
+        Effect effect = new AddCardTypeSourceEffect(Duration.WhileOnBattlefield, CardType.ARTIFACT, CardType.CREATURE)
+                .setText("This Vehicle becomes an artifact creature");
+        Ability ability = new ExhaustAbility(effect, new TapTargetCost(new TargetControlledPermanent(filter)));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), mountAndVehicleCount)
+                .setText("Put a +1/+1 counter on it for each Mount and/or Vehicle you control other than this Vehicle"));
+        this.addAbility(ability);
+        // Crew 2
+        this.addAbility(new CrewAbility(2));
+
+    }
+
+    private SpireMechcycle(final SpireMechcycle card) {
+        super(card);
+    }
+
+    @Override
+    public SpireMechcycle copy() {
+        return new SpireMechcycle(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
+++ b/Mage.Sets/src/mage/cards/s/SpireMechcycle.java
@@ -31,12 +31,18 @@ import mage.target.common.TargetControlledPermanent;
 public final class SpireMechcycle extends CardImpl {
 
     private static final FilterControlledPermanent filter = new FilterControlledPermanent("another untapped Mount or Vehicle you control");
-    private static final DynamicValue mountAndVehicleCount = new PermanentsOnBattlefieldCount(filter);
+    private static final FilterControlledPermanent mountAndVehicleFilter = new FilterControlledPermanent("Mount and/or Vehicle you control other than this Vehicle");
+    private static final DynamicValue mountAndVehicleCount = new PermanentsOnBattlefieldCount(mountAndVehicleFilter);
 
     static {
         filter.add(AnotherPredicate.instance);
         filter.add(TappedPredicate.UNTAPPED);
         filter.add(Predicates.or(
+                SubType.MOUNT.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+        mountAndVehicleFilter.add(AnotherPredicate.instance);
+        mountAndVehicleFilter.add(Predicates.or(
                 SubType.MOUNT.getPredicate(),
                 SubType.VEHICLE.getPredicate()
         ));

--- a/Mage.Sets/src/mage/cards/t/ThunderousVelocipede.java
+++ b/Mage.Sets/src/mage/cards/t/ThunderousVelocipede.java
@@ -1,0 +1,71 @@
+package mage.cards.t;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.EntersWithCountersControlledEffect;
+import mage.constants.ComparisonType;
+import mage.constants.SubType;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.counters.CounterType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.ManaValuePredicate;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class ThunderousVelocipede extends CardImpl {
+
+    private static final FilterPermanent fourOrLessFilter = new FilterPermanent("other Vehicle and creature you control with mana value 4 or less");
+    private static final FilterPermanent greaterThanFourFilter = new FilterPermanent("other Vehicle and creature you control with mana value greater than 4");
+
+    static {
+        fourOrLessFilter.add(new ManaValuePredicate(ComparisonType.OR_LESS, 4));
+        fourOrLessFilter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+        greaterThanFourFilter.add(new ManaValuePredicate(ComparisonType.MORE_THAN, 4));
+        greaterThanFourFilter.add(Predicates.or(
+                CardType.CREATURE.getPredicate(),
+                SubType.VEHICLE.getPredicate()
+        ));
+    }
+
+    public ThunderousVelocipede(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{G}{G}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.
+        Ability ability = new SimpleStaticAbility(new EntersWithCountersControlledEffect(fourOrLessFilter, CounterType.P1P1.createInstance(1), true)
+                .setText("Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less."));
+        ability.addEffect(new EntersWithCountersControlledEffect(greaterThanFourFilter, CounterType.P1P1.createInstance(3), true)
+                .setText("otherwise, it enters with three additional +1/+1 counters on it."));
+        this.addAbility(ability);
+        // Crew 3
+        this.addAbility(new CrewAbility(3));
+
+    }
+
+    private ThunderousVelocipede(final ThunderousVelocipede card) {
+        super(card);
+    }
+
+    @Override
+    public ThunderousVelocipede copy() {
+        return new ThunderousVelocipede(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WinterCursedRider.java
+++ b/Mage.Sets/src/mage/cards/w/WinterCursedRider.java
@@ -1,0 +1,78 @@
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.common.ExileXFromYourGraveCost;
+import mage.abilities.costs.common.PayLifeCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
+import mage.abilities.effects.common.continuous.BoostAllEffect;
+import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.keyword.WardAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.Predicates;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class WinterCursedRider extends CardImpl {
+
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("Each other nonartifact creature");
+    private static final DynamicValue xValue = new SignInversionDynamicValue(GetXValue.instance);
+
+    static {
+        filter.add(Predicates.not(CardType.ARTIFACT.getPredicate()));
+    }
+
+    public WinterCursedRider(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{U}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WARLOCK);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(2);
+
+        // Ward--Pay 2 life.
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("")));
+
+        // Artifacts you control have "Ward--Pay 2 life."
+        WardAbility wardAbility = new WardAbility(new PayLifeCost(2));
+        this.addAbility(new SimpleStaticAbility(
+                new GainAbilityAllEffect(wardAbility, Duration.WhileOnBattlefield, StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACTS)
+                        .setText("Artifacts you control have " + "\"" + wardAbility.getRuleWithoutHint() + "\"")
+        ));
+        // Exhaust -- {2}{U}{B}, {T}, Exile X artifact cards from your graveyard: Each other nonartifact creature gets -X/-X until end of turn.
+        Ability ability = new ExhaustAbility(new BoostAllEffect(xValue, xValue, Duration.EndOfTurn, filter, true),
+                new ManaCostsImpl<>("{2}{U}{B}"));
+        ability.addCost(new TapSourceCost());
+        ability.addCost(new ExileXFromYourGraveCost(StaticFilters.FILTER_CARD_ARTIFACTS)
+                .setText("Exile X artifact cards from your graveyard"));
+        this.addAbility(ability);
+    }
+
+    private WinterCursedRider(final WinterCursedRider card) {
+        super(card);
+    }
+
+    @Override
+    public WinterCursedRider copy() {
+        return new WinterCursedRider(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WinterCursedRider.java
+++ b/Mage.Sets/src/mage/cards/w/WinterCursedRider.java
@@ -4,7 +4,6 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.CompositeCost;
 import mage.abilities.costs.common.ExileXFromYourGraveCost;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.costs.common.TapSourceCost;
@@ -22,7 +21,6 @@ import mage.abilities.keyword.WardAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
@@ -50,7 +48,7 @@ public final class WinterCursedRider extends CardImpl {
         this.toughness = new MageInt(2);
 
         // Ward--Pay 2 life.
-        this.addAbility(new WardAbility(new ManaCostsImpl<>("")));
+        this.addAbility(new WardAbility(new PayLifeCost(2)));
 
         // Artifacts you control have "Ward--Pay 2 life."
         WardAbility wardAbility = new WardAbility(new PayLifeCost(2));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -111,6 +111,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Endrider Catalyzer", 124, Rarity.COMMON, mage.cards.e.EndriderCatalyzer.class));
         cards.add(new SetCardInfo("Endrider Spikespitter", 125, Rarity.UNCOMMON, mage.cards.e.EndriderSpikespitter.class));
         cards.add(new SetCardInfo("Engine Rat", 84, Rarity.COMMON, mage.cards.e.EngineRat.class));
+        cards.add(new SetCardInfo("Explosive Getaway", 202, Rarity.RARE, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 390, Rarity.RARE, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 403, Rarity.MYTHIC, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 413, Rarity.MYTHIC, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Explosive Getaway", 479, Rarity.RARE, mage.cards.e.ExplosiveGetaway.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Fang Guardian", 162, Rarity.UNCOMMON, mage.cards.f.FangGuardian.class));
         cards.add(new SetCardInfo("Fang-Druid Summoner", 163, Rarity.UNCOMMON, mage.cards.f.FangDruidSummoner.class));
         cards.add(new SetCardInfo("Far Fortune, End Boss", 203, Rarity.RARE, mage.cards.f.FarFortuneEndBoss.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -242,6 +242,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Skycrash", 146, Rarity.UNCOMMON, mage.cards.s.Skycrash.class));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));
         cards.add(new SetCardInfo("Slick Imitator", 62, Rarity.UNCOMMON, mage.cards.s.SlickImitator.class));
+        cards.add(new SetCardInfo("Spectacular Pileup", 29, Rarity.RARE, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 378, Rarity.RARE, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 398, Rarity.MYTHIC, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 408, Rarity.MYTHIC, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spectacular Pileup", 433, Rarity.RARE, mage.cards.s.SpectacularPileup.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Spectral Interference", 63, Rarity.COMMON, mage.cards.s.SpectralInterference.class));
         cards.add(new SetCardInfo("Spell Pierce", 64, Rarity.UNCOMMON, mage.cards.s.SpellPierce.class));
         cards.add(new SetCardInfo("Spikeshell Harrier", 65, Rarity.UNCOMMON, mage.cards.s.SpikeshellHarrier.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -165,6 +165,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Lumbering Worldwagon", 168, Rarity.RARE, mage.cards.l.LumberingWorldwagon.class));
         cards.add(new SetCardInfo("Magmakin Artillerist", 137, Rarity.COMMON, mage.cards.m.MagmakinArtillerist.class));
         cards.add(new SetCardInfo("Marauding Mako", 138, Rarity.UNCOMMON, mage.cards.m.MaraudingMako.class));
+        cards.add(new SetCardInfo("March of the World Ooze", 169, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 388, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 402, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 412, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("March of the World Ooze", 468, Rarity.MYTHIC, mage.cards.m.MarchOfTheWorldOoze.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Marketback Walker", 235, Rarity.RARE, mage.cards.m.MarketbackWalker.class));
         cards.add(new SetCardInfo("Marshals' Pathcruiser", 236, Rarity.UNCOMMON, mage.cards.m.MarshalsPathcruiser.class));
         cards.add(new SetCardInfo("Maximum Overdrive", 96, Rarity.COMMON, mage.cards.m.MaximumOverdrive.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -112,6 +112,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Endrider Spikespitter", 125, Rarity.UNCOMMON, mage.cards.e.EndriderSpikespitter.class));
         cards.add(new SetCardInfo("Engine Rat", 84, Rarity.COMMON, mage.cards.e.EngineRat.class));
         cards.add(new SetCardInfo("Fang Guardian", 162, Rarity.UNCOMMON, mage.cards.f.FangGuardian.class));
+        cards.add(new SetCardInfo("Fang-Druid Summoner", 163, Rarity.UNCOMMON, mage.cards.f.FangDruidSummoner.class));
         cards.add(new SetCardInfo("Far Fortune, End Boss", 203, Rarity.RARE, mage.cards.f.FarFortuneEndBoss.class));
         cards.add(new SetCardInfo("Fearless Swashbuckler", 204, Rarity.RARE, mage.cards.f.FearlessSwashbuckler.class));
         cards.add(new SetCardInfo("Flood the Engine", 42, Rarity.COMMON, mage.cards.f.FloodTheEngine.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -300,6 +300,9 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Wild Roads", 269, Rarity.UNCOMMON, mage.cards.w.WildRoads.class));
         cards.add(new SetCardInfo("Willowrush Verge", 270, Rarity.RARE, mage.cards.w.WillowrushVerge.class));
         cards.add(new SetCardInfo("Wind-Scarred Crag", 271, Rarity.COMMON, mage.cards.w.WindScarredCrag.class));
+        cards.add(new SetCardInfo("Winter, Cursed Rider", 228, Rarity.RARE, mage.cards.w.WinterCursedRider.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Winter, Cursed Rider", 369, Rarity.RARE, mage.cards.w.WinterCursedRider.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Winter, Cursed Rider", 494, Rarity.RARE, mage.cards.w.WinterCursedRider.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Wreck Remover", 247, Rarity.COMMON, mage.cards.w.WreckRemover.class));
         cards.add(new SetCardInfo("Wreckage Wickerfolk", 110, Rarity.COMMON, mage.cards.w.WreckageWickerfolk.class));
         cards.add(new SetCardInfo("Wretched Doll", 111, Rarity.UNCOMMON, mage.cards.w.WretchedDoll.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -251,6 +251,8 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Spell Pierce", 64, Rarity.UNCOMMON, mage.cards.s.SpellPierce.class));
         cards.add(new SetCardInfo("Spikeshell Harrier", 65, Rarity.UNCOMMON, mage.cards.s.SpikeshellHarrier.class));
         cards.add(new SetCardInfo("Spin Out", 106, Rarity.COMMON, mage.cards.s.SpinOut.class));
+        cards.add(new SetCardInfo("Spire Mechcycle", 147, Rarity.UNCOMMON, mage.cards.s.SpireMechcycle.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Spire Mechcycle", 314, Rarity.UNCOMMON, mage.cards.s.SpireMechcycle.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Spotcycle Scouter", 30, Rarity.COMMON, mage.cards.s.SpotcycleScouter.class));
         cards.add(new SetCardInfo("Stall Out", 66, Rarity.COMMON, mage.cards.s.StallOut.class));
         cards.add(new SetCardInfo("Stampeding Scurryfoot", 181, Rarity.COMMON, mage.cards.s.StampedingScurryfoot.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -273,6 +273,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Thornwood Falls", 266, Rarity.COMMON, mage.cards.t.ThornwoodFalls.class));
         cards.add(new SetCardInfo("Thunderhead Gunner", 148, Rarity.COMMON, mage.cards.t.ThunderheadGunner.class));
         cards.add(new SetCardInfo("Thundering Broodwagon", 225, Rarity.UNCOMMON, mage.cards.t.ThunderingBroodwagon.class));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 183, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 317, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 471, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Thunderous Velocipede", 529, Rarity.MYTHIC, mage.cards.t.ThunderousVelocipede.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Ticket Tortoise", 245, Rarity.COMMON, mage.cards.t.TicketTortoise.class));
         cards.add(new SetCardInfo("Trade the Helm", 69, Rarity.UNCOMMON, mage.cards.t.TradeTheHelm.class));
         cards.add(new SetCardInfo("Tranquil Cove", 267, Rarity.COMMON, mage.cards.t.TranquilCove.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -213,6 +213,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Repurposing Bay", 56, Rarity.RARE, mage.cards.r.RepurposingBay.class));
         cards.add(new SetCardInfo("Ride's End", 25, Rarity.COMMON, mage.cards.r.RidesEnd.class));
         cards.add(new SetCardInfo("Ripclaw Wrangler", 101, Rarity.COMMON, mage.cards.r.RipclawWrangler.class));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 219, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 353, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 490, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Riptide Gearhulk", 552, Rarity.MYTHIC, mage.cards.r.RiptideGearhulk.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Rise from the Wreck", 178, Rarity.UNCOMMON, mage.cards.r.RiseFromTheWreck.class));
         cards.add(new SetCardInfo("Risen Necroregent", 102, Rarity.UNCOMMON, mage.cards.r.RisenNecroregent.class));
         cards.add(new SetCardInfo("Risky Shortcut", 103, Rarity.COMMON, mage.cards.r.RiskyShortcut.class));


### PR DESCRIPTION
For #13033
This adds the following cards that do not require any custom classes or engine changes:
- Explosive Getaway
- Fang-Druid Summoner
- March of the World Ooze
- Riptide Gearhulk
- Spectacular Pileup
- Spire Mechcycle
- Thunderous Velocipede
- Winter, the Cursed Rider