### PR TITLE
refactor: find targeting stack object

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AgrusKosEternalSoldier.java
+++ b/Mage.Sets/src/mage/cards/a/AgrusKosEternalSoldier.java
@@ -90,11 +90,8 @@ class AgrusKosEternalSoldierTriggeredAbility extends TriggeredAbilityImpl {
         if (!event.getTargetId().equals(getSourceId())) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || targetingObject instanceof Spell) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         Set<UUID> targets = targetingObject

--- a/Mage.Sets/src/mage/cards/p/PawpatchRecruit.java
+++ b/Mage.Sets/src/mage/cards/p/PawpatchRecruit.java
@@ -96,11 +96,8 @@ class PawpatchRecruitTriggeredAbility extends TriggeredAbilityImpl {
         if (permanent == null || !filterTarget.match(permanent, getControllerId(), this, game)) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || !filterStack.match(targetingObject, getControllerId(), this, game)) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         this.getTargets().clear();

--- a/Mage.Sets/src/mage/cards/s/SurrakElusiveHunter.java
+++ b/Mage.Sets/src/mage/cards/s/SurrakElusiveHunter.java
@@ -90,9 +90,7 @@ class SurrakElusiveHunterTriggeredAbility extends TriggeredAbilityImpl {
         if (!checkTargeted(event.getTargetId(), game)) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
-        return targetingObject != null
-                && game.getOpponents(getControllerId()).contains(targetingObject.getControllerId())
-                && !CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
+        return targetingObject != null && game.getOpponents(getControllerId()).contains(targetingObject.getControllerId());
     }
 }

