### PR TITLE
[WHO] Implement Danny Pink

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DannyPink.java
+++ b/Mage.Sets/src/mage/cards/d/DannyPink.java
@@ -1,0 +1,99 @@
+package mage.cards.d;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.TriggeredAbility;
+import mage.abilities.TriggeredAbilityImpl;
+import mage.abilities.keyword.MentorAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.counters.Counters;
+import mage.counters.Counter;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.watchers.common.CountersAddedFirstTimeWatcher;
+
+/**
+ *
+ * @author padfoot
+ */
+public final class DannyPink extends CardImpl {
+
+    public DannyPink(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");
+        
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SOLDIER);
+        this.subtype.add(SubType.ADVISOR);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(3);
+
+        // Mentor
+        this.addAbility(new MentorAbility());
+
+        // Creatures you control have "Whenever one or more counters are put on this creature for the first time each turn, draw a card."
+        this.addAbility(new SimpleStaticAbility(
+	        new GainAbilityControlledEffect(
+		        new DannyPinkTriggeredAbility(), 
+			Duration.WhileOnBattlefield,
+			StaticFilters.FILTER_PERMANENT_CREATURES
+	)));
+
+    }
+
+    private DannyPink(final DannyPink card) {
+        super(card);
+    }
+
+    @Override
+    public DannyPink copy() {  
+      	    return new DannyPink(this);
+    }
+}
+
+class DannyPinkTriggeredAbility extends TriggeredAbilityImpl {
+
+    DannyPinkTriggeredAbility() {
+        super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
+	this.setTriggerPhrase("Whenever one or more counters are put on this creature for the first time each turn, ");
+	this.addWatcher(new CountersAddedFirstTimeWatcher());
+    }
+    
+    private DannyPinkTriggeredAbility(final DannyPinkTriggeredAbility ability) {
+	super(ability);
+    }
+
+    // We have to check for creatures entering with counters
+    @Override
+    public boolean checkEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.COUNTERS_ADDED
+		|| (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD);
+    }
+
+    @Override
+    public boolean checkTrigger(GameEvent event, Game game) {
+	Permanent permanent = game.getPermanent(event.getTargetId());
+	boolean entersWithCounters = false;
+	if (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD) {
+	    Counters counters = permanent.getCounters(game);
+	    entersWithCounters = !counters.values().stream().mapToInt(Counter::getCount).noneMatch(x -> x > 0);
+	}
+	// true if counters are added and the watcher is valid, or if the creature enters with counters (in that case, no need to check the watcher).
+	return ((event.getType() == GameEvent.EventType.COUNTERS_ADDED 
+	       	&& CountersAddedFirstTimeWatcher.checkEvent(event, permanent, game, 0))
+	        || (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD && entersWithCounters))
+		&& this.getSourceId().equals(event.getTargetId());
+    }
+    
+    @Override
+    public DannyPinkTriggeredAbility copy() {
+        return new DannyPinkTriggeredAbility(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/d/DannyPink.java
+++ b/Mage.Sets/src/mage/cards/d/DannyPink.java
@@ -21,7 +21,7 @@ import mage.watchers.common.CountersAddedFirstTimeWatcher;
 
 /**
  *
- * @author padfoot
+ * @author padfoothelix
  */
 public final class DannyPink extends CardImpl {
 
@@ -37,14 +37,14 @@ public final class DannyPink extends CardImpl {
 
         // Mentor
         this.addAbility(new MentorAbility());
-
+        
         // Creatures you control have "Whenever one or more counters are put on this creature for the first time each turn, draw a card."
         this.addAbility(new SimpleStaticAbility(
-	        new GainAbilityControlledEffect(
-		        new DannyPinkTriggeredAbility(), 
-			Duration.WhileOnBattlefield,
-			StaticFilters.FILTER_PERMANENT_CREATURES
-	)));
+                new GainAbilityControlledEffect(
+                        new DannyPinkTriggeredAbility(), 
+                        Duration.WhileOnBattlefield,
+                        StaticFilters.FILTER_PERMANENT_CREATURES
+        )));
 
     }
 
@@ -54,7 +54,7 @@ public final class DannyPink extends CardImpl {
 
     @Override
     public DannyPink copy() {  
-      	    return new DannyPink(this);
+        return new DannyPink(this);
     }
 }
 
@@ -62,34 +62,34 @@ class DannyPinkTriggeredAbility extends TriggeredAbilityImpl {
 
     DannyPinkTriggeredAbility() {
         super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), false);
-	this.setTriggerPhrase("Whenever one or more counters are put on this creature for the first time each turn, ");
-	this.addWatcher(new CountersAddedFirstTimeWatcher());
+        this.setTriggerPhrase("Whenever one or more counters are put on this creature for the first time each turn, ");
+        this.addWatcher(new CountersAddedFirstTimeWatcher());
     }
     
     private DannyPinkTriggeredAbility(final DannyPinkTriggeredAbility ability) {
-	super(ability);
+        super(ability);
     }
 
     // We have to check for creatures entering with counters
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.COUNTERS_ADDED
-		|| (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD);
+                || (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD);
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-	Permanent permanent = game.getPermanent(event.getTargetId());
-	boolean entersWithCounters = false;
-	if (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD) {
-	    Counters counters = permanent.getCounters(game);
-	    entersWithCounters = !counters.values().stream().mapToInt(Counter::getCount).noneMatch(x -> x > 0);
-	}
-	// true if counters are added and the watcher is valid, or if the creature enters with counters (in that case, no need to check the watcher).
-	return ((event.getType() == GameEvent.EventType.COUNTERS_ADDED 
-	       	&& CountersAddedFirstTimeWatcher.checkEvent(event, permanent, game, 0))
-	        || (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD && entersWithCounters))
-		&& this.getSourceId().equals(event.getTargetId());
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        boolean entersWithCounters = false;
+        if (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD) {
+            Counters counters = permanent.getCounters(game);
+            entersWithCounters = !counters.values().stream().mapToInt(Counter::getCount).noneMatch(x -> x > 0);
+        }
+        // true if counters are added and the watcher is valid, or if the creature enters with counters (in that case, no need to check the watcher).
+        return ((event.getType() == GameEvent.EventType.COUNTERS_ADDED 
+                && CountersAddedFirstTimeWatcher.checkEvent(event, permanent, game, 0))
+                || (event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD && entersWithCounters))
+                && this.getSourceId().equals(event.getTargetId());
     }
     
     @Override

