### PR TITLE
Update render mode selection

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.form
@@ -2183,7 +2183,7 @@
                       <Component id="panelCardStyles" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="panelCardImages" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="306" max="32767" attributes="0"/>
+                      <EmptySpace pref="309" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -2224,7 +2224,7 @@
                                           <Component id="cbPreferredImageLanguage" min="-2" pref="153" max="-2" attributes="0"/>
                                       </Group>
                                   </Group>
-                                  <EmptySpace min="0" pref="480" max="32767" attributes="0"/>
+                                  <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                               </Group>
                           </Group>
                           <EmptySpace max="-2" attributes="0"/>
@@ -2283,7 +2283,6 @@
                 </Component>
                 <Component class="javax.swing.JComboBox" name="cbPreferredImageLanguage">
                   <Properties>
-                    <Property name="maximumRowCount" type="int" value="20"/>
                     <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                       <StringArray count="4">
                         <StringItem index="0" value="Item 1"/>
@@ -2318,15 +2317,48 @@
                 </Property>
               </Properties>
 
-              <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBoxLayout">
-                <Property name="axis" type="int" value="1"/>
+              <Layout>
+                <DimensionLayout dim="0">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="cbCardRenderIconsForAbilities" min="-2" max="-2" attributes="0"/>
+                      <Component id="cbCardRenderIconsForPlayable" min="-2" max="-2" attributes="0"/>
+                      <Component id="jSeparator1" min="-2" pref="775" max="-2" attributes="0"/>
+                      <Component id="cbCardRenderShowReminderText" min="-2" max="-2" attributes="0"/>
+                      <Component id="cbCardRenderHideSetSymbol" min="-2" max="-2" attributes="0"/>
+                      <Component id="cbCardRenderShowAbilityTextOverlay" min="-2" max="-2" attributes="0"/>
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
+                          <Component id="labelRenderMode" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Component id="cbCardRenderImageFallback" min="-2" pref="122" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
+                <DimensionLayout dim="1">
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" attributes="0">
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="3" attributes="0">
+                              <Component id="labelRenderMode" alignment="3" min="-2" max="-2" attributes="0"/>
+                              <Component id="cbCardRenderImageFallback" alignment="3" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Component id="cbCardRenderIconsForAbilities" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Component id="cbCardRenderIconsForPlayable" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Component id="jSeparator1" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Component id="cbCardRenderShowReminderText" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Component id="cbCardRenderHideSetSymbol" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
+                          <Component id="cbCardRenderShowAbilityTextOverlay" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                </DimensionLayout>
               </Layout>
               <SubComponents>
-                <Component class="javax.swing.JCheckBox" name="cbCardRenderImageFallback">
-                  <Properties>
-                    <Property name="text" type="java.lang.String" value="Render mode: MTGO style (off) or IMAGE style (on)"/>
-                  </Properties>
-                </Component>
                 <Component class="javax.swing.JCheckBox" name="cbCardRenderIconsForAbilities">
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Enable card icons for abilities (example: flying, deathtouch)"/>
@@ -2353,6 +2385,28 @@
                   <Properties>
                     <Property name="text" type="java.lang.String" value="Show ability text as overlay in big card view"/>
                   </Properties>
+                </Component>
+                <Component class="javax.swing.JLabel" name="labelRenderMode">
+                  <Properties>
+                    <Property name="text" type="java.lang.String" value="Render Mode:"/>
+                    <Property name="toolTipText" type="java.lang.String" value="&lt;HTML&gt;Image - Renders card image with text overlay&lt;br&gt; MTGO - Renders card frame around card art&lt;br&gt; Forced M15 - Renders all cards in the modern frame&lt;br&gt; Forced Retro - Renders all cards in the retro frame"/>
+                  </Properties>
+                </Component>
+                <Component class="javax.swing.JComboBox" name="cbCardRenderImageFallback">
+                  <Properties>
+                    <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                      <StringArray count="4">
+                        <StringItem index="0" value="Item 1"/>
+                        <StringItem index="1" value="Item 2"/>
+                        <StringItem index="2" value="Item 3"/>
+                        <StringItem index="3" value="Item 4"/>
+                      </StringArray>
+                    </Property>
+                    <Property name="toolTipText" type="java.lang.String" value="&lt;HTML&gt;Image - Renders card image with text overlay&lt;br&gt; MTGO - Renders card frame around card art&lt;br&gt; Forced M15 - Renders all cards in the modern frame&lt;br&gt; Forced Retro - Renders all cards in the retro frame"/>
+                  </Properties>
+                  <AuxValues>
+                    <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+                  </AuxValues>
                 </Component>
               </SubComponents>
             </Container>

