### PR TITLE
Reworked cost adjuster logic for better support of X, early target and cost modification effects

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -1863,8 +1863,11 @@ public class ComputerPlayer extends PlayerImpl {
 
     @Override
     public int announceXMana(int min, int max, String message, Game game, Ability ability) {
-        log.debug("announceXMana");
-        //TODO: improve this
+        // current logic - use max possible mana
+
+        // TODO: add good/bad effects support
+        // TODO: add simple game simulations like declare blocker?
+
         int numAvailable = getAvailableManaProducers(game).size() - ability.getManaCosts().manaValue();
         if (numAvailable < 0) {
             numAvailable = 0;
@@ -1881,12 +1884,17 @@ public class ComputerPlayer extends PlayerImpl {
 
     @Override
     public int announceXCost(int min, int max, String message, Game game, Ability ability, VariableCost variablCost) {
-        log.debug("announceXCost");
+        // current logic - use random non-zero value
+
+        // TODO: add good/bad effects support
+        // TODO: remove random logic
+
         int value = RandomUtil.nextInt(CardUtil.overflowInc(max, 1));
         if (value < min) {
             value = min;
         }
         if (value < max) {
+            // do not use zero values
             value++;
         }
         return value;

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -1709,6 +1709,8 @@ public class HumanPlayer extends PlayerImpl {
             if (response.getInteger() != null) {
                 break;
             }
+
+            // TODO: add response verify here
         }
 
         if (response.getInteger() != null) {

--- a/Mage.Server/release/config/init.example.txt
+++ b/Mage.Server/release/config/init.example.txt
@@ -62,9 +62,6 @@ hand:Human:Angelic Edict:3
 battlefield:Computer:Grizzly Bears:2
 battlefield:Human:Grizzly Bears:2
 
-// special command, see SystemUtil for more special commands list
-[@activate opponent ability]
-
 [diff set codes example]
 battlefield:Human:XLN-Island:1
 battlefield:Human:UST-Island:1

--- a/Mage.Sets/src/mage/cards/a/AbandonHope.java
+++ b/Mage.Sets/src/mage/cards/a/AbandonHope.java
@@ -1,43 +1,30 @@
 package mage.cards.a;
 
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.common.DiscardTargetCost;
+import mage.abilities.costs.costadjusters.DiscardXCardsCostAdjuster;
 import mage.abilities.dynamicvalue.common.GetXValue;
-import mage.abilities.effects.common.InfoEffect;
 import mage.abilities.effects.common.discard.LookTargetHandChooseDiscardEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetOpponent;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
 /**
- * @author fireshoes
+ * @author fireshoes, JayDi85
  */
 public final class AbandonHope extends CardImpl {
 
     public AbandonHope(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{1}{B}");
 
-        // As an additional cost to cast Abandon Hope, discard X cards.
-        Ability ability = new SimpleStaticAbility(
-                Zone.ALL, new InfoEffect("As an additional cost to cast this spell, discard X cards")
-        );
-        ability.setRuleAtTheTop(true);
-        this.addAbility(ability);
+        // As an additional cost to cast this spell, discard X cards.
+        DiscardXCardsCostAdjuster.addAdjusterAndMessage(this, StaticFilters.FILTER_CARD_CARDS);
 
         // Look at target opponent's hand and choose X cards from it. That player discards those cards.
         this.getSpellAbility().addEffect(new LookTargetHandChooseDiscardEffect(false, GetXValue.instance, StaticFilters.FILTER_CARD_CARDS));
         this.getSpellAbility().addTarget(new TargetOpponent());
-        this.getSpellAbility().setCostAdjuster(AbandonHopeAdjuster.instance);
     }
 
     private AbandonHope(final AbandonHope card) {
@@ -47,17 +34,5 @@ public final class AbandonHope extends CardImpl {
     @Override
     public AbandonHope copy() {
         return new AbandonHope(this);
-    }
-}
-
-enum AbandonHopeAdjuster implements CostAdjuster {
-    instance;
-
-    @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int xValue = CardUtil.getSourceCostsTag(game, ability, "X", 0);
-        if (xValue > 0) {
-            ability.addCost(new DiscardTargetCost(new TargetCardInHand(xValue, xValue, StaticFilters.FILTER_CARD_CARDS)));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/a/AeonChronicler.java
+++ b/Mage.Sets/src/mage/cards/a/AeonChronicler.java
@@ -31,7 +31,7 @@ public final class AeonChronicler extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Aeon Chronicler's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.ANY)));
 
         // Suspend X-{X}{3}{U}. X can't be 0.
         this.addAbility(new SuspendAbility(Integer.MAX_VALUE, new ManaCostsImpl<>("{3}{U}"), this, true));

--- a/Mage.Sets/src/mage/cards/a/AetherTide.java
+++ b/Mage.Sets/src/mage/cards/a/AetherTide.java
@@ -1,27 +1,18 @@
 package mage.cards.a;
 
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.common.DiscardTargetCost;
+import mage.abilities.costs.costadjusters.DiscardXCardsCostAdjuster;
 import mage.abilities.effects.Effect;
-import mage.abilities.effects.common.InfoEffect;
 import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetadjustment.XTargetsCountAdjuster;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
 /**
- *
  * @author jeffwadsworth
  */
 public final class AetherTide extends CardImpl {
@@ -29,10 +20,8 @@ public final class AetherTide extends CardImpl {
     public AetherTide(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{U}");
 
-        // As an additional cost to cast Aether Tide, discard X creature cards.
-        Ability ability = new SimpleStaticAbility(Zone.ALL, new InfoEffect("As an additional cost to cast this spell, discard X creature cards"));
-        ability.setRuleAtTheTop(true);
-        this.addAbility(ability);
+        // As an additional cost to cast this spell, discard X creature cards.
+        DiscardXCardsCostAdjuster.addAdjusterAndMessage(this, StaticFilters.FILTER_CARD_CREATURES);
 
         // Return X target creatures to their owners' hands.
         Effect effect = new ReturnToHandTargetEffect();
@@ -40,8 +29,6 @@ public final class AetherTide extends CardImpl {
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().setTargetAdjuster(new XTargetsCountAdjuster());
-        this.getSpellAbility().setCostAdjuster(AetherTideCostAdjuster.instance);
-
     }
 
     private AetherTide(final AetherTide card) {
@@ -51,17 +38,5 @@ public final class AetherTide extends CardImpl {
     @Override
     public AetherTide copy() {
         return new AetherTide(this);
-    }
-}
-
-enum AetherTideCostAdjuster implements CostAdjuster {
-    instance;
-
-    @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int xValue = CardUtil.getSourceCostsTag(game, ability, "X", 0);
-        if (xValue > 0) {
-            ability.addCost(new DiscardTargetCost(new TargetCardInHand(xValue, xValue, StaticFilters.FILTER_CARD_CREATURES)));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
+++ b/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
@@ -5,7 +5,6 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.effects.ReplacementEffectImpl;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -36,12 +35,8 @@ public final class AladdinsLamp extends CardImpl {
         // {X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your library, put all but one of them on the bottom of your library in a random order, then draw a card. X can't be 0.
         Ability ability = new SimpleActivatedAbility(new AladdinsLampEffect(), new ManaCostsImpl<>("{X}"));
         ability.addCost(new TapSourceCost());
-        for (Object cost : ability.getManaCosts()) {
-            if (cost instanceof VariableManaCost) {
-                ((VariableManaCost) cost).setMinX(1);
-                break;
-            }
-        }
+        ability.setVariableCostsMinMax(1, Integer.MAX_VALUE);
+        // TODO: add costAdjuster for min/max values due library size
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
+++ b/Mage.Sets/src/mage/cards/a/AladdinsLamp.java
@@ -3,6 +3,7 @@ package mage.cards.a;
 
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.CostAdjuster;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.ReplacementEffectImpl;
@@ -35,8 +36,8 @@ public final class AladdinsLamp extends CardImpl {
         // {X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your library, put all but one of them on the bottom of your library in a random order, then draw a card. X can't be 0.
         Ability ability = new SimpleActivatedAbility(new AladdinsLampEffect(), new ManaCostsImpl<>("{X}"));
         ability.addCost(new TapSourceCost());
-        ability.setVariableCostsMinMax(1, Integer.MAX_VALUE);
-        // TODO: add costAdjuster for min/max values due library size
+        ability.setCostAdjuster(AladdinsLampCostAdjuster.instance);
+
         this.addAbility(ability);
     }
 
@@ -94,5 +95,19 @@ class AladdinsLampEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         return source.isControlledBy(event.getPlayerId());
+    }
+}
+
+enum AladdinsLampCostAdjuster implements CostAdjuster {
+    instance;
+
+    @Override
+    public void prepareX(Ability ability, Game game) {
+        Player controller = game.getPlayer(ability.getControllerId());
+        if (controller == null) {
+            return;
+        }
+
+        ability.setVariableCostsMinMax(1, Math.max(1, controller.getLibrary().size()));
     }
 }

--- a/Mage.Sets/src/mage/cards/a/AlandraSkyDreamer.java
+++ b/Mage.Sets/src/mage/cards/a/AlandraSkyDreamer.java
@@ -47,8 +47,8 @@ public final class AlandraSkyDreamer extends CardImpl {
         // Whenever you draw your fifth card each turn, Alandra, Sky Dreamer and Drakes you control each get +X/+X until end of turn, where X is the number of cards in your hand.
         DrawNthCardTriggeredAbility drawNthCardTriggeredAbility = new DrawNthCardTriggeredAbility(
                 new BoostSourceEffect(
-                        CardsInControllerHandCount.instance,
-                        CardsInControllerHandCount.instance,
+                        CardsInControllerHandCount.ANY,
+                        CardsInControllerHandCount.ANY,
                         Duration.EndOfTurn
                 ).setText("{this}"),
                 false,
@@ -56,8 +56,8 @@ public final class AlandraSkyDreamer extends CardImpl {
         );
         drawNthCardTriggeredAbility.addEffect(
                 new BoostControlledEffect(
-                        CardsInControllerHandCount.instance,
-                        CardsInControllerHandCount.instance,
+                        CardsInControllerHandCount.ANY,
+                        CardsInControllerHandCount.ANY,
                         Duration.EndOfTurn,
                         filter,
                         false

--- a/Mage.Sets/src/mage/cards/a/AncientExcavation.java
+++ b/Mage.Sets/src/mage/cards/a/AncientExcavation.java
@@ -61,7 +61,7 @@ class AncientExcavationEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(source.getControllerId());
         if (player != null) {
-            DynamicValue numCards = CardsInControllerHandCount.instance;
+            DynamicValue numCards = CardsInControllerHandCount.ANY;
             int amount = numCards.calculate(game, source, this);
             int cardsDrawn = player.drawCards(amount, source, game);
             player.discard(cardsDrawn, false, false, source, game);

--- a/Mage.Sets/src/mage/cards/a/Archivist.java
+++ b/Mage.Sets/src/mage/cards/a/Archivist.java
@@ -1,4 +1,3 @@
-
 package mage.cards.a;
 
 import java.util.UUID;
@@ -26,7 +25,7 @@ public final class Archivist extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
-        //{T}: Draw a card.
+        // {T}: Draw a card.
         this.addAbility(new SimpleActivatedAbility(new DrawCardSourceControllerEffect(1), new TapSourceCost()));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArmMountedAnchor.java
+++ b/Mage.Sets/src/mage/cards/a/ArmMountedAnchor.java
@@ -71,7 +71,7 @@ enum ArmMountedAnchorAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         // checking state
         if (HeckbentCondition.instance.apply(game, ability)) {
             CardUtil.reduceCost(ability, 2);

--- a/Mage.Sets/src/mage/cards/b/BaldinCenturyHerdmaster.java
+++ b/Mage.Sets/src/mage/cards/b/BaldinCenturyHerdmaster.java
@@ -43,7 +43,7 @@ public final class BaldinCenturyHerdmaster extends CardImpl {
 
         // Whenever Baldin, Century Herdmaster attacks, up to one hundred target creatures each get +0/+X until end of turn, where X is the number of cards in your hand.
         Ability ability = new AttacksTriggeredAbility(new BoostTargetEffect(
-                StaticValue.get(0), CardsInControllerHandCount.instance, Duration.EndOfTurn
+                StaticValue.get(0), CardsInControllerHandCount.ANY, Duration.EndOfTurn
         ).setText("up to one hundred target creatures each get +0/+X until end of turn, where X is the number of cards in your hand"));
         ability.addTarget(new TargetCreaturePermanent(0, 100));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/b/BaruWurmspeaker.java
+++ b/Mage.Sets/src/mage/cards/b/BaruWurmspeaker.java
@@ -19,10 +19,7 @@ import mage.abilities.hint.ValueHint;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.SubType;
-import mage.constants.SuperType;
+import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreaturePermanent;
@@ -116,7 +113,7 @@ enum BaruWurmspeakerAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         int value = BaruWurmspeakerValue.instance.calculate(game, ability, null);
         if (value > 0) {
             CardUtil.reduceCost(ability, value);

--- a/Mage.Sets/src/mage/cards/b/BattlefieldButcher.java
+++ b/Mage.Sets/src/mage/cards/b/BattlefieldButcher.java
@@ -58,7 +58,7 @@ enum BattlefieldButcherAdjuster implements CostAdjuster {
     private static final Hint hint = new ValueHint("Creature cards in your graveyard", xValue);
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, xValue.calculate(game, ability, null));
     }
 

--- a/Mage.Sets/src/mage/cards/b/BeltOfGiantStrength.java
+++ b/Mage.Sets/src/mage/cards/b/BeltOfGiantStrength.java
@@ -3,20 +3,21 @@ package mage.cards.b;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.CostAdjuster;
+import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.continuous.SetBasePowerToughnessEnchantedEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Outcome;
 import mage.constants.SubType;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
+import mage.target.common.TargetControlledCreaturePermanent;
 import mage.util.CardUtil;
 
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
-import mage.abilities.costs.mana.GenericManaCost;
-import mage.constants.Outcome;
-import mage.target.common.TargetControlledCreaturePermanent;
 
 /**
  * @author TheElk801
@@ -35,7 +36,7 @@ public final class BeltOfGiantStrength extends CardImpl {
         // Equip {10}. This ability costs {X} less to activate where X is the power of the creature it targets.
         EquipAbility ability = new EquipAbility(Outcome.BoostCreature, new GenericManaCost(10), new TargetControlledCreaturePermanent(), false);
         ability.setCostReduceText("This ability costs {X} less to activate, where X is the power of the creature it targets.");
-        ability.setCostAdjuster(BeltOfGiantStrengthAdjuster.instance);
+        ability.setCostAdjuster(BeltOfGiantStrengthCostAdjuster.instance);
         this.addAbility(ability);
     }
 
@@ -49,33 +50,23 @@ public final class BeltOfGiantStrength extends CardImpl {
     }
 }
 
-enum BeltOfGiantStrengthAdjuster implements CostAdjuster {
+enum BeltOfGiantStrengthCostAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
+        int power;
         if (game.inCheckPlayableState()) {
-            int maxPower = 0;
-            for (UUID permId : CardUtil.getAllPossibleTargets(ability, game)) {
-                Permanent permanent = game.getPermanent(permId);
-                if (permanent != null) {
-                    int power = permanent.getPower().getValue();
-                    if (power > maxPower) {
-                        maxPower = power;
-                    }
-                }
-            }
-            if (maxPower > 0) {
-                CardUtil.reduceCost(ability, maxPower);
-            }
+            power = CardUtil.getAllPossibleTargets(ability, game).stream()
+                    .map(game::getPermanent)
+                    .filter(Objects::nonNull)
+                    .mapToInt(p -> p.getPower().getValue())
+                    .max().orElse(0);
         } else {
-            Permanent permanent = game.getPermanent(ability.getFirstTarget());
-            if (permanent != null) {
-                int power = permanent.getPower().getValue();
-                if (power > 0) {
-                    CardUtil.reduceCost(ability, power);
-                }
-            }
+            power = Optional.ofNullable(game.getPermanent(ability.getFirstTarget()))
+                    .map(p -> p.getPower().getValue())
+                    .orElse(0);
         }
+        CardUtil.reduceCost(ability, power);
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BiteDownOnCrime.java
+++ b/Mage.Sets/src/mage/cards/b/BiteDownOnCrime.java
@@ -60,7 +60,7 @@ enum BiteDownOnCrimeAdjuster implements CostAdjuster {
     private static final OptionalAdditionalCost collectEvidenceCost = CollectEvidenceAbility.makeCost(6);
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (CollectedEvidenceCondition.instance.apply(game, ability)
                 || (game.inCheckPlayableState() && collectEvidenceCost.canPay(ability, null, ability.getControllerId(), game))) {
             CardUtil.reduceCost(ability, 2);

--- a/Mage.Sets/src/mage/cards/b/BodyOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/b/BodyOfKnowledge.java
@@ -33,7 +33,7 @@ public final class BodyOfKnowledge extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL,
                 new SetBasePowerToughnessSourceEffect(
-                        CardsInControllerHandCount.instance
+                        CardsInControllerHandCount.ANY
                 )
         ));
 

--- a/Mage.Sets/src/mage/cards/c/CallerOfTheHunt.java
+++ b/Mage.Sets/src/mage/cards/c/CallerOfTheHunt.java
@@ -59,7 +59,7 @@ enum CallerOfTheHuntAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareCost(Ability ability, Game game) {
         if (game.inCheckPlayableState()) {
             return;
         }
@@ -103,6 +103,7 @@ enum CallerOfTheHuntAdjuster implements CostAdjuster {
             game.getState().setValue(sourceObject.getId() + "_type", maxSubType);
         } else {
             // human choose
+            // TODO: need early target cost instead dialog here
             Effect effect = new ChooseCreatureTypeEffect(Outcome.Benefit);
             effect.apply(game, ability);
         }

--- a/Mage.Sets/src/mage/cards/c/CaptainAmericaFirstAvenger.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainAmericaFirstAvenger.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
+import mage.abilities.costs.CostImpl;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.Cost;
@@ -130,7 +131,7 @@ enum CaptainAmericaFirstAvengerValue implements DynamicValue {
     }
 }
 
-class CaptainAmericaFirstAvengerUnattachCost extends EarlyTargetCost {
+class CaptainAmericaFirstAvengerUnattachCost extends CostImpl implements EarlyTargetCost {
 
     private static final FilterPermanent filter = new FilterEquipmentPermanent("equipment attached to this creature");
     private static final FilterPermanent subfilter = new FilterControlledPermanent("{this}");

--- a/Mage.Sets/src/mage/cards/c/CastleLocthwain.java
+++ b/Mage.Sets/src/mage/cards/c/CastleLocthwain.java
@@ -40,7 +40,7 @@ public final class CastleLocthwain extends CardImpl {
         Ability ability = new SimpleActivatedAbility(
                 new DrawCardSourceControllerEffect(1).setText("draw a card,"), new ManaCostsImpl<>("{1}{B}{B}")
         );
-        ability.addEffect(new LoseLifeSourceControllerEffect(CardsInControllerHandCount.instance)
+        ability.addEffect(new LoseLifeSourceControllerEffect(CardsInControllerHandCount.ANY)
                 .setText("then you lose life equal to the number of cards in your hand"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/c/ChanneledForce.java
+++ b/Mage.Sets/src/mage/cards/c/ChanneledForce.java
@@ -25,7 +25,7 @@ public final class ChanneledForce extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{U}{R}");
 
         // As an additional cost to cast this spell, discard X cards.
-        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS));
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Target player draws X cards. Channeled Force deals X damage to up to one target creature or planeswalker.
         this.getSpellAbility().addEffect(new ChanneledForceEffect());

--- a/Mage.Sets/src/mage/cards/c/CrownOfGondor.java
+++ b/Mage.Sets/src/mage/cards/c/CrownOfGondor.java
@@ -72,7 +72,7 @@ enum CrownOfGondorAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (MonarchIsSourceControllerCondition.instance.apply(game, ability)) {
             CardUtil.reduceCost(ability, 3);
         }

--- a/Mage.Sets/src/mage/cards/d/DamiaSageOfStone.java
+++ b/Mage.Sets/src/mage/cards/d/DamiaSageOfStone.java
@@ -17,7 +17,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.TargetController;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
 
@@ -59,7 +58,7 @@ public final class DamiaSageOfStone extends CardImpl {
 class DamiaSageOfStoneTriggeredAbility extends BeginningOfUpkeepTriggeredAbility {
 
     DamiaSageOfStoneTriggeredAbility() {
-        super(TargetController.YOU, new DrawCardSourceControllerEffect(new IntPlusDynamicValue(7, new MultipliedValue(CardsInControllerHandCount.instance, -1))), false);
+        super(TargetController.YOU, new DrawCardSourceControllerEffect(new IntPlusDynamicValue(7, new MultipliedValue(CardsInControllerHandCount.ANY, -1))), false);
     }
 
     private DamiaSageOfStoneTriggeredAbility(final DamiaSageOfStoneTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/d/DeepwoodDenizen.java
+++ b/Mage.Sets/src/mage/cards/d/DeepwoodDenizen.java
@@ -62,7 +62,7 @@ enum DeepwoodDenizenAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, DeepwoodDenizenValue.instance.calculate(game, ability, null));
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DemonicLore.java
+++ b/Mage.Sets/src/mage/cards/d/DemonicLore.java
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public final class DemonicLore extends CardImpl {
 
-    private static final DynamicValue xValue = new MultipliedValue(CardsInControllerHandCount.instance, 2);
+    private static final DynamicValue xValue = new MultipliedValue(CardsInControllerHandCount.ANY, 2);
 
     public DemonicLore(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{B}");

--- a/Mage.Sets/src/mage/cards/d/DescendantOfSoramaro.java
+++ b/Mage.Sets/src/mage/cards/d/DescendantOfSoramaro.java
@@ -12,7 +12,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 
 /**
  *
@@ -28,7 +27,7 @@ public final class DescendantOfSoramaro extends CardImpl {
         this.power = new MageInt(2);
         this.toughness = new MageInt(3);
         // {1}{U}: Look at the top X cards of your library, where X is the number of cards in your hand, then put them back in any order.
-        Effect effect = new LookLibraryControllerEffect(CardsInControllerHandCount.instance);
+        Effect effect = new LookLibraryControllerEffect(CardsInControllerHandCount.ANY);
         effect.setText("Look at the top X cards of your library, where X is the number of cards in your hand, then put them back in any order");
         this.addAbility(new SimpleActivatedAbility(
                 effect, new ManaCostsImpl<>("{1}{U}")));

--- a/Mage.Sets/src/mage/cards/d/DevastatingDreams.java
+++ b/Mage.Sets/src/mage/cards/d/DevastatingDreams.java
@@ -5,6 +5,8 @@ import mage.abilities.costs.Cost;
 import mage.abilities.costs.VariableCostImpl;
 import mage.abilities.costs.VariableCostType;
 import mage.abilities.costs.common.DiscardTargetCost;
+import mage.abilities.costs.common.DiscardXTargetCost;
+import mage.abilities.costs.costadjusters.DiscardXCardsCostAdjuster;
 import mage.abilities.dynamicvalue.common.GetXValue;
 import mage.abilities.effects.common.DamageAllEffect;
 import mage.abilities.effects.common.SacrificeAllEffect;
@@ -12,6 +14,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
@@ -28,8 +31,8 @@ public final class DevastatingDreams extends CardImpl {
     public DevastatingDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{R}{R}");
 
-        // As an additional cost to cast Devastating Dreams, discard X cards at random.
-        this.getSpellAbility().addCost(new DevastatingDreamsAdditionalCost());
+        // As an additional cost to cast this spell, discard X cards at random.
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true).withRandom());
 
         // Each player sacrifices X lands.
         this.getSpellAbility().addEffect(new SacrificeAllEffect(GetXValue.instance, new FilterControlledLandPermanent("lands")));

--- a/Mage.Sets/src/mage/cards/d/DivinersPortent.java
+++ b/Mage.Sets/src/mage/cards/d/DivinersPortent.java
@@ -27,7 +27,7 @@ public final class DivinersPortent extends CardImpl {
         // Roll a d20 and add the number of cards in your hand.
         RollDieWithResultTableEffect effect = new RollDieWithResultTableEffect(
                 20, "roll a d20 and add the number " +
-                "of cards in your hand", CardsInControllerHandCount.instance, 0
+                "of cards in your hand", CardsInControllerHandCount.ANY, 0
         );
         this.getSpellAbility().addEffect(effect);
 

--- a/Mage.Sets/src/mage/cards/d/DreadSlag.java
+++ b/Mage.Sets/src/mage/cards/d/DreadSlag.java
@@ -15,7 +15,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 
 /**
  *
@@ -32,7 +31,7 @@ public final class DreadSlag extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Dread Slag gets -4/-4 for each card in your hand.
-        DynamicValue amount = new MultipliedValue(CardsInControllerHandCount.instance, -4);
+        DynamicValue amount = new MultipliedValue(CardsInControllerHandCount.ANY, -4);
         Effect effect = new BoostSourceEffect(amount, amount, Duration.WhileOnBattlefield);
         effect.setText("{this} gets -4/-4 for each card in your hand");
         this.addAbility(new SimpleStaticAbility(effect));

--- a/Mage.Sets/src/mage/cards/d/DugganPrivateDetective.java
+++ b/Mage.Sets/src/mage/cards/d/DugganPrivateDetective.java
@@ -36,7 +36,7 @@ public final class DugganPrivateDetective extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Duggan's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.ANY)));
 
         // Whenever Duggan enters the battlefield or attacks, investigate.
         this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(new InvestigateEffect().setText("investigate")));

--- a/Mage.Sets/src/mage/cards/e/EliteArcanist.java
+++ b/Mage.Sets/src/mage/cards/e/EliteArcanist.java
@@ -1,12 +1,13 @@
 package mage.cards.e;
 
+import mage.ApprovingObject;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.CostAdjuster;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.costs.mana.GenericManaCost;
+import mage.abilities.costs.costadjusters.ImprintedManaValueXCostAdjuster;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -23,7 +24,6 @@ import mage.players.Player;
 import mage.target.TargetCard;
 
 import java.util.UUID;
-import mage.ApprovingObject;
 
 /**
  * @author LevelX2
@@ -44,7 +44,7 @@ public final class EliteArcanist extends CardImpl {
         // {X}, {T}: Copy the exiled card. You may cast the copy without paying its mana cost. X is the converted mana cost of the exiled card.
         Ability ability = new SimpleActivatedAbility(new EliteArcanistCopyEffect(), new ManaCostsImpl<>("{X}"));
         ability.addCost(new TapSourceCost());
-        ability.setCostAdjuster(EliteArcanistAdjuster.instance);
+        ability.setCostAdjuster(ImprintedManaValueXCostAdjuster.instance);
         this.addAbility(ability);
     }
 
@@ -55,29 +55,6 @@ public final class EliteArcanist extends CardImpl {
     @Override
     public EliteArcanist copy() {
         return new EliteArcanist(this);
-    }
-}
-
-enum EliteArcanistAdjuster implements CostAdjuster {
-    instance;
-
-    @Override
-    public void adjustCosts(Ability ability, Game game) {
-        Permanent sourcePermanent = game.getPermanent(ability.getSourceId());
-        if (sourcePermanent == null
-                || sourcePermanent.getImprinted() == null
-                || sourcePermanent.getImprinted().isEmpty()) {
-            return;
-        }
-        Card imprintedInstant = game.getCard(sourcePermanent.getImprinted().get(0));
-        if (imprintedInstant == null) {
-            return;
-        }
-        int cmc = imprintedInstant.getManaValue();
-        if (cmc > 0) {
-            ability.clearManaCostsToPay();
-            ability.addManaCostsToPay(new GenericManaCost(cmc));
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/e/EmpyrialArmor.java
+++ b/Mage.Sets/src/mage/cards/e/EmpyrialArmor.java
@@ -15,7 +15,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -38,7 +37,7 @@ public final class EmpyrialArmor extends CardImpl {
         this.addAbility(ability);
 
         // Enchanted creature gets +1/+1 for each card in your hand.
-        DynamicValue xValue = CardsInControllerHandCount.instance;
+        DynamicValue xValue = CardsInControllerHandCount.ANY;
         this.addAbility(new SimpleStaticAbility(new BoostEnchantedEffect(xValue, xValue, Duration.WhileOnBattlefield)));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmpyrialPlate.java
+++ b/Mage.Sets/src/mage/cards/e/EmpyrialPlate.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 
 /**
  *
@@ -25,7 +24,7 @@ public final class EmpyrialPlate extends CardImpl {
         this.subtype.add(SubType.EQUIPMENT);
 
         // Equipped creature gets +1/+1 for each card in your hand.
-        this.addAbility(new SimpleStaticAbility(new BoostEquippedEffect(CardsInControllerHandCount.instance, CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(new BoostEquippedEffect(CardsInControllerHandCount.ANY, CardsInControllerHandCount.ANY)));
         
         // Equip {2}
         this.addAbility(new EquipAbility(Outcome.BoostCreature, new GenericManaCost(2), false));

--- a/Mage.Sets/src/mage/cards/e/EndlessSwarm.java
+++ b/Mage.Sets/src/mage/cards/e/EndlessSwarm.java
@@ -22,7 +22,7 @@ public final class EndlessSwarm extends CardImpl {
 
 
         // Create a 1/1 green Snake creature token for each card in your hand.
-        this.getSpellAbility().addEffect(new CreateTokenEffect(new SnakeToken(), CardsInControllerHandCount.instance).setText("create a 1/1 green Snake creature token for each card in your hand"));
+        this.getSpellAbility().addEffect(new CreateTokenEffect(new SnakeToken(), CardsInControllerHandCount.ANY).setText("create a 1/1 green Snake creature token for each card in your hand"));
 
         // Epic
         this.getSpellAbility().addEffect(new EpicEffect());

--- a/Mage.Sets/src/mage/cards/e/EsquireOfTheKing.java
+++ b/Mage.Sets/src/mage/cards/e/EsquireOfTheKing.java
@@ -64,7 +64,7 @@ enum EsquireOfTheKingAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (game.getBattlefield().contains(StaticFilters.FILTER_CONTROLLED_CREATURE_LEGENDARY, ability, game, 1)) {
             CardUtil.reduceCost(ability, 2);
         }

--- a/Mage.Sets/src/mage/cards/e/EtheriumPteramander.java
+++ b/Mage.Sets/src/mage/cards/e/EtheriumPteramander.java
@@ -80,8 +80,7 @@ enum EtheriumPteramanderAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int count = artifactCount.calculate(game, ability, null);
-        CardUtil.reduceCost(ability, count);
+    public void reduceCost(Ability ability, Game game) {
+        CardUtil.reduceCost(ability, artifactCount.calculate(game, ability, null));
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FatefulShowdown.java
+++ b/Mage.Sets/src/mage/cards/f/FatefulShowdown.java
@@ -21,7 +21,7 @@ public final class FatefulShowdown extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{R}{R}");
 
         // Fateful Showdown deals damage to any target equal to the number of cards in your hand. Discard all the cards in your hand, then draw that many cards.
-        Effect effect = new DamageTargetEffect(CardsInControllerHandCount.instance);
+        Effect effect = new DamageTargetEffect(CardsInControllerHandCount.ANY);
         effect.setText("{this} deals damage to any target equal to the number of cards in your hand");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/f/Fireball.java
+++ b/Mage.Sets/src/mage/cards/f/Fireball.java
@@ -2,11 +2,11 @@ package mage.cards.f;
 
 import mage.abilities.Ability;
 import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.CostModificationType;
 import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -24,8 +24,8 @@ public final class Fireball extends CardImpl {
     public Fireball(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{R}");
 
-        // Fireball deals X damage divided evenly, rounded down, among any number of target creatures and/or players.
-        // Fireball costs 1 more to cast for each target beyond the first.
+        // This spell costs {1} more to cast for each target beyond the first.
+        // Fireball deals X damage divided evenly, rounded down, among any number of targets.
         this.getSpellAbility().addTarget(new FireballTargetCreatureOrPlayer(0, Integer.MAX_VALUE));
         this.getSpellAbility().addEffect(new FireballEffect());
         this.getSpellAbility().setCostAdjuster(FireballAdjuster.instance);
@@ -45,10 +45,10 @@ enum FireballAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void increaseCost(Ability ability, Game game) {
         int numTargets = ability.getTargets().isEmpty() ? 0 : ability.getTargets().get(0).getTargets().size();
         if (numTargets > 1) {
-            ability.addManaCostsToPay(new GenericManaCost(numTargets - 1));
+            CardUtil.increaseCost(ability, numTargets - 1);
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/f/FiresOfVictory.java
+++ b/Mage.Sets/src/mage/cards/f/FiresOfVictory.java
@@ -31,7 +31,7 @@ public final class FiresOfVictory extends CardImpl {
                 KickedCondition.ONCE,
                 "If this spell was kicked, draw a card."
         ));
-        this.getSpellAbility().addEffect(new DamageTargetEffect(CardsInControllerHandCount.instance)
+        this.getSpellAbility().addEffect(new DamageTargetEffect(CardsInControllerHandCount.ANY)
                 .setText("{this} deals damage to target creature or planeswalker equal to the number of cards in your hand."));
         this.getSpellAbility().addTarget(new TargetCreatureOrPlaneswalker());
     }

--- a/Mage.Sets/src/mage/cards/f/Firestorm.java
+++ b/Mage.Sets/src/mage/cards/f/Firestorm.java
@@ -9,6 +9,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
@@ -25,8 +26,8 @@ public final class Firestorm extends CardImpl {
     public Firestorm(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{R}");
 
-        // As an additional cost to cast Firestorm, discard X cards.
-        this.getSpellAbility().addCost(new DiscardXTargetCost(new FilterCard("cards"), true));
+        // As an additional cost to cast this spell, discard X cards.
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Firestorm deals X damage to each of X target creatures and/or players.
         this.getSpellAbility().addEffect(new FirestormEffect());

--- a/Mage.Sets/src/mage/cards/f/FugitiveCodebreaker.java
+++ b/Mage.Sets/src/mage/cards/f/FugitiveCodebreaker.java
@@ -92,7 +92,7 @@ enum FugitiveCodebreakerAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, FugitiveCodebreakerDisguiseAbility.xValue.calculate(game, ability, null));
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GeralfsMasterpiece.java
+++ b/Mage.Sets/src/mage/cards/g/GeralfsMasterpiece.java
@@ -21,7 +21,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.target.common.TargetCardInHand;
 
@@ -42,7 +41,7 @@ public final class GeralfsMasterpiece extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Geralf's Masterpiece gets -1/-1 for each card in your hand.
-        DynamicValue count = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+        DynamicValue count = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
         Effect effect = new BoostSourceEffect(count, count, Duration.WhileOnBattlefield);
         effect.setText("{this} gets -1/-1 for each card in your hand");
         this.addAbility(new SimpleStaticAbility(effect));

--- a/Mage.Sets/src/mage/cards/g/GerrardsWisdom.java
+++ b/Mage.Sets/src/mage/cards/g/GerrardsWisdom.java
@@ -20,7 +20,7 @@ public final class GerrardsWisdom extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{W}{W}");
 
         // You gain 2 life for each card in your hand.
-        this.getSpellAbility().addEffect(new GainLifeEffect(new MultipliedValue(CardsInControllerHandCount.instance, 2),
+        this.getSpellAbility().addEffect(new GainLifeEffect(new MultipliedValue(CardsInControllerHandCount.ANY, 2),
             "You gain 2 life for each card in your hand"));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GhostfireBlade.java
+++ b/Mage.Sets/src/mage/cards/g/GhostfireBlade.java
@@ -55,9 +55,9 @@ enum GhostfireBladeAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
-        // checking state
+    public void reduceCost(Ability ability, Game game) {
         if (game.inCheckPlayableState()) {
+            // possible
             if (CardUtil
                     .getAllPossibleTargets(ability, game)
                     .stream()
@@ -67,6 +67,7 @@ enum GhostfireBladeAdjuster implements CostAdjuster {
                 return;
             }
         } else {
+            // real
             Permanent permanent = game.getPermanent(ability.getFirstTarget());
             if (permanent == null || !permanent.getColor(game).isColorless()) {
                 return;

--- a/Mage.Sets/src/mage/cards/g/GrimGiganotosaurus.java
+++ b/Mage.Sets/src/mage/cards/g/GrimGiganotosaurus.java
@@ -74,7 +74,7 @@ enum GrimGiganotosaurusAdjuster implements CostAdjuster {
     private static final DynamicValue xValue = new PermanentsOnBattlefieldCount(filter);
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller != null) {
             CardUtil.reduceCost(ability, xValue.calculate(game, ability, null));

--- a/Mage.Sets/src/mage/cards/g/GrimStrider.java
+++ b/Mage.Sets/src/mage/cards/g/GrimStrider.java
@@ -14,7 +14,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 
 /**
  *
@@ -29,7 +28,7 @@ public final class GrimStrider extends CardImpl {
         this.toughness = new MageInt(6);
 
         // Grim Strider gets -1/-1 for each card in your hand.
-        DynamicValue count = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+        DynamicValue count = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
         Effect effect = new BoostSourceEffect(count, count, Duration.WhileOnBattlefield);
         effect.setText("{this} gets -1/-1 for each card in your hand");
         this.addAbility(new SimpleStaticAbility(effect));

--- a/Mage.Sets/src/mage/cards/h/HamletGlutton.java
+++ b/Mage.Sets/src/mage/cards/h/HamletGlutton.java
@@ -61,7 +61,7 @@ enum HamletGluttonAdjuster implements CostAdjuster {
     private static OptionalAdditionalCost bargainCost = BargainAbility.makeBargainCost();
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (BargainedCondition.instance.apply(game, ability)
                 || (game.inCheckPlayableState() && bargainCost.canPay(ability, null, ability.getControllerId(), game))) {
             CardUtil.reduceCost(ability, 2);

--- a/Mage.Sets/src/mage/cards/h/HandOfVecna.java
+++ b/Mage.Sets/src/mage/cards/h/HandOfVecna.java
@@ -47,7 +47,7 @@ public final class HandOfVecna extends CardImpl {
         this.addAbility(new EquipAbility(
                 Outcome.Benefit,
                 new PayLifeCost(
-                CardsInControllerHandCount.instance, "1 life for each card in your hand"),
+                CardsInControllerHandCount.ANY, "1 life for each card in your hand"),
                 false
         ));
 

--- a/Mage.Sets/src/mage/cards/h/HelmOfObedience.java
+++ b/Mage.Sets/src/mage/cards/h/HelmOfObedience.java
@@ -2,9 +2,8 @@ package mage.cards.h;
 
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.VariableCostType;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.costs.mana.VariableManaCost;
+import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.dynamicvalue.common.GetXValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.*;
@@ -29,9 +28,8 @@ public final class HelmOfObedience extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{4}");
 
         // {X}, {T}: Target opponent puts cards from the top of their library into their graveyard until a creature card or X cards are put into that graveyard this way, whichever comes first. If a creature card is put into that graveyard this way, sacrifice Helm of Obedience and put that card onto the battlefield under your control. X can't be 0.
-        VariableManaCost xCosts = new VariableManaCost(VariableCostType.NORMAL);
-        xCosts.setMinX(1);
-        Ability ability = new SimpleActivatedAbility(new HelmOfObedienceEffect(), xCosts);
+        Ability ability = new SimpleActivatedAbility(new HelmOfObedienceEffect(), new ManaCostsImpl<>("{X}"));
+        ability.setVariableCostsMinMax(1, Integer.MAX_VALUE);
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetOpponent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/h/HinataDawnCrowned.java
+++ b/Mage.Sets/src/mage/cards/h/HinataDawnCrowned.java
@@ -117,6 +117,10 @@ final class HinataDawnCrownedEffectUtility
     public static int getTargetCount(Game game, Ability abilityToModify)
     {
         if (game.inCheckPlayableState()) {
+            abilityToModify.getTargets().stream()
+                    .mapToInt(a -> !a.isRequired() ? 0 : a.getMinNumberOfTargets())
+                    .min()
+                    .orElse(0);
             Optional<Integer> max = abilityToModify.getTargets().stream().map(x -> x.getMaxNumberOfTargets()).max(Integer::compare);
             int allPossibleSize = CardUtil.getAllPossibleTargets(abilityToModify, game).size();
             return max.isPresent() ?

--- a/Mage.Sets/src/mage/cards/h/HurkylsFinalMeditation.java
+++ b/Mage.Sets/src/mage/cards/h/HurkylsFinalMeditation.java
@@ -49,7 +49,7 @@ enum HurkylsFinalMeditationAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void increaseCost(Ability ability, Game game) {
         if (!game.isActivePlayer(ability.getControllerId())) {
             CardUtil.increaseCost(ability, 3);
         }

--- a/Mage.Sets/src/mage/cards/h/HyldasCrownOfWinter.java
+++ b/Mage.Sets/src/mage/cards/h/HyldasCrownOfWinter.java
@@ -82,7 +82,7 @@ enum HyldasCrownOfWinterAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (ability.getControllerId().equals(game.getActivePlayerId())) {
             CardUtil.reduceCost(ability, 1);
         }

--- a/Mage.Sets/src/mage/cards/i/IceOut.java
+++ b/Mage.Sets/src/mage/cards/i/IceOut.java
@@ -52,7 +52,7 @@ enum IceOutAdjuster implements CostAdjuster {
     private static OptionalAdditionalCost bargainCost = BargainAbility.makeBargainCost();
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (BargainedCondition.instance.apply(game, ability)
                 || (game.inCheckPlayableState() && bargainCost.canPay(ability, null, ability.getControllerId(), game))) {
             CardUtil.reduceCost(ability, 1);

--- a/Mage.Sets/src/mage/cards/i/InnerCalmOuterStrength.java
+++ b/Mage.Sets/src/mage/cards/i/InnerCalmOuterStrength.java
@@ -24,7 +24,7 @@ public final class InnerCalmOuterStrength extends CardImpl {
         this.subtype.add(SubType.ARCANE);
 
         // Target creature gets +X/+X until end of turn, where X is the number of cards in your hand.
-        DynamicValue xValue= CardsInControllerHandCount.instance;
+        DynamicValue xValue= CardsInControllerHandCount.ANY;
         Effect effect = new BoostTargetEffect(xValue, xValue, Duration.EndOfTurn);
         effect.setText("Target creature gets +X/+X until end of turn, where X is the number of cards in your hand");
         this.getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/i/InnerFire.java
+++ b/Mage.Sets/src/mage/cards/i/InnerFire.java
@@ -20,7 +20,7 @@ public final class InnerFire extends CardImpl {
 
 
         // Add {R} for each card in your hand.
-        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1), CardsInControllerHandCount.instance));
+        this.getSpellAbility().addEffect(new DynamicManaEffect(Mana.RedMana(1), CardsInControllerHandCount.ANY));
     }
 
     private InnerFire(final InnerFire card) {

--- a/Mage.Sets/src/mage/cards/i/InsidiousDreams.java
+++ b/Mage.Sets/src/mage/cards/i/InsidiousDreams.java
@@ -25,7 +25,7 @@ public final class InsidiousDreams extends CardImpl {
     public InsidiousDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{3}{B}");
 
-        // As an additional cost to cast Insidious Dreams, discard X cards.
+        // As an additional cost to cast this spell, discard X cards.
         this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Search your library for X cards. Then shuffle your library and put those cards on top of it in any order.

--- a/Mage.Sets/src/mage/cards/j/JohannsStopgap.java
+++ b/Mage.Sets/src/mage/cards/j/JohannsStopgap.java
@@ -54,7 +54,7 @@ enum JohannsStopgapAdjuster implements CostAdjuster {
     private static OptionalAdditionalCost bargainCost = BargainAbility.makeBargainCost();
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (BargainedCondition.instance.apply(game, ability)
                 || (game.inCheckPlayableState() && bargainCost.canPay(ability, null, ability.getControllerId(), game))) {
             CardUtil.reduceCost(ability, 2);

--- a/Mage.Sets/src/mage/cards/j/JolraelMwonvuliRecluse.java
+++ b/Mage.Sets/src/mage/cards/j/JolraelMwonvuliRecluse.java
@@ -37,7 +37,7 @@ public final class JolraelMwonvuliRecluse extends CardImpl {
 
         // {4}{G}{G}: Until end of turn, creatures you control have base power and toughness X/X, where X is the number of cards in your hand.
         this.addAbility(new SimpleActivatedAbility(new SetBasePowerToughnessAllEffect(
-                CardsInControllerHandCount.instance, CardsInControllerHandCount.instance,
+                CardsInControllerHandCount.ANY, CardsInControllerHandCount.ANY,
                 Duration.EndOfTurn, StaticFilters.FILTER_CONTROLLED_CREATURES
         ).setText("until end of turn, creatures you control have base power and toughness X/X, " +
                 "where X is the number of cards in your hand"), new ManaCostsImpl<>("{4}{G}{G}")));

--- a/Mage.Sets/src/mage/cards/j/JushiApprentice.java
+++ b/Mage.Sets/src/mage/cards/j/JushiApprentice.java
@@ -19,7 +19,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.ComparisonType;
 import mage.constants.SuperType;
-import mage.constants.Zone;
 import mage.game.permanent.token.TokenImpl;
 import mage.target.TargetPlayer;
 
@@ -70,7 +69,7 @@ class TomoyaTheRevealer extends TokenImpl {
         toughness = new MageInt(3);
 
         // {3}{U}{U},{T} : Target player draws X cards, where X is the number of cards in your hand.
-        Ability ability = new SimpleActivatedAbility(new DrawCardTargetEffect(CardsInControllerHandCount.instance), new ManaCostsImpl<>("{3}{U}{U}"));
+        Ability ability = new SimpleActivatedAbility(new DrawCardTargetEffect(CardsInControllerHandCount.ANY), new ManaCostsImpl<>("{3}{U}{U}"));
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetPlayer());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/k/KagemaroFirstToSuffer.java
+++ b/Mage.Sets/src/mage/cards/k/KagemaroFirstToSuffer.java
@@ -37,7 +37,7 @@ public final class KagemaroFirstToSuffer extends CardImpl {
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
 
-        DynamicValue xValue = CardsInControllerHandCount.instance;
+        DynamicValue xValue = CardsInControllerHandCount.ANY;
         // Kagemaro, First to Suffer's power and toughness are each equal to the number of cards in your hand.
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
         // {B}, Sacrifice Kagemaro: All creatures get -X/-X until end of turn, where X is the number of cards in your hand.

--- a/Mage.Sets/src/mage/cards/k/KagemarosClutch.java
+++ b/Mage.Sets/src/mage/cards/k/KagemarosClutch.java
@@ -17,7 +17,6 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -40,7 +39,7 @@ public final class KagemarosClutch extends CardImpl {
         this.addAbility(ability);
 
         // Enchanted creature gets -X/-X, where X is the number of cards in your hand.
-        DynamicValue xMinusValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+        DynamicValue xMinusValue = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
         Effect effect = new BoostEnchantedEffect(xMinusValue, xMinusValue, Duration.WhileOnBattlefield);
         effect.setText("Enchanted creature gets -X/-X, where X is the number of cards in your hand");
         this.addAbility(new SimpleStaticAbility(effect));

--- a/Mage.Sets/src/mage/cards/k/KamiOfJealousThirst.java
+++ b/Mage.Sets/src/mage/cards/k/KamiOfJealousThirst.java
@@ -60,7 +60,7 @@ enum KamiOfJealousThirstAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void increaseCost(Ability ability, Game game) {
         int amount = CardsDrawnThisTurnDynamicValue.instance.calculate(game, ability, null);
         if (amount >= 3) {
             CardUtil.adjustCost(ability, new ManaCostsImpl<>("{4}{B}"), false);

--- a/Mage.Sets/src/mage/cards/k/KitsuneLoreweaver.java
+++ b/Mage.Sets/src/mage/cards/k/KitsuneLoreweaver.java
@@ -14,7 +14,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 
 /**
  *
@@ -30,7 +29,7 @@ public final class KitsuneLoreweaver extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {1}{W}: Kitsune Loreweaver gets +0/+X until end of turn, where X is the number of cards in your hand.
-        Effect effect = new BoostSourceEffect(StaticValue.get(0), CardsInControllerHandCount.instance, Duration.EndOfTurn);
+        Effect effect = new BoostSourceEffect(StaticValue.get(0), CardsInControllerHandCount.ANY, Duration.EndOfTurn);
         effect.setText("{this} gets +0/+X until end of turn, where X is the number of cards in your hand");
         this.addAbility(new SimpleActivatedAbility(effect, new ManaCostsImpl<>("{1}{W}")));
     }

--- a/Mage.Sets/src/mage/cards/k/KiyomaroFirstToStand.java
+++ b/Mage.Sets/src/mage/cards/k/KiyomaroFirstToStand.java
@@ -31,7 +31,7 @@ public final class KiyomaroFirstToStand extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Kiyomaro, First to Stand's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.ANY)));
 
         // As long as you have four or more cards in hand, Kiyomaro has vigilance.
         Condition condition = new CardsInHandCondition(ComparisonType.MORE_THAN, 3);

--- a/Mage.Sets/src/mage/cards/k/KnollspineInvocation.java
+++ b/Mage.Sets/src/mage/cards/k/KnollspineInvocation.java
@@ -1,40 +1,43 @@
 package mage.cards.k;
 
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.common.DiscardTargetCost;
+import mage.abilities.costs.CostImpl;
+import mage.abilities.costs.EarlyTargetCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.dynamicvalue.common.GetXValue;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.ComparisonType;
-import mage.constants.Zone;
+import mage.constants.Outcome;
 import mage.filter.FilterCard;
-import mage.filter.predicate.mageobject.ManaValuePredicate;
 import mage.game.Game;
+import mage.players.Player;
+import mage.target.Target;
 import mage.target.common.TargetAnyTarget;
 import mage.target.common.TargetCardInHand;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
 /**
- * @author anonymous
+ * @author JayDi85
  */
 public final class KnollspineInvocation extends CardImpl {
 
-    private static final FilterCard filter = new FilterCard("a card with mana value X");
+    protected static final FilterCard filter = new FilterCard("a card with mana value X");
 
     public KnollspineInvocation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{R}{R}");
 
-        // {X}, Discard a card with converted mana cost X: Knollspine Invocation deals X damage to any target.
+        // {X}, Discard a card with mana value X: This enchantment deals X damage to any target.
         Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(GetXValue.instance, true), new ManaCostsImpl<>("{X}"));
-        ability.addCost(new DiscardTargetCost(new TargetCardInHand(filter)));
+        ability.addCost(new KnollspineInvocationDiscardCost());
         ability.addTarget(new TargetAnyTarget());
         ability.setCostAdjuster(KnollspineInvocationAdjuster.instance);
         this.addAbility(ability);
@@ -50,22 +53,103 @@ public final class KnollspineInvocation extends CardImpl {
     }
 }
 
+class KnollspineInvocationDiscardCost extends CostImpl implements EarlyTargetCost {
+
+    // discard card with early target selection, so {X} mana cost can be setup after choose
+
+    public KnollspineInvocationDiscardCost() {
+        super();
+        this.text = "Discard a card with mana value X";
+    }
+
+    public KnollspineInvocationDiscardCost(final KnollspineInvocationDiscardCost cost) {
+        super(cost);
+    }
+
+    @Override
+    public KnollspineInvocationDiscardCost copy() {
+        return new KnollspineInvocationDiscardCost(this);
+    }
+
+    @Override
+    public void chooseTarget(Game game, Ability source, Player controller) {
+        Target target = new TargetCardInHand().withChooseHint("to discard with mana value for X");
+        controller.choose(Outcome.Discard, target, source, game);
+        addTarget(target);
+    }
+
+    @Override
+    public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
+        Player controller = game.getPlayer(controllerId);
+        return controller != null && !controller.getHand().isEmpty();
+    }
+
+    @Override
+    public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
+        this.paid = false;
+
+        Player controller = game.getPlayer(controllerId);
+        if (controller == null) {
+            return false;
+        }
+
+        Card card = controller.getHand().get(this.getTargets().getFirstTarget(), game);
+        if (card == null) {
+            return false;
+        }
+
+        this.paid = controller.discard(card, true, source, game);
+
+        return this.paid;
+    }
+}
+
 enum KnollspineInvocationAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int xValue = CardUtil.getSourceCostsTag(game, ability, "X", 0);
-        for (Cost cost : ability.getCosts()) {
-            if (!(cost instanceof DiscardTargetCost)) {
-                continue;
-            }
-            DiscardTargetCost discardCost = (DiscardTargetCost) cost;
-            discardCost.getTargets().clear();
-            FilterCard adjustedFilter = new FilterCard("a card with mana value X");
-            adjustedFilter.add(new ManaValuePredicate(ComparisonType.EQUAL_TO, xValue));
-            discardCost.addTarget(new TargetCardInHand(adjustedFilter));
+    public void prepareX(Ability ability, Game game) {
+        Player controller = game.getPlayer(ability.getControllerId());
+        if (controller == null) {
             return;
+        }
+
+        // make sure early target used
+        VariableManaCost costX = ability.getManaCostsToPay().stream()
+                .filter(c -> c instanceof VariableManaCost)
+                .map(c -> (VariableManaCost) c)
+                .findFirst()
+                .orElse(null);
+        if (costX == null) {
+            throw new IllegalArgumentException("Wrong code usage: costX lost");
+        }
+        KnollspineInvocationDiscardCost costDiscard = ability.getCosts().stream()
+                .filter(c -> c instanceof KnollspineInvocationDiscardCost)
+                .map(c -> (KnollspineInvocationDiscardCost) c)
+                .findFirst()
+                .orElse(null);
+        if (costDiscard == null) {
+            throw new IllegalArgumentException("Wrong code usage: costDiscard lost");
+        }
+
+        if (game.inCheckPlayableState()) {
+            // possible X
+            int minManaValue = controller.getHand().getCards(game).stream()
+                    .mapToInt(MageObject::getManaValue)
+                    .min()
+                    .orElse(0);
+            int maxManaValue = controller.getHand().getCards(game).stream()
+                    .mapToInt(MageObject::getManaValue)
+                    .max()
+                    .orElse(0);
+            ability.setVariableCostsMinMax(minManaValue, maxManaValue);
+        } else {
+            // real X
+            Card card = controller.getHand().get(costDiscard.getTargets().getFirstTarget(), game);
+            if (card == null) {
+                throw new IllegalStateException("Wrong code usage: card to discard lost");
+            }
+            ability.setVariableCostsValue(card.getManaValue());
         }
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LeonardoDaVinci.java
+++ b/Mage.Sets/src/mage/cards/l/LeonardoDaVinci.java
@@ -43,7 +43,7 @@ public final class LeonardoDaVinci extends CardImpl {
         this.power = new MageInt(3);
         this.toughness = new MageInt(3);
 
-        DynamicValue xValue = CardsInControllerHandCount.instance;
+        DynamicValue xValue = CardsInControllerHandCount.ANY;
         // {3}{U}{U}: Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand.
         this.addAbility(new SimpleActivatedAbility(new BoostControlledEffect(xValue, xValue, Duration.EndOfTurn, filter, false).setText(
                 "Until end of turn, Thopters you control have base power and toughness X/X, where X is the number of cards in your hand."

--- a/Mage.Sets/src/mage/cards/l/LoreseekersStone.java
+++ b/Mage.Sets/src/mage/cards/l/LoreseekersStone.java
@@ -48,7 +48,7 @@ enum LoreseekersStoneAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void increaseCost(Ability ability, Game game) {
         Player player = game.getPlayer(ability.getControllerId());
         if (player != null) {
             CardUtil.increaseCost(ability, player.getHand().size());

--- a/Mage.Sets/src/mage/cards/m/Malignus.java
+++ b/Mage.Sets/src/mage/cards/m/Malignus.java
@@ -74,7 +74,7 @@ class HighestLifeTotalAmongOpponentsCount implements DynamicValue {
 
     @Override
     public DynamicValue copy() {
-        return CardsInControllerHandCount.instance;
+        return CardsInControllerHandCount.ANY;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/ManifestationSage.java
+++ b/Mage.Sets/src/mage/cards/m/ManifestationSage.java
@@ -26,7 +26,7 @@ public final class ManifestationSage extends CardImpl {
 
         // When Manifestation Sage enters the battlefield, create a 0/0 green and blue Fractal creature token. Put X +1/+1 counters on it, where X is the number of cards in your hand.
         this.addAbility(new EntersBattlefieldTriggeredAbility(FractalToken.getEffect(
-                CardsInControllerHandCount.instance, "Put X +1/+1 counters on it, " +
+                CardsInControllerHandCount.ANY, "Put X +1/+1 counters on it, " +
                         "where X is the number of cards in your hand"
         )));
     }

--- a/Mage.Sets/src/mage/cards/m/MariposaMilitaryBase.java
+++ b/Mage.Sets/src/mage/cards/m/MariposaMilitaryBase.java
@@ -64,7 +64,7 @@ enum MariposaMilitaryBaseAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, SourceControllerCountersCount.RAD.calculate(game, ability, null));
     }
 }

--- a/Mage.Sets/src/mage/cards/m/Maro.java
+++ b/Mage.Sets/src/mage/cards/m/Maro.java
@@ -26,7 +26,7 @@ public final class Maro extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Maro's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.ANY)));
     }
 
     private Maro(final Maro card) {

--- a/Mage.Sets/src/mage/cards/m/MasterTheWay.java
+++ b/Mage.Sets/src/mage/cards/m/MasterTheWay.java
@@ -23,7 +23,7 @@ public final class MasterTheWay extends CardImpl {
 
         // Draw a card. Master the Way deals damage to any target equal to the number of cards in your hand.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));
-        Effect effect = new DamageTargetEffect(CardsInControllerHandCount.instance);
+        Effect effect = new DamageTargetEffect(CardsInControllerHandCount.ANY);
         effect.setText("{this} deals damage to any target equal to the number of cards in your hand");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/m/MasumaroFirstToLive.java
+++ b/Mage.Sets/src/mage/cards/m/MasumaroFirstToLive.java
@@ -31,7 +31,7 @@ public final class MasumaroFirstToLive extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Masumaro, First to Live's power and toughness are each equal to twice the number of cards in your hand.
-        DynamicValue xValue= new MultipliedValue(CardsInControllerHandCount.instance, 2);
+        DynamicValue xValue= new MultipliedValue(CardsInControllerHandCount.ANY, 2);
         Effect effect = new SetBasePowerToughnessSourceEffect(xValue);
         effect.setText("{this}'s power and toughness are each equal to twice the number of cards in your hand");
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));

--- a/Mage.Sets/src/mage/cards/m/MeishinTheMindCage.java
+++ b/Mage.Sets/src/mage/cards/m/MeishinTheMindCage.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SuperType;
-import mage.constants.Zone;
 import mage.filter.StaticFilters;
 
 /**
@@ -26,7 +25,7 @@ public final class MeishinTheMindCage extends CardImpl {
         this.supertype.add(SuperType.LEGENDARY);
 
         // All creatures get -X/-0, where X is the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(new BoostAllEffect(new SignInversionDynamicValue(CardsInControllerHandCount.instance), StaticValue.get(0), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURE, false, "All creatures get -X/-0, where X is the number of cards in your hand")));
+        this.addAbility(new SimpleStaticAbility(new BoostAllEffect(new SignInversionDynamicValue(CardsInControllerHandCount.ANY), StaticValue.get(0), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURE, false, "All creatures get -X/-0, where X is the number of cards in your hand")));
     }
 
     private MeishinTheMindCage(final MeishinTheMindCage card) {

--- a/Mage.Sets/src/mage/cards/m/MinasTirithGarrison.java
+++ b/Mage.Sets/src/mage/cards/m/MinasTirithGarrison.java
@@ -39,7 +39,7 @@ public final class MinasTirithGarrison extends CardImpl {
 
         // Minas Tirith Garrison's power is equal to the number of cards in your hand.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.instance)
+                Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.ANY)
         ));
 
         // Whenever Minas Tirith Garrison attacks, you may tap any number of untapped Humans you control. Draw a card for each Human tapped this way.

--- a/Mage.Sets/src/mage/cards/m/MirrorOfGaladriel.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorOfGaladriel.java
@@ -66,7 +66,7 @@ enum MirrorOfGaladrielAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         int value = game.getBattlefield().count(
                 StaticFilters.FILTER_CONTROLLED_CREATURE_LEGENDARY,
                 ability.getControllerId(), ability, game

--- a/Mage.Sets/src/mage/cards/m/MobilizedDistrict.java
+++ b/Mage.Sets/src/mage/cards/m/MobilizedDistrict.java
@@ -74,7 +74,7 @@ enum MobilizedDistrictAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller != null) {
             int count = cardsCount.calculate(game, ability, null);

--- a/Mage.Sets/src/mage/cards/n/NahirisWrath.java
+++ b/Mage.Sets/src/mage/cards/n/NahirisWrath.java
@@ -8,6 +8,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetCreatureOrPlaneswalker;
 import mage.target.targetadjustment.XTargetsCountAdjuster;
 
@@ -21,8 +22,8 @@ public final class NahirisWrath extends CardImpl {
     public NahirisWrath(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{R}");
 
-        // As an additional cost to cast Nahiri's Wrath, discard X cards.
-        this.getSpellAbility().addCost(new DiscardXTargetCost(new FilterCard("cards"), true));
+        // As an additional cost to cast this spell, discard X cards.
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Nahiri's Wrath deals damage equal to the total converted mana cost of the discarded cards to each of up to X target creatures and/or planeswalkers.
         Effect effect = new DamageTargetEffect(DiscardCostCardManaValue.instance);

--- a/Mage.Sets/src/mage/cards/n/NecropolisFiend.java
+++ b/Mage.Sets/src/mage/cards/n/NecropolisFiend.java
@@ -6,11 +6,9 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.VariableCost;
 import mage.abilities.costs.common.ExileFromGraveCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.GetXValue;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
@@ -86,16 +84,12 @@ enum NecropolisFiendCostAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareX(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller == null) {
             return;
         }
-        for (VariableCost variableCost : ability.getManaCostsToPay().getVariableCosts()) {
-            if (variableCost instanceof VariableManaCost) {
-                ((VariableManaCost) variableCost).setMaxX(controller.getGraveyard().size());
-            }
-        }
+        ability.setVariableCostsMinMax(0, controller.getGraveyard().size());
     }
 }
 

--- a/Mage.Sets/src/mage/cards/n/NemesisOfMortals.java
+++ b/Mage.Sets/src/mage/cards/n/NemesisOfMortals.java
@@ -63,7 +63,7 @@ enum NemesisOfMortalsAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller != null) {
             CardUtil.reduceCost(ability, controller.getGraveyard().count(StaticFilters.FILTER_CARD_CREATURE, game));

--- a/Mage.Sets/src/mage/cards/n/NightmarishEnd.java
+++ b/Mage.Sets/src/mage/cards/n/NightmarishEnd.java
@@ -18,7 +18,7 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class NightmarishEnd extends CardImpl {
 
-    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
 
     public NightmarishEnd(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{2}{B}");

--- a/Mage.Sets/src/mage/cards/n/NostalgicDreams.java
+++ b/Mage.Sets/src/mage/cards/n/NostalgicDreams.java
@@ -22,8 +22,8 @@ public final class NostalgicDreams extends CardImpl {
     public NostalgicDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{G}{G}");
 
-        // As an additional cost to cast Nostalgic Dreams, discard X cards.
-        this.getSpellAbility().addCost(new DiscardXTargetCost(new FilterCard("cards"), true));
+        // As an additional cost to cast this spell, discard X cards.
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Return X target cards from your graveyard to your hand.
         Effect effect = new ReturnFromGraveyardToHandTargetEffect();

--- a/Mage.Sets/src/mage/cards/o/OboroEnvoy.java
+++ b/Mage.Sets/src/mage/cards/o/OboroEnvoy.java
@@ -28,7 +28,7 @@ import mage.target.common.TargetCreaturePermanent;
  */
 public final class OboroEnvoy extends CardImpl {
 
-    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
 
     public OboroEnvoy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{U}");

--- a/Mage.Sets/src/mage/cards/o/OpenTheWay.java
+++ b/Mage.Sets/src/mage/cards/o/OpenTheWay.java
@@ -3,7 +3,6 @@ package mage.cards.o;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.mana.VariableManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.InfoEffect;
 import mage.cards.*;
@@ -28,7 +27,7 @@ public final class OpenTheWay extends CardImpl {
         this.addAbility(new SimpleStaticAbility(
                 Zone.ALL, new InfoEffect("X can't be greater than the number of players in the game")
         ).setRuleAtTheTop(true));
-        this.getSpellAbility().setCostAdjuster(OpenTheWayAdjuster.instance);
+        this.getSpellAbility().setCostAdjuster(OpenTheWayCostAdjuster.instance);
 
         // Reveal cards from the top of your library until you reveal X land cards. Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.
         this.getSpellAbility().addEffect(new OpenTheWayEffect());
@@ -44,14 +43,12 @@ public final class OpenTheWay extends CardImpl {
     }
 }
 
-enum OpenTheWayAdjuster implements CostAdjuster {
+enum OpenTheWayCostAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int playerCount = game.getPlayers().size();
-        CardUtil.castStream(ability.getCosts().stream(), VariableManaCost.class)
-                .forEach(cost -> cost.setMaxX(playerCount));
+    public void prepareX(Ability ability, Game game) {
+        ability.setVariableCostsMinMax(0, game.getState().getPlayersInRange(ability.getControllerId(), game, true).size());
     }
 }
 

--- a/Mage.Sets/src/mage/cards/o/OsgirTheReconstructor.java
+++ b/Mage.Sets/src/mage/cards/o/OsgirTheReconstructor.java
@@ -33,7 +33,6 @@ import mage.util.CardUtil;
 import java.util.UUID;
 
 /**
- *
  * @author Arketec
  */
 public final class OsgirTheReconstructor extends CardImpl {
@@ -81,15 +80,15 @@ enum OsgirTheReconstructorCostAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareCost(Ability ability, Game game) {
         int xValue = CardUtil.getSourceCostsTag(game, ability, "X", 0);
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller == null) {
             return;
         }
-        FilterCard filter = new FilterArtifactCard("an artifact card with mana value "+xValue+" from your graveyard");
+        FilterCard filter = new FilterArtifactCard("an artifact card with mana value " + xValue + " from your graveyard");
         filter.add(new ManaValuePredicate(ComparisonType.EQUAL_TO, xValue));
-        for (Cost cost: ability.getCosts()) {
+        for (Cost cost : ability.getCosts()) {
             if (cost instanceof ExileFromGraveCost) {
                 cost.getTargets().set(0, new TargetCardInYourGraveyard(filter));
             }
@@ -104,7 +103,7 @@ class OsgirTheReconstructorCreateArtifactTokensEffect extends OneShotEffect {
         this.staticText = "Create two tokens that are copies of the exiled card.";
     }
 
-    private OsgirTheReconstructorCreateArtifactTokensEffect(final OsgirTheReconstructorCreateArtifactTokensEffect effect)  {
+    private OsgirTheReconstructorCreateArtifactTokensEffect(final OsgirTheReconstructorCreateArtifactTokensEffect effect) {
         super(effect);
     }
 
@@ -127,11 +126,11 @@ class OsgirTheReconstructorCreateArtifactTokensEffect extends OneShotEffect {
         effect.setTargetPointer(new FixedTarget(card.getId(), game.getState().getZoneChangeCounter(card.getId())));
         effect.apply(game, source);
 
-        return  true;
+        return true;
     }
 
     @Override
-    public OsgirTheReconstructorCreateArtifactTokensEffect  copy() {
+    public OsgirTheReconstructorCreateArtifactTokensEffect copy() {
         return new OsgirTheReconstructorCreateArtifactTokensEffect(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/o/OverbeingOfMyth.java
+++ b/Mage.Sets/src/mage/cards/o/OverbeingOfMyth.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.TargetController;
 import mage.constants.Zone;
 
 /**
@@ -32,7 +31,7 @@ public final class OverbeingOfMyth extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Overbeing of Myth's power and toughness are each equal to the number of cards in your hand.
-        DynamicValue number = CardsInControllerHandCount.instance;
+        DynamicValue number = CardsInControllerHandCount.ANY;
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(number)));
 
         // At the beginning of your draw step, draw an additional card.

--- a/Mage.Sets/src/mage/cards/p/PhyrexianPurge.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianPurge.java
@@ -46,7 +46,7 @@ enum PhyrexianPurgeCostAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void increaseCost(Ability ability, Game game) {
         int numTargets = ability.getTargets().get(0).getTargets().size();
         if (numTargets > 0) {
             ability.addCost(new PayLifeCost(numTargets * 3));

--- a/Mage.Sets/src/mage/cards/p/PlateArmor.java
+++ b/Mage.Sets/src/mage/cards/p/PlateArmor.java
@@ -81,7 +81,7 @@ enum PlateArmorAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller != null) {
             int count = equipmentCount.calculate(game, ability, null);

--- a/Mage.Sets/src/mage/cards/p/PresenceOfTheWise.java
+++ b/Mage.Sets/src/mage/cards/p/PresenceOfTheWise.java
@@ -20,7 +20,7 @@ public final class PresenceOfTheWise extends CardImpl {
 
         // You gain 2 life for each card in your hand.
         this.getSpellAbility().addEffect(new GainLifeEffect(
-                new MultipliedValue(CardsInControllerHandCount.instance, 2),"You gain 2 life for each card in your hand"));
+                new MultipliedValue(CardsInControllerHandCount.ANY, 2),"You gain 2 life for each card in your hand"));
     }
 
     private PresenceOfTheWise(final PresenceOfTheWise card) {

--- a/Mage.Sets/src/mage/cards/p/PrototypePortal.java
+++ b/Mage.Sets/src/mage/cards/p/PrototypePortal.java
@@ -4,11 +4,8 @@ import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.VariableCost;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.costadjusters.ImprintedManaValueXCostAdjuster;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
@@ -42,10 +39,10 @@ public final class PrototypePortal extends CardImpl {
                 .setAbilityWord(AbilityWord.IMPRINT)
         );
 
-        // {X}, {tap}: Create a token that's a copy of the exiled card. X is the converted mana cost of that card.
+        // {X}, {T}: Create a token that's a copy of the exiled card. X is the converted mana cost of that card.
         Ability ability = new SimpleActivatedAbility(new PrototypePortalCreateTokenEffect(), new ManaCostsImpl<>("{X}"));
         ability.addCost(new TapSourceCost());
-        ability.setCostAdjuster(PrototypePortalAdjuster.instance);
+        ability.setCostAdjuster(ImprintedManaValueXCostAdjuster.instance);
         this.addAbility(ability);
     }
 
@@ -56,31 +53,6 @@ public final class PrototypePortal extends CardImpl {
     @Override
     public PrototypePortal copy() {
         return new PrototypePortal(this);
-    }
-}
-
-enum PrototypePortalAdjuster implements CostAdjuster {
-    instance;
-
-    @Override
-    public void adjustCosts(Ability ability, Game game) {
-        Permanent card = game.getPermanent(ability.getSourceId());
-        if (card != null) {
-            if (!card.getImprinted().isEmpty()) {
-                Card imprinted = game.getCard(card.getImprinted().get(0));
-                if (imprinted != null) {
-                    ability.clearManaCostsToPay();
-                    ability.addManaCostsToPay(new GenericManaCost(imprinted.getManaValue()));
-                }
-            }
-        }
-
-        // no {X} anymore as we already have imprinted the card with defined manacost
-        for (ManaCost cost : ability.getManaCostsToPay()) {
-            if (cost instanceof VariableCost) {
-                cost.setPaid();
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/p/PsychosisCrawler.java
+++ b/Mage.Sets/src/mage/cards/p/PsychosisCrawler.java
@@ -28,7 +28,7 @@ public final class PsychosisCrawler extends CardImpl {
         this.power = new MageInt(0);
         this.toughness = new MageInt(0);
 
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.ANY)));
         this.addAbility(new DrawCardControllerTriggeredAbility(new LoseLifeOpponentsEffect(1), false));
     }
 

--- a/Mage.Sets/src/mage/cards/p/Pteramander.java
+++ b/Mage.Sets/src/mage/cards/p/Pteramander.java
@@ -70,7 +70,7 @@ enum PteramanderAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         int count = cardsCount.calculate(game, ability, null);
         CardUtil.reduceCost(ability, count);
     }

--- a/Mage.Sets/src/mage/cards/q/QuestForTheNecropolis.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForTheNecropolis.java
@@ -56,7 +56,7 @@ enum QuestForTheNecropolisAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         int amount = Optional
                 .ofNullable(ability.getSourcePermanentIfItStillExists(game))
                 .map(permanent -> permanent.getCounters(game).getCount(CounterType.QUEST))

--- a/Mage.Sets/src/mage/cards/r/RalsStaticaster.java
+++ b/Mage.Sets/src/mage/cards/r/RalsStaticaster.java
@@ -45,7 +45,7 @@ public final class RalsStaticaster extends CardImpl {
         // Whenever Ral's Staticaster attacks, if you control a Ral planeswalker, Ral's Staticaster gets +1/+0 for each card in your hand until end of turn.
         this.addAbility(new ConditionalInterveningIfTriggeredAbility(
                 new AttacksTriggeredAbility(new BoostSourceEffect(
-                        CardsInControllerHandCount.instance, StaticValue.get(0),
+                        CardsInControllerHandCount.ANY, StaticValue.get(0),
                         Duration.EndOfTurn), false),
                 new PermanentsOnTheBattlefieldCondition(filter),
                 "Whenever {this} attacks, if you control a Ral planeswalker, "

--- a/Mage.Sets/src/mage/cards/r/RazorlashTransmogrant.java
+++ b/Mage.Sets/src/mage/cards/r/RazorlashTransmogrant.java
@@ -69,7 +69,7 @@ enum RazorlashTransmograntAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (makeMap(game, ability).values().stream().anyMatch(x -> x >= 4)) {
             CardUtil.reduceCost(ability, 4);
         }

--- a/Mage.Sets/src/mage/cards/r/RestlessDreams.java
+++ b/Mage.Sets/src/mage/cards/r/RestlessDreams.java
@@ -20,7 +20,7 @@ public final class RestlessDreams extends CardImpl {
     public RestlessDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{B}");
 
-        // As an additional cost to cast Restless Dreams, discard X cards.
+        // As an additional cost to cast this spell, discard X cards.
         this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Return X target creature cards from your graveyard to your hand.

--- a/Mage.Sets/src/mage/cards/r/RobobrainWarMind.java
+++ b/Mage.Sets/src/mage/cards/r/RobobrainWarMind.java
@@ -42,7 +42,7 @@ public final class RobobrainWarMind extends CardImpl {
         this.toughness = new MageInt(5);
 
         // Robobrain War Mind's power is equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.ANY)));
 
         // When Robobrain War Mind enters the battlefield, you get an amount of {E} equal to the number of artifact creatures you control.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new GetEnergyCountersControllerEffect(new PermanentsOnBattlefieldCount(filter))

--- a/Mage.Sets/src/mage/cards/s/SageOfAncientLore.java
+++ b/Mage.Sets/src/mage/cards/s/SageOfAncientLore.java
@@ -35,7 +35,7 @@ public final class SageOfAncientLore extends CardImpl {
         this.secondSideCardClazz = mage.cards.w.WerewolfOfAncientHunger.class;
 
         // Sage of Ancient Lore's power and toughness are each equal to the number of cards in your hand.
-        DynamicValue xValue = CardsInControllerHandCount.instance;
+        DynamicValue xValue = CardsInControllerHandCount.ANY;
         this.addAbility(new SimpleStaticAbility(Zone.ALL,
                 new ConditionalContinuousEffect(new SetBasePowerToughnessSourceEffect(xValue),
                         new TransformedCondition(true), "{this}'s power and toughness are each equal to the total number of cards in your hand")));

--- a/Mage.Sets/src/mage/cards/s/SanctumOfTranquilLight.java
+++ b/Mage.Sets/src/mage/cards/s/SanctumOfTranquilLight.java
@@ -65,7 +65,7 @@ enum SanctumOfTranquilLightAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller != null) {
             CardUtil.reduceCost(ability, count.calculate(game, ability, null));

--- a/Mage.Sets/src/mage/cards/s/ScorchedEarth.java
+++ b/Mage.Sets/src/mage/cards/s/ScorchedEarth.java
@@ -1,23 +1,15 @@
-
 package mage.cards.s;
 
-import mage.abilities.Ability;
-import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.common.DiscardTargetCost;
+import mage.abilities.costs.costadjusters.DiscardXCardsCostAdjuster;
+import mage.abilities.dynamicvalue.common.CardsInControllerHandCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DestroyTargetEffect;
-import mage.abilities.effects.common.InfoEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
-import mage.filter.common.FilterLandCard;
-import mage.game.Game;
-import mage.target.common.TargetCardInHand;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetLandPermanent;
 import mage.target.targetadjustment.XTargetsCountAdjuster;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -29,10 +21,8 @@ public final class ScorchedEarth extends CardImpl {
     public ScorchedEarth(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{R}");
 
-        // As an additional cost to cast Scorched Earth, discard X land cards.
-        Ability ability = new SimpleStaticAbility(Zone.ALL, new InfoEffect("as an additional cost to cast this spell, discard X land cards"));
-        ability.setRuleAtTheTop(true);
-        this.addAbility(ability);
+        // As an additional cost to cast this spell, discard X land cards.
+        DiscardXCardsCostAdjuster.addAdjusterAndMessage(this, StaticFilters.FILTER_CARD_LANDS);
 
         // Destroy X target lands.
         Effect effect = new DestroyTargetEffect();
@@ -40,7 +30,7 @@ public final class ScorchedEarth extends CardImpl {
         this.getSpellAbility().addTarget(new TargetLandPermanent());
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().setTargetAdjuster(new XTargetsCountAdjuster());
-        this.getSpellAbility().setCostAdjuster(ScorchedEarthCostAdjuster.instance);
+        this.getSpellAbility().addHint(CardsInControllerHandCount.LANDS.getHint());
     }
 
     private ScorchedEarth(final ScorchedEarth card) {
@@ -50,17 +40,5 @@ public final class ScorchedEarth extends CardImpl {
     @Override
     public ScorchedEarth copy() {
         return new ScorchedEarth(this);
-    }
-}
-
-enum ScorchedEarthCostAdjuster implements CostAdjuster {
-    instance;
-
-    @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int xValue = CardUtil.getSourceCostsTag(game, ability, "X", 0);
-        if (xValue > 0) {
-            ability.addCost(new DiscardTargetCost(new TargetCardInHand(xValue, xValue, new FilterLandCard("land cards"))));
-        }
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SeaGateRestoration.java
+++ b/Mage.Sets/src/mage/cards/s/SeaGateRestoration.java
@@ -22,7 +22,7 @@ import java.util.UUID;
  */
 public final class SeaGateRestoration extends ModalDoubleFacedCard {
 
-    private static final DynamicValue xValue = new IntPlusDynamicValue(1, CardsInControllerHandCount.instance);
+    private static final DynamicValue xValue = new IntPlusDynamicValue(1, CardsInControllerHandCount.ANY);
 
     public SeaGateRestoration(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo,

--- a/Mage.Sets/src/mage/cards/s/SeafloorStalker.java
+++ b/Mage.Sets/src/mage/cards/s/SeafloorStalker.java
@@ -60,7 +60,7 @@ enum SeafloorStalkerAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         Player controller = game.getPlayer(ability.getControllerId());
         if (controller != null) {
             int count = PartyCount.instance.calculate(game, ability, null);

--- a/Mage.Sets/src/mage/cards/s/SewerCrocodile.java
+++ b/Mage.Sets/src/mage/cards/s/SewerCrocodile.java
@@ -55,7 +55,7 @@ enum SewerCrocodileAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (DifferentManaValuesInGraveCondition.FIVE.apply(game, ability)) {
             CardUtil.reduceCost(ability, 3);
         }

--- a/Mage.Sets/src/mage/cards/s/SickeningDreams.java
+++ b/Mage.Sets/src/mage/cards/s/SickeningDreams.java
@@ -7,6 +7,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 
 import java.util.UUID;
@@ -19,8 +20,8 @@ public final class SickeningDreams extends CardImpl {
     public SickeningDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{1}{B}");
 
-        // As an additional cost to cast Sickening Dreams, discard X cards.
-        this.getSpellAbility().addCost(new DiscardXTargetCost(new FilterCard("cards"), true));
+        // As an additional cost to cast this spell, discard X cards.
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Sickening Dreams deals X damage to each creature and each player.
         this.getSpellAbility().addEffect(new DamageEverythingEffect(GetXValue.instance, new FilterCreaturePermanent()));

--- a/Mage.Sets/src/mage/cards/s/SkeletalScrying.java
+++ b/Mage.Sets/src/mage/cards/s/SkeletalScrying.java
@@ -61,7 +61,7 @@ enum SkeletalScryingAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareCost(Ability ability, Game game) {
         int xValue = CardUtil.getSourceCostsTag(game, ability, "X", 0);
         if (xValue > 0) {
             ability.addCost(new ExileFromGraveCost(new TargetCardInYourGraveyard(xValue, xValue, StaticFilters.FILTER_CARDS_FROM_YOUR_GRAVEYARD)));

--- a/Mage.Sets/src/mage/cards/s/SkirgeFamiliar.java
+++ b/Mage.Sets/src/mage/cards/s/SkirgeFamiliar.java
@@ -37,7 +37,7 @@ public final class SkirgeFamiliar extends CardImpl {
                 new DiscardCardCost(false),
                 // not perfect but for hand cards correct, activated abilities on Battlefield will miss one possible available mana
                 // to solve this we have to do possible mana calculation per pell/ability to use.
-                new IntPlusDynamicValue(-1, CardsInControllerHandCount.instance)
+                new IntPlusDynamicValue(-1, CardsInControllerHandCount.ANY)
                 ));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SokenzanSpellblade.java
+++ b/Mage.Sets/src/mage/cards/s/SokenzanSpellblade.java
@@ -15,7 +15,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 
 /**
  *
@@ -35,7 +34,7 @@ public final class SokenzanSpellblade extends CardImpl {
         // Bushido 1
         this.addAbility(new BushidoAbility(1));
         // {1}{R}: Sokenzan Spellblade gets +X/+0 until end of turn, where X is the number of cards in your hand.
-        Effect effect = new BoostSourceEffect(CardsInControllerHandCount.instance, StaticValue.get(0), Duration.EndOfTurn);
+        Effect effect = new BoostSourceEffect(CardsInControllerHandCount.ANY, StaticValue.get(0), Duration.EndOfTurn);
         effect.setText("{this} gets +X/+0 until end of turn, where X is the number of cards in your hand");
         this.addAbility(new SimpleActivatedAbility(
                 effect, new ManaCostsImpl<>("{1}{R}")

--- a/Mage.Sets/src/mage/cards/s/SophicCentaur.java
+++ b/Mage.Sets/src/mage/cards/s/SophicCentaur.java
@@ -17,7 +17,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 
 /**
  *
@@ -33,7 +32,7 @@ public final class SophicCentaur extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {2}{G}{G}, {tap}, Discard a card: You gain 2 life for each card in your hand.
-        DynamicValue lifeToGainAmount = new MultipliedValue(CardsInControllerHandCount.instance, 2);
+        DynamicValue lifeToGainAmount = new MultipliedValue(CardsInControllerHandCount.ANY, 2);
         Effect effect = new GainLifeEffect(lifeToGainAmount);
         effect.setText("You gain 2 life for each card in your hand");
         Ability ability = new SimpleActivatedAbility(effect, new ManaCostsImpl<>("{2}{G}{G}"));

--- a/Mage.Sets/src/mage/cards/s/SoramaroFirstToDream.java
+++ b/Mage.Sets/src/mage/cards/s/SoramaroFirstToDream.java
@@ -38,7 +38,7 @@ public final class SoramaroFirstToDream extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Soramaro, First to Dream's power and toughness are each equal to the number of cards in your hand.
-         DynamicValue xValue= CardsInControllerHandCount.instance;
+         DynamicValue xValue= CardsInControllerHandCount.ANY;
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // {4}, Return a land you control to its owner's hand: Draw a card.

--- a/Mage.Sets/src/mage/cards/s/SoulFoundry.java
+++ b/Mage.Sets/src/mage/cards/s/SoulFoundry.java
@@ -3,11 +3,8 @@ package mage.cards.s;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.costs.CostAdjuster;
-import mage.abilities.costs.VariableCost;
 import mage.abilities.costs.common.TapSourceCost;
-import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.costadjusters.ImprintedManaValueXCostAdjuster;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
@@ -45,7 +42,7 @@ public final class SoulFoundry extends CardImpl {
         // {X}, {T}: Create a token that's a copy of the exiled card. X is the converted mana cost of that card.
         Ability ability = new SimpleActivatedAbility(new SoulFoundryEffect(), new ManaCostsImpl<>("{X}"));
         ability.addCost(new TapSourceCost());
-        ability.setCostAdjuster(SoulFoundryAdjuster.instance);
+        ability.setCostAdjuster(ImprintedManaValueXCostAdjuster.instance);
         this.addAbility(ability);
     }
 
@@ -56,31 +53,6 @@ public final class SoulFoundry extends CardImpl {
     @Override
     public SoulFoundry copy() {
         return new SoulFoundry(this);
-    }
-}
-
-enum SoulFoundryAdjuster implements CostAdjuster {
-    instance;
-
-    @Override
-    public void adjustCosts(Ability ability, Game game) {
-        Permanent sourcePermanent = game.getPermanent(ability.getSourceId());
-        if (sourcePermanent != null) {
-            if (!sourcePermanent.getImprinted().isEmpty()) {
-                Card imprinted = game.getCard(sourcePermanent.getImprinted().get(0));
-                if (imprinted != null) {
-                    ability.clearManaCostsToPay();
-                    ability.addManaCostsToPay(new GenericManaCost(imprinted.getManaValue()));
-                }
-            }
-        }
-
-        // no {X} anymore as we already have imprinted the card with defined manacost
-        for (ManaCost cost : ability.getManaCostsToPay()) {
-            if (cost instanceof VariableCost) {
-                cost.setPaid();
-            }
-        }
     }
 }
 

--- a/Mage.Sets/src/mage/cards/s/SpiralingEmbers.java
+++ b/Mage.Sets/src/mage/cards/s/SpiralingEmbers.java
@@ -23,7 +23,7 @@ public final class SpiralingEmbers extends CardImpl {
 
 
         // Spiraling Embers deals damage to any target equal to the number of cards in your hand.
-        Effect effect = new DamageTargetEffect(CardsInControllerHandCount.instance);
+        Effect effect = new DamageTargetEffect(CardsInControllerHandCount.ANY);
         effect.setText("{this} deals damage to any target equal to the number of cards in your hand.");
         this.getSpellAbility().addEffect(effect);
         this.getSpellAbility().addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/s/SpontaneousGeneration.java
+++ b/Mage.Sets/src/mage/cards/s/SpontaneousGeneration.java
@@ -19,7 +19,7 @@ public final class SpontaneousGeneration extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{G}");
 
         // Create a 1/1 green Saproling creature token for each card in your hand.
-        this.getSpellAbility().addEffect(new CreateTokenEffect(new SaprolingToken(), CardsInControllerHandCount.instance));
+        this.getSpellAbility().addEffect(new CreateTokenEffect(new SaprolingToken(), CardsInControllerHandCount.ANY));
     }
 
     private SpontaneousGeneration(final SpontaneousGeneration card) {

--- a/Mage.Sets/src/mage/cards/s/StingerbackTerror.java
+++ b/Mage.Sets/src/mage/cards/s/StingerbackTerror.java
@@ -22,7 +22,7 @@ import java.util.UUID;
  */
 public final class StingerbackTerror extends CardImpl {
 
-    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
 
     public StingerbackTerror(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}{R}");

--- a/Mage.Sets/src/mage/cards/s/Sturmgeist.java
+++ b/Mage.Sets/src/mage/cards/s/Sturmgeist.java
@@ -30,7 +30,7 @@ public final class Sturmgeist extends CardImpl {
 
         this.addAbility(FlyingAbility.getInstance());
         // Sturmgeist's power and toughness are each equal to the number of cards in your hand.
-        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.instance)));
+        this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(CardsInControllerHandCount.ANY)));
         // Whenever Sturmgeist deals combat damage to a player, draw a card.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new DrawCardSourceControllerEffect(1), false));
     }

--- a/Mage.Sets/src/mage/cards/s/SunbringersTouch.java
+++ b/Mage.Sets/src/mage/cards/s/SunbringersTouch.java
@@ -23,7 +23,7 @@ public final class SunbringersTouch extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{G}{G}");
 
         // Bolster X, where X is the number of cards in your hand. 
-        this.getSpellAbility().addEffect(new BolsterEffect(CardsInControllerHandCount.instance).setText("Bolster X, where X is the number of cards in your hand."));
+        this.getSpellAbility().addEffect(new BolsterEffect(CardsInControllerHandCount.ANY).setText("Bolster X, where X is the number of cards in your hand."));
         
         // Each creature you control with a +1/+1 counter on it gains trample until end of turn.
         Effect effect = new GainAbilityControlledEffect(

--- a/Mage.Sets/src/mage/cards/s/SwordOfWarAndPeace.java
+++ b/Mage.Sets/src/mage/cards/s/SwordOfWarAndPeace.java
@@ -62,7 +62,7 @@ class SwordOfWarAndPeaceAbility extends TriggeredAbilityImpl {
 
     public SwordOfWarAndPeaceAbility() {
         super(Zone.BATTLEFIELD, new SwordOfWarAndPeaceDamageEffect());
-        this.addEffect(new GainLifeEffect(CardsInControllerHandCount.instance));
+        this.addEffect(new GainLifeEffect(CardsInControllerHandCount.ANY));
     }
 
     private SwordOfWarAndPeaceAbility(final SwordOfWarAndPeaceAbility ability) {

--- a/Mage.Sets/src/mage/cards/s/SylvanYeti.java
+++ b/Mage.Sets/src/mage/cards/s/SylvanYeti.java
@@ -26,7 +26,7 @@ public final class SylvanYeti extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Sylvan Yeti's power is equal to the number of cards in your hand.
-        Effect effect = new SetBasePowerSourceEffect(CardsInControllerHandCount.instance);
+        Effect effect = new SetBasePowerSourceEffect(CardsInControllerHandCount.ANY);
         this.addAbility(new SimpleStaticAbility(Zone.ALL, effect));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SyrElenoraTheDiscerning.java
+++ b/Mage.Sets/src/mage/cards/s/SyrElenoraTheDiscerning.java
@@ -30,7 +30,7 @@ public final class SyrElenoraTheDiscerning extends CardImpl {
 
         // Syr Elenora the Discerning's power is equal to the number of cards in your hand.
         this.addAbility(new SimpleStaticAbility(
-                Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.instance)
+                Zone.ALL, new SetBasePowerSourceEffect(CardsInControllerHandCount.ANY)
         ));
 
         // When Syr Elenora enters the battlefield, draw a card.

--- a/Mage.Sets/src/mage/cards/t/TamiyosLogbook.java
+++ b/Mage.Sets/src/mage/cards/t/TamiyosLogbook.java
@@ -61,7 +61,7 @@ enum TamiyosLogbookAdjuster implements CostAdjuster {
     );
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         int count = game.getBattlefield().count(filter, ability.getControllerId(), ability, game);
         CardUtil.reduceCost(ability, count);
     }

--- a/Mage.Sets/src/mage/cards/t/TheArchimandrite.java
+++ b/Mage.Sets/src/mage/cards/t/TheArchimandrite.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 public final class TheArchimandrite extends CardImpl {
 
     private static final DynamicValue xValue = new AdditiveDynamicValue(
-            CardsInControllerHandCount.instance, StaticValue.get(-4)
+            CardsInControllerHandCount.ANY, StaticValue.get(-4)
     );
     private static final FilterPermanent filter = new FilterControlledPermanent();
     private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent();

--- a/Mage.Sets/src/mage/cards/t/TheGreatSynthesis.java
+++ b/Mage.Sets/src/mage/cards/t/TheGreatSynthesis.java
@@ -41,7 +41,7 @@ public class TheGreatSynthesis extends CardImpl {
         //I — Draw cards equal to the number of cards in your hand. You have no maximum hand size for as long as you
         //control The Great Synthesis.
         sagaAbility.addChapterEffect(this, SagaChapter.CHAPTER_I,
-                new DrawCardSourceControllerEffect(CardsInControllerHandCount.instance)
+                new DrawCardSourceControllerEffect(CardsInControllerHandCount.ANY)
                         .setText("draw cards equal to the number of cards in your hand"),
                 new MaximumHandSizeControllerEffect(Integer.MAX_VALUE, Duration.WhileOnBattlefield,
                         MaximumHandSizeControllerEffect.HandSizeModification.SET)

--- a/Mage.Sets/src/mage/cards/t/TheRoyalScions.java
+++ b/Mage.Sets/src/mage/cards/t/TheRoyalScions.java
@@ -88,7 +88,7 @@ class TheRoyalScionsCreateReflexiveTriggerEffect extends OneShotEffect {
     public boolean apply(Game game, Ability source) {
         effect.apply(game, source);
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(
-                new DamageTargetEffect(CardsInControllerHandCount.instance), false,
+                new DamageTargetEffect(CardsInControllerHandCount.ANY), false,
                 "{this} deals damage to any target equal to the number of cards in your hand"
         );
         ability.addTarget(new TargetAnyTarget());

--- a/Mage.Sets/src/mage/cards/t/ThroneOfEldraine.java
+++ b/Mage.Sets/src/mage/cards/t/ThroneOfEldraine.java
@@ -170,7 +170,7 @@ enum ThroneOfEldraineAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareCost(Ability ability, Game game) {
         ObjectColor color = (ObjectColor) game.getState().getValue(ability.getSourceId() + "_color");
         if (color == null) {
             return;

--- a/Mage.Sets/src/mage/cards/t/TishanaVoiceOfThunder.java
+++ b/Mage.Sets/src/mage/cards/t/TishanaVoiceOfThunder.java
@@ -32,7 +32,7 @@ public final class TishanaVoiceOfThunder extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Tishana, Voice of Thunder's power and toughness are each equal to the number of cards in your hand.
-        DynamicValue xValue = CardsInControllerHandCount.instance;
+        DynamicValue xValue = CardsInControllerHandCount.ANY;
         this.addAbility(new SimpleStaticAbility(Zone.ALL, new SetBasePowerToughnessSourceEffect(xValue)));
 
         // You have no maximum hand size.

--- a/Mage.Sets/src/mage/cards/t/TowashiGuideBot.java
+++ b/Mage.Sets/src/mage/cards/t/TowashiGuideBot.java
@@ -81,7 +81,7 @@ enum TowashiGuideBotAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, game.getBattlefield().count(
                 filter, ability.getControllerId(), ability, game
         ));

--- a/Mage.Sets/src/mage/cards/t/TurbulentDreams.java
+++ b/Mage.Sets/src/mage/cards/t/TurbulentDreams.java
@@ -20,7 +20,7 @@ public final class TurbulentDreams extends CardImpl {
     public TurbulentDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{U}{U}");
 
-        // As an additional cost to cast Turbulent Dreams, discard X cards.
+        // As an additional cost to cast this spell, discard X cards.
         this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Return X target nonland permanents to their owners' hands.

--- a/Mage.Sets/src/mage/cards/u/UnionOfTheThirdPath.java
+++ b/Mage.Sets/src/mage/cards/u/UnionOfTheThirdPath.java
@@ -20,7 +20,7 @@ public final class UnionOfTheThirdPath extends CardImpl {
 
         // Draw a card, then you gain life equal to the number of cards in your hand.
         this.getSpellAbility().addEffect(new DrawCardSourceControllerEffect(1));
-        this.getSpellAbility().addEffect(new GainLifeEffect(CardsInControllerHandCount.instance).concatBy(", then"));
+        this.getSpellAbility().addEffect(new GainLifeEffect(CardsInControllerHandCount.ANY).concatBy(", then"));
     }
 
     private UnionOfTheThirdPath(final UnionOfTheThirdPath card) {

--- a/Mage.Sets/src/mage/cards/u/UrgentNecropsy.java
+++ b/Mage.Sets/src/mage/cards/u/UrgentNecropsy.java
@@ -61,7 +61,7 @@ enum UrgentNecropsyAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareCost(Ability ability, Game game) {
         int xValue = ability
                 .getTargets()
                 .stream()

--- a/Mage.Sets/src/mage/cards/v/VengefulDreams.java
+++ b/Mage.Sets/src/mage/cards/v/VengefulDreams.java
@@ -21,8 +21,8 @@ public final class VengefulDreams extends CardImpl {
     public VengefulDreams(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{W}{W}");
 
-        // As an additional cost to cast Vengeful Dreams, discard X cards.
-        this.getSpellAbility().addCost(new DiscardXTargetCost(new FilterCard("cards"), true));
+        // As an additional cost to cast this spell, discard X cards.
+        this.getSpellAbility().addCost(new DiscardXTargetCost(StaticFilters.FILTER_CARD_CARDS, true));
 
         // Exile X target attacking creatures.
         Effect effect = new ExileTargetEffect();

--- a/Mage.Sets/src/mage/cards/v/VensersJournal.java
+++ b/Mage.Sets/src/mage/cards/v/VensersJournal.java
@@ -13,7 +13,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Zone;
 
 /**
  *
@@ -29,7 +28,7 @@ public final class VensersJournal extends CardImpl {
         this.addAbility(new SimpleStaticAbility(effect));
 
         // At the beginning of your upkeep, you gain 1 life for each card in your hand.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new GainLifeEffect(CardsInControllerHandCount.instance)
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new GainLifeEffect(CardsInControllerHandCount.ANY)
                 .setText("you gain 1 life for each card in your hand")));
     }
 

--- a/Mage.Sets/src/mage/cards/v/VindictiveFlamestoker.java
+++ b/Mage.Sets/src/mage/cards/v/VindictiveFlamestoker.java
@@ -65,7 +65,7 @@ enum VindictiveFlamestokerAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         int amount = Optional
                 .ofNullable(ability.getSourcePermanentIfItStillExists(game))
                 .filter(Objects::nonNull)

--- a/Mage.Sets/src/mage/cards/v/VisionOfTheUnspeakable.java
+++ b/Mage.Sets/src/mage/cards/v/VisionOfTheUnspeakable.java
@@ -36,8 +36,8 @@ public final class VisionOfTheUnspeakable extends CardImpl {
 
         // Vision of the Unspeakable gets +1/+1 for each card in your hand.
         this.addAbility(new SimpleStaticAbility(new BoostSourceEffect(
-                CardsInControllerHandCount.instance,
-                CardsInControllerHandCount.instance,
+                CardsInControllerHandCount.ANY,
+                CardsInControllerHandCount.ANY,
                 Duration.WhileOnBattlefield
         )));
     }

--- a/Mage.Sets/src/mage/cards/v/VoldarenEstate.java
+++ b/Mage.Sets/src/mage/cards/v/VoldarenEstate.java
@@ -132,7 +132,7 @@ enum VoldarenEstateCostAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, vampireCount.calculate(game, ability, null));
     }
 }

--- a/Mage.Sets/src/mage/cards/v/VoodooDoll.java
+++ b/Mage.Sets/src/mage/cards/v/VoodooDoll.java
@@ -72,7 +72,7 @@ enum VoodooDollAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void prepareCost(Ability ability, Game game) {
         Permanent sourcePermanent = game.getPermanent(ability.getSourceId());
         if (sourcePermanent != null) {
             int pin = sourcePermanent.getCounters(game).getCount(CounterType.PIN);

--- a/Mage.Sets/src/mage/cards/w/WarpedPhysique.java
+++ b/Mage.Sets/src/mage/cards/w/WarpedPhysique.java
@@ -18,13 +18,13 @@ import mage.target.common.TargetCreaturePermanent;
 
 public final class WarpedPhysique extends CardImpl {
 
-    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.instance);
+    private static final DynamicValue xValue = new SignInversionDynamicValue(CardsInControllerHandCount.ANY);
 
     public WarpedPhysique(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{U}{B}");
 
         // Target creature gets +X/-X until end of turn, where X is the number of cards in your hand.
-        this.getSpellAbility().addEffect(new BoostTargetEffect(CardsInControllerHandCount.instance, xValue, Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(CardsInControllerHandCount.ANY, xValue, Duration.EndOfTurn));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/w/WaytaTrainerProdigy.java
+++ b/Mage.Sets/src/mage/cards/w/WaytaTrainerProdigy.java
@@ -101,7 +101,7 @@ enum WaytaTrainerProdigyAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         if (game.inCheckPlayableState()) {
             int controllerTargets = 0; //number of possible targets controlled by the ability's controller
             for (UUID permId : CardUtil.getAllPossibleTargets(ability, game)) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/AdjusterCostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/AdjusterCostTest.java
@@ -1,0 +1,587 @@
+package org.mage.test.cards.cost.additional;
+
+import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.CostAdjuster;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.CreateTokenEffect;
+import mage.constants.CardType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.permanent.token.custom.CreatureToken;
+import mage.util.CardUtil;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+import java.util.Arrays;
+
+/**
+ * @author JayDi85
+ */
+public class AdjusterCostTest extends CardTestPlayerBaseWithAIHelps {
+
+    private void prepareCustomCardInHand(String cardName, String spellManaCost, CostAdjuster costAdjuster) {
+        SpellAbility spellAbility = new SpellAbility(new ManaCostsImpl<>(spellManaCost), cardName);
+        if (costAdjuster != null) {
+            spellAbility.setCostAdjuster(costAdjuster);
+        }
+        addCustomCardWithAbility(
+                cardName,
+                playerA,
+                null,
+                spellAbility,
+                CardType.ENCHANTMENT,
+                spellManaCost,
+                Zone.HAND
+        );
+    }
+
+    private void prepareCustomPermanent(String cardName, String abilityName, String abilityManaCost, CostAdjuster costAdjuster) {
+        Ability ability = new SimpleActivatedAbility(
+                new CreateTokenEffect(new CreatureToken(1, 1).withName("test token")).setText(abilityName),
+                new ManaCostsImpl<>(abilityManaCost)
+        );
+        if (costAdjuster != null) {
+            ability.setCostAdjuster(costAdjuster);
+        }
+        addCustomCardWithAbility(cardName, playerA, ability);
+    }
+
+    @Test
+    public void test_DistributeValues() {
+        // make sure it can distribute values between min and max and skip useless values (example: mana optimization)
+
+        Assert.assertEquals(Arrays.asList(), CardUtil.distributeValues(0, 0, 0));
+        Assert.assertEquals(Arrays.asList(), CardUtil.distributeValues(0, -10, 10));
+        Assert.assertEquals(Arrays.asList(), CardUtil.distributeValues(0, Integer.MIN_VALUE, Integer.MAX_VALUE));
+
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(1, 0, 0));
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(1, 0, 1));
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(1, 0, 2));
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(1, 0, 3));
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(1, 0, 9));
+
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(2, 0, 0));
+        Assert.assertEquals(Arrays.asList(0, 1), CardUtil.distributeValues(2, 0, 1));
+        Assert.assertEquals(Arrays.asList(0, 2), CardUtil.distributeValues(2, 0, 2));
+        Assert.assertEquals(Arrays.asList(0, 3), CardUtil.distributeValues(2, 0, 3));
+        Assert.assertEquals(Arrays.asList(0, 9), CardUtil.distributeValues(2, 0, 9));
+
+        Assert.assertEquals(Arrays.asList(0), CardUtil.distributeValues(3, 0, 0));
+        Assert.assertEquals(Arrays.asList(0, 1), CardUtil.distributeValues(3, 0, 1));
+        Assert.assertEquals(Arrays.asList(0, 1, 2), CardUtil.distributeValues(3, 0, 2));
+        Assert.assertEquals(Arrays.asList(0, 2, 3), CardUtil.distributeValues(3, 0, 3));
+        Assert.assertEquals(Arrays.asList(0, 5, 9), CardUtil.distributeValues(3, 0, 9));
+
+        Assert.assertEquals(Arrays.asList(10, 15, 20), CardUtil.distributeValues(3, 10, 20));
+        Assert.assertEquals(Arrays.asList(10, 16, 21), CardUtil.distributeValues(3, 10, 21));
+        Assert.assertEquals(Arrays.asList(10, 16, 22), CardUtil.distributeValues(3, 10, 22));
+        Assert.assertEquals(Arrays.asList(10, 17, 23), CardUtil.distributeValues(3, 10, 23));
+        Assert.assertEquals(Arrays.asList(10, 20, 29), CardUtil.distributeValues(3, 10, 29));
+
+        Assert.assertEquals(Arrays.asList(10), CardUtil.distributeValues(5, 10, 10));
+        Assert.assertEquals(Arrays.asList(10, 11), CardUtil.distributeValues(5, 10, 11));
+        Assert.assertEquals(Arrays.asList(10, 11, 12), CardUtil.distributeValues(5, 10, 12));
+        Assert.assertEquals(Arrays.asList(10, 11, 12, 13), CardUtil.distributeValues(5, 10, 13));
+        Assert.assertEquals(Arrays.asList(10, 11, 13, 14, 15), CardUtil.distributeValues(5, 10, 15));
+        Assert.assertEquals(Arrays.asList(10, 13, 15, 18, 20), CardUtil.distributeValues(5, 10, 20));
+    }
+
+    @Test
+    public void test_X_SpellAbility() {
+        prepareCustomCardInHand("test card", "{X}{1}", null);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "test card");
+        setChoice(playerA, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "test card", 1);
+    }
+
+    @Test
+    public void test_X_ActivatedAbility() {
+        prepareCustomPermanent("test card", "test ability", "{X}{1}", null);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}{1}:");
+        setChoice(playerA, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "test token", 1);
+    }
+
+    @Test
+    public void test_prepareX_SpellAbility_TestFrameworkMustCatchLimits() {
+        prepareCustomCardInHand("test card", "{X}{1}", new CostAdjuster() {
+            @Override
+            public void prepareX(Ability ability, Game game) {
+                ability.setVariableCostsMinMax(0, 1);
+            }
+        });
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "test card");
+        setChoice(playerA, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertTrue("X must have limits: " + e.getMessage(), e.getMessage().contains("Found wrong X value = 2"));
+            Assert.assertTrue("X must have limits: " + e.getMessage(), e.getMessage().contains("from 0 to 1"));
+            return;
+        }
+        Assert.fail("test must fail");
+    }
+
+    @Test
+    @Ignore // TODO: AI must support game simulations for X choice, see announceXMana
+    public void test_prepareX_SpellAbility_AI() {
+        prepareCustomCardInHand("test card", "{X}{1}", new CostAdjuster() {
+            @Override
+            public void prepareX(Ability ability, Game game) {
+                ability.setVariableCostsMinMax(0, 10);
+            }
+        });
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        // AI must play card and use min good value
+        // it's bad to set X=1 for battlefield score cause card will give same score for X=0, X=1
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "test card", 1);
+        assertTappedCount("Forest", true, 1); // must choose X=0
+    }
+
+    @Test
+    public void test_prepareX_ActivatedAbility_TestFrameworkMustCatchLimits() {
+        prepareCustomPermanent("test card", "test ability", "{X}{1}", new CostAdjuster() {
+            @Override
+            public void prepareX(Ability ability, Game game) {
+                ability.setVariableCostsMinMax(0, 1);
+            }
+        });
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}{1}:");
+        setChoice(playerA, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertTrue("X must have limits: " + e.getMessage(), e.getMessage().contains("Found wrong X value = 2"));
+            Assert.assertTrue("X must have limits: " + e.getMessage(), e.getMessage().contains("from 0 to 1"));
+            return;
+        }
+        Assert.fail("test must fail");
+    }
+
+    @Test
+    @Ignore // TODO: AI must support game simulations for X choice, see announceXMana
+    // TODO: implement AI and add tests for non-mana X values (announceXCost)
+    public void test_prepareX_ActivatedAbility_AI() {
+        prepareCustomPermanent("test card", "test ability", "{X}{1}", new CostAdjuster() {
+            @Override
+            public void prepareX(Ability ability, Game game) {
+                ability.setVariableCostsMinMax(0, 10);
+            }
+        });
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        // AI must activate ability with min good value for X
+        // it's bad to set X=1 for battlefield score cause card will give same score for X=0, X=1
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "test token", 1);
+        assertTappedCount("Forest", true, 1); // must choose X=0
+    }
+
+    @Test
+    public void test_prepareX_SpellAbility_ScorchedEarth_PayZero() {
+        // with X announce
+
+        // As an additional cost to cast this spell, discard X land cards.
+        // Destroy X target lands.
+        addCard(Zone.HAND, playerA, "Scorched Earth"); // {X}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 0 + 1);
+        addCard(Zone.HAND, playerA, "Island", 1);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 10);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scorched Earth");
+        setChoice(playerA, "X=0");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+    }
+
+    @Test
+    public void test_prepareX_SpellAbility_ScorchedEarth_PaySome() {
+        // with X announce
+
+        // As an additional cost to cast this spell, discard X land cards.
+        // Destroy X target lands.
+        addCard(Zone.HAND, playerA, "Scorched Earth"); // {X}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2 + 1);
+        addCard(Zone.HAND, playerA, "Island", 10);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 10);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scorched Earth");
+        setChoice(playerA, "X=2");
+        addTarget(playerA, "Forest", 2); // to destroy
+        setChoice(playerA, "Island", 2); // discard cost
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+    }
+
+    @Test
+    public void test_prepareX_SpellAbility_ScorchedEarth_PayAll() {
+        // with X announce
+
+        // As an additional cost to cast this spell, discard X land cards.
+        // Destroy X target lands.
+        addCard(Zone.HAND, playerA, "Scorched Earth"); // {X}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 10 + 1);
+        addCard(Zone.HAND, playerA, "Island", 10);
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 10);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scorched Earth");
+        setChoice(playerA, "X=10");
+        addTarget(playerA, "Forest", 10); // to destroy
+        setChoice(playerA, "Island", 10); // discard cost
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+    }
+
+    @Test
+    public void test_prepareX_ActivatedAbility_BargainingTable_PayZero() {
+        // with direct X (without announce)
+
+        // {X}, {T}: Draw a card. X is the number of cards in an opponent's hand.
+        addCard(Zone.BATTLEFIELD, playerA, "Bargaining Table");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        //
+        // no cards in opponent's hand
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}:");
+        setChoice(playerA, playerB.getName());
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, 1);
+    }
+
+    @Test
+    public void test_prepareX_ActivatedAbility_BargainingTable_PaySome() {
+        // with direct X (without announce)
+
+        // {X}, {T}: Draw a card. X is the number of cards in an opponent's hand.
+        addCard(Zone.BATTLEFIELD, playerA, "Bargaining Table");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        //
+        addCard(Zone.HAND, playerB, "Forest", 3);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}:");
+        setChoice(playerA, playerB.getName());
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, 1);
+    }
+
+    @Test
+    public void test_prepareX_ActivatedAbility_BargainingTable_CantPay() {
+        // with direct X (without announce)
+
+        // {X}, {T}: Draw a card. X is the number of cards in an opponent's hand.
+        addCard(Zone.BATTLEFIELD, playerA, "Bargaining Table");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        //
+        addCard(Zone.HAND, playerB, "Forest", 3);
+
+        // must not request opponent choice because it must see min hand size as 3
+        checkPlayableAbility("must not able to activate due lack of mana", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}:", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, 0);
+    }
+
+    @Test
+    public void test_prepareX_ActivatedAbility_BargainingTable_UnboundFlourishingMustCopy() {
+        // with direct X (without announce)
+
+        // {X}, {T}: Draw a card. X is the number of cards in an opponent's hand.
+        addCard(Zone.BATTLEFIELD, playerA, "Bargaining Table");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        //
+        addCard(Zone.HAND, playerB, "Forest", 3);
+        //
+        // Whenever you cast a permanent spell with a mana cost that contains {X}, double the value of X.
+        // Whenever you cast an instant or sorcery spell or activate an ability, if that spell’s mana cost or that
+        // ability’s activation cost contains {X}, copy that spell or ability. You may choose new targets for the copy.
+        addCard(Zone.BATTLEFIELD, playerA, "Unbound Flourishing", 1);
+
+        // Unbound Flourishing must see {X} mana cost and duplicate ability on stack
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}:");
+        setChoice(playerA, playerB.getName());
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, 2); // from original and copied abilities
+    }
+
+    @Test
+    public void test_prepareX_NecropolisFiend() {
+        // {X}, {T}, Exile X cards from your graveyard: Target creature gets -X/-X until end of turn.
+        addCard(Zone.BATTLEFIELD, playerA, "Necropolis Fiend");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears", 3);
+        //
+        addCard(Zone.BATTLEFIELD, playerB, "Ancient Bronze Dragon"); // 7/7
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}, Exile");
+        setChoice(playerA, "X=2");
+        addTarget(playerA, "Ancient Bronze Dragon"); // to -2/-2
+        setChoice(playerA, "Grizzly Bears", 2);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPowerToughness(playerB, "Ancient Bronze Dragon", 7 - 2, 7 - 2);
+    }
+
+    @Test
+    public void test_prepareX_OpenTheWay() {
+        skipInitShuffling();
+
+        // X can't be greater than the number of players in the game.
+        // Reveal cards from the top of your library until you reveal X land cards.
+        // Put those land cards onto the battlefield tapped and the rest on the bottom of your library in a random order.
+        addCard(Zone.HAND, playerA, "Open the Way"); // {X}{G}{G}
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2 + 2);
+        addCard(Zone.LIBRARY, playerA, "Island", 5);
+
+        // min/max test require multiple tests (see above), so just disable setChoice and look at logs for good limits
+        // example: Message: Announce the value for {X} (any value)
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Open the Way");
+        setChoice(playerA, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Island", 2);
+    }
+
+    @Test
+    public void test_prepareX_KnollspineInvocation() {
+        skipInitShuffling();
+
+        // {X}, Discard a card with mana value X: This enchantment deals X damage to any target.
+        addCard(Zone.BATTLEFIELD, playerA, "Knollspine Invocation");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        //
+        addCard(Zone.LIBRARY, playerA, "Grizzly Bears", 1); // {1}{G}
+
+        // turn 1 - can't play due empty hand
+        checkPlayableAbility("no cards to discard", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, Discard", false);
+
+        // turn 3 - can't play due no mana
+        activateManaAbility(3, PhaseStep.UPKEEP, playerA, "{T}: Add {G}", 2);
+        checkPlayableAbility("no mana to activate", 3, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, Discard", false);
+
+        // turn 5 - can play
+        checkPlayableAbility("must able to activate", 5, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, Discard", true);
+        activateAbility(5, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, Discard");
+        setChoice(playerA, "Grizzly Bears"); // discard
+        addTarget(playerA, playerB); // damage
+
+        setStrictChooseMode(true);
+        setStopAt(5, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 2);
+    }
+
+    @Test
+    public void test_prepareX_EliteArcanist() {
+        // When Elite Arcanist enters the battlefield, you may exile an instant card from your hand.
+        // {X}, {T}: Copy the exiled card. You may cast the copy without paying its mana cost. X is the converted mana cost of the exiled card.
+        addCard(Zone.HAND, playerA, "Elite Arcanist"); // {3}{U}
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4 + 1);
+        addCard(Zone.HAND, playerA, "Lightning Bolt", 1);
+
+        // turn 1
+        // prepare arcanist
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Elite Arcanist");
+        setChoice(playerA, true); // use exile
+        setChoice(playerA, "Lightning Bolt"); // to exile and copy later
+
+        // turn 3
+        // cast copy
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}: Copy");
+        setChoice(playerA, true); // cast copy
+        addTarget(playerA, playerB); // damage
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertTappedCount("Island", true, 1); // used to cast copy for {1}
+        assertLife(playerB, 20 - 3);
+    }
+
+    @Test
+    public void test_modifyCost_Fireball() {
+        // This spell costs {1} more to cast for each target beyond the first.
+        // Fireball deals X damage divided evenly, rounded down, among any number of targets.
+        addCard(Zone.HAND, playerA, "Fireball"); // {X}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3 + 1); // 3 for x=2 cast, 1 for x2 targets
+        //
+        addCard(Zone.BATTLEFIELD, playerA, "Arbor Elf", 3); // 1/1
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fireball");
+        setChoice(playerA, "X=2");
+        addTarget(playerA, "Arbor Elf^Arbor Elf");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 20);
+        assertTappedCount("Mountain", true, 3 + 1); // 3 for x=2 cast, 1 for x2 targets
+        assertGraveyardCount(playerA, "Arbor Elf", 2);
+        assertPermanentCount(playerA, "Arbor Elf", 1);
+    }
+
+    @Test
+    public void test_modifyCost_DeepwoodDenizen() {
+        // {5}{G}, {T}: Draw a card. This ability costs {1} less to activate for each +1/+1 counter on creatures you control.
+        addCard(Zone.BATTLEFIELD, playerA, "Deepwood Denizen");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 6 - 3);
+        //
+        // +1: Distribute three +1/+1 counters among one, two, or three target creatures you control
+        addCard(Zone.BATTLEFIELD, playerA, "Ajani, Mentor of Heroes", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Arbor Elf", 1);
+
+        checkPlayableAbility("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "{5}{G}, {T}: Draw", false);
+
+        // add +3 counters and get -3 cost decrease
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+1: Distribute");
+        addTargetAmount(playerA, "Arbor Elf", 2);
+        addTargetAmount(playerA, "Deepwood Denizen", 1);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        checkPlayableAbility("after", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "{5}{G}, {T}: Draw", true);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{5}{G}, {T}: Draw");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, 1); // +1 from draw ability
+    }
+
+    @Test
+    public void test_modifyCost_BaruWurmspeaker() {
+        // Wurms you control get +2/+2 and have trample.
+        // {7}{G}, {T}: Create a 4/4 green Wurm creature token. This ability costs {X} less to activate, where X is the greatest power among Wurms you control.
+        addCard(Zone.BATTLEFIELD, playerA, "Baru, Wurmspeaker");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+        //
+        // When this creature dies, create a 3/3 colorless Phyrexian Wurm artifact creature token with deathtouch
+        // and a 3/3 colorless Phyrexian Wurm artifact creature token with lifelink.
+        addCard(Zone.HAND, playerA, "Wurmcoil Engine", 1); // {6}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 6);
+
+        checkPlayableAbility("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "{7}{G}, {T}: Create", false);
+
+        // turn 1
+        // prepare wurm and get -8 cost decrease (6 wurm + 2 boost)
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wurmcoil Engine");
+
+        // turn 3
+        waitStackResolved(3, PhaseStep.PRECOMBAT_MAIN, playerA);
+        checkPlayableAbility("after", 3, PhaseStep.PRECOMBAT_MAIN, playerA, "{7}{G}, {T}: Create", true);
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{7}{G}, {T}: Create");
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertTokenCount(playerA, "Wurm Token", 1);
+        assertTappedCount("Forest", true, 1);
+        assertTappedCount("Mountain", true, 0);
+    }
+
+    @Test
+    public void test_Other_AbandonHope() {
+        // used both modify and cost reduction in one cost adjuster
+
+        // As an additional cost to cast this spell, discard X cards.
+        // Look at target opponent's hand and choose X cards from it. That player discards those cards.
+        addCard(Zone.HAND, playerA, "Abandon Hope"); // {X}{1}{B}
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2 + 2);
+        addCard(Zone.HAND, playerA, "Forest", 2);
+        addCard(Zone.HAND, playerB, "Grizzly Bears", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Abandon Hope");
+        setChoice(playerA, "X=2");
+        addTarget(playerA, playerB);
+        setChoice(playerA, "Forest^Forest"); // discard cost
+        setChoice(playerA, "Grizzly Bears^Grizzly Bears"); // discard from hand
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerA, "Forest", 2);
+        assertGraveyardCount(playerB, "Grizzly Bears", 2);
+    }
+
+    // additional tasks to improve code base:
+    // TODO: OsgirTheReconstructorCostAdjuster - migrate to EarlyTargetCost
+    // TODO: SkeletalScryingAdjuster - migrate to EarlyTargetCost
+    // TODO: NecropolisFiend - migrate to EarlyTargetCost
+    // TODO: KnollspineInvocation - migrate to EarlyTargetCost
+    // TODO: ExileCardsFromHandAdjuster - need rework to remove dialog from inside, e.g. migrate to EarlyTargetCost?
+    // TODO: CallerOfTheHuntAdjuster - research and add test
+    // TODO: VoodooDoll - research and add test
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/AdjusterCostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/AdjusterCostTest.java
@@ -468,6 +468,36 @@ public class AdjusterCostTest extends CardTestPlayerBaseWithAIHelps {
     }
 
     @Test
+    public void test_prepareX_AladdinsLamp() {
+        skipInitShuffling();
+
+        // {X}, {T}: The next time you would draw a card this turn, instead look at the top X cards of your library,
+        // put all but one of them on the bottom of your library in a random order, then draw a card. X can't be 0.
+        addCard(Zone.BATTLEFIELD, playerA, "Aladdin's Lamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+        // {T}: Draw a card.
+        addCard(Zone.BATTLEFIELD, playerA, "Archivist");
+        addCard(Zone.LIBRARY, playerA, "Island", 1);
+        addCard(Zone.LIBRARY, playerA, "Grizzly Bears", 1);
+        addCard(Zone.LIBRARY, playerA, "Island", 3);
+
+        // prepare effect
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{X}, {T}: The next time");
+        setChoice(playerA, "X=5");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        // improved draw
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Draw");
+        setChoice(playerA, "Grizzly Bears"); // keep on top and draw
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertHandCount(playerA, "Grizzly Bears", 1);
+    }
+
+    @Test
     public void test_modifyCost_Fireball() {
         // This spell costs {1} more to cast for each target beyond the first.
         // Fireball deals X damage divided evenly, rounded down, among any number of targets.

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/BeltOfGiantStrengthTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/BeltOfGiantStrengthTest.java
@@ -13,8 +13,12 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
  */
 public class BeltOfGiantStrengthTest extends CardTestPlayerBase {
 
+    /**
+     * Equipped creature has base power and toughness 10/10.
+     * Equip {10}. This ability costs {X} less to activate where X is the power of the creature it targets.
+     */
     private static final String belt = "Belt of Giant Strength";
-    private static final String gigantosauras = "Gigantosaurus";
+    private static final String gigantosauras = "Gigantosaurus"; // 10/10
 
     @Test
     public void testWithManaAvailable() {

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2927,6 +2927,7 @@ public class TestPlayer implements Player {
             for (String choice : choices) {
                 if (choice.startsWith("X=")) {
                     int xValue = Integer.parseInt(choice.substring(2));
+                    assertXMinMaxValue(game, ability, xValue, min, max);
                     choices.remove(choice);
                     return xValue;
                 }
@@ -2934,7 +2935,7 @@ public class TestPlayer implements Player {
         }
 
         this.chooseStrictModeFailed("choice", game, getInfo(ability, game)
-                + "\nMessage: " + message);
+                + "\nMessage: " + message +  prepareXMaxInfo(min, max));
         return computerPlayer.announceXMana(min, max, message, game, ability);
     }
 
@@ -2944,14 +2945,32 @@ public class TestPlayer implements Player {
         if (!choices.isEmpty()) {
             if (choices.get(0).startsWith("X=")) {
                 int xValue = Integer.parseInt(choices.get(0).substring(2));
+                assertXMinMaxValue(game, ability, xValue, min, max);
                 choices.remove(0);
                 return xValue;
             }
         }
 
         this.chooseStrictModeFailed("choice", game, getInfo(ability, game)
-                + "\nMessage: " + message);
+                + "\nMessage: " + message + prepareXMaxInfo(min, max));
         return computerPlayer.announceXCost(min, max, message, game, ability, null);
+    }
+
+    private String prepareXMaxInfo(int min, int max) {
+        if (min == 0 && max == Integer.MAX_VALUE) {
+            return " (any value)";
+        } else {
+            return String.format(" (from %s to %s)",
+                    min,
+                    (max == Integer.MAX_VALUE) ? "any" : String.valueOf(max)
+            );
+        }
+    }
+
+    private void assertXMinMaxValue(Game game, Ability source, int xValue, int min, int max) {
+        if (xValue < min || xValue > max) {
+            Assert.fail("Found wrong X value = " + xValue + ", for " + CardUtil.getSourceName(game, source) + ", must" + prepareXMaxInfo(min, max));
+        }
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/Ability.java
+++ b/Mage/src/main/java/mage/abilities/Ability.java
@@ -126,7 +126,7 @@ public interface Ability extends Controllable, Serializable {
     /**
      * Gets all {@link ManaCosts} associated with this ability. These returned
      * costs should never be modified as they represent the base costs before
-     * any modifications.
+     * any modifications (only cost adjusters can change it, e.g. set min/max values)
      *
      * @return All {@link ManaCosts} that must be paid.
      */
@@ -150,6 +150,17 @@ public interface Ability extends Controllable, Serializable {
     ManaCosts<ManaCost> getManaCostsToPay();
 
     void addManaCostsToPay(ManaCost manaCost);
+
+    /**
+     * Helper method to setup actual min/max limits of current X costs BEFORE player's X announcement
+     */
+    void setVariableCostsMinMax(int min, int max);
+
+    /**
+     * Helper method to replace X by direct value BEFORE player's X announcement
+     * If you need additional target for X then use CostAdjuster + EarlyTargetCost (example: Bargaining Table)
+     */
+    void setVariableCostsValue(int xValue);
 
     /**
      * Gets a map of the cost tags (set while casting/activating) of this ability, can be null if no tags have been set yet.
@@ -356,7 +367,7 @@ public interface Ability extends Controllable, Serializable {
      * - for dies triggers - override and use TriggeredAbilityImpl.isInUseableZoneDiesTrigger inside + set setLeavesTheBattlefieldTrigger(true)
      *
      * @param sourceObject can be null for static continues effects checking like rules modification (example: Yixlid Jailer)
-     * @param event can be null for state base effects checking like "when you control seven or more" (example: Endrek Sahr, Master Breeder)
+     * @param event        can be null for state base effects checking like "when you control seven or more" (example: Endrek Sahr, Master Breeder)
      */
     boolean isInUseableZone(Game game, MageObject sourceObject, GameEvent event);
 
@@ -533,11 +544,25 @@ public interface Ability extends Controllable, Serializable {
 
     void adjustTargets(Game game);
 
+    /**
+     * Dynamic X and cost modification, see CostAdjuster for more details on usage
+     */
     Ability setCostAdjuster(CostAdjuster costAdjuster);
 
-    CostAdjuster getCostAdjuster();
+    /**
+     * Prepare {X} settings for announce
+     */
+    void adjustX(Game game);
 
-    void adjustCosts(Game game);
+    /**
+     * Prepare costs (generate due game state or announce)
+     */
+    void adjustCostsPrepare(Game game);
+
+    /**
+     * Apply additional cost modifications logic/effects
+     */
+    void adjustCostsModify(Game game, CostModificationType costModificationType);
 
     List<Hint> getHints();
 

--- a/Mage/src/main/java/mage/abilities/costs/CostAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/CostAdjuster.java
@@ -11,9 +11,9 @@ import java.io.Serializable;
  * <p>
  * Possible use cases:
  * - define {X} costs like X cards to discard (mana and non-mana values);
- * - define {X} limits before announce (to help in UX and AI logic)
- * - define any dynamic costs
- * - use as simple cost increase/reduce effect
+ * - define {X} limits before announce (to help in UX and AI logic);
+ * - define any dynamic costs;
+ * - use as simple cost increase/reduce effect;
  * <p>
  * Calls order by game engine:
  * - ... early cost target selection for EarlyTargetCost ...

--- a/Mage/src/main/java/mage/abilities/costs/CostAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/CostAdjuster.java
@@ -1,24 +1,86 @@
 package mage.abilities.costs;
 
 import mage.abilities.Ability;
+import mage.constants.CostModificationType;
 import mage.game.Game;
 
 import java.io.Serializable;
 
 /**
- * @author TheElk801
+ * Dynamic costs implementation to control {X} or other costs, can be used in spells and abilities
+ * <p>
+ * Possible use cases:
+ * - define {X} costs like X cards to discard (mana and non-mana values);
+ * - define {X} limits before announce (to help in UX and AI logic)
+ * - define any dynamic costs
+ * - use as simple cost increase/reduce effect
+ * <p>
+ * Calls order by game engine:
+ * - ... early cost target selection for EarlyTargetCost ...
+ * - prepareX
+ * - ... x announce ...
+ * - prepareCost
+ * - increaseCost
+ * - reduceCost
+ * - ... normal target selection and payment ...
+ *
+ * @author TheElk801, JayDi85
  */
-@FunctionalInterface
 public interface CostAdjuster extends Serializable {
 
     /**
-     * Must check playable and real cast states.
-     * Example: if it need stack related info (like real targets) then must check two states (game.inCheckPlayableState):
-     * 1. In playable state it must check all possible use cases (e.g. allow to reduce on any available target and modes)
-     * 2. In real cast state it must check current use case (e.g. real selected targets and modes)
-     *
-     * @param ability
-     * @param game
+     * Prepare {X} costs settings or define auto-announced mana values
+     * <p>
+     * Usage example:
+     * - define auto-announced mana value {X} by ability.setVariableCostsValue
+     * - define possible {X} settings by ability.setVariableCostsMinMax
      */
-    void adjustCosts(Ability ability, Game game);
+    default void prepareX(Ability ability, Game game) {
+        // do nothing
+    }
+
+    /**
+     * Prepare any dynamic costs
+     * <p>
+     * Usage example:
+     * - add real cost after {X} mana value announce by CardUtil.getSourceCostsTagX
+     * - add dynamic cost from game data
+     */
+    default void prepareCost(Ability ability, Game game) {
+        // do nothing
+    }
+
+    /**
+     * Simple cost reduction effect
+     */
+    default void reduceCost(Ability ability, Game game) {
+        // do nothing
+    }
+
+    /**
+     * Simple cost increase effect
+     */
+    default void increaseCost(Ability ability, Game game) {
+        // do nothing
+    }
+
+    /**
+     * Default implementation. Override reduceCost or increaseCost instead
+     * TODO: make it private after java 9+ migrate
+     */
+    default void modifyCost(Ability ability, Game game, CostModificationType costModificationType) {
+        switch (costModificationType) {
+            case REDUCE_COST:
+                reduceCost(ability, game);
+                break;
+            case INCREASE_COST:
+                increaseCost(ability, game);
+                break;
+            case SET_COST:
+                // do nothing
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown mod type: " + costModificationType);
+        }
+    }
 }

--- a/Mage/src/main/java/mage/abilities/costs/EarlyTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/EarlyTargetCost.java
@@ -6,20 +6,11 @@ import mage.players.Player;
 
 /**
  * @author Grath
- * Costs which extend this class need to have targets chosen, and those targets must be chosen during 601.2b step.
+ * <p>
+ * Support 601.2b rules for ealry target choice before X announce and other actions
  */
-public abstract class EarlyTargetCost extends CostImpl {
+public interface EarlyTargetCost {
 
-    protected EarlyTargetCost() {
-        super();
-    }
+    void chooseTarget(Game game, Ability source, Player controller);
 
-    protected EarlyTargetCost(final EarlyTargetCost cost) {
-        super(cost);
-    }
-
-    @Override
-    public abstract EarlyTargetCost copy();
-
-    public abstract void chooseTarget(Game game, Ability source, Player controller);
 }

--- a/Mage/src/main/java/mage/abilities/costs/MinMaxVariableCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/MinMaxVariableCost.java
@@ -1,0 +1,15 @@
+package mage.abilities.costs;
+
+/**
+ * @author jayDi85
+ */
+public interface MinMaxVariableCost extends VariableCost {
+
+    int getMinX();
+
+    void setMinX(int minX);
+
+    int getMaxX();
+
+    void setMaxX(int maxX);
+}

--- a/Mage/src/main/java/mage/abilities/costs/common/DiscardXTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/DiscardXTargetCost.java
@@ -10,11 +10,20 @@ import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 
 /**
+ * Used to setup discard cost WITHOUT {X} mana cost
+ * <p>
+ * If you have {X} in spell's mana cost then use DiscardXCardsCostAdjuster instead
+ * <p>
+ * Example:
+ * - {2}{U}{R}
+ * - As an additional cost to cast this spell, discard X cards.
+ *
  * @author LevelX2
  */
 public class DiscardXTargetCost extends VariableCostImpl {
 
     protected FilterCard filter;
+    protected boolean isRandom = false;
 
     public DiscardXTargetCost(FilterCard filter) {
         this(filter, false);
@@ -30,6 +39,12 @@ public class DiscardXTargetCost extends VariableCostImpl {
     protected DiscardXTargetCost(final DiscardXTargetCost cost) {
         super(cost);
         this.filter = cost.filter;
+        this.isRandom = cost.isRandom;
+    }
+
+    public DiscardXTargetCost withRandom() {
+        this.isRandom = true;
+        return this;
     }
 
     @Override
@@ -49,6 +64,6 @@ public class DiscardXTargetCost extends VariableCostImpl {
     @Override
     public Cost getFixedCostsFromAnnouncedValue(int xValue) {
         TargetCardInHand target = new TargetCardInHand(xValue, filter);
-        return new DiscardTargetCost(target);
+        return new DiscardTargetCost(target, this.isRandom);
     }
 }

--- a/Mage/src/main/java/mage/abilities/costs/common/PayLoyaltyCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PayLoyaltyCost.java
@@ -35,10 +35,10 @@ public class PayLoyaltyCost extends CostImpl {
 
         int loyaltyCost = amount;
 
-        // apply cost modification
+        // apply dynamic costs and cost modification
         if (ability instanceof LoyaltyAbility) {
             LoyaltyAbility copiedAbility = ((LoyaltyAbility) ability).copy();
-            copiedAbility.adjustCosts(game);
+            copiedAbility.adjustX(game);
             game.getContinuousEffects().costModification(copiedAbility, game);
             loyaltyCost = 0;
             for (Cost cost : copiedAbility.getCosts()) {

--- a/Mage/src/main/java/mage/abilities/costs/common/PayVariableLoyaltyCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PayVariableLoyaltyCost.java
@@ -59,10 +59,10 @@ public class PayVariableLoyaltyCost extends VariableCostImpl {
 
         int maxValue = permanent.getCounters(game).getCount(CounterType.LOYALTY);
 
-        // apply cost modification
+        // apply dynamic costs and cost modification
         if (source instanceof LoyaltyAbility) {
             LoyaltyAbility copiedAbility = ((LoyaltyAbility) source).copy();
-            copiedAbility.adjustCosts(game);
+            copiedAbility.adjustX(game);
             game.getContinuousEffects().costModification(copiedAbility, game);
             for (Cost cost : copiedAbility.getCosts()) {
                 if (cost instanceof PayVariableLoyaltyCost) {

--- a/Mage/src/main/java/mage/abilities/costs/costadjusters/CommanderManaValueAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/costadjusters/CommanderManaValueAdjuster.java
@@ -13,7 +13,7 @@ public enum CommanderManaValueAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, GreatestCommanderManaValue.instance.calculate(game, ability, null));
     }
 }

--- a/Mage/src/main/java/mage/abilities/costs/costadjusters/DiscardXCardsCostAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/costadjusters/DiscardXCardsCostAdjuster.java
@@ -1,0 +1,73 @@
+package mage.abilities.costs.costadjusters;
+
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.CostAdjuster;
+import mage.abilities.costs.common.DiscardTargetCost;
+import mage.abilities.effects.common.InfoEffect;
+import mage.cards.Card;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
+
+/**
+ * Used to setup discard cost with {X} mana cost
+ * <p>
+ * If you don't have {X} then use DiscardXTargetCost instead
+ * <p>
+ * Example:
+ * - {X}{1}{B}
+ * - As an additional cost to cast this spell, discard X cards.
+ *
+ * @author JayDi85
+ */
+public class DiscardXCardsCostAdjuster implements CostAdjuster {
+
+    private final FilterCard filter;
+
+    private DiscardXCardsCostAdjuster(FilterCard filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public void prepareX(Ability ability, Game game) {
+        Player controller = game.getPlayer(ability.getControllerId());
+        if (controller == null) {
+            return;
+        }
+
+        int minX = 0;
+        int maxX = controller.getHand().getCards(this.filter, ability.getControllerId(), ability, game).size();
+        ability.setVariableCostsMinMax(minX, maxX);
+    }
+
+    @Override
+    public void prepareCost(Ability ability, Game game) {
+        int x = CardUtil.getSourceCostsTagX(game, ability, -1);
+        if (x >= 0) {
+            ability.addCost(new DiscardTargetCost(new TargetCardInHand(x, x, this.filter)));
+        }
+    }
+
+    public static void addAdjusterAndMessage(Card card, FilterCard filter) {
+        addAdjusterAndMessage(card, filter, false);
+    }
+
+    public static void addAdjusterAndMessage(Card card, FilterCard filter, boolean isRandom) {
+        if (card.getSpellAbility().getManaCosts().getVariableCosts().isEmpty()) {
+            // how to fix: use DiscardXTargetCost
+            throw new IllegalArgumentException("Wrong code usage: that's cost adjuster must be used with {X} in mana costs only - " + card);
+        }
+
+        Ability ability = new SimpleStaticAbility(
+                Zone.ALL, new InfoEffect("As an additional cost to cast this spell, discard X " + filter.getMessage())
+        );
+        ability.setRuleAtTheTop(true);
+        card.addAbility(ability);
+
+        card.getSpellAbility().setCostAdjuster(new DiscardXCardsCostAdjuster(filter));
+    }
+}

--- a/Mage/src/main/java/mage/abilities/costs/costadjusters/DomainAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/costadjusters/DomainAdjuster.java
@@ -13,7 +13,7 @@ public enum DomainAdjuster implements CostAdjuster {
     instance;
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
+    public void reduceCost(Ability ability, Game game) {
         CardUtil.reduceCost(ability, DomainValue.REGULAR.calculate(game, ability, null));
     }
 }

--- a/Mage/src/main/java/mage/abilities/costs/costadjusters/ExileCardsFromHandAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/costadjusters/ExileCardsFromHandAdjuster.java
@@ -25,22 +25,29 @@ public class ExileCardsFromHandAdjuster implements CostAdjuster {
     }
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
-        if (game.inCheckPlayableState()) {
-            return;
-        }
+    public void reduceCost(Ability ability, Game game) {
         Player player = game.getPlayer(ability.getControllerId());
         if (player == null) {
             return;
         }
+
         int cardCount = player.getHand().count(filter, game);
-        int toExile = cardCount > 0 ? player.getAmount(
-                0, cardCount, "Choose how many " + filter.getMessage() + " to exile", game
-        ) : 0;
-        if (toExile > 0) {
-            ability.addCost(new ExileFromHandCost(new TargetCardInHand(toExile, filter)));
-            CardUtil.reduceCost(ability, 2 * toExile);
+        int reduceCount;
+        if (game.inCheckPlayableState()) {
+            // possible
+            reduceCount = 2 * cardCount;
+        } else {
+            // real - need to choose
+            // TODO: need early target cost instead dialog here
+            int toExile = cardCount == 0 ? 0 : player.getAmount(
+                    0, cardCount, "Choose how many " + filter.getMessage() + " to exile", game
+            );
+            reduceCount = 2 * toExile;
+            if (toExile > 0) {
+                ability.addCost(new ExileFromHandCost(new TargetCardInHand(toExile, filter)));
+            }
         }
+        CardUtil.reduceCost(ability, 2 * reduceCount);
     }
 
     public static final void addAdjusterAndMessage(Card card, FilterCard filter) {

--- a/Mage/src/main/java/mage/abilities/costs/costadjusters/ImprintedManaValueXCostAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/costadjusters/ImprintedManaValueXCostAdjuster.java
@@ -1,0 +1,37 @@
+package mage.abilities.costs.costadjusters;
+
+import mage.abilities.Ability;
+import mage.abilities.costs.CostAdjuster;
+import mage.cards.Card;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ * Used for {X} mana cost that must be replaced by imprinted mana value
+ * <p>
+ * Example:
+ * - Elite Arcanist
+ * - {X}, {T}: Copy the exiled card. ... X is the converted mana cost of the exiled card.
+ *
+ * @author JayDi85
+ */
+public enum ImprintedManaValueXCostAdjuster implements CostAdjuster {
+    instance;
+
+    @Override
+    public void prepareX(Ability ability, Game game) {
+        int manaValue = Integer.MAX_VALUE;
+
+        Permanent sourcePermanent = game.getPermanent(ability.getSourceId());
+        if (sourcePermanent != null
+                && sourcePermanent.getImprinted() != null
+                && !sourcePermanent.getImprinted().isEmpty()) {
+            Card imprintedInstant = game.getCard(sourcePermanent.getImprinted().get(0));
+            if (imprintedInstant != null) {
+                manaValue = imprintedInstant.getManaValue();
+            }
+        }
+
+        ability.setVariableCostsValue(manaValue);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/costs/costadjusters/LegendaryCreatureCostAdjuster.java
+++ b/Mage/src/main/java/mage/abilities/costs/costadjusters/LegendaryCreatureCostAdjuster.java
@@ -29,10 +29,8 @@ public enum LegendaryCreatureCostAdjuster implements CostAdjuster {
     );
 
     @Override
-    public void adjustCosts(Ability ability, Game game) {
-        int count = game.getBattlefield().count(
-                filter, ability.getControllerId(), ability, game
-        );
+    public void reduceCost(Ability ability, Game game) {
+        int count = game.getBattlefield().count(filter, ability.getControllerId(), ability, game);
         if (count > 0) {
             CardUtil.reduceCost(ability, count);
         }

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCost.java
@@ -32,7 +32,7 @@ public interface ManaCost extends Cost {
     ManaOptions getOptions();
 
     /**
-     * Return all options for paying the mana cost (this) while taking into accoutn if the player can pay life.
+     * Return all options for paying the mana cost (this) while taking into account if the player can pay life.
      * Used to correctly highlight (or not) spells with Phyrexian mana depending on if the player can pay life costs.
      * <p>
      * E.g. Tezzeret's Gambit has a cost of {3}{U/P}.

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCostImpl.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCostImpl.java
@@ -72,7 +72,7 @@ public abstract class ManaCostImpl extends CostImpl implements ManaCost {
     }
 
     @Override
-    public ManaOptions getOptions() {
+    public final ManaOptions getOptions() {
         return getOptions(true);
     }
 

--- a/Mage/src/main/java/mage/abilities/costs/mana/ManaCostsImpl.java
+++ b/Mage/src/main/java/mage/abilities/costs/mana/ManaCostsImpl.java
@@ -439,7 +439,7 @@ public class ManaCostsImpl<T extends ManaCost> extends ArrayList<T> implements M
                     this.add(new ColoredManaCost(ColoredManaSymbol.lookup(symbol.charAt(0))));
                 } else // check X wasn't added before
                     if (modifierForX == 0) {
-                        // count X occurence
+                        // count X occurrence
                         for (String s : symbols) {
                             if (s.equals("X")) {
                                 modifierForX++;

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerHandCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerHandCount.java
@@ -3,11 +3,27 @@ package mage.abilities.dynamicvalue.common;
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
+import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 
 public enum CardsInControllerHandCount implements DynamicValue {
-    instance;
+
+    instance(StaticFilters.FILTER_CARD_CARDS), // TODO: replace usage to ANY
+    ANY(StaticFilters.FILTER_CARD_CARDS),
+    CREATURES(StaticFilters.FILTER_CARD_CREATURES),
+    LANDS(StaticFilters.FILTER_CARD_LANDS);
+
+    FilterCard filter;
+    ValueHint hint;
+
+    CardsInControllerHandCount(FilterCard filter) {
+        this.filter = filter;
+        this.hint = new ValueHint(filter.getMessage() + " in your hand", this);
+    }
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
@@ -22,16 +38,20 @@ public enum CardsInControllerHandCount implements DynamicValue {
 
     @Override
     public CardsInControllerHandCount copy() {
-        return CardsInControllerHandCount.instance;
+        return this;
     }
 
     @Override
     public String getMessage() {
-        return "cards in your hand";
+        return this.filter.getMessage() + " in your hand";
     }
 
     @Override
     public String toString() {
         return "1";
+    }
+
+    public Hint getHint() {
+        return this.hint;
     }
 }

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerHandCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/CardsInControllerHandCount.java
@@ -12,7 +12,6 @@ import mage.players.Player;
 
 public enum CardsInControllerHandCount implements DynamicValue {
 
-    instance(StaticFilters.FILTER_CARD_CARDS), // TODO: replace usage to ANY
     ANY(StaticFilters.FILTER_CARD_CARDS),
     CREATURES(StaticFilters.FILTER_CARD_CREATURES),
     LANDS(StaticFilters.FILTER_CARD_LANDS);

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -688,6 +688,8 @@ public class ContinuousEffects implements Serializable {
      * the battlefield for
      * {@link CostModificationEffect cost modification effects} and applies them
      * if necessary.
+     * <p>
+     * Warning, don't forget to call ability.adjustX before any cost modifications
      *
      * @param abilityToModify
      * @param game
@@ -695,6 +697,10 @@ public class ContinuousEffects implements Serializable {
     public void costModification(Ability abilityToModify, Game game) {
         List<CostModificationEffect> costEffects = getApplicableCostModificationEffects(game);
 
+        // add dynamic costs from X and other places
+        abilityToModify.adjustCostsPrepare(game);
+
+        abilityToModify.adjustCostsModify(game, CostModificationType.INCREASE_COST);
         for (CostModificationEffect effect : costEffects) {
             if (effect.getModificationType() == CostModificationType.INCREASE_COST) {
                 Set<Ability> abilities = costModificationEffects.getAbility(effect.getId());
@@ -706,6 +712,7 @@ public class ContinuousEffects implements Serializable {
             }
         }
 
+        abilityToModify.adjustCostsModify(game, CostModificationType.REDUCE_COST);
         for (CostModificationEffect effect : costEffects) {
             if (effect.getModificationType() == CostModificationType.REDUCE_COST) {
                 Set<Ability> abilities = costModificationEffects.getAbility(effect.getId());
@@ -717,6 +724,7 @@ public class ContinuousEffects implements Serializable {
             }
         }
 
+        abilityToModify.adjustCostsModify(game, CostModificationType.SET_COST);
         for (CostModificationEffect effect : costEffects) {
             if (effect.getModificationType() == CostModificationType.SET_COST) {
                 Set<Ability> abilities = costModificationEffects.getAbility(effect.getId());

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/LookTargetHandChooseDiscardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/LookTargetHandChooseDiscardEffect.java
@@ -62,6 +62,9 @@ public class LookTargetHandChooseDiscardEffect extends OneShotEffect {
         }
         TargetCard target = new TargetCardInHand(upTo ? 0 : num, num, filter);
         if (controller.choose(Outcome.Discard, player.getHand(), target, source, game)) {
+            // TODO: must fizzle discard effect on not full choice
+            // - tests: affected (allow to choose and discard 1 instead 2)
+            // - real game: need to check
             player.discard(new CardsImpl(target.getTargets()), false, source, game);
         }
         return true;

--- a/Mage/src/main/java/mage/abilities/keyword/SuspendAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SuspendAbility.java
@@ -132,6 +132,8 @@ public class SuspendAbility extends SpecialAction {
         this.addEffect(new SuspendExileEffect(suspend));
         this.usesStack = false;
         if (suspend == Integer.MAX_VALUE) {
+            // example: Suspend X-{X}{W}{W}. X can't be 0.
+            // TODO: replace by costAdjuster for shared logic
             VariableManaCost xCosts = new VariableManaCost(VariableCostType.ALTERNATIVE);
             xCosts.setMinX(1);
             this.addCost(xCosts);

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -427,6 +427,16 @@ public class StackAbility extends StackObjectImpl implements Ability {
     }
 
     @Override
+    public void setVariableCostsMinMax(int min, int max) {
+        ability.setVariableCostsMinMax(min, max);
+    }
+
+    @Override
+    public void setVariableCostsValue(int xValue) {
+        ability.setVariableCostsValue(xValue);
+    }
+
+    @Override
     public Map<String, Object> getCostsTagMap() {
         return ability.getCostsTagMap();
     }
@@ -778,14 +788,23 @@ public class StackAbility extends StackObjectImpl implements Ability {
     }
 
     @Override
-    public CostAdjuster getCostAdjuster() {
-        return costAdjuster;
+    public void adjustX(Game game) {
+        if (costAdjuster != null) {
+            costAdjuster.prepareX(this, game);
+        }
     }
 
     @Override
-    public void adjustCosts(Game game) {
+    public void adjustCostsPrepare(Game game) {
         if (costAdjuster != null) {
-            costAdjuster.adjustCosts(this, game);
+            costAdjuster.prepareCost(this, game);
+        }
+    }
+
+    @Override
+    public void adjustCostsModify(Game game, CostModificationType costModificationType) {
+        if (costAdjuster != null) {
+            costAdjuster.modifyCost(this, game, costModificationType);
         }
     }
 

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -743,10 +743,14 @@ public interface Player extends MageItem, Copyable<Player> {
 
     boolean shuffleCardsToLibrary(Card card, Game game, Ability source);
 
-    // set the value for X mana spells and abilities
+    /**
+     * Set the value for X mana spells and abilities
+     */
     int announceXMana(int min, int max, String message, Game game, Ability ability);
 
-    // set the value for non mana X costs
+    /**
+     * Set the value for non mana X costs
+     */
     int announceXCost(int min, int max, String message, Game game, Ability ability, VariableCost variableCost);
 
     // TODO: rework to use pair's list of effect + ability instead string's map

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -3679,8 +3679,11 @@ public abstract class PlayerImpl implements Player, Serializable {
             if (!copy.canActivate(playerId, game).canActivate()) {
                 return false;
             }
+
+            // apply dynamic costs and cost modification
+            copy.adjustX(game);
             if (availableMana != null) {
-                copy.adjustCosts(game);
+                // TODO: need research, why it look at availableMana here - can delete condition?
                 game.getContinuousEffects().costModification(copy, game);
             }
             boolean canBeCastRegularly = true;
@@ -3891,7 +3894,8 @@ public abstract class PlayerImpl implements Player, Serializable {
                 copyAbility = ability.copy();
                 copyAbility.clearManaCostsToPay();
                 copyAbility.addManaCostsToPay(manaCosts.copy());
-                copyAbility.adjustCosts(game);
+                // apply dynamic costs and cost modification
+                copyAbility.adjustX(game);
                 game.getContinuousEffects().costModification(copyAbility, game);
 
                 // reduced all cost
@@ -3963,12 +3967,9 @@ public abstract class PlayerImpl implements Player, Serializable {
                 // alternative cost reduce
                 copyAbility = ability.copy();
                 copyAbility.clearManaCostsToPay();
-                // TODO: IDE warning:
-                //              Unchecked assignment: 'mage.abilities.costs.mana.ManaCosts' to
-                //              'java.util.Collection<? extends mage.abilities.costs.mana.ManaCost>'.
-                //              Reason: 'manaCosts' has raw type, so result of copy is erased
                 copyAbility.addManaCostsToPay(manaCosts.copy());
-                copyAbility.adjustCosts(game);
+                // apply dynamic costs and cost modification
+                copyAbility.adjustX(game);
                 game.getContinuousEffects().costModification(copyAbility, game);
 
                 // reduced all cost

--- a/Mage/src/main/java/mage/target/targetadjustment/TargetsCountAdjuster.java
+++ b/Mage/src/main/java/mage/target/targetadjustment/TargetsCountAdjuster.java
@@ -25,8 +25,13 @@ public class TargetsCountAdjuster extends GenericTargetAdjuster {
 
     @Override
     public void adjustTargets(Ability ability, Game game) {
-        Target newTarget = blueprintTarget.copy();
         int count = dynamicValue.calculate(game, ability, ability.getEffects().get(0));
+        ability.getTargets().clear();
+        if (count <= 0) {
+            return;
+        }
+
+        Target newTarget = blueprintTarget.copy();
         newTarget.setMaxNumberOfTargets(count);
         Filter filter = newTarget.getFilter();
         if (blueprintTarget.getMinNumberOfTargets() != 0) {
@@ -35,7 +40,6 @@ public class TargetsCountAdjuster extends GenericTargetAdjuster {
         } else {
             newTarget.withTargetName(filter.getMessage() + " (up to " + count + " targets)");
         }
-        ability.getTargets().clear();
         ability.addTarget(newTarget);
     }
 }

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1079,6 +1079,53 @@ public final class CardUtil {
                 .collect(Collectors.toSet());
     }
 
+    public static Set<UUID> getAllPossibleTargets(Cost cost, Game game, Ability source) {
+        return cost.getTargets()
+                .stream()
+                .map(t -> t.possibleTargets(source.getControllerId(), source, game))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Distribute values between min and max and make sure that the values will be evenly distributed
+     * Use it to limit possible values list like mana options
+     */
+    public static List<Integer> distributeValues(int count, int min, int max) {
+        List<Integer> res = new ArrayList<>();
+        if (count <= 0 || min > max) {
+            return res;
+        }
+
+        if (min == max) {
+            res.add(min);
+            return res;
+        }
+
+        int range = max - min + 1;
+
+        // low possible amount
+        if (range <= count) {
+            for (int i = 0; i < range; i++) {
+                res.add(min + i);
+            }
+            return res;
+        }
+
+        // big possible amount, so skip some values
+        double step = (double) (max - min) / (count - 1);
+        for (int i = 0; i < count; i++) {
+            res.add(min + (int) Math.round(i * step));
+        }
+        // make sure first and last elements are good
+        res.set(0, min);
+        if (res.size() > 1) {
+            res.set(res.size() - 1, max);
+        }
+
+        return res;
+    }
+
     /**
      * For finding the spell or ability on the stack for "becomes the target" triggers.
      *
@@ -1906,6 +1953,10 @@ public final class CardUtil {
             return (T) value;
         }
         return defaultValue;
+    }
+
+    public static int getSourceCostsTagX(Game game, Ability source, int defaultValue) {
+        return getSourceCostsTag(game, source, "X", defaultValue);
     }
 
     public static String addCostVerb(String text) {


### PR DESCRIPTION
The main idea behind `CostAdjuster` and other improves:
* better control of {X} cost settings;
* better combo support with cost modification effects;
* better support of test framework and AI;
* better support of 601.2b rules for [early target choice](https://github.com/magefree/mage/pull/13023);
* more easy usages;

New `CostAdjuster` allow:
* define {X} costs like X cards to discard (mana and non-mana values);
* define {X} limits before announce (to help in UX and AI logic);
* define any dynamic costs;
* use as simple cost increase/reduce effect;

Calls order of `CostAdjuster` methods (you must override only needed):
* ... activate ability ....
* ... early cost target selection for `EarlyTargetCost` ...
* **prepareX**
* ... x announce ...
* **prepareCost**
* **increaseCost**
* **reduceCost**
* ... normal target selection and payment ...

Full changes log

Improves:
* refactor: split CostAdjuster logic in multiple parts - prepare X, prepare cost, increase cost, reduce cost;
* refactor: improved VariableManaCost to support min/max values, playable and AI calculations, test framework;
* refactor: improved EarlyTargetCost to support mana costs too (related to #13023);
* refactor: migrated some cards with CostAdjuster and X to EarlyTargetCost (Knollspine Invocation, etc - related to #13023);
* refactor: added shared code for "As an additional cost to cast this spell, discard X creature cards";
* refactor: added shared code for "X is the converted mana cost of the exiled card";
* tests: added dozens tests with cost adjusters;

Bug fixes:
* game: fixed that some cards with CostAdjuster ignore min/max limits for X (allow to choose any X, example: Scorched Earth, Open The Way);
* game: fixed that some cards ask to announce already defined X values (example: Bargaining Table);
* game: fixed that some cards with CostAdjuster do not support combo with other cost modification effects;
* game, gui: fixed missing game logs about predefined X values;
* game, gui: fixed wrong X icon for predefined X values;

Test framework:
* test framework: added X min/max check for wrong values;
* test framework: added X min/max info in miss X value announce;
* test framework: added check to find duplicated effect bugs (see assertNoDuplicatedEffects);

Cards:
* Open The Way - fixed that it allow to choose any X without limits (close #12810);
* Unbound Flourishing - improved combo support for activated abilities with predefined X mana costs like Bargaining Table;