### PR TITLE
[DFT] Implement Custom Effect Cards

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
+++ b/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
@@ -53,7 +53,7 @@ class ArtifactOrActivatedManaBuilder extends ConditionalManaBuilder {
 
     @Override
     public String getRule() {
-        return "Spend this mana only to cast artifact spells or activate abilities of artifacts";
+        return "Spend this mana only to cast an artifact spells or activate an ability";
     }
 }
 
@@ -61,7 +61,7 @@ class ArtifactOrActivatedConditionalMana extends ConditionalMana {
 
     public ArtifactOrActivatedConditionalMana(Mana mana) {
         super(mana);
-        staticText = "Spend this mana only to cast artifact spells or activate abilities of artifacts";
+        staticText = "Spend this mana only to cast an artifact spells or activate an ability";
         addCondition(new ArtifactOrActivatedManaCondition());
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
+++ b/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
@@ -1,0 +1,83 @@
+package mage.cards.g;
+
+import java.util.UUID;
+
+import mage.ConditionalMana;
+import mage.MageInt;
+import mage.MageObject;
+import mage.Mana;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.mana.ConditionalColoredManaAbility;
+import mage.abilities.mana.builder.ConditionalManaBuilder;
+import mage.abilities.mana.conditional.ManaCondition;
+import mage.constants.SubType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.game.Game;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class GuidelightOptimizer extends CardImpl {
+
+    public GuidelightOptimizer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{1}{U}");
+        
+        this.subtype.add(SubType.ROBOT);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(1);
+
+        // {T}: Add {U}. Spend this mana only to cast an artifact spell or activate an ability.
+        this.addAbility(new ConditionalColoredManaAbility(Mana.BlueMana(1), new ArtifactOrActivatedManaBuilder()));
+    }
+
+    private GuidelightOptimizer(final GuidelightOptimizer card) {
+        super(card);
+    }
+
+    @Override
+    public GuidelightOptimizer copy() {
+        return new GuidelightOptimizer(this);
+    }
+}
+
+class ArtifactOrActivatedManaBuilder extends ConditionalManaBuilder {
+
+    @Override
+    public ConditionalMana build(Object... options) {
+        return new ArtifactOrActivatedConditionalMana(this.mana);
+    }
+
+    @Override
+    public String getRule() {
+        return "Spend this mana only to cast artifact spells or activate abilities of artifacts";
+    }
+}
+
+class ArtifactOrActivatedConditionalMana extends ConditionalMana {
+
+    public ArtifactOrActivatedConditionalMana(Mana mana) {
+        super(mana);
+        staticText = "Spend this mana only to cast artifact spells or activate abilities of artifacts";
+        addCondition(new ArtifactOrActivatedManaCondition());
+    }
+}
+
+class ArtifactOrActivatedManaCondition extends ManaCondition implements Condition {
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        MageObject sourceObject = game.getObject(source);
+        return source != null
+                && (source.isActivatedAbility() && !source.isActivated())
+                || (sourceObject != null && sourceObject.isArtifact());
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, UUID originalId, mage.abilities.costs.Cost costsToPay) {
+        return apply(game, source);
+    }
+}

--- a/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
+++ b/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
@@ -2,6 +2,7 @@ package mage.cards.l;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.abilities.Ability;
 import mage.abilities.costs.CompositeCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