--- a/Mage.Sets/src/mage/sets/DoctorWho.java
+++ b/Mage.Sets/src/mage/sets/DoctorWho.java
@@ -218,10 +218,10 @@ public final class DoctorWho extends ExpansionSet {
         cards.add(new SetCardInfo("Dan Lewis", 683, Rarity.RARE, mage.cards.d.DanLewis.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Dan Lewis", 78, Rarity.RARE, mage.cards.d.DanLewis.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Dan Lewis", 971, Rarity.RARE, mage.cards.d.DanLewis.class, NON_FULL_USE_VARIOUS));
-        //cards.add(new SetCardInfo("Danny Pink", 356, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
-        //cards.add(new SetCardInfo("Danny Pink", 39, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
-        //cards.add(new SetCardInfo("Danny Pink", 644, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
-        //cards.add(new SetCardInfo("Danny Pink", 947, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Danny Pink", 356, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Danny Pink", 39, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Danny Pink", 644, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Danny Pink", 947, Rarity.RARE, mage.cards.d.DannyPink.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Darkwater Catacombs", 1078, Rarity.RARE, mage.cards.d.DarkwaterCatacombs.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Darkwater Catacombs", 269, Rarity.RARE, mage.cards.d.DarkwaterCatacombs.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Darkwater Catacombs", 487, Rarity.RARE, mage.cards.d.DarkwaterCatacombs.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/java/mage/watchers/common/CountersAddedFirstTimeWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/CountersAddedFirstTimeWatcher.java
@@ -1,0 +1,58 @@
+package mage.watchers.common;
+
+import mage.MageObjectReference;
+import mage.constants.WatcherScope;
+import mage.counters.CounterType;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.watchers.Watcher;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * @author padfoot
+ */
+// copied almost entirely from BoostCountersAddedFirstTimeWatcher
+public class CountersAddedFirstTimeWatcher extends Watcher {
+
+    private final Map<MageObjectReference, UUID> map = new HashMap<>();
+
+    public CountersAddedFirstTimeWatcher() {
+        super(WatcherScope.GAME);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (event.getType() != GameEvent.EventType.COUNTERS_ADDED) {
+            return;
+        }
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        int offset = 0;
+        if (permanent == null) {
+            permanent = game.getPermanentEntering(event.getTargetId());
+            offset++;
+        }
+        if (permanent != null) {
+            map.putIfAbsent(new MageObjectReference(permanent, game, offset), event.getId());
+        }
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        map.clear();
+    }
+
+    public static boolean checkEvent(GameEvent event, Permanent permanent, Game game, int offset) {
+        return event
+                .getId()
+                .equals(game
+                        .getState()
+                        .getWatcher(CountersAddedFirstTimeWatcher.class)
+                        .map
+                        .getOrDefault(new MageObjectReference(permanent, game, offset), null));
+    }
+}


### PR DESCRIPTION
Part of #10653.

Card was tested and behaves as expected.

A new watcher is added (`CountersAddedFirstTimeWatcher`), copied almost entirely from `BoostCountersAddedFirstTimeWatcher`.

At first it seemed like the implementation would be easy, but I ran into a problem : a nontoken creature with a `TriggeredAbility` given through `GainAbilityControlledEffect` will not see a COUNTERS_ADDED event if it enters the battlefield with counters.
That means that creatures with modular, undying or persist will not trigger if we just check for a COUNTERS_ADDED event.

This is baffling, since a creature with that same ability will see an ENTERS_THE_BATTLEFIELD event when it enters. What's more, if a creature has this ability itself (instead of being given it by Danny Pink), then it will see the COUNTERS_ADDED event when it enters with counters.

This feels like a bug, but I am not sure how to correct it.
I have resolved the problem by checking explicitely if the creature enters with counters, but it kinda feels like a hack.