### PR TITLE
Skip prompting player with no blockers to select blockers

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
@@ -2621,19 +2621,19 @@
                 <Component class="javax.swing.JCheckBox" name="cbStopBlockWithAny">
                   <Properties>
                     <Property name="selected" type="boolean" value="true"/>
-                    <Property name="text" type="java.lang.String" value="STOP skips on declare blockers if ANY blockers are available"/>
+                    <Property name="text" type="java.lang.String" value="STOP skips when attacked and on declare blockers if ANY blockers are available"/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="cbStopBlockWithZero">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="STOP skips on declare blockers if ZERO blockers are available"/>
+                    <Property name="text" type="java.lang.String" value="STOP skips when attacked if ZERO blockers are available"/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                   </Properties>
                 </Component>
                 <Component class="javax.swing.JCheckBox" name="cbStopOnNewStackObjects">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Skip to STACK resolved (F10): stop on new objects added (on) or stop until empty (off)"/>
+                    <Property name="text" type="java.lang.String" value="Skip to STACK resolved (F10): stop on new objects added (on) or stop when stack empty (off)"/>
                     <Property name="actionCommand" type="java.lang.String" value=""/>
                     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
                       <Dimension value="[300, 25]"/>

--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -2396,15 +2396,15 @@ public class PreferencesDialog extends javax.swing.JDialog {
         phases_stopSettings.add(cbStopAttack);
 
         cbStopBlockWithAny.setSelected(true);
-        cbStopBlockWithAny.setText("STOP skips on declare blockers if ANY blockers are available");
+        cbStopBlockWithAny.setText("STOP skips when attacked and on declare blockers if ANY blockers are available");
         cbStopBlockWithAny.setActionCommand("");
         phases_stopSettings.add(cbStopBlockWithAny);
 
-        cbStopBlockWithZero.setText("STOP skips on declare blockers if ZERO blockers are available");
+        cbStopBlockWithZero.setText("STOP skips when attacked if ZERO blockers are available");
         cbStopBlockWithZero.setActionCommand("");
         phases_stopSettings.add(cbStopBlockWithZero);
 
-        cbStopOnNewStackObjects.setText("Skip to STACK resolved (F10): stop on new objects added (on) or stop until empty (off)");
+        cbStopOnNewStackObjects.setText("Skip to STACK resolved (F10): stop on new objects added (on) or stop when stack empty (off)");
         cbStopOnNewStackObjects.setActionCommand("");
         cbStopOnNewStackObjects.setPreferredSize(new java.awt.Dimension(300, 25));
         phases_stopSettings.add(cbStopOnNewStackObjects);

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2072,7 +2072,6 @@ public class HumanPlayer extends PlayerImpl {
         // stop skip on any/zero permanents available
         int possibleBlockersCount = game.getBattlefield().count(filter, playerId, source, game);
         boolean canStopOnAny = possibleBlockersCount != 0 && getControllingPlayersUserData(game).getUserSkipPrioritySteps().isStopOnDeclareBlockersWithAnyPermanents();
-        boolean canStopOnZero = possibleBlockersCount == 0 && getControllingPlayersUserData(game).getUserSkipPrioritySteps().isStopOnDeclareBlockersWithZeroPermanents();
 
         // skip declare blocker step
         // as opposed to declare attacker - it can be skipped by ANY skip button TODO: make same for declare attackers and rework skip buttons (normal and forced)
@@ -2081,7 +2080,7 @@ public class HumanPlayer extends PlayerImpl {
                 || passedTurn
                 || passedUntilEndOfTurn
                 || passedUntilNextMain;
-        if (skipButtonActivated && !canStopOnAny && !canStopOnZero) {
+        if (skipButtonActivated && !canStopOnAny) {
             return;
         }
         // Skip prompt to select blockers if player has none

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2084,16 +2084,16 @@ public class HumanPlayer extends PlayerImpl {
         if (skipButtonActivated && !canStopOnAny && !canStopOnZero) {
             return;
         }
-        java.util.List<UUID> possibleBlockers = game.getBattlefield().getActivePermanents(filter, playerId, game).stream()
-                .map(p -> p.getId())
-                .collect(Collectors.toList());
         // Skip prompt to select blockers if player has none
-        if (possibleBlockers.isEmpty()) return;
+        if (possibleBlockersCount == 0) return;
 
         while (canRespond()) {
             prepareForResponse(game);
             if (!isExecutingMacro()) {
                 Map<String, Serializable> options = new HashMap<>();
+                java.util.List<UUID> possibleBlockers = game.getBattlefield().getActivePermanents(filter, playerId, game).stream()
+                        .map(p -> p.getId())
+                        .collect(Collectors.toList());
                 options.put(Constants.Option.POSSIBLE_BLOCKERS, (Serializable) possibleBlockers);
                 game.fireSelectEvent(playerId, "Select blockers", options);
             }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2084,14 +2084,16 @@ public class HumanPlayer extends PlayerImpl {
         if (skipButtonActivated && !canStopOnAny && !canStopOnZero) {
             return;
         }
+        java.util.List<UUID> possibleBlockers = game.getBattlefield().getActivePermanents(filter, playerId, game).stream()
+                .map(p -> p.getId())
+                .collect(Collectors.toList());
+        // Skip prompt to select blockers if player has none
+        if (possibleBlockers.isEmpty()) return;
 
         while (canRespond()) {
             prepareForResponse(game);
             if (!isExecutingMacro()) {
                 Map<String, Serializable> options = new HashMap<>();
-                java.util.List<UUID> possibleBlockers = game.getBattlefield().getActivePermanents(filter, playerId, game).stream()
-                        .map(p -> p.getId())
-                        .collect(Collectors.toList());
                 options.put(Constants.Option.POSSIBLE_BLOCKERS, (Serializable) possibleBlockers);
                 game.fireSelectEvent(playerId, "Select blockers", options);
             }


### PR DESCRIPTION
Currently if I have no creatures and a player attacks me I still need to click through the "Select blockers" prompt even though I have literally no creatures with which to block anything anyway. This PR is a minor quality of life improvement that removes that unnecessary extra click by checking that the player actually *has* any possible blockers before prompting them to assign them.

Image attached is before this PR, with me being prompted to "Select blockers" despite having nothing to assign. The only game action I can take is to click the "Done" button and nothing else.

![image](https://github.com/user-attachments/assets/be585a2e-513a-4ac9-9a10-5582062f7d03)

Note: this PR has **no gameplay implications at all**. The player still correctly gains priority during the declare blockers step at the same time they normally would. It *only* skips the "Select blockers" prompt when the game sees that there aren't any valid blockers to choose from.