### PR TITLE
Discord bug report: Firkraag doesn't trigger with War's Toll

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WarsToll.java
+++ b/Mage.Sets/src/mage/cards/w/WarsToll.java
@@ -14,6 +14,8 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -102,6 +104,14 @@ class WarsTollAttackRestrictionEffect extends RestrictionEffect {
                 return false;
             }
         }
+        return true;
+    }
+
+    @Override
+    public boolean updateForcedAttackersAfter(int numberAttackers, Permanent attackingCreature, Ability source, Game game, Map<UUID, Set<UUID>> creaturesForcedToAttack) {
+        if (numberAttackers == 0) return true;
+        Set<UUID> opponents = game.getOpponents(attackingCreature.getControllerId());
+        creaturesForcedToAttack.put(attackingCreature.getId(), opponents);
         return true;
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/RestrictionEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/RestrictionEffect.java
@@ -1,5 +1,7 @@
 package mage.abilities.effects;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import mage.abilities.Ability;
@@ -54,6 +56,10 @@ public abstract class RestrictionEffect extends ContinuousEffectImpl {
     }
 
     public boolean canAttackCheckAfter(int numberOfAttackers, Ability source, Game game, boolean canUseChooseDialogs) {
+        return true;
+    }
+
+    public boolean updateForcedAttackersAfter(int numberAttackers, Permanent attackingCreature, Ability source, Game game, Map<UUID, Set<UUID>> creaturesForcedToAttack) {
         return true;
     }
 

--- a/Mage/src/main/java/mage/game/combat/Combat.java
+++ b/Mage/src/main/java/mage/game/combat/Combat.java
@@ -644,6 +644,16 @@ public class Combat implements Serializable, Copyable<Combat> {
                     }
                 }
             }
+            // Allow unconventional forced attacks (War's Toll) to record creatures as having been forced to attack.
+            for (UUID attackingCreatureId : this.getAttackers()) {
+                Permanent attackingCreature = game.getPermanent(attackingCreatureId);
+                for (Map.Entry<RestrictionEffect, Set<Ability>> entry : game.getContinuousEffects().getApplicableRestrictionEffects(attackingCreature, game).entrySet()) {
+                    RestrictionEffect effect = entry.getKey();
+                    for (Ability ability : entry.getValue()) {
+                        effect.updateForcedAttackersAfter(numberAttackers, attackingCreature, ability, game, creaturesForcedToAttack);
+                    }
+                }
+            }
         }
         return true;
     }


### PR DESCRIPTION
Added an extra function to `RestrictionEffect` to allow it to update the `creaturesForcedToAttack` map at the end of checking restriction effects, used this to make War's Toll mark every creature as having been forced to attack for the purposes of Firkraag.