### PR TITLE
[LGN] Legions Collation

### DIFF
--- a/Mage.Sets/src/mage/sets/Legions.java
+++ b/Mage.Sets/src/mage/sets/Legions.java
@@ -9,6 +9,9 @@ import mage.collation.BoosterStructure;
 import mage.collation.CardRun;
 import mage.collation.RarityConfiguration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  *
  * @author North


### PR DESCRIPTION
```
C: min 1922, max 2078
U: min 515, max 734 (shortprinted 515-580, regular 645-734)
R: min 196, max 256
```
<details>
<summary>10000 boosters opened via draftmancer using same logic
</summary>
150000	Total Cards Opened			10000
100.00%	10000	boosters missing mythic		
100.00%	10000	boosters missing land		
100.00%	10000	boosters missing special		
100.00%	10000	boosters missing common multicolour		
100.00%	10000	boosters missing common colourless		
0.16%	16	boosters missing common white		
3.97%	397	boosters missing common red		
4.27%	427	boosters missing common green		
8.40%	840	boosters missing 1 common colour		
2078	cB	Blood Celebrant	2078	[lgn:61]
2077	cG	Berserk Murlodont	2077	[lgn:117]
2077	cU	Glintwing Invoker	2077	[lgn:40]
2075	cU	Aven Envoy	2075	[lgn:30]
2075	cR	Skirk Marauder	2075	[lgn:113]
2055	cR	Flamewave Invoker	2055	[lgn:92]
2051	cW	Plated Sliver	2051	[lgn:19]
2048	cB	Vile Deacon	2048	[lgn:85]
2047	cB	Crypt Sliver	2047	[lgn:63]
2034	cG	Needleshot Gourna	2034	[lgn:133]
2033	cG	Hundroog	2033	[lgn:129]
2029	cB	Skinthinner	2029	[lgn:80]
2028	cU	Merchant of Secrets	2028	[lgn:44]
2026	cR	Shaleskin Plower	2026	[lgn:110]
2024	cR	Crested Craghorn	2024	[lgn:91]
2024	cW	Wall of Hope	2024	[lgn:24]
2022	cU	Voidmage Apprentice	2022	[lgn:54]
2021	cW	Lowland Tracker	2021	[lgn:17]
2017	cW	Deftblade Elite	2017	[lgn:12]
2013	cG	Nantuko Vigilante	2013	[lgn:132]
2012	cW	Whipgrass Entangler	2012	[lgn:26]
2011	cR	Goblin Grappler	2011	[lgn:100]
2011	cG	Stonewood Invoker	2011	[lgn:139]
2009	cU	Keeneye Aven	2009	[lgn:41]
2008	cG	Quick Sliver	2008	[lgn:136]
2008	cB	Smokespew Invoker	2008	[lgn:81]
2007	cB	Embalmed Brawler	2007	[lgn:69]
2007	cG	Patron of the Wild	2007	[lgn:134]
2003	cR	Goblin Lookout	2003	[lgn:101]
2002	cG	Krosan Vorine	2002	[lgn:131]
1996	cW	Daru Stinger	1996	[lgn:10]
1994	cU	Mistform Sliver	1994	[lgn:46]
1987	cB	Infernal Caretaker	1987	[lgn:76]
1986	cW	Wingbeat Warrior	1986	[lgn:29]
1980	cU	Cephalid Pathmage	1980	[lgn:31]
1980	cG	Defiant Elf	1980	[lgn:123]
1978	cW	Aven Redeemer	1978	[lgn:3]
1975	cR	Bloodstoke Howler	1975	[lgn:89]
1975	cB	Goblin Turncoat	1975	[lgn:72]
1974	cB	Sootfeather Flock	1974	[lgn:82]
1974	cG	Timberwatch Elf	1974	[lgn:140]
1966	cR	Goblin Firebug	1966	[lgn:98]
1965	cW	Daru Sanctifier	1965	[lgn:9]
1962	cB	Dripping Dead	1962	[lgn:67]
1961	cU	Covert Operative	1961	[lgn:33]
1961	cR	Hunter Sliver	1961	[lgn:102]
1954	cU	Fugitive Wizard	1954	[lgn:38]
1954	cR	Macetail Hystrodon	1954	[lgn:106]
1946	cR	Skirk Outrider	1946	[lgn:114]
1944	cB	Gempalm Polluter	1944	[lgn:70]
1940	cG	Glowering Rogon	1940	[lgn:128]
1936	cU	Mistform Seaswift	1936	[lgn:45]
1931	cW	Gempalm Avenger	1931	[lgn:14]
1927	cU	Echo Tracer	1927	[lgn:37]
1922	cW	Starlight Invoker	1922	[lgn:20]
734	u	Frenetic Raptor	734	[lgn:93]
728	u	Totem Speaker	728	[lgn:141]
720	u	Corpse Harvester	720	[lgn:62]
707	u	Withered Wretch	707	[lgn:86]
705	u	Skirk Drill Sergeant	705	[lgn:112]
703	u	Canopy Crawler	703	[lgn:122]
700	u	Daru Mender	700	[lgn:8]
699	u	Stoic Champion	699	[lgn:21]
698	u	Gempalm Incinerator	698	[lgn:94]
697	u	Branchsnap Lorian	697	[lgn:118]
696	u	Brontotherium	696	[lgn:119]
693	u	Ridgetop Raptor	693	[lgn:108]
693	u	Wirewood Hivemaster	693	[lgn:145]
692	u	Shifting Sliver	692	[lgn:52]
691	u	Aphetto Exterminator	691	[lgn:59]
690	u	Wirewood Channeler	690	[lgn:144]
688	u	Spectral Sliver	688	[lgn:83]
685	u	Blade Sliver	685	[lgn:88]
684	u	Liege of the Axe	684	[lgn:16]
683	u	Root Sliver	683	[lgn:137]
679	u	Aven Warhawk	679	[lgn:4]
679	u	White Knight	679	[lgn:27]
677	u	Warbreak Trumpeter	677	[lgn:116]
674	u	Deathmark Prelate	674	[lgn:65]
671	u	Mistform Wakecaster	671	[lgn:48]
670	u	Gempalm Strider	670	[lgn:127]
669	u	Cloudreach Cavalry	669	[lgn:7]
669	u	Noxious Ghoul	669	[lgn:77]
669	u	Zombie Brute	669	[lgn:87]
668	u	Wall of Deceit	668	[lgn:55]
664	u	Primoc Escapee	664	[lgn:49]
663	u	Crookclaw Elder	663	[lgn:34]
660	u	Goblin Assassin	660	[lgn:95]
660	u	Willbender	660	[lgn:58]
657	u	Ward Sliver	657	[lgn:25]
656	u	Goblin Clearcutter	656	[lgn:96]
654	u	Master of the Veil	654	[lgn:43]
654	u	Swooping Talon	654	[lgn:23]
651	u	Dark Supplicant	651	[lgn:64]
645	u	Warped Researcher	645	[lgn:56]
580	u	Gempalm Sorcerer	580	[lgn:39]
553	u	Earthblighter	553	[lgn:68]
549	u	Goblin Dynamo	549	[lgn:97]
528	u	Akroma's Devoted	528	[lgn:2]
515	u	Enormous Baloth	515	[lgn:125]
256	r	Havoc Demon	256	[lgn:74]
253	r	Defender of the Order	253	[lgn:11]
247	r	Riptide Mangler	247	[lgn:51]
245	r	Essence Sliver	245	[lgn:13]
241	r	Sunstrike Legionnaire	241	[lgn:22]
238	r	Bane of the Living	238	[lgn:60]
237	r	Vexing Beetle	237	[lgn:143]
235	r	Chromeshell Crab	235	[lgn:32]
234	r	Clickslither	234	[lgn:90]
234	r	Synapse Sliver	234	[lgn:53]
232	r	Beacon of Destiny	232	[lgn:5]
232	r	Graveborn Muse	232	[lgn:73]
231	r	Akroma, Angel of Wrath	231	[lgn:1]
230	r	Rockshard Elemental	230	[lgn:109]
229	r	Caller of the Claw	229	[lgn:121]
229	r	Imperial Hellkite	229	[lgn:103]
228	r	Keeper of the Nine Gales	228	[lgn:42]
227	r	Scion of Darkness	227	[lgn:79]
225	r	Goblin Goon	225	[lgn:99]
224	r	Celestial Gatekeeper	224	[lgn:6]
223	r	Mistform Ultimus	223	[lgn:47]
222	r	Dermoplasm	222	[lgn:35]
222	r	Elvish Soultiller	222	[lgn:124]
222	r	Ghastly Remains	222	[lgn:71]
221	r	Drinker of Sorrow	221	[lgn:66]
219	r	Magma Sliver	219	[lgn:107]
217	r	Feral Throwback	217	[lgn:126]
216	r	Riptide Director	216	[lgn:50]
215	r	Glowrider	215	[lgn:15]
213	r	Krosan Cloudscraper	213	[lgn:130]
213	r	Lavaborn Muse	213	[lgn:105]
213	r	Primal Whisperer	213	[lgn:135]
213	r	Seedborn Muse	213	[lgn:138]
213	r	Skirk Alarmist	213	[lgn:111]
212	r	Kilnmouth Dragon	212	[lgn:104]
211	r	Hollow Specter	211	[lgn:75]
208	r	Weaver of Lies	208	[lgn:57]
208	r	Windborn Muse	208	[lgn:28]
207	r	Toxin Sliver	207	[lgn:84]
205	r	Brood Sliver	205	[lgn:120]
205	r	Dreamborn Muse	205	[lgn:36]
202	r	Phage the Untouchable	202	[lgn:78]
201	r	Planar Guide	201	[lgn:18]
196	r	Tribal Forcemage	196	[lgn:142]
196	r	Unstable Hulk	196	[lgn:115]</details>
