### PR TITLE
[FIN] Implement Emet-Selch, Unsundered / Hades, Sorcerer of Eld

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EmetSelchUnsundered.java
+++ b/Mage.Sets/src/mage/cards/e/EmetSelchUnsundered.java
@@ -1,0 +1,56 @@
+package mage.cards.e;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.condition.common.CardsInControllerGraveyardCondition;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.common.EntersBattlefieldOrAttacksSourceTriggeredAbility;
+import mage.abilities.effects.common.DrawDiscardControllerEffect;
+import mage.abilities.effects.common.TransformSourceEffect;
+import mage.abilities.keyword.TransformAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ * @author balazskristof
+ */
+public final class EmetSelchUnsundered extends CardImpl {
+
+    public EmetSelchUnsundered(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{U}{B}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ELDER);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        this.secondSideCardClazz = mage.cards.h.HadesSorcererOfEld.class;
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Whenever Emet-Selch enters or attacks, draw a card, then discard a card.
+        this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(new DrawDiscardControllerEffect(1, 1)));
+
+        // At the beginning of your upkeep, if there are fourteen or more cards in your graveyard, you may transform Emet-Selch.
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(
+                new TransformSourceEffect(),
+                true
+        ).withInterveningIf(new CardsInControllerGraveyardCondition(14)));
+        this.addAbility(new TransformAbility());
+    }
+
+    private EmetSelchUnsundered(final EmetSelchUnsundered card) {
+        super(card);
+    }
+
+    @Override
+    public EmetSelchUnsundered copy() {
+        return new EmetSelchUnsundered(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/h/HadesSorcererOfEld.java
+++ b/Mage.Sets/src/mage/cards/h/HadesSorcererOfEld.java
@@ -1,0 +1,50 @@
+package mage.cards.h;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.replacement.GraveyardFromAnywhereExileReplacementEffect;
+import mage.abilities.effects.common.ruleModifying.PlayFromGraveyardControllerEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ * @author balazskristof
+ */
+public final class HadesSorcererOfEld extends CardImpl {
+
+    public HadesSorcererOfEld(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.AVATAR);
+        this.power = new MageInt(6);
+        this.toughness = new MageInt(6);
+
+        this.color.setBlue(true);
+        this.color.setBlack(true);
+        this.nightCard = true;
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Echo of the Lost -- During your turn you may play cards from your graveyard.
+        this.addAbility(new SimpleStaticAbility(PlayFromGraveyardControllerEffect.playCards()).withFlavorWord("Echo of the Lost"));
+
+        // If a card or token would be put into your graveyard from anywhere, exile it instead.
+        this.addAbility(new SimpleStaticAbility(new GraveyardFromAnywhereExileReplacementEffect(true, true)));
+    }
+
+    private HadesSorcererOfEld(final HadesSorcererOfEld card) {
+        super(card);
+    }
+
+    @Override
+    public HadesSorcererOfEld copy() {
+        return new HadesSorcererOfEld(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/FinalFantasy.java
+++ b/Mage.Sets/src/mage/sets/FinalFantasy.java
@@ -23,8 +23,14 @@ public final class FinalFantasy extends ExpansionSet {
         cards.add(new SetCardInfo("Chaos, the Endless", 221, Rarity.UNCOMMON, mage.cards.c.ChaosTheEndless.class));
         cards.add(new SetCardInfo("Cloud, Planet's Champion", 552, Rarity.MYTHIC, mage.cards.c.CloudPlanetsChampion.class));
         cards.add(new SetCardInfo("Cooking Campsite", 31, Rarity.UNCOMMON, mage.cards.c.CookingCampsite.class));
+        cards.add(new SetCardInfo("Emet-Selch, Unsundered", 218, Rarity.MYTHIC, mage.cards.e.EmetSelchUnsundered.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Emet-Selch, Unsundered", 394, Rarity.MYTHIC, mage.cards.e.EmetSelchUnsundered.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Emet-Selch, Unsundered", 483, Rarity.MYTHIC, mage.cards.e.EmetSelchUnsundered.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Garland, Knight of Cornelia", 221, Rarity.UNCOMMON, mage.cards.g.GarlandKnightOfCornelia.class));
         cards.add(new SetCardInfo("Gladiolus Amicitia", 224, Rarity.UNCOMMON, mage.cards.g.GladiolusAmicitia.class));
+        cards.add(new SetCardInfo("Hades, Sorcerer of Eld", 218, Rarity.MYTHIC, mage.cards.h.HadesSorcererOfEld.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Hades, Sorcerer of Eld", 394, Rarity.MYTHIC, mage.cards.h.HadesSorcererOfEld.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Hades, Sorcerer of Eld", 483, Rarity.MYTHIC, mage.cards.h.HadesSorcererOfEld.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Jumbo Cactuar", 191, Rarity.RARE, mage.cards.j.JumboCactuar.class));
         cards.add(new SetCardInfo("Sazh's Chocobo", 200, Rarity.UNCOMMON, mage.cards.s.SazhsChocobo.class));
         cards.add(new SetCardInfo("Sephiroth, Planet's Heir", 553, Rarity.MYTHIC, mage.cards.s.SephirothPlanetsHeir.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/PlayFromGraveyardControllerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/PlayFromGraveyardControllerEffect.java
@@ -19,10 +19,18 @@ import java.util.UUID;
  */
 public class PlayFromGraveyardControllerEffect extends AsThoughEffectImpl {
 
+    private static final FilterCard filterPlayCards = new FilterCard("cards");
     private static final FilterCard filterPlayLands = new FilterLandCard("lands");
     private static final FilterCard filterPlayCast = new FilterCard("play lands and cast spells");
 
     private final FilterCard filter;
+
+    /**
+     * You may play cards from your graveyard.
+     */
+    public static PlayFromGraveyardControllerEffect playCards() {
+        return new PlayFromGraveyardControllerEffect(filterPlayCards);
+    }
 
     /**
      * You may play lands from your graveyard.
@@ -53,7 +61,7 @@ public class PlayFromGraveyardControllerEffect extends AsThoughEffectImpl {
         this.filter = filter;
         String filterMessage = filter.getMessage();
         if (!filterMessage.startsWith("play ") && !filterMessage.startsWith("cast")) {
-            if (filterMessage.contains("lands")) {
+            if (filterMessage.contains("cards") || filterMessage.contains("lands")) {
                 filterMessage = "play " + filterMessage;
             } else {
                 filterMessage = "cast " + filterMessage;


### PR DESCRIPTION
Implements [Emet-Selch, Unsundered / Hades, Sorcerer of Eld](https://scryfall.com/card/fin/218/emet-selch-unsundered-hades-sorcerer-of-eld) for https://github.com/magefree/mage/issues/13364

`PlayFromGraveyardControllerEffect` is extended to allow playing any card from the player's graveyard.