### PR TITLE
Remove another card restriction for phyrexian dreadnought

### DIFF
--- a/Mage.Sets/src/mage/cards/p/PhyrexianDreadnought.java
+++ b/Mage.Sets/src/mage/cards/p/PhyrexianDreadnought.java
@@ -16,7 +16,6 @@ import mage.constants.SubType;
 import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.common.TargetControlledCreaturePermanent;
@@ -56,10 +55,6 @@ class PhyrexianDreadnoughtSacrificeCost extends CostImpl {
 
     private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("any number of creatures with total power 12 or greater");
 
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
     public PhyrexianDreadnoughtSacrificeCost() {
         this.addTarget(new TargetControlledCreaturePermanent(0, Integer.MAX_VALUE, filter, true));
         this.text = "sacrifice any number of creatures with total power 12 or greater";
@@ -89,9 +84,7 @@ class PhyrexianDreadnoughtSacrificeCost extends CostImpl {
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
         int sumPower = 0;
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, controllerId, game)) {
-            if (!permanent.getId().equals(source.getSourceId())) {
-                sumPower += permanent.getPower().getValue();
-            }
+            sumPower += permanent.getPower().getValue();
         }
         return sumPower >= 12;
     }


### PR DESCRIPTION
Happy to be corrected, but I I believe the current implementation is incorrect. 

I believe you should be able to pay the cost of sacrificing creatures with 12 power using the dreadnought itself, if it is still on the battlefield.
e.g.
I have a Protean Hulk on the battlefield, I then play Phyrexian Dreadnought. When the effect resolves, i choose to sacrifice greater than 12 power, and sac both the hulk and dreadnought as the power is greater than 12.