--- a/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/TestCardRenderDialog.java
@@ -16,7 +16,7 @@ import mage.client.cards.BigCard;
 import mage.client.game.PlayAreaPanel;
 import mage.client.game.PlayerPanelExt;
 import mage.client.themes.ThemeType;
-import mage.client.util.ClientEventType;
+import mage.client.util.*;
 import mage.client.util.Event;
 import mage.client.util.GUISizeHelper;
 import mage.client.util.Listener;
@@ -424,6 +424,7 @@ public class TestCardRenderDialog extends MageDialog {
         cardViews.add(createPermanentCard(game, playerYou.getId(), "RNA", "185", 0, 0, 0, true, false, null)); // Judith, the Scourge Diva
         cardViews.add(createHandCard(game, playerYou.getId(), "DIS", "153")); // Odds // Ends (split card)
         cardViews.add(createHandCard(game, playerYou.getId(), "ELD", "38")); // Animating Faerie (adventure card)
+        cardViews.add(createHandCard(game, playerYou.getId(), "LEA", "278")); // Bayou (retro frame)
         cardViews.add(createFaceDownCard(game, playerOpponent.getId(), "ELD", "38", false, false, false)); // face down
         cardViews.add(createFaceDownCard(game, playerOpponent.getId(), "ELD", "38", true, false, true)); // morphed
         cardViews.add(createFaceDownCard(game, playerOpponent.getId(), "ELD", "38", false, true, false)); // manifested
@@ -628,7 +629,7 @@ public class TestCardRenderDialog extends MageDialog {
 
         labelRenderMode.setText("Render mode:");
 
-        comboRenderMode.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "MTGO", "Image" }));
+        comboRenderMode.setModel(new javax.swing.DefaultComboBoxModel<>(CardRenderMode.toList()));
         comboRenderMode.addItemListener(new java.awt.event.ItemListener() {
             public void itemStateChanged(java.awt.event.ItemEvent evt) {
                 comboRenderModeItemStateChanged(evt);

--- a/Mage.Client/src/main/java/mage/client/util/CardRenderMode.java
+++ b/Mage.Client/src/main/java/mage/client/util/CardRenderMode.java
@@ -1,0 +1,44 @@
+package mage.client.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public enum CardRenderMode {
+
+    MTGO("MTGO"),
+    IMAGE("Image"),
+    FORCED_M15("Forced M15"),
+    FORCED_RETRO("Forced Retro");
+
+    private final String text;
+
+    CardRenderMode(String text) {
+        this.text = text;
+    }
+
+    @Override
+    public String toString() {
+        return text;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public static String[] toList() {
+        List<String> list = new ArrayList<>();
+        for (CardRenderMode mode : CardRenderMode.values()) {
+            list.add(mode.toString());
+        }
+        return list.toArray(new String[0]);
+    }
+
+    public static CardRenderMode fromString(String text) {
+        for (CardRenderMode mode : CardRenderMode.values()) {
+            if (mode.text.equals(text)) {
+                return mode;
+            }
+        }
+        return IMAGE;
+    }
+}

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeMTGO.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeMTGO.java
@@ -50,6 +50,7 @@ public class CardPanelRenderModeMTGO extends CardPanel {
     private CardRenderer cardRenderer;
 
     private int updateArtImageStamp;
+    private final int cardRenderMode;
 
     private static class ImageKey {
         final BufferedImage artImage;
@@ -143,12 +144,13 @@ public class CardPanelRenderModeMTGO extends CardPanel {
     }
 
     public CardPanelRenderModeMTGO(CardView newGameCard, UUID gameId, final boolean loadImage, ActionCallback callback,
-                                   final boolean foil, Dimension dimension, boolean needFullPermanentRender) {
+                                   final boolean foil, Dimension dimension, boolean needFullPermanentRender, int renderMode) {
         // Call to super
         super(newGameCard, gameId, loadImage, callback, foil, dimension, needFullPermanentRender);
 
         // Renderer
-        cardRenderer = cardRendererFactory.create(getGameCard());
+        cardRenderMode = renderMode;
+        cardRenderer = cardRendererFactory.create(getGameCard(), cardRenderMode);
 
         // Draw the parts
         initialDraw();
@@ -265,7 +267,7 @@ public class CardPanelRenderModeMTGO extends CardPanel {
 
         // Update renderer
         cardImage = null;
-        cardRenderer = cardRendererFactory.create(getGameCard());
+        cardRenderer = cardRendererFactory.create(getGameCard(), cardRenderMode);
         cardRenderer.setArtImage(artImage);
 
         // Repaint

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardRendererFactory.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardRendererFactory.java
@@ -2,6 +2,7 @@ package org.mage.card.arcane;
 
 import mage.cards.FrameStyle;
 import mage.client.dialog.PreferencesDialog;
+import mage.client.util.CardRenderMode;
 import mage.view.CardView;
 
 /**
@@ -13,12 +14,27 @@ public class CardRendererFactory {
     }
 
     public CardRenderer create(CardView card) {
+        return create(card, -1);
+    }
+
+    public CardRenderer create(CardView card, int renderModeOverride) {
         if (card.isSplitCard()) {
             return new ModernSplitCardRenderer(card);
-        } else if (card.getFrameStyle().equals(FrameStyle.RETRO)  || card.getFrameStyle().equals(FrameStyle.LEA_ORIGINAL_DUAL_LAND_ART_BASIC) || PreferencesDialog.getRenderRetroFrames()) {
+        } else if (shouldRenderRetro(card, renderModeOverride)) {
+            // TODO: implement split card renderer for retro cards
             return new RetroCardRenderer(card);
         } else {
             return new ModernCardRenderer(card);
         }
+    }
+
+    private static boolean shouldRenderRetro(CardView card, int renderModeOverride) {
+        int renderMode = PreferencesDialog.getRenderMode();
+        if (renderModeOverride != -1) {
+            renderMode = renderModeOverride;
+        }
+        boolean renderMTGO = (card.getFrameStyle().equals(FrameStyle.RETRO) || card.getFrameStyle().equals(FrameStyle.LEA_ORIGINAL_DUAL_LAND_ART_BASIC)) && renderMode == CardRenderMode.MTGO.ordinal();
+        boolean forcedRetro = renderMode == CardRenderMode.FORCED_RETRO.ordinal();
+        return renderMTGO || forcedRetro;
     }
 }

--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -105,8 +105,10 @@ public class CardPluginImpl implements CardPlugin {
                                     boolean isFoil, Dimension dimension, int renderMode, boolean needFullPermanentRender) {
         switch (renderMode) {
             case 0:
+            case 2:
+            case 3:
                 return new CardPanelRenderModeMTGO(view, gameId, loadImage, callback, isFoil, dimension,
-                        needFullPermanentRender);
+                        needFullPermanentRender, renderMode);
             case 1:
                 return new CardPanelRenderModeImage(view, gameId, loadImage, callback, isFoil, dimension,
                         needFullPermanentRender);


### PR DESCRIPTION
* changes render mode selection to a drop-down
* modes include MTGO, Image, Forced M15, Forced Retro
* debug card test panel updated with additional modes as well
PreferencesDialog.getRenderMode() uses the enum ordinal to reduce the amount of refactoring

![image](https://github.com/user-attachments/assets/44c75537-3955-4fcd-b255-ddb73f60fb8a)
![image](https://github.com/user-attachments/assets/b79d044e-c5df-49be-a523-c5f2e473bca7)
![image](https://github.com/user-attachments/assets/9fe66bcc-533c-447a-aa79-d8264451f10e)
