### PR TITLE
Fix Overwhelming Surge filter

### DIFF
--- a/Mage/src/main/java/mage/filter/StaticFilters.java
+++ b/Mage/src/main/java/mage/filter/StaticFilters.java
@@ -341,7 +341,7 @@ public final class StaticFilters {
         FILTER_PERMANENTS_ARTIFACT_CREATURE.setLockedFilter(true);
     }
 
-    public static final FilterControlledArtifactPermanent FILTER_ARTIFACT_NON_CREATURE = new FilterControlledArtifactPermanent("noncreature artifact");
+    public static final FilterArtifactPermanent FILTER_ARTIFACT_NON_CREATURE = new FilterArtifactPermanent("noncreature artifact");
 
     static {
         FILTER_ARTIFACT_NON_CREATURE.add(Predicates.not(CardType.CREATURE.getPredicate()));


### PR DESCRIPTION
[[Overwhelming Surge]] (and [[Case of the Filched Falcon]] and [[Kenku Artificer]]) use the static filter `FILTER_ARTIFACT_NON_CREATURE`. Since these spells can target any noncreature artifact the filter should be based on `FilterArtifactPermanent`, however it is based on `FilterControlledArtifactPermanent`.

Other users of the filter are Iron Man, Titan of Innovation (sacrifice noncreature artifact) and Guardian Beast (controlled noncreature artifacts get indestructible and other effects), they continue to work as intended.