@@ -17,6 +18,7 @@ import mage.abilities.keyword.HasteAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.target.common.TargetAnyTarget;
 
 /**
  *
@@ -43,14 +45,20 @@ public final class LootThePathfinder extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
 
         // Exhaust -- {G}, {T}: Add three mana of any one color.
-        this.addAbility(new ExhaustAbility(new AddManaOfAnyColorEffect(3),
-                new CompositeCost(new ManaCostsImpl<>("{G}"), new TapSourceCost(), "{G}, {T}")));
+        Ability abilityOne = new ExhaustAbility(new AddManaOfAnyColorEffect(3), new ManaCostsImpl<>("G"));
+        abilityOne.addCost(new TapSourceCost());
+        this.addAbility(abilityOne);
+
         // Exhaust -- {U}, {T}: Draw three cards.
-        this.addAbility(new ExhaustAbility(new DrawCardSourceControllerEffect(3),
-                new CompositeCost(new ManaCostsImpl<>("{U}"), new TapSourceCost(), "{U}, {T}"),false));
+        Ability abilityTwo = new ExhaustAbility(new DrawCardSourceControllerEffect(3), new ManaCostsImpl<>("U"), false);
+        abilityTwo.addCost(new TapSourceCost());
+        this.addAbility(abilityTwo);
+
         // Exhaust -- {R}, {T}: Loot deals 3 damage to any target.
-        this.addAbility(new ExhaustAbility(new DamageTargetEffect(3),
-                new CompositeCost(new ManaCostsImpl<>("{R}"), new TapSourceCost(), "{R}, {T}"), false));
+        Ability abilityThree = new ExhaustAbility(new DamageTargetEffect(3), new ManaCostsImpl<>("R"), false);
+        abilityThree.addCost(new TapSourceCost());
+        abilityThree.addTarget(new TargetAnyTarget());
+        this.addAbility(abilityThree);
     }
 
     private LootThePathfinder(final LootThePathfinder card) {

--- a/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
+++ b/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
@@ -47,12 +47,10 @@ public final class LootThePathfinder extends CardImpl {
                 new CompositeCost(new ManaCostsImpl<>("{G}"), new TapSourceCost(), "{G}, {T}")));
         // Exhaust -- {U}, {T}: Draw three cards.
         this.addAbility(new ExhaustAbility(new DrawCardSourceControllerEffect(3),
-                new CompositeCost(new ManaCostsImpl<>("{U}"), new TapSourceCost(), "{U}, {T}"))
-                .withReminderText(false));
+                new CompositeCost(new ManaCostsImpl<>("{U}"), new TapSourceCost(), "{U}, {T}"),false));
         // Exhaust -- {R}, {T}: Loot deals 3 damage to any target.
         this.addAbility(new ExhaustAbility(new DamageTargetEffect(3),
-                new CompositeCost(new ManaCostsImpl<>("{R}"), new TapSourceCost(), "{R}, {T}"))
-                .withReminderText(false));
+                new CompositeCost(new ManaCostsImpl<>("{R}"), new TapSourceCost(), "{R}, {T}"), false));
     }
 
     private LootThePathfinder(final LootThePathfinder card) {

--- a/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
+++ b/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
@@ -1,0 +1,66 @@
+package mage.cards.l;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.mana.AddManaOfAnyColorEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.keyword.DoubleStrikeAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class LootThePathfinder extends CardImpl {
+
+    public LootThePathfinder(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{U}{R}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.BEAST);
+        this.subtype.add(SubType.NOBLE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // Double strike
+        this.addAbility(DoubleStrikeAbility.getInstance());
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Exhaust -- {G}, {T}: Add three mana of any one color.
+        this.addAbility(new ExhaustAbility(new AddManaOfAnyColorEffect(3),
+                new CompositeCost(new ManaCostsImpl<>("{G}"), new TapSourceCost(), "{G}, {T}")));
+        // Exhaust -- {U}, {T}: Draw three cards.
+        this.addAbility(new ExhaustAbility(new DrawCardSourceControllerEffect(3),
+                new CompositeCost(new ManaCostsImpl<>("{U}"), new TapSourceCost(), "{U}, {T}"))
+                .withReminderText(false));
+        // Exhaust -- {R}, {T}: Loot deals 3 damage to any target.
+        this.addAbility(new ExhaustAbility(new DamageTargetEffect(3),
+                new CompositeCost(new ManaCostsImpl<>("{R}"), new TapSourceCost(), "{R}, {T}"))
+                .withReminderText(false));
+    }
+
+    private LootThePathfinder(final LootThePathfinder card) {
+        super(card);
+    }
+
+    @Override
+    public LootThePathfinder copy() {
+        return new LootThePathfinder(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
+++ b/Mage.Sets/src/mage/cards/l/LootThePathfinder.java
@@ -45,17 +45,17 @@ public final class LootThePathfinder extends CardImpl {
         this.addAbility(HasteAbility.getInstance());
 
         // Exhaust -- {G}, {T}: Add three mana of any one color.
-        Ability abilityOne = new ExhaustAbility(new AddManaOfAnyColorEffect(3), new ManaCostsImpl<>("G"));
+        Ability abilityOne = new ExhaustAbility(new AddManaOfAnyColorEffect(3), new ManaCostsImpl<>("{G}"));
         abilityOne.addCost(new TapSourceCost());
         this.addAbility(abilityOne);
 
         // Exhaust -- {U}, {T}: Draw three cards.
-        Ability abilityTwo = new ExhaustAbility(new DrawCardSourceControllerEffect(3), new ManaCostsImpl<>("U"), false);
+        Ability abilityTwo = new ExhaustAbility(new DrawCardSourceControllerEffect(3), new ManaCostsImpl<>("{U}"), false);
         abilityTwo.addCost(new TapSourceCost());
         this.addAbility(abilityTwo);
 
         // Exhaust -- {R}, {T}: Loot deals 3 damage to any target.
-        Ability abilityThree = new ExhaustAbility(new DamageTargetEffect(3), new ManaCostsImpl<>("R"), false);
+        Ability abilityThree = new ExhaustAbility(new DamageTargetEffect(3), new ManaCostsImpl<>("{R}"), false);
         abilityThree.addCost(new TapSourceCost());
         abilityThree.addTarget(new TargetAnyTarget());
         this.addAbility(abilityThree);

--- a/Mage.Sets/src/mage/cards/m/MomentumBreaker.java
+++ b/Mage.Sets/src/mage/cards/m/MomentumBreaker.java
@@ -45,9 +45,8 @@ public final class MomentumBreaker extends CardImpl {
         this.addAbility(new EntersBattlefieldTriggeredAbility(new MomentumBreakerEffect()));
         // {2}, Sacrifice this enchantment: You gain life equal to your speed.
         Effect gainLifeEffect = new GainLifeEffect(ControllerSpeedCount.instance).setText("You gain life equal to your speed");
-        Ability ability = (new SimpleActivatedAbility(gainLifeEffect,
-                new CompositeCost(new ManaCostsImpl<>("{2}"), new SacrificeSourceCost(), "{2}, Sacrifice this enchantment")
-                ));
+        Ability ability = new SimpleActivatedAbility(gainLifeEffect,new ManaCostsImpl<>("{2}"));
+        ability.addCost(new SacrificeSourceCost());
         this.addAbility(ability);
     }
 
@@ -89,13 +88,11 @@ class MomentumBreakerEffect extends OneShotEffect {
                         SubType.VEHICLE.getPredicate()
                 ));
                 filter.add(new ControllerIdPredicate(opponent));
-                if (game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game).isEmpty()) {
-                    player.discard(1, false, false, source, game);
-                } else {
                     Effect effect = new SacrificeEffect(filter, 1, null);
                     effect.setTargetPointer(new FixedTarget(player.getId(), game));
-                    effect.apply(game, source);
-                }
+                    if (!effect.apply(game, source)) {
+                        player.discard(1, false, false, source, game);
+                    }
             }
         });
         return true;

--- a/Mage.Sets/src/mage/cards/m/MomentumBreaker.java
+++ b/Mage.Sets/src/mage/cards/m/MomentumBreaker.java
@@ -1,0 +1,103 @@
+package mage.cards.m;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SacrificeSourceTriggeredAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.CompositeCost;
+import mage.abilities.costs.common.SacrificeSourceCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.ControllerSpeedCount;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.GainLifeEffect;
+import mage.abilities.effects.common.SacrificeEffect;
+import mage.abilities.keyword.StartYourEnginesAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.filter.FilterPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.permanent.ControllerIdPredicate;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.targetpointer.FixedTarget;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class MomentumBreaker extends CardImpl {
+
+    public MomentumBreaker(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{B}");
+        
+
+        // Start your engines!
+        this.addAbility(new StartYourEnginesAbility());
+
+        // When this enchantment enters, each opponent sacrifices a creature or Vehicle of their choice. Each opponent who can't discards a card.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new MomentumBreakerEffect()));
+        // {2}, Sacrifice this enchantment: You gain life equal to your speed.
+        Effect gainLifeEffect = new GainLifeEffect(ControllerSpeedCount.instance).setText("You gain life equal to your speed");
+        Ability ability = (new SimpleActivatedAbility(gainLifeEffect,
+                new CompositeCost(new ManaCostsImpl<>("{2}"), new SacrificeSourceCost(), "{2}, Sacrifice this enchantment")
+                ));
+        this.addAbility(ability);
+    }
+
+    private MomentumBreaker(final MomentumBreaker card) {
+        super(card);
+    }
+
+    @Override
+    public MomentumBreaker copy() {
+        return new MomentumBreaker(this);
+    }
+}
+
+class MomentumBreakerEffect extends OneShotEffect {
+
+    MomentumBreakerEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "each opponent sacrifices a creature or Vehicle of their choice. " +
+                "Each opponent who can't discards a card.";
+    }
+
+    private MomentumBreakerEffect(final MomentumBreakerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MomentumBreakerEffect copy() {
+        return new MomentumBreakerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        game.getOpponents(source.getControllerId()).forEach(opponent -> {
+            Player player = game.getPlayer(opponent);
+            if (player != null) {
+                FilterPermanent filter = new FilterPermanent("creature or Vehicle");
+                filter.add(Predicates.or(
+                        CardType.CREATURE.getPredicate(),
+                        SubType.VEHICLE.getPredicate()
+                ));
+                filter.add(new ControllerIdPredicate(opponent));
+                if (game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game).isEmpty()) {
+                    player.discard(1, false, false, source, game);
+                } else {
+                    Effect effect = new SacrificeEffect(filter, 1, null);
+                    effect.setTargetPointer(new FixedTarget(player.getId(), game));
+                    effect.apply(game, source);
+                }
+            }
+        });
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -1,0 +1,95 @@
+package mage.cards.o;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawDiscardTargetEffect;
+import mage.abilities.effects.common.LookAtTargetPlayerHandEffect;
+import mage.abilities.effects.common.discard.DiscardAndDrawThatManyEffect;
+import mage.cards.Card;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.abilities.keyword.LifelinkAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.keyword.WardAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetCard;
+import mage.target.common.TargetCardInHand;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class OildeepGearhulk extends CardImpl {
+
+    public OildeepGearhulk(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{U}{U}{B}{B}");
+        
+        this.subtype.add(SubType.CONSTRUCT);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Lifelink
+        this.addAbility(LifelinkAbility.getInstance());
+
+        // Ward {1}
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{1}")));
+
+        // When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.
+        Ability ability = new EntersBattlefieldTriggeredAbility(new LookAtTargetPlayerHandEffect());
+        ability.addEffect(new OildeepGearhulkEffect());
+        this.addAbility(ability);
+    }
+
+    private OildeepGearhulk(final OildeepGearhulk card) {
+        super(card);
+    }
+
+    @Override
+    public OildeepGearhulk copy() {
+        return new OildeepGearhulk(this);
+    }
+}
+
+class OildeepGearhulkEffect extends OneShotEffect {
+
+    public OildeepGearhulkEffect() {
+        super(Outcome.Benefit);
+        staticText = "look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card";
+    }
+
+    public OildeepGearhulkEffect(final OildeepGearhulkEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public OildeepGearhulkEffect copy() {
+        return new OildeepGearhulkEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        Player targetPlayer = game.getPlayer(source.getFirstTarget());
+        if (controller == null || targetPlayer == null) {
+            return false;
+        }
+
+        controller.lookAtCards(targetPlayer.getName() + " Hand", targetPlayer.getHand(), game);
+        TargetCard chosenCard = new TargetCardInHand(0, 1, new FilterCard("card to discard"));
+        if (controller.choose(outcome, targetPlayer.getHand(), chosenCard, source, game)) {
+            Card card = game.getCard(chosenCard.getFirstTarget());
+            targetPlayer.discard(card, false, source, game);
+            targetPlayer.drawCards(1, source, game);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -18,9 +18,11 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
+import mage.target.TargetPlayer;
 import mage.target.common.TargetCardInHand;
 
 /**
@@ -45,6 +47,7 @@ public final class OildeepGearhulk extends CardImpl {
         // When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.
         Ability ability = new EntersBattlefieldTriggeredAbility(new LookAtTargetPlayerHandEffect());
         ability.addEffect(new OildeepGearhulkEffect());
+        ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -45,8 +45,7 @@ public final class OildeepGearhulk extends CardImpl {
         this.addAbility(new WardAbility(new ManaCostsImpl<>("{1}")));
 
         // When this creature enters, look at target player's hand. You may choose a card from it. If you do, that player discards that card, then draws a card.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new LookAtTargetPlayerHandEffect());
-        ability.addEffect(new OildeepGearhulkEffect());
+        Ability ability = new EntersBattlefieldTriggeredAbility(new OildeepGearhulkEffect());
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -86,7 +86,7 @@ class OildeepGearhulkEffect extends OneShotEffect {
 
         controller.lookAtCards(targetPlayer.getName() + " Hand", targetPlayer.getHand(), game);
         TargetCard chosenCard = new TargetCardInHand(0, 1, new FilterCard("card to discard"));
-        if (controller.choose(outcome, targetPlayer.getHand(), chosenCard, source, game)) {
+        if (controller.choose(Outcome.Discard, targetPlayer.getHand(), chosenCard, source, game)) {
             Card card = game.getCard(chosenCard.getFirstTarget());
             targetPlayer.discard(card, false, source, game);
             targetPlayer.drawCards(1, source, game);

--- a/Mage.Sets/src/mage/cards/r/RadiantLotus.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantLotus.java
@@ -51,7 +51,7 @@ public final class RadiantLotus extends CardImpl {
 class RadiantLotusEffect extends OneShotEffect {
 
     public RadiantLotusEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.AIDontUseIt);
         staticText = "Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way";
     }
 

--- a/Mage.Sets/src/mage/cards/r/RadiantLotus.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantLotus.java
@@ -1,0 +1,88 @@
+package mage.cards.r;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.SacrificeTargetCost;
+import mage.abilities.costs.common.SacrificeXTargetCost;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.choices.ChoiceColor;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledArtifactPermanent;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.TargetPlayer;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class RadiantLotus extends CardImpl {
+
+    private static final FilterPermanent filter = new FilterControlledArtifactPermanent("artifacts");
+    public RadiantLotus(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{6}");
+        
+
+        // {T}, Sacrifice one or more artifacts: Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way.
+        Ability ability = new SimpleActivatedAbility(new RadiantLotusEffect(), new TapSourceCost());
+        ability.addCost(new SacrificeXTargetCost(filter, true, 1).setText("Sacrifice one or more artifacts"));
+        ability.addTarget(new TargetPlayer());
+        this.addAbility(ability);
+    }
+
+    private RadiantLotus(final RadiantLotus card) {
+        super(card);
+    }
+
+    @Override
+    public RadiantLotus copy() {
+        return new RadiantLotus(this);
+    }
+}
+
+
+class RadiantLotusEffect extends OneShotEffect {
+
+    public RadiantLotusEffect() {
+        super(Outcome.Benefit);
+        staticText = "Choose a color. Target player adds three mana of the chosen color for each artifact sacrificed this way";
+    }
+
+    public RadiantLotusEffect(final RadiantLotusEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RadiantLotusEffect copy() {
+        return new RadiantLotusEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        int manaCount = source.getCosts().stream()
+            .filter(SacrificeTargetCost.class::isInstance)
+            .mapToInt(cost -> ((SacrificeTargetCost) cost).getPermanents().size() * 3)
+            .sum();
+
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller != null) {
+            String mes = String.format("Select a color of mana to add %d of it", manaCount);
+            ChoiceColor choice = new ChoiceColor(true, mes, game.getObject(source));
+            if (controller.choose(outcome, choice, game)) {
+                Player player = game.getPlayer(source.getFirstTarget());
+                if (choice.getColor() != null && player != null) {
+                    player.getManaPool().addMana(choice.getMana(manaCount), game, source);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SitaVarmaMaskedRacer.java
+++ b/Mage.Sets/src/mage/cards/s/SitaVarmaMaskedRacer.java
@@ -1,0 +1,87 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.costs.Cost;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.dynamicvalue.common.SourcePermanentPowerValue;
+import mage.abilities.effects.ContinuousEffect;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.continuous.SetBasePowerToughnessAllEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.constants.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SitaVarmaMaskedRacer extends CardImpl {
+
+    public SitaVarmaMaskedRacer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{U}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.ROGUE);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(3);
+
+        // Exhaust -- {X}{G}{G}{U}: Put X +1/+1 counters on Sita Varma. Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.
+        Cost cost = new ManaCostsImpl<>("{X}{G}{G}{U}");
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(), GetXValue.instance);
+        Ability ability = new ExhaustAbility(effect, cost);
+        ability.addEffect(new SitaVarmaMaskedRacerMayEffect());
+        this.addAbility(ability);
+    }
+
+    private SitaVarmaMaskedRacer(final SitaVarmaMaskedRacer card) {
+        super(card);
+    }
+
+    @Override
+    public SitaVarmaMaskedRacer copy() {
+        return new SitaVarmaMaskedRacer(this);
+    }
+}
+
+class SitaVarmaMaskedRacerMayEffect extends OneShotEffect {
+    private static final String choiceText = "Have the base power and toughness of each other creature you control" +
+            " become equal to Sita Varma's power until end of turn?";
+
+    public SitaVarmaMaskedRacerMayEffect() {
+        super(Outcome.Benefit);
+        this.staticText = "Then you may have the base power and toughness of each other creature you control become equal to Sita Varma's power until end of turn.";
+    }
+
+    public SitaVarmaMaskedRacerMayEffect(final SitaVarmaMaskedRacerMayEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SitaVarmaMaskedRacerMayEffect copy() {
+        return new SitaVarmaMaskedRacerMayEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null || !controller.chooseUse(outcome, choiceText, source, game)) {
+            return false;
+        }
+        ContinuousEffect setBasePowerToughnessEffect = new SetBasePowerToughnessAllEffect(SourcePermanentPowerValue.ALLOW_NEGATIVE,
+                SourcePermanentPowerValue.ALLOW_NEGATIVE, Duration.EndOfTurn,
+                StaticFilters.FILTER_OTHER_CONTROLLED_CREATURES);
+        game.addEffect(setBasePowerToughnessEffect, source);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
+++ b/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
@@ -1,0 +1,89 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.common.AsEntersBattlefieldAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.ChooseACardNameEffect;
+import mage.abilities.effects.common.cost.CostModificationEffectImpl;
+import mage.abilities.effects.common.cost.SpellsCostIncreasingAllEffect;
+import mage.constants.*;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.CrewAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.game.Game;
+import mage.util.CardUtil;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SkyseersChariot extends CardImpl {
+
+    public SkyseersChariot(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{1}{W}");
+        
+        this.subtype.add(SubType.VEHICLE);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // As this Vehicle enters, choose a nonland card name.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseACardNameEffect(ChooseACardNameEffect.TypeOfName.NON_LAND_NAME)));
+        // Activated abilities of sources with the chosen name cost {2} more to activate.
+        this.addAbility(new SimpleStaticAbility(new SkyseersChariotEffect()));
+
+        // Crew 2
+        this.addAbility(new CrewAbility(2));
+
+    }
+
+    private SkyseersChariot(final SkyseersChariot card) {
+        super(card);
+    }
+
+    @Override
+    public SkyseersChariot copy() {
+        return new SkyseersChariot(this);
+    }
+}
+
+class SkyseersChariotEffect extends CostModificationEffectImpl {
+
+    SkyseersChariotEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.Detriment, CostModificationType.INCREASE_COST);
+        staticText = "Activated abilities of sources with the chosen name cost {2} more to activate";
+    }
+
+    private SkyseersChariotEffect(final SkyseersChariotEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SkyseersChariotEffect copy() {
+        return new SkyseersChariotEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, Ability abilityToModify) {
+        CardUtil.increaseCost(abilityToModify, 2);
+        return true;
+    }
+
+    @Override
+    public boolean applies(Ability abilityToModify, Ability source, Game game) {
+        MageObject activatedSource = game.getObject(abilityToModify.getSourceId());
+        if (activatedSource == null) {
+            return false;
+        }
+        String chosenName = (String) game.getState().getValue(
+                source.getSourceId().toString() + ChooseACardNameEffect.INFO_KEY
+        );
+        return CardUtil.haveSameNames(activatedSource, chosenName, game);
+    }
+}

--- a/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
+++ b/Mage.Sets/src/mage/cards/s/SkyseersChariot.java
@@ -84,6 +84,7 @@ class SkyseersChariotEffect extends CostModificationEffectImpl {
         String chosenName = (String) game.getState().getValue(
                 source.getSourceId().toString() + ChooseACardNameEffect.INFO_KEY
         );
-        return CardUtil.haveSameNames(activatedSource, chosenName, game);
+        return CardUtil.haveSameNames(activatedSource, chosenName, game)
+                && abilityToModify.isActivatedAbility();
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SkyserpentSeeker.java
+++ b/Mage.Sets/src/mage/cards/s/SkyserpentSeeker.java
@@ -1,0 +1,95 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.RevealCardsFromLibraryUntilEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ExhaustAbility;
+import mage.cards.*;
+import mage.constants.*;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.DeathtouchAbility;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.players.Player;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class SkyserpentSeeker extends CardImpl {
+
+    public SkyserpentSeeker(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{U}");
+        
+        this.subtype.add(SubType.SNAKE);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(1);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Deathtouch
+        this.addAbility(DeathtouchAbility.getInstance());
+
+        // Exhaust -- {4}: Reveal cards from the top of your library until you reveal two land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order. Put a +1/+1 counter on this creature.
+        Ability ability = (new ExhaustAbility(new SkyserpentSeekerEffect(), new ManaCostsImpl<>("{4}")));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), StaticValue.get(1)));
+        this.addAbility(ability);
+    }
+
+    private SkyserpentSeeker(final SkyserpentSeeker card) {
+        super(card);
+    }
+
+    @Override
+    public SkyserpentSeeker copy() {
+        return new SkyserpentSeeker(this);
+    }
+
+}
+class SkyserpentSeekerEffect extends OneShotEffect {
+
+    SkyserpentSeekerEffect() {
+        super(Outcome.PutLandInPlay);
+        this.staticText = "Reveal cards from the top of your library until you reveal two land cards. " +
+                "Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order";
+    }
+
+    private SkyserpentSeekerEffect(final SkyserpentSeekerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SkyserpentSeekerEffect copy() {
+        return new SkyserpentSeekerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+        Cards revealedCards = new CardsImpl();
+        Cards lands = new CardsImpl();
+        for (Card card : controller.getLibrary().getCards(game)) {
+            if (card.isLand()) {
+                lands.add(card);
+                if (lands.size() == 2) {
+                    break;
+                }
+            }
+            revealedCards.add(card);
+        }
+        controller.revealCards(source, revealedCards, game);
+        PutCards.BATTLEFIELD_TAPPED.moveCards(controller, lands, source, game);
+        PutCards.BOTTOM_RANDOM.moveCards(controller, revealedCards, source, game);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/t/TuneUp.java
+++ b/Mage.Sets/src/mage/cards/t/TuneUp.java
@@ -1,0 +1,70 @@
+package mage.cards.t;
+
+import java.util.UUID;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
+import mage.abilities.effects.common.ReturnFromYourGraveyardToBattlefieldAllEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.target.common.TargetCardInYourGraveyard;
+
+/**
+ *
+ * @author Jmlundeen
+ */
+public final class TuneUp extends CardImpl {
+
+    public TuneUp(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{W}");
+        
+
+        // Return target artifact card from your graveyard to the battlefield. If it's a Vehicle, it becomes an artifact creature.
+        this.getSpellAbility().addEffect(new ReturnFromGraveyardToBattlefieldTargetEffect());
+        this.getSpellAbility().addEffect(new TuneUpEffect());
+        this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_ARTIFACT_FROM_YOUR_GRAVEYARD));
+    }
+
+    private TuneUp(final TuneUp card) {
+        super(card);
+    }
+
+    @Override
+    public TuneUp copy() {
+        return new TuneUp(this);
+    }
+}
+
+class TuneUpEffect extends OneShotEffect {
+
+    TuneUpEffect() {
+        super(Outcome.BecomeCreature);
+        this.staticText = "If it's a Vehicle, it becomes an artifact creature";
+    }
+
+    private TuneUpEffect(final TuneUpEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public TuneUpEffect copy() {
+        return new TuneUpEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getFirstTarget());
+        if (permanent != null && permanent.hasSubtype(SubType.VEHICLE, game)) {
+            permanent.addCardType(CardType.CREATURE);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -186,6 +186,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Nesting Bot", 22, Rarity.UNCOMMON, mage.cards.n.NestingBot.class));
         cards.add(new SetCardInfo("Night Market", 258, Rarity.COMMON, mage.cards.n.NightMarket.class));
         cards.add(new SetCardInfo("Nimble Thopterist", 53, Rarity.COMMON, mage.cards.n.NimbleThopterist.class));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 215, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 351, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 487, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Oildeep Gearhulk", 550, Rarity.MYTHIC, mage.cards.o.OildeepGearhulk.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Ooze Patrol", 172, Rarity.UNCOMMON, mage.cards.o.OozePatrol.class));
         cards.add(new SetCardInfo("Outpace Oblivion", 139, Rarity.UNCOMMON, mage.cards.o.OutpaceOblivion.class));
         cards.add(new SetCardInfo("Oviya, Automech Artisan", 173, Rarity.RARE, mage.cards.o.OviyaAutomechArtisan.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -134,6 +134,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Grim Bauble", 88, Rarity.COMMON, mage.cards.g.GrimBauble.class));
         cards.add(new SetCardInfo("Grim Javelineer", 89, Rarity.COMMON, mage.cards.g.GrimJavelineer.class));
         cards.add(new SetCardInfo("Guardian Sunmare", 15, Rarity.RARE, mage.cards.g.GuardianSunmare.class));
+        cards.add(new SetCardInfo("Guidelight Optimizer", 45, Rarity.COMMON, mage.cards.g.GuidelightOptimizer.class));
         cards.add(new SetCardInfo("Guidelight Pathmaker", 206, Rarity.UNCOMMON, mage.cards.g.GuidelightPathmaker.class));
         cards.add(new SetCardInfo("Guidelight Synergist", 16, Rarity.UNCOMMON, mage.cards.g.GuidelightSynergist.class));
         cards.add(new SetCardInfo("Haunt the Network", 207, Rarity.UNCOMMON, mage.cards.h.HauntTheNetwork.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -178,6 +178,7 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Migrating Ketradon", 170, Rarity.COMMON, mage.cards.m.MigratingKetradon.class));
         cards.add(new SetCardInfo("Mindspring Merfolk", 51, Rarity.RARE, mage.cards.m.MindspringMerfolk.class));
         cards.add(new SetCardInfo("Molt Tender", 171, Rarity.UNCOMMON, mage.cards.m.MoltTender.class));
+        cards.add(new SetCardInfo("Momentum Breaker", 97, Rarity.UNCOMMON, mage.cards.m.MomentumBreaker.class));
         cards.add(new SetCardInfo("Monument to Endurance", 237, Rarity.RARE, mage.cards.m.MonumentToEndurance.class));
         cards.add(new SetCardInfo("Mountain", 286, Rarity.LAND, mage.cards.basiclands.Mountain.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Mu Yanling, Wind Rider", 52, Rarity.MYTHIC, mage.cards.m.MuYanlingWindRider.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -159,6 +159,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Lightshield Parry", 19, Rarity.COMMON, mage.cards.l.LightshieldParry.class));
         cards.add(new SetCardInfo("Lightwheel Enhancements", 20, Rarity.COMMON, mage.cards.l.LightwheelEnhancements.class));
         cards.add(new SetCardInfo("Locust Spray", 95, Rarity.UNCOMMON, mage.cards.l.LocustSpray.class));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 212, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 391, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 404, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 414, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Loot, the Pathfinder", 484, Rarity.MYTHIC, mage.cards.l.LootThePathfinder.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Lotusguard Disciple", 21, Rarity.COMMON, mage.cards.l.LotusguardDisciple.class));
         cards.add(new SetCardInfo("Loxodon Surveyor", 167, Rarity.COMMON, mage.cards.l.LoxodonSurveyor.class));
         cards.add(new SetCardInfo("Lumbering Worldwagon", 168, Rarity.RARE, mage.cards.l.LumberingWorldwagon.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -253,6 +253,8 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Skyseer's Chariot", 296, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skyseer's Chariot", 432, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skyseer's Chariot", 518, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyserpent Seeker", 224, Rarity.UNCOMMON, mage.cards.s.SkyserpentSeeker.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyserpent Seeker", 420, Rarity.UNCOMMON, mage.cards.s.SkyserpentSeeker.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));
         cards.add(new SetCardInfo("Slick Imitator", 62, Rarity.UNCOMMON, mage.cards.s.SlickImitator.class));
         cards.add(new SetCardInfo("Spectral Interference", 63, Rarity.COMMON, mage.cards.s.SpectralInterference.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -249,6 +249,10 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Sita Varma, Masked Racer", 493, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skybox Ferry", 243, Rarity.COMMON, mage.cards.s.SkyboxFerry.class));
         cards.add(new SetCardInfo("Skycrash", 146, Rarity.UNCOMMON, mage.cards.s.Skycrash.class));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 28, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 296, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 432, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Skyseer's Chariot", 518, Rarity.RARE, mage.cards.s.SkyseersChariot.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));
         cards.add(new SetCardInfo("Slick Imitator", 62, Rarity.UNCOMMON, mage.cards.s.SlickImitator.class));
         cards.add(new SetCardInfo("Spectral Interference", 63, Rarity.COMMON, mage.cards.s.SpectralInterference.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -204,6 +204,11 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Pyrewood Gearhulk", 216, Rarity.MYTHIC, mage.cards.p.PyrewoodGearhulk.class));
         cards.add(new SetCardInfo("Quag Feast", 100, Rarity.RARE, mage.cards.q.QuagFeast.class));
         cards.add(new SetCardInfo("Racers' Scoreboard", 239, Rarity.UNCOMMON, mage.cards.r.RacersScoreboard.class));
+        cards.add(new SetCardInfo("Radiant Lotus", 240, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 395, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 406, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 416, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Radiant Lotus", 500, Rarity.MYTHIC, mage.cards.r.RadiantLotus.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Rangers' Aetherhive", 217, Rarity.UNCOMMON, mage.cards.r.RangersAetherhive.class));
         cards.add(new SetCardInfo("Rangers' Refueler", 55, Rarity.UNCOMMON, mage.cards.r.RangersRefueler.class));
         cards.add(new SetCardInfo("Reckless Velocitaur", 144, Rarity.UNCOMMON, mage.cards.r.RecklessVelocitaur.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -244,6 +244,9 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Scrounging Skyray", 60, Rarity.UNCOMMON, mage.cards.s.ScroungingSkyray.class));
         cards.add(new SetCardInfo("Shefet Archfiend", 104, Rarity.UNCOMMON, mage.cards.s.ShefetArchfiend.class));
         cards.add(new SetCardInfo("Silken Strength", 180, Rarity.COMMON, mage.cards.s.SilkenStrength.class));
+        cards.add(new SetCardInfo("Sita Varma, Masked Racer", 223, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sita Varma, Masked Racer", 368, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sita Varma, Masked Racer", 493, Rarity.RARE, mage.cards.s.SitaVarmaMaskedRacer.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skybox Ferry", 243, Rarity.COMMON, mage.cards.s.SkyboxFerry.class));
         cards.add(new SetCardInfo("Skycrash", 146, Rarity.UNCOMMON, mage.cards.s.Skycrash.class));
         cards.add(new SetCardInfo("Skystreak Engineer", 61, Rarity.COMMON, mage.cards.s.SkystreakEngineer.class));

--- a/Mage.Sets/src/mage/sets/Aetherdrift.java
+++ b/Mage.Sets/src/mage/sets/Aetherdrift.java
@@ -286,6 +286,8 @@ public final class Aetherdrift extends ExpansionSet {
         cards.add(new SetCardInfo("Tranquil Cove", 267, Rarity.COMMON, mage.cards.t.TranquilCove.class));
         cards.add(new SetCardInfo("Transit Mage", 70, Rarity.UNCOMMON, mage.cards.t.TransitMage.class));
         cards.add(new SetCardInfo("Trip Up", 71, Rarity.COMMON, mage.cards.t.TripUp.class));
+        cards.add(new SetCardInfo("Tune Up", 33, Rarity.UNCOMMON, mage.cards.t.TuneUp.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Tune Up", 417, Rarity.UNCOMMON, mage.cards.t.TuneUp.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Tyrox, Saurid Tyrant", 149, Rarity.UNCOMMON, mage.cards.t.TyroxSauridTyrant.class));
         cards.add(new SetCardInfo("Unstoppable Plan", 72, Rarity.RARE, mage.cards.u.UnstoppablePlan.class));
         cards.add(new SetCardInfo("Unswerving Sloth", 34, Rarity.UNCOMMON, mage.cards.u.UnswervingSloth.class));

--- a/Mage/src/main/java/mage/abilities/keyword/ExhaustAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ExhaustAbility.java
@@ -10,13 +10,27 @@ import mage.constants.Zone;
  */
 public class ExhaustAbility extends ActivatedAbilityImpl {
 
+    private boolean withReminderText = true;
+
     public ExhaustAbility(Effect effect, Cost cost) {
         super(Zone.BATTLEFIELD, effect, cost);
+    }
+
+    public ExhaustAbility(Effect effect, Cost cost, boolean withReminderText) {
+        super(Zone.BATTLEFIELD, effect, cost);
+        this.setRuleVisible(false);
+        this.withReminderText = withReminderText;
     }
 
     private ExhaustAbility(final ExhaustAbility ability) {
         super(ability);
         this.maxActivationsPerGame = 1;
+        this.withReminderText = ability.withReminderText;
+    }
+
+    public ExhaustAbility withReminderText(boolean withReminderText) {
+        this.withReminderText = withReminderText;
+        return this;
     }
 
     @Override
@@ -26,6 +40,7 @@ public class ExhaustAbility extends ActivatedAbilityImpl {
 
     @Override
     public String getRule() {
-        return "Exhaust &mdash; " + super.getRule() + " <i>(Activate each exhaust ability only once.)</i>";
+        return "Exhaust &mdash; " + super.getRule() +
+                (withReminderText ? " <i>(Activate each exhaust ability only once.)</i>" : "");
     }
 }


### PR DESCRIPTION
For #13033
This implements cards that have custom effects. This also adds a change to the Exhaust ability to remove reminder text on the rule. [[Loot, the Pathfinder]] has multiple exhaust abilities and the reminder text is unnecessary for all of them.

- Guidelight Optimizer
- Loot, the Pathfinder
- Momentum Breaker
- Oildeep Gearhulk
- Radiant Lotus
- Sita Varma, Masked Racer
- Skyseer's Chariot
- Skyserpent Seeker
- TuneUp