### PR TITLE
[TDM] Implement Mobilize keyword ability and Dragonback Lancer and Voice of Victory

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DragonbackLancer.java
+++ b/Mage.Sets/src/mage/cards/d/DragonbackLancer.java
@@ -1,0 +1,40 @@
+package mage.cards.d;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.constants.SubType;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.MobilizeAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ * @author balazskristof
+ */
+public final class DragonbackLancer extends CardImpl {
+
+    public DragonbackLancer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{W}");
+        
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SOLDIER);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(3);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Mobilize 1
+        this.addAbility(new MobilizeAbility(1));
+    }
+
+    private DragonbackLancer(final DragonbackLancer card) {
+        super(card);
+    }
+
+    @Override
+    public DragonbackLancer copy() {
+        return new DragonbackLancer(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/v/VoiceOfVictory.java
+++ b/Mage.Sets/src/mage/cards/v/VoiceOfVictory.java
@@ -1,0 +1,41 @@
+package mage.cards.v;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.ruleModifying.CantCastDuringYourTurnEffect;
+import mage.abilities.keyword.MobilizeAbility;
+import mage.constants.SubType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ * @author balazskristof
+ */
+public final class VoiceOfVictory extends CardImpl {
+
+    public VoiceOfVictory(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}");
+        
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.BARD);
+        this.power = new MageInt(1);
+        this.toughness = new MageInt(3);
+
+        // Mobilize 2
+        this.addAbility(new MobilizeAbility(2));
+
+        // Your opponents can't cast spells during your turn.
+        this.addAbility(new SimpleStaticAbility(new CantCastDuringYourTurnEffect()));
+    }
+
+    private VoiceOfVictory(final VoiceOfVictory card) {
+        super(card);
+    }
+
+    @Override
+    public VoiceOfVictory copy() {
+        return new VoiceOfVictory(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/TarkirDragonstorm.java
+++ b/Mage.Sets/src/mage/sets/TarkirDragonstorm.java
@@ -33,5 +33,6 @@ public final class TarkirDragonstorm extends ExpansionSet {
         cards.add(new SetCardInfo("Skirmish Rhino", 224, Rarity.UNCOMMON, mage.cards.s.SkirmishRhino.class));
         cards.add(new SetCardInfo("Smile at Death", 24, Rarity.MYTHIC, mage.cards.s.SmileAtDeath.class));
         cards.add(new SetCardInfo("Stormscale Scion", 123, Rarity.MYTHIC, mage.cards.s.StormscaleScion.class));
+        cards.add(new SetCardInfo("Voice of Victory", 33, Rarity.RARE, mage.cards.v.VoiceOfVictory.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/TarkirDragonstorm.java
+++ b/Mage.Sets/src/mage/sets/TarkirDragonstorm.java
@@ -24,6 +24,7 @@ public final class TarkirDragonstorm extends ExpansionSet {
         cards.add(new SetCardInfo("Barrensteppe Siege", 171, Rarity.RARE, mage.cards.b.BarrensteppeSiege.class));
         cards.add(new SetCardInfo("Craterhoof Behemoth", 138, Rarity.MYTHIC, mage.cards.c.CraterhoofBehemoth.class));
         cards.add(new SetCardInfo("Devoted Duelist", 104, Rarity.COMMON, mage.cards.d.DevotedDuelist.class));
+        cards.add(new SetCardInfo("Dragonback Lancer", 9, Rarity.COMMON, mage.cards.d.DragonbackLancer.class));
         cards.add(new SetCardInfo("Inevitable Defeat", 194, Rarity.RARE, mage.cards.i.InevitableDefeat.class));
         cards.add(new SetCardInfo("Mox Jasper", 246, Rarity.MYTHIC, mage.cards.m.MoxJasper.class));
         cards.add(new SetCardInfo("Narset, Jeskai Waymaster", 209, Rarity.RARE, mage.cards.n.NarsetJeskaiWaymaster.class));

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateTokenEffect.java
@@ -121,6 +121,17 @@ public class CreateTokenEffect extends OneShotEffect {
         return lastAddedTokenIds;
     }
 
+    public void sacrificeTokensCreatedAtNextEndStep(Game game, Ability source) {
+        for (UUID tokenId : this.getLastAddedTokenIds()) {
+            Permanent tokenPermanent = game.getPermanent(tokenId);
+            if (tokenPermanent != null) {
+                SacrificeTargetEffect sacrificeEffect = new SacrificeTargetEffect();
+                sacrificeEffect.setTargetPointer(new FixedTarget(tokenPermanent, game));
+                game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(sacrificeEffect), source);
+            }
+        }
+    }
+
     public void exileTokensCreatedAtNextEndStep(Game game, Ability source) {
         for (UUID tokenId : this.getLastAddedTokenIds()) {
             Permanent tokenPermanent = game.getPermanent(tokenId);

--- a/Mage/src/main/java/mage/abilities/keyword/MobilizeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/MobilizeAbility.java
@@ -1,0 +1,65 @@
+package mage.abilities.keyword;
+
+import mage.abilities.Ability;
+import mage.abilities.common.AttacksTriggeredAbility;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.token.RedWarriorToken;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+/**
+ * @author balazskristof
+ */
+public class MobilizeAbility extends AttacksTriggeredAbility {
+
+    public MobilizeAbility(int count) {
+        super(new MobilizeEffect(count), false, "Mobilize " + count + " <i>(Whenever this creature attacks, create "
+            + (count == 1 ? "a" : CardUtil.numberToText(count)) + " tapped and attacking 1/1 red Warrior creature "
+            + (count == 1 ? "token" : "tokens") + ". Sacrifice " + (count == 1 ? "it" : "them")
+            + " at the beginning of the next end step.)");
+    }
+
+    protected MobilizeAbility(final MobilizeAbility ability) {
+        super(ability);
+    }
+
+    @Override
+    public MobilizeAbility copy() {
+        return new MobilizeAbility(this);
+    }
+}
+
+class MobilizeEffect extends OneShotEffect {
+
+    private final int count;
+
+    MobilizeEffect(int count) {
+        super(Outcome.Benefit);
+        this.count = count;
+    }
+
+    private MobilizeEffect(final MobilizeEffect effect) {
+        super(effect);
+        this.count = effect.count;
+    }
+
+    @Override
+    public MobilizeEffect copy() {
+        return new MobilizeEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        CreateTokenEffect effect = new CreateTokenEffect(new RedWarriorToken(), this.count, true, true);
+        effect.apply(game, source);
+        effect.sacrificeTokensCreatedAtNextEndStep(game, source);
+        return true;
+    }
+}

--- a/Mage/src/main/java/mage/game/permanent/token/RedWarriorToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/RedWarriorToken.java
@@ -1,0 +1,29 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author balazskristof
+ */
+public final class RedWarriorToken extends TokenImpl {
+
+    public RedWarriorToken() {
+        super("Warrior Token", "1/1 red Warrior creature token");
+        cardType.add(CardType.CREATURE);
+        color.setRed(true);
+        subtype.add(SubType.WARRIOR);
+        power = new MageInt(1);
+        toughness = new MageInt(1);
+    }
+
+    private RedWarriorToken(final RedWarriorToken token) {
+        super(token);
+    }
+
+    @Override
+    public RedWarriorToken copy() {
+        return new RedWarriorToken(this);
+    }
+}

--- a/Utils/keywords.txt
+++ b/Utils/keywords.txt
@@ -85,6 +85,7 @@ Melee|new|
 Menace|new|
 Mentor|new|
 Miracle|manaString|
+Mobilize|number|
 Modular|card, number|
 Mountaincycling|cost|
 Mountainwalk|new|


### PR DESCRIPTION
Implements the new keyword ability:
> Mobilize X <i>(Whenever this creature attacks, create X tapped and attacking 1/1 red Warrior creature tokens. Sacrifice them at the beginning of the next end step.)</i>

And two cards using it - Dragonback Lancer and Voice of Victory - for https://github.com/magefree/mage/issues/13375