### PR TITLE
Fix 1-of-1 The One Ring image

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -684,7 +684,7 @@ public class ScryfallImageSupportCards {
             put("CALC/C-Pillar of the Paruns", "https://api.scryfall.com/cards/dis/176/");
 
             // LTR - 0 number for tokens only
-            put("LTR/The One Ring/001", "https://api.scryfall.com/cards/ltr/0/");
+            put("LTR/The One Ring/001", "https://api.scryfall.com/cards/ltr/0/qya?format=image");
 
             // REX - double faced lands (xmage uses two diff lands for it)
             put("REX/Command Tower/26b", "https://api.scryfall.com/cards/rex/26/en?format=image&face=back");

--- a/Mage.Client/src/test/java/mage/client/game/ScryfallImagesDownloadTest.java
+++ b/Mage.Client/src/test/java/mage/client/game/ScryfallImagesDownloadTest.java
@@ -43,7 +43,7 @@ public class ScryfallImagesDownloadTest {
                 .anyMatch(c -> c.getCardNumber().equals("001"))
         );
         urls = imageSource.generateCardUrl(new CardDownloadData("The One Ring", "LTR", "001", false, 0));
-        Assert.assertEquals("https://api.scryfall.com/cards/ltr/0/en?format=image", urls.getBaseUrl());
+        Assert.assertEquals("https://api.scryfall.com/cards/ltr/0/qya?format=image", urls.getBaseUrl());
 
 
         // added same tests for small images
@@ -74,6 +74,6 @@ public class ScryfallImagesDownloadTest {
                 .anyMatch(c -> c.getCardNumber().equals("001"))
         );
         urls = imageSourceSmall.generateCardUrl(new CardDownloadData("The One Ring", "LTR", "001", false, 0));
-        Assert.assertEquals("https://api.scryfall.com/cards/ltr/0/en?format=image&version=small", urls.getBaseUrl());
+        Assert.assertEquals("https://api.scryfall.com/cards/ltr/0/qya?format=image&version=small", urls.getBaseUrl());
     }
 }


### PR DESCRIPTION
XMage tries to download the 1-of-1 _The One Ring_ from `https://api.scryfall.com/cards/ltr/0/en?format=image`, which is wrong, because the card doesn't exist in English (`en`), but in Quenya (`qya` - an Elvish language) - which Scryfall follows.

The URL should be `https://api.scryfall.com/cards/ltr/0/qya?format=image` with the `qya` language code.