--- a/Mage/src/main/java/mage/abilities/common/BecomesTargetAnyTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTargetAnyTriggeredAbility.java
@@ -70,11 +70,8 @@ public class BecomesTargetAnyTriggeredAbility extends TriggeredAbilityImpl {
         if (permanent == null || !filterTarget.match(permanent, getControllerId(), this, game)) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || !filterStack.match(targetingObject, getControllerId(), this, game)) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         switch (setTargetPointer) {

--- a/Mage/src/main/java/mage/abilities/common/BecomesTargetAttachedTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTargetAttachedTriggeredAbility.java
@@ -54,11 +54,8 @@ public class BecomesTargetAttachedTriggeredAbility extends TriggeredAbilityImpl 
         if (enchantment == null || enchantment.getAttachedTo() == null || !event.getTargetId().equals(enchantment.getAttachedTo())) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || !filter.match(targetingObject, getControllerId(), this, game)) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         switch (setTargetPointer) {

--- a/Mage/src/main/java/mage/abilities/common/BecomesTargetControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTargetControllerTriggeredAbility.java
@@ -63,11 +63,8 @@ public class BecomesTargetControllerTriggeredAbility extends TriggeredAbilityImp
                 return false;
             }
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || !filterStack.match(targetingObject, getControllerId(), this, game)) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         switch (setTargetPointer) {

--- a/Mage/src/main/java/mage/abilities/common/BecomesTargetSourceTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesTargetSourceTriggeredAbility.java
@@ -57,11 +57,8 @@ public class BecomesTargetSourceTriggeredAbility extends TriggeredAbilityImpl {
         if (!event.getTargetId().equals(getSourceId())) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || !filter.match(targetingObject, getControllerId(), this, game)) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         switch (setTargetPointer) {

--- a/Mage/src/main/java/mage/abilities/keyword/WardAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/WardAbility.java
@@ -77,11 +77,8 @@ public class WardAbility extends TriggeredAbilityImpl {
         if (!getSourceId().equals(event.getTargetId())) {
             return false;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getId().toString(), event, game);
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getId().toString(), event, game);
         if (targetingObject == null || !game.getOpponents(getControllerId()).contains(targetingObject.getControllerId())) {
-            return false;
-        }
-        if (CardUtil.checkTargetedEventAlreadyUsed(this.getId().toString(), targetingObject, event, game)) {
             return false;
         }
         getEffects().setTargetPointer(new FixedTarget(targetingObject.getId()));

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1128,14 +1128,19 @@ public final class CardUtil {
 
     /**
      * For finding the spell or ability on the stack for "becomes the target" triggers.
-     *
+     * Also ensures that spells/abilities that target the same object twice only trigger each "becomes the target" ability once.
+     * If this is the first attempt at triggering for a given ability targeting a given object,
+     * this method records that in the game state for later checks by this same method, to not return the same object again.
+     * 
+     * @param checkingReference must be unique for each usage (this.getId().toString() of the TriggeredAbility, or this.getKey() of the watcher)
      * @param event the GameEvent.EventType.TARGETED from checkTrigger() or watch()
      * @param game  the Game from checkTrigger() or watch()
      * @return the StackObject which targeted the source, or null if not found
      */
-    public static StackObject getTargetingStackObject(String checkingReference, GameEvent event, Game game) {
+    public static StackObject findTargetingStackObject(String checkingReference, GameEvent event, Game game) {
         // In case of multiple simultaneous triggered abilities from the same source,
         // need to get the actual one that targeted, see #8026, #8378
+        // In case of copied triggered abilities, need to trigger on each independently, see #13498
         // Also avoids triggering on cancelled selections, see #8802
         String stateKey = "targetedMap" + checkingReference;
         Map<UUID, Set<UUID>> targetMap = (Map<UUID, Set<UUID>>) game.getState().getValue(stateKey);
@@ -1148,48 +1153,20 @@ public final class CardUtil {
         Set<UUID> targetingObjects = targetMap.computeIfAbsent(event.getTargetId(), k -> new HashSet<>());
         for (StackObject stackObject : game.getStack()) {
             Ability stackAbility = stackObject.getStackAbility();
-            if (stackAbility == null || !stackAbility.getSourceId().equals(event.getSourceId()) || targetingObjects.contains(stackObject.getId())) {
+            if (stackAbility == null || !stackAbility.getSourceId().equals(event.getSourceId())) {
                 continue;
             }
             if (CardUtil.getAllSelectedTargets(stackAbility, game).contains(event.getTargetId())) {
+                if (!targetingObjects.add(stackObject.getId())) {
+                    continue; // The trigger/watcher already recorded that target of the stack object, check for another
+                }
+                // Otherwise, store this combination of trigger/watcher + target + stack object
+                targetMap.put(event.getTargetId(), targetingObjects);
+                game.getState().setValue(stateKey, targetMap);
                 return stackObject;
             }
         }
         return null;
-    }
-
-    /**
-     * For ensuring that spells/abilities that target the same object twice only trigger each "becomes the target" ability once.
-     * If this is the first attempt at triggering for a given ability targeting a given object,
-     * this method records that in the game state for later checks by this same method.
-     *
-     * @param checkingReference must be unique for each usage (this.id.toString() of the TriggeredAbility, or this.getKey() of the watcher)
-     * @param targetingObject   from getTargetingStackObject
-     * @param event             the GameEvent.EventType.TARGETED from checkTrigger() or watch()
-     * @param game              the Game from checkTrigger() or watch()
-     * @return true if already triggered/watched, false if this is the first/only trigger/watch
-     */
-    public static boolean checkTargetedEventAlreadyUsed(String checkingReference, StackObject targetingObject, GameEvent event, Game game) {
-        String stateKey = "targetedMap" + checkingReference;
-        // If a spell or ability an opponent controls targets a single permanent you control more than once,
-        // Battle Mammoth's triggered ability will trigger only once.
-        // However, if a spell or ability an opponent controls targets multiple permanents you control,
-        // Battle Mammoth's triggered ability will trigger once for each of those permanents. (2021-02-05)
-        Map<UUID, Set<UUID>> targetMap = (Map<UUID, Set<UUID>>) game.getState().getValue(stateKey);
-        // targetMap: key - targetId; value - Set of stackObject Ids
-        if (targetMap == null) {
-            targetMap = new HashMap<>();
-        } else {
-            targetMap = new HashMap<>(targetMap); // must have new object reference if saved back to game state
-        }
-        Set<UUID> targetingObjects = targetMap.computeIfAbsent(event.getTargetId(), k -> new HashSet<>());
-        if (!targetingObjects.add(targetingObject.getId())) {
-            return true; // The trigger/watcher already recorded that target of the stack object
-        }
-        // Otherwise, store this combination of trigger/watcher + target + stack object
-        targetMap.put(event.getTargetId(), targetingObjects);
-        game.getState().setValue(stateKey, targetMap);
-        return false;
     }
 
     /**

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1135,11 +1135,11 @@ public final class CardUtil {
      * @param checkingReference must be unique for each usage (this.getId().toString() of the TriggeredAbility, or this.getKey() of the watcher)
      * @param event the GameEvent.EventType.TARGETED from checkTrigger() or watch()
      * @param game  the Game from checkTrigger() or watch()
-     * @return the StackObject which targeted the source, or null if not found
+     * @return the StackObject which targeted the source, or null if already used or not found
      */
     public static StackObject findTargetingStackObject(String checkingReference, GameEvent event, Game game) {
         // In case of multiple simultaneous triggered abilities from the same source,
-        // need to get the actual one that targeted, see #8026, #8378
+        // need to get the actual one that targeted, see #8026, #8378, rulings for Battle Mammoth
         // In case of copied triggered abilities, need to trigger on each independently, see #13498
         // Also avoids triggering on cancelled selections, see #8802
         String stateKey = "targetedMap" + checkingReference;

--- a/Mage/src/main/java/mage/watchers/common/NumberOfTimesPermanentTargetedATurnWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/NumberOfTimesPermanentTargetedATurnWatcher.java
@@ -29,8 +29,8 @@ public class NumberOfTimesPermanentTargetedATurnWatcher extends Watcher {
         if (event.getType() != GameEvent.EventType.TARGETED) {
             return;
         }
-        StackObject targetingObject = CardUtil.getTargetingStackObject(this.getKey(), event, game);
-        if (targetingObject == null || CardUtil.checkTargetedEventAlreadyUsed(this.getKey(), targetingObject, event, game)) {
+        StackObject targetingObject = CardUtil.findTargetingStackObject(this.getKey(), event, game);
+        if (targetingObject == null) {
             return;
         }
         Permanent permanent = game.getPermanent(event.getTargetId());


### PR DESCRIPTION
This is a cleanup of the original #11185 . Based on the bug #13498 and the quick fix for it in 8e1805c, what I initially designed as two separate methods really should just be a single method. Test coverage from 8e1805c.