### PR TITLE
Update effects that find a permanent from a card put to battlefield

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AchHansRun.java
+++ b/Mage.Sets/src/mage/cards/a/AchHansRun.java
@@ -21,6 +21,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -82,7 +83,7 @@ class AchHansRunEffect extends OneShotEffect {
         if (card == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent creature = game.getPermanent(card.getId());
+        Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (creature == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/a/AethermagesTouch.java
+++ b/Mage.Sets/src/mage/cards/a/AethermagesTouch.java
@@ -17,6 +17,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -73,7 +74,7 @@ class AethermagesTouchEffect extends OneShotEffect {
                         cards.remove(card);
                         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
                             // It gains \"At the beginning of your end step, return this creature to its owner's hand.\"
-                            Permanent permanent = game.getPermanent(card.getId());
+                            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                             if (permanent != null) {
                                 Ability ability = new BeginningOfEndStepTriggeredAbility(TargetController.YOU, new ReturnToHandSourceEffect(true), false, null);
                                 ContinuousEffect effect = new GainAbilityTargetEffect(ability, Duration.Custom);

--- a/Mage.Sets/src/mage/cards/a/AnimistsAwakening.java
+++ b/Mage.Sets/src/mage/cards/a/AnimistsAwakening.java
@@ -77,7 +77,7 @@ class AnimistsAwakeningEffect extends OneShotEffect {
 
             if (SpellMasteryCondition.instance.apply(game, source)) {
                 for (Card card : toBattlefield) {
-                    Permanent land = game.getPermanent(card.getId());
+                    Permanent land = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                     if (land != null) {
                         land.untap(game);
                     }

--- a/Mage.Sets/src/mage/cards/a/AnzragsRampage.java
+++ b/Mage.Sets/src/mage/cards/a/AnzragsRampage.java
@@ -157,7 +157,7 @@ class AnzragsRampageEffect extends OneShotEffect {
         }
 
         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent == null) {
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/a/ApprenticeNecromancer.java
+++ b/Mage.Sets/src/mage/cards/a/ApprenticeNecromancer.java
@@ -25,6 +25,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -80,7 +81,7 @@ class ApprenticeNecromancerEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && card != null) {
             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent creature = game.getPermanent(card.getId());
+                Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (creature != null) {
                     // Gains haste
                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/a/ArbiterOfTheIdeal.java
+++ b/Mage.Sets/src/mage/cards/a/ArbiterOfTheIdeal.java
@@ -19,6 +19,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -86,7 +87,7 @@ class ArbiterOfTheIdealEffect extends OneShotEffect {
             controller.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
             if (filter.match(card, game) && controller.chooseUse(outcome, "Put " + card.getName() + " onto the battlefield?", source, game)) {
                 controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     permanent.addCounters(CounterType.MANIFESTATION.createInstance(), source.getControllerId(), source, game);
                     ContinuousEffect effect = new AddCardTypeTargetEffect(Duration.Custom, CardType.ENCHANTMENT);

--- a/Mage.Sets/src/mage/cards/a/ArmoredSkyhunter.java
+++ b/Mage.Sets/src/mage/cards/a/ArmoredSkyhunter.java
@@ -18,6 +18,7 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -94,7 +95,7 @@ class ArmoredSkyhunterEffect extends OneShotEffect {
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
         cards.removeIf(uuid -> game.getState().getZone(uuid) != Zone.LIBRARY);
-        Permanent equipment = game.getPermanent(card.getId());
+        Permanent equipment = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (equipment == null || !equipment.hasSubtype(SubType.EQUIPMENT, game)) {
             return player.putCardsOnBottomOfLibrary(cards, game, source, false);
         }

--- a/Mage.Sets/src/mage/cards/a/ArniMetalbrow.java
+++ b/Mage.Sets/src/mage/cards/a/ArniMetalbrow.java
@@ -16,6 +16,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -131,7 +132,7 @@ class ArniMetalbrowEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-        Permanent creature = game.getPermanent(card.getId());
+        Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (creature != null) {
             game.getCombat().addAttackingCreature(creature.getId(), game);
         }

--- a/Mage.Sets/src/mage/cards/a/ArthurMarigoldKnight.java
+++ b/Mage.Sets/src/mage/cards/a/ArthurMarigoldKnight.java
@@ -19,6 +19,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -111,7 +112,7 @@ class ArthurMarigoldKnightEffect extends OneShotEffect {
         )) {
             return player.putCardsOnBottomOfLibrary(cards, game, source, false);
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return player.putCardsOnBottomOfLibrary(cards, game, source, false);
         }

--- a/Mage.Sets/src/mage/cards/a/AscentOfTheWorthy.java
+++ b/Mage.Sets/src/mage/cards/a/AscentOfTheWorthy.java
@@ -22,6 +22,7 @@ import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -172,7 +173,7 @@ class AscentOfTheWorthyReturnEffect extends OneShotEffect {
         countersToAdd.addCounter(CounterType.FLYING.createInstance());
         game.setEnterWithCounters(card.getId(), countersToAdd);
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/a/AshiokNightmareWeaver.java
+++ b/Mage.Sets/src/mage/cards/a/AshiokNightmareWeaver.java
@@ -125,7 +125,7 @@ class AshiokNightmareWeaverPutIntoPlayEffect extends OneShotEffect {
             return true;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             game.addEffect(new AddCardSubTypeTargetEffect(
                     SubType.NIGHTMARE, Duration.EndOfTurn

--- a/Mage.Sets/src/mage/cards/a/AspiringChampion.java
+++ b/Mage.Sets/src/mage/cards/a/AspiringChampion.java
@@ -13,6 +13,7 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -81,7 +82,8 @@ class AspiringChampionEffect extends OneShotEffect {
         toReveal.retainZone(Zone.LIBRARY, game);
         player.putCardsOnBottomOfLibrary(toReveal, game, source, false);
         player.shuffleLibrary(source, game);
-        Permanent creature = game.getPermanent(card.getId());
+        game.processAction();
+        Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (creature == null
                 || !creature.hasSubtype(SubType.DEMON, game)
                 || creature.getPower().getValue() < 1) {

--- a/Mage.Sets/src/mage/cards/a/AyaraFurnaceQueen.java
+++ b/Mage.Sets/src/mage/cards/a/AyaraFurnaceQueen.java
@@ -15,9 +15,11 @@ import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -90,17 +92,18 @@ class AyaraFurnaceQueenEffect extends OneShotEffect {
         if (player == null || card == null) {
             return false;
         }
-        player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        if (game.getPermanent(card.getId()) == null) {
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
+        if (permanent == null) {
             return false;
         }
         game.addEffect(new GainAbilityTargetEffect(
                 HasteAbility.getInstance(), Duration.Custom
-        ).setTargetPointer(new FixedTarget(card.getId(), game)), source);
+        ).setTargetPointer(new FixedTarget(permanent.getId(), game)), source);
         game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(
                 new ExileTargetEffect().setText("exile it")
-                        .setTargetPointer(new FixedTarget(card.getId(), game)),
+                        .setTargetPointer(new FixedTarget(permanent.getId(), game)),
                 TargetController.ANY
         ), source);
-    return true;}
+    return true;
+    }
 }

--- a/Mage.Sets/src/mage/cards/b/BackForMore.java
+++ b/Mage.Sets/src/mage/cards/b/BackForMore.java
@@ -19,6 +19,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -79,7 +80,7 @@ class BackForMoreEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/b/BalduvianAtrocity.java
+++ b/Mage.Sets/src/mage/cards/b/BalduvianAtrocity.java
@@ -24,6 +24,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -98,7 +99,7 @@ class BalduvianAtrocityEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/b/BronzehideLion.java
+++ b/Mage.Sets/src/mage/cards/b/BronzehideLion.java
@@ -24,6 +24,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 /**
  * @author LevelX2, TheElk801
@@ -94,7 +95,7 @@ class BronzehideLionReturnEffect extends OneShotEffect {
         }
         game.addEffect(new BronzehideLionContinuousEffect(game.getState().getZoneChangeCounter(source.getSourceId()) + 1), source);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent aura = game.getPermanent(card.getId());
+        Permanent aura = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         Permanent creature = game.getPermanent(target.getFirstTarget());
         if (aura == null || creature == null) {
             return true;

--- a/Mage.Sets/src/mage/cards/c/CauldronDance.java
+++ b/Mage.Sets/src/mage/cards/c/CauldronDance.java
@@ -22,6 +22,7 @@ import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  * @author nomage
@@ -76,7 +77,7 @@ class CauldronDanceReturnFromGraveyardToBattlefieldTargetEffect extends OneShotE
             Card card = game.getCard(targetId);
             if (card != null) {
                 controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                Permanent creature = game.getPermanent(card.getId());
+                Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (creature != null) {
                     ContinuousEffect hasteEffect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                     hasteEffect.setTargetPointer(new FixedTarget(creature, game));
@@ -123,7 +124,7 @@ class CauldronDancePutCreatureFromHandOntoBattlefieldEffect extends OneShotEffec
                     Card card = game.getCard(target.getFirstTarget());
                     if (card != null) {
                         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                            Permanent permanent = game.getPermanent(card.getId());
+                            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                             if (permanent != null) {
                                 ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                                 effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/c/ClericClass.java
+++ b/Mage.Sets/src/mage/cards/c/ClericClass.java
@@ -24,6 +24,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -98,7 +99,7 @@ class ClericClassReturnEffect extends OneShotEffect {
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
         game.processAction();
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         int toughness = permanent != null ? permanent.getToughness().getValue() : card.getToughness().getValue();
         player.gainLife(toughness, game, source);
         return true;

--- a/Mage.Sets/src/mage/cards/c/CoilingRebirth.java
+++ b/Mage.Sets/src/mage/cards/c/CoilingRebirth.java
@@ -18,6 +18,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -74,7 +75,7 @@ class CoilingRebirthEffect extends OneShotEffect {
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
         if (GiftWasPromisedCondition.TRUE.apply(game, source)) {
             game.processAction();
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null && !permanent.isLegendary(game)) {
                 CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(
                         null, null, false, 1, false, false,

--- a/Mage.Sets/src/mage/cards/c/ComeBackWrong.java
+++ b/Mage.Sets/src/mage/cards/c/ComeBackWrong.java
@@ -18,6 +18,7 @@ import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
 import mage.game.permanent.PermanentToken;
+import mage.util.CardUtil;
 
 /**
  * @author TheElk801
@@ -81,7 +82,7 @@ class ComeBackWrongEffect extends OneShotEffect {
             return true;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent creature = game.getPermanent(card.getId());
+        Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (creature != null) {
             game.addDelayedTriggeredAbility(new AtTheBeginOfPlayersNextEndStepDelayedTriggeredAbility(
                     new SacrificeTargetEffect("sacrifice it")

--- a/Mage.Sets/src/mage/cards/c/CultivatorColossus.java
+++ b/Mage.Sets/src/mage/cards/c/CultivatorColossus.java
@@ -14,9 +14,11 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -78,7 +80,7 @@ class CultivatorColossusEffect extends OneShotEffect {
         if (player == null) {
             return false;
         }
-        while (player.getHand().count(StaticFilters.FILTER_CARD_LAND, game) > 0) {
+        while (player.canRespond() && player.getHand().count(StaticFilters.FILTER_CARD_LAND, game) > 0) {
             TargetCard target = new TargetCardInHand(
                     0, 1, StaticFilters.FILTER_CARD_LAND
             );
@@ -91,10 +93,10 @@ class CultivatorColossusEffect extends OneShotEffect {
                     card, Zone.BATTLEFIELD, source, game, true,
                     false, false, null
             );
-            if (game.getPermanent(card.getId()) == null) {
-                break;
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
+            if (permanent != null) {
+                player.drawCards(1, source, game);
             }
-            player.drawCards(1, source, game);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/d/DawnOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DawnOfTheDead.java
@@ -22,6 +22,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -74,7 +75,7 @@ class DawnOfTheDeadEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && card != null) {
             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent creature = game.getPermanent(card.getId());
+                Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (creature != null) {
                     // gains haste
                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);

--- a/Mage.Sets/src/mage/cards/d/Defossilize.java
+++ b/Mage.Sets/src/mage/cards/d/Defossilize.java
@@ -14,6 +14,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -66,7 +67,7 @@ class DefossilizeEffect extends OneShotEffect {
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
         game.processAction();
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/d/DoorsOfDurin.java
+++ b/Mage.Sets/src/mage/cards/d/DoorsOfDurin.java
@@ -17,6 +17,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -81,7 +82,7 @@ class DoorsOfDurinEffect extends OneShotEffect {
             return true;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/d/DreamsOfTheDead.java
+++ b/Mage.Sets/src/mage/cards/d/DreamsOfTheDead.java
@@ -25,6 +25,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -82,7 +83,7 @@ class DreamsOfTheDeadEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && card != null) {
             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent creature = game.getPermanent(card.getId());
+                Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (creature != null) {
                     ContinuousEffect effect = new GainAbilityTargetEffect(new CumulativeUpkeepAbility(new ManaCostsImpl<>("{2}")), Duration.Custom);
                     effect.setTargetPointer(new FixedTarget(creature, game));

--- a/Mage.Sets/src/mage/cards/e/ElspethConquersDeath.java
+++ b/Mage.Sets/src/mage/cards/e/ElspethConquersDeath.java
@@ -139,7 +139,7 @@ class ElspethConquersDeathReturnEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/e/ElspethResplendent.java
+++ b/Mage.Sets/src/mage/cards/e/ElspethResplendent.java
@@ -19,6 +19,7 @@ import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.*;
 
@@ -136,7 +137,7 @@ class ElspethResplendentLookEffect extends OneShotEffect {
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {
             player.moveCards(card, Zone.BATTLEFIELD, source, game);
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null) {
                 permanent.addCounters(CounterType.SHIELD.createInstance(), source, game);
             }

--- a/Mage.Sets/src/mage/cards/e/EmperorOfBones.java
+++ b/Mage.Sets/src/mage/cards/e/EmperorOfBones.java
@@ -101,7 +101,7 @@ class EmperorOfBonesEffect extends OneShotEffect {
         }
         game.setEnterWithCounters(card.getId(), new Counters().addCounter(CounterType.FINALITY.createInstance()));
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(CardUtil.getDefaultCardSideForBattlefield(game, card).getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/e/ExtractionSpecialist.java
+++ b/Mage.Sets/src/mage/cards/e/ExtractionSpecialist.java
@@ -18,6 +18,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -86,7 +87,7 @@ class ExtractionSpecialistEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null
                 && source.getSourcePermanentIfItStillExists(game) != null
                 && source.isControlledBy(game.getControllerId(source.getSourceId()))) {

--- a/Mage.Sets/src/mage/cards/f/FierceInvocation.java
+++ b/Mage.Sets/src/mage/cards/f/FierceInvocation.java
@@ -17,6 +17,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -64,7 +65,7 @@ class FierceInvocationEffect extends OneShotEffect {
             Card card = controller.getLibrary().getFromTop(game);
             if (card != null) {
                 new ManifestEffect(1).apply(game, source);
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(2));
                     effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/f/Flash.java
+++ b/Mage.Sets/src/mage/cards/f/Flash.java
@@ -80,7 +80,7 @@ class FlashEffect extends OneShotEffect {
                 }
 
                 game.processAction();
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     permanent.sacrifice(source, game);
                 }

--- a/Mage.Sets/src/mage/cards/f/FootstepsOfTheGoryo.java
+++ b/Mage.Sets/src/mage/cards/f/FootstepsOfTheGoryo.java
@@ -20,6 +20,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -69,7 +70,7 @@ class FootstepsOfTheGoryoEffect extends OneShotEffect {
             Card card = game.getCard(getTargetPointer().getFirst(game, source));
             if (card != null) {
                 if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                    Permanent permanent = game.getPermanent(card.getId());
+                    Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                     if (permanent != null) {
                         // Sacrifice it at end of turn
                         Effect sacrificeEffect = new SacrificeTargetEffect("Sacrifice that creature at the beginning of next end step", source.getControllerId());

--- a/Mage.Sets/src/mage/cards/g/GiftOfImmortality.java
+++ b/Mage.Sets/src/mage/cards/g/GiftOfImmortality.java
@@ -23,6 +23,7 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -86,7 +87,7 @@ class GiftOfImmortalityEffect extends OneShotEffect {
         }
 
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, true, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/g/GoryosVengeance.java
+++ b/Mage.Sets/src/mage/cards/g/GoryosVengeance.java
@@ -21,6 +21,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -83,7 +84,7 @@ class GoryosVengeanceEffect extends OneShotEffect {
         if (card == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/g/GreasefangOkibaBoss.java
+++ b/Mage.Sets/src/mage/cards/g/GreasefangOkibaBoss.java
@@ -21,6 +21,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -83,7 +84,7 @@ class GreasefangOkibaBossEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             ContinuousEffect hasteEffect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
             hasteEffect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/g/GruesomeEncore.java
+++ b/Mage.Sets/src/mage/cards/g/GruesomeEncore.java
@@ -22,6 +22,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInOpponentsGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -78,7 +79,7 @@ class GruesomeEncoreEffect extends OneShotEffect {
         Card card = game.getCard(getTargetPointer().getFirst(game, source));
         if (card != null) {
             controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null) {
                 ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                 effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/h/HansEriksson.java
+++ b/Mage.Sets/src/mage/cards/h/HansEriksson.java
@@ -23,6 +23,7 @@ import mage.target.common.TargetPlayerOrPlaneswalker;
 import java.util.UUID;
 import mage.abilities.effects.Effect;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  * @author TheElk801
@@ -88,7 +89,7 @@ class HansErikssonEffect extends OneShotEffect {
             return player.moveCards(card, Zone.HAND, source, game);
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/h/HavengulMystery.java
+++ b/Mage.Sets/src/mage/cards/h/HavengulMystery.java
@@ -91,7 +91,7 @@ class HavengulMysteryEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/h/HellkiteCourser.java
+++ b/Mage.Sets/src/mage/cards/h/HellkiteCourser.java
@@ -20,6 +20,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -90,7 +91,7 @@ class HellkiteCourserEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/h/HowlpackPiper.java
+++ b/Mage.Sets/src/mage/cards/h/HowlpackPiper.java
@@ -21,6 +21,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -92,7 +93,7 @@ class HowlpackPiperEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         Permanent sourcePermanent = source.getSourcePermanentIfItStillExists(game);
         if (permanent == null || sourcePermanent == null) {
             return true;

--- a/Mage.Sets/src/mage/cards/i/IlhargTheRazeBoar.java
+++ b/Mage.Sets/src/mage/cards/i/IlhargTheRazeBoar.java
@@ -20,6 +20,7 @@ import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -89,7 +90,7 @@ class IlhargTheRazeBoarEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/i/ImpromptuRaid.java
+++ b/Mage.Sets/src/mage/cards/i/ImpromptuRaid.java
@@ -28,6 +28,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -90,7 +91,7 @@ class ImpromptuRaidEffect extends OneShotEffect {
                     return true;
                 }
                 if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                    Permanent permanent = game.getPermanent(card.getId());
+                    Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                     if (permanent != null) {
                         ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);
                         effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/i/InfernalVessel.java
+++ b/Mage.Sets/src/mage/cards/i/InfernalVessel.java
@@ -17,6 +17,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -94,7 +95,7 @@ class InfernalVesselReturnEffect extends OneShotEffect {
         effect.setTargetPointer(new FixedTarget(card, game));
         effect.apply(game, source);
         game.processAction();
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             game.addEffect(new AddCardSubTypeTargetEffect(
                     SubType.DEMON, Duration.Custom

--- a/Mage.Sets/src/mage/cards/i/ItDoesntAddUp.java
+++ b/Mage.Sets/src/mage/cards/i/ItDoesntAddUp.java
@@ -12,6 +12,7 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -63,7 +64,7 @@ class ItDoesntAddUpEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Optional.ofNullable(game.getPermanent(card.getId()))
+        Optional.ofNullable(CardUtil.getPermanentFromCardPutToBattlefield(card, game))
                 .ifPresent(permanent -> permanent.setSuspected(true, game, source));
         return true;
     }

--- a/Mage.Sets/src/mage/cards/k/KamiOfIndustry.java
+++ b/Mage.Sets/src/mage/cards/k/KamiOfIndustry.java
@@ -20,6 +20,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -83,7 +84,7 @@ class KamiOfIndustryEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/k/KarnLiberated.java
+++ b/Mage.Sets/src/mage/cards/k/KarnLiberated.java
@@ -201,7 +201,7 @@ class KarnLiberatedDelayedEffect extends OneShotEffect {
         controller.moveCards(cards, Zone.BATTLEFIELD, source, game);
         for (Card card : cards.getCards(game)) {
             if (card != null) {
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     ((PermanentImpl) permanent).removeSummoningSickness();
                 }

--- a/Mage.Sets/src/mage/cards/k/KarnLiberated.java
+++ b/Mage.Sets/src/mage/cards/k/KarnLiberated.java
@@ -70,6 +70,7 @@ class KarnLiberatedEffect extends OneShotEffect {
 
     private KarnLiberatedEffect(final KarnLiberatedEffect effect) {
         super(effect);
+        this.exileId = effect.exileId;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/k/KheruLichLord.java
+++ b/Mage.Sets/src/mage/cards/k/KheruLichLord.java
@@ -23,6 +23,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -79,7 +80,7 @@ class KheruLichLordEffect extends OneShotEffect {
             Card card = cards.getRandom(game);
             if (card != null) {
                 controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     FixedTarget blueprintTarget = new FixedTarget(permanent, game);
                     ContinuousEffect effect = new GainAbilityTargetEffect(FlyingAbility.getInstance(), Duration.EndOfTurn);

--- a/Mage.Sets/src/mage/cards/k/KillerInstinct.java
+++ b/Mage.Sets/src/mage/cards/k/KillerInstinct.java
@@ -25,6 +25,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Library;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -82,7 +83,7 @@ class KillerInstinctEffect extends OneShotEffect {
         }
         player.revealCards(sourceObject.getIdName(), new CardsImpl(card), game);
         if (card.isCreature(game) && player.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null) {
                 FixedTarget blueprintTarget = new FixedTarget(permanent, game);
                 ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);

--- a/Mage.Sets/src/mage/cards/k/KodamaOfTheEastTree.java
+++ b/Mage.Sets/src/mage/cards/k/KodamaOfTheEastTree.java
@@ -25,6 +25,7 @@ import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 import mage.watchers.Watcher;
 
 import java.util.*;
@@ -134,7 +135,7 @@ class KodamaOfTheEastTreeEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent otherPermanent = game.getPermanent(card.getId());
+        Permanent otherPermanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (otherPermanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/l/LimDulTheNecromancer.java
+++ b/Mage.Sets/src/mage/cards/l/LimDulTheNecromancer.java
@@ -16,12 +16,12 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -88,7 +88,7 @@ class LimDulTheNecromancerEffect extends OneShotEffect {
             if (card != null) {
                 if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)
                         && card.isCreature(game)) {
-                    Permanent creature = game.getPermanent(card.getId());
+                    Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                     ContinuousEffect effect = new AddCardSubTypeTargetEffect(SubType.ZOMBIE, Duration.WhileOnBattlefield);
                     effect.setTargetPointer(new FixedTarget(creature.getId(), game));
                     game.addEffect(effect, source);

--- a/Mage.Sets/src/mage/cards/m/MacabreMockery.java
+++ b/Mage.Sets/src/mage/cards/m/MacabreMockery.java
@@ -22,6 +22,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInOpponentsGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -75,7 +76,7 @@ class MacabreMockeryEffect extends OneShotEffect {
         if (controller == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/m/MilaCraftyCompanion.java
+++ b/Mage.Sets/src/mage/cards/m/MilaCraftyCompanion.java
@@ -26,6 +26,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -185,7 +186,7 @@ class LukkaWaywardBonderReturnEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/m/MinionOfTheMighty.java
+++ b/Mage.Sets/src/mage/cards/m/MinionOfTheMighty.java
@@ -18,6 +18,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -88,7 +89,7 @@ class MinionOfTheMightyEffect extends OneShotEffect {
                 card, Zone.BATTLEFIELD, source, game, true,
                 false, true, null
         );
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             game.getCombat().addAttackingCreature(permanent.getId(), game);
         }

--- a/Mage.Sets/src/mage/cards/m/MoiraAndTeshar.java
+++ b/Mage.Sets/src/mage/cards/m/MoiraAndTeshar.java
@@ -24,6 +24,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -91,7 +92,7 @@ class MoiraAndTesharEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && card != null) {
             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     // It gains haste
                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/n/NahiriTheHarbinger.java
+++ b/Mage.Sets/src/mage/cards/n/NahiriTheHarbinger.java
@@ -34,6 +34,7 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -113,7 +114,7 @@ class NahiriTheHarbingerEffect extends SearchEffect {
                     Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
                     if (card != null) {
                         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                        Permanent permanent = game.getPermanent(card.getId());
+                        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                         if (permanent != null) {
                             ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                             effect.setTargetPointer(new FixedTarget(permanent.getId(), permanent.getZoneChangeCounter(game)));

--- a/Mage.Sets/src/mage/cards/n/NimDeathmantle.java
+++ b/Mage.Sets/src/mage/cards/n/NimDeathmantle.java
@@ -26,6 +26,7 @@ import mage.game.permanent.PermanentToken;
 import mage.players.Player;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 import mage.util.ManaUtil;
 
 import java.util.UUID;
@@ -144,7 +145,7 @@ class NimDeathmantleEffect extends OneShotEffect {
                         // check if it's still in graveyard
                         if (card != null && game.getState().getZone(card.getId()) == Zone.GRAVEYARD) {
                             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                                Permanent permanent = game.getPermanent(card.getId());
+                                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                                 if (permanent != null) {
                                     permanent.addAttachment(equipment.getId(), source, game);
                                 }

--- a/Mage.Sets/src/mage/cards/n/NissaWorldwaker.java
+++ b/Mage.Sets/src/mage/cards/n/NissaWorldwaker.java
@@ -22,6 +22,7 @@ import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -93,7 +94,7 @@ class NissaWorldwakerSearchEffect extends OneShotEffect {
                     Card card = controller.getLibrary().getCard(cardId, game);
                     if (card != null) {
                         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                            Permanent land = game.getPermanent(card.getId());
+                            Permanent land = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                             if (land != null) {
                                 ContinuousEffect effect = new BecomesCreatureTargetEffect(new NissaWorldwakerToken(), false, true, Duration.Custom);
                                 effect.setTargetPointer(new FixedTarget(land, game));

--- a/Mage.Sets/src/mage/cards/n/NotDeadAfterAll.java
+++ b/Mage.Sets/src/mage/cards/n/NotDeadAfterAll.java
@@ -14,6 +14,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -76,7 +77,7 @@ class NotDeadAfterAllEffect extends OneShotEffect {
         }
 
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/o/OkibaSalvage.java
+++ b/Mage.Sets/src/mage/cards/o/OkibaSalvage.java
@@ -18,6 +18,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -79,7 +80,7 @@ class OkibaSalvageEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null && ControlArtifactAndEnchantmentCondition.instance.apply(game, source)) {
             permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
         }

--- a/Mage.Sets/src/mage/cards/o/OldGrowthTroll.java
+++ b/Mage.Sets/src/mage/cards/o/OldGrowthTroll.java
@@ -32,6 +32,7 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.token.TrollWarriorToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -117,7 +118,7 @@ class OldGrowthTrollReturnEffect extends OneShotEffect {
         }
         game.addEffect(new OldGrowthTrollContinuousEffect(game.getState().getZoneChangeCounter(source.getSourceId()) + 1), source);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent aura = game.getPermanent(card.getId());
+        Permanent aura = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         Permanent creature = game.getPermanent(target.getFirstTarget());
         if (aura == null || creature == null) {
             return true;

--- a/Mage.Sets/src/mage/cards/o/OldGrowthTroll.java
+++ b/Mage.Sets/src/mage/cards/o/OldGrowthTroll.java
@@ -199,7 +199,7 @@ class OldGrowthTrollContinuousEffect extends ContinuousEffectImpl {
         return new OldGrowthTrollContinuousEffect(this);
     }
 
-    private static final Ability makeAbility() {
+    private static Ability makeAbility() {
         Ability activatedAbility = new SimpleActivatedAbility(
                 new CreateTokenEffect(new TrollWarriorToken(), 1, true, false), new GenericManaCost(1)
         );

--- a/Mage.Sets/src/mage/cards/o/OliviaCrimsonBride.java
+++ b/Mage.Sets/src/mage/cards/o/OliviaCrimsonBride.java
@@ -22,6 +22,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -89,7 +90,7 @@ class OliviaCrimsonBrideEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/o/OviyaAutomechArtisan.java
+++ b/Mage.Sets/src/mage/cards/o/OviyaAutomechArtisan.java
@@ -25,6 +25,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -120,7 +121,7 @@ class OviyaAutomechArtisanEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null && permanent.isArtifact(game)) {
             permanent.addCounters(CounterType.P1P1.createInstance(2), source, game);
         }

--- a/Mage.Sets/src/mage/cards/o/OwlbearCub.java
+++ b/Mage.Sets/src/mage/cards/o/OwlbearCub.java
@@ -17,6 +17,7 @@ import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -116,7 +117,7 @@ class OwlbearCubEffect extends OneShotEffect {
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {
             player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null) {
                 game.getCombat().addAttackerToCombat(permanent.getId(), getTargetPointer().getFirst(game, source), game);
             }

--- a/Mage.Sets/src/mage/cards/p/PaladinElizabethTaggerdy.java
+++ b/Mage.Sets/src/mage/cards/p/PaladinElizabethTaggerdy.java
@@ -16,6 +16,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -79,7 +80,7 @@ class PaladinElizabethTaggerdyEffect extends OneShotEffect {
                 Card card = controller.getHand().get(cardId, game);
                 if (card != null) {
                     if (controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null)) {
-                        Permanent permanent = game.getPermanent(card.getId());
+                        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                         if (permanent != null) {
                             game.getCombat().addAttackingCreature(permanent.getId(), game);
                         }

--- a/Mage.Sets/src/mage/cards/p/PheliaExuberantShepherd.java
+++ b/Mage.Sets/src/mage/cards/p/PheliaExuberantShepherd.java
@@ -106,7 +106,7 @@ class PheliaExuberantShepherdEffect extends OneShotEffect {
         boolean enteredUnderYourControl = false;
         for (Card card : cards) {
             // Try to find the permanent that card became
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null && permanent.getControllerId().equals(source.getControllerId())) {
                 enteredUnderYourControl = true;
                 break;

--- a/Mage.Sets/src/mage/cards/p/PlaneboundAccomplice.java
+++ b/Mage.Sets/src/mage/cards/p/PlaneboundAccomplice.java
@@ -22,6 +22,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -91,7 +92,7 @@ class PlaneboundAccompliceEffect extends OneShotEffect {
         if (!controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PostmortemLunge.java
+++ b/Mage.Sets/src/mage/cards/p/PostmortemLunge.java
@@ -21,6 +21,7 @@ import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetadjustment.XManaValueTargetAdjuster;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -73,7 +74,7 @@ class PostmortemLungeEffect extends OneShotEffect {
                 return false;
             }
             if (cardOwner.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                     effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/p/PreWarFormalwear.java
+++ b/Mage.Sets/src/mage/cards/p/PreWarFormalwear.java
@@ -21,6 +21,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -90,7 +91,7 @@ class PreWarFormalwerEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             new AttachEffect(Outcome.BoostCreature)
                     .setTargetPointer(new FixedTarget(permanent.getId()))

--- a/Mage.Sets/src/mage/cards/p/PreeminentCaptain.java
+++ b/Mage.Sets/src/mage/cards/p/PreeminentCaptain.java
@@ -17,6 +17,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -77,7 +78,7 @@ class PreeminentCaptainEffect extends OneShotEffect {
                 Card card = controller.getHand().get(cardId, game);
                 if (card != null) {
                     if (controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null)) {
-                        Permanent permanent = game.getPermanent(card.getId());
+                        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                         if (permanent != null) {
                             game.getCombat().addAttackingCreature(permanent.getId(), game);
                         }

--- a/Mage.Sets/src/mage/cards/p/PresumedDead.java
+++ b/Mage.Sets/src/mage/cards/p/PresumedDead.java
@@ -16,6 +16,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -71,7 +72,7 @@ class PresumedDeadEffect extends OneShotEffect {
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, true, null);
         game.processAction();
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             permanent.setSuspected(true, game, source);
         }

--- a/Mage.Sets/src/mage/cards/p/PuppeteerClique.java
+++ b/Mage.Sets/src/mage/cards/p/PuppeteerClique.java
@@ -24,6 +24,7 @@ import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInOpponentsGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -89,7 +90,7 @@ class PuppeteerCliqueEffect extends OneShotEffect {
         if (controller == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/p/PurphorosBronzeBlooded.java
+++ b/Mage.Sets/src/mage/cards/p/PurphorosBronzeBlooded.java
@@ -28,6 +28,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -114,7 +115,7 @@ class PurphurosBronzeBloodedEffect extends OneShotEffect {
         if (card == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/p/PushTheLimit.java
+++ b/Mage.Sets/src/mage/cards/p/PushTheLimit.java
@@ -1,51 +1,47 @@
 package mage.cards.p;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import mage.MageObjectReference;
 import mage.abilities.Ability;
-import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.*;
-import mage.abilities.effects.common.continuous.BecomesSubtypeAllEffect;
-import mage.abilities.effects.common.continuous.CreaturesBecomeOtherTypeEffect;
+import mage.abilities.effects.common.SacrificeTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
 import mage.abilities.effects.common.continuous.VehiclesBecomeArtifactCreatureEffect;
 import mage.abilities.keyword.HasteAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.Cards;
 import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.Predicates;
-import mage.filter.predicate.mageobject.MageObjectReferencePredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTargets;
+import mage.util.CardUtil;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  *
  * @author Jmlundeen
  */
 public final class PushTheLimit extends CardImpl {
+
     private static final FilterPermanent filterCreatures = new FilterControlledPermanent("Creatures you control");
 
     public PushTheLimit(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{5}{R}{R}");
-        
 
         // Return all Mount and Vehicle cards from your graveyard to the battlefield. Sacrifice them at the beginning of the next end step.
         this.getSpellAbility().addEffect(new PushTheLimitEffect());
+
         // Vehicles you control become artifact creatures until end of turn. Creatures you control gain haste until end of turn.
         this.getSpellAbility().addEffect(new VehiclesBecomeArtifactCreatureEffect(Duration.EndOfTurn)
                 .concatBy("<br>"));
@@ -63,6 +59,7 @@ public final class PushTheLimit extends CardImpl {
 }
 
 class PushTheLimitEffect extends OneShotEffect {
+
     private static final FilterCard filter = new FilterCard("Mount and Vehicle cards");
     static {
         filter.add(Predicates.or(
@@ -70,13 +67,14 @@ class PushTheLimitEffect extends OneShotEffect {
                 SubType.VEHICLE.getPredicate()
         ));
     }
-    public PushTheLimitEffect() {
+
+    PushTheLimitEffect() {
         super(Outcome.PutCreatureInPlay);
         staticText = "return all " + filter.getMessage() + " from your graveyard to the battlefield. " +
                 "Sacrifice them at the beginning of the next end step.";
     }
 
-    public PushTheLimitEffect(final PushTheLimitEffect effect) {
+    private PushTheLimitEffect(final PushTheLimitEffect effect) {
         super(effect);
     }
 
@@ -96,7 +94,7 @@ class PushTheLimitEffect extends OneShotEffect {
                 false, false, false, null);
         if (result) {
             List<Permanent> permanentsToSac = cards.stream()
-                    .map(card -> game.getPermanent(card.getId()))
+                    .map(card -> CardUtil.getPermanentFromCardPutToBattlefield(card, game))
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             Effect sacrificeEffect = new SacrificeTargetEffect("sacrifice them", source.getControllerId());

--- a/Mage.Sets/src/mage/cards/q/QuestForTheHolyRelic.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForTheHolyRelic.java
@@ -24,6 +24,7 @@ import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -91,7 +92,7 @@ class QuestForTheHolyRelicEffect extends OneShotEffect {
         if (controller.searchLibrary(target, source, game)) {
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
             if (card != null && controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent equipment = game.getPermanent(card.getId());
+                Permanent equipment = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 Target targetCreature = new TargetControlledCreaturePermanent();
                 if (equipment != null && controller.choose(Outcome.BoostCreature, targetCreature, source, game)) {
                     Permanent permanent = game.getPermanent(targetCreature.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/r/RallyTheAncestors.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheAncestors.java
@@ -81,7 +81,7 @@ class RallyTheAncestorsEffect extends OneShotEffect {
             List<Permanent> toExile = new ArrayList<>(cards.size());
             for (Card card : cards) {
                 if (card != null) {
-                    Permanent permanent = game.getPermanent(card.getId());
+                    Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                     if (permanent != null) {
                         toExile.add(permanent);
                     }

--- a/Mage.Sets/src/mage/cards/r/RampagingGrowth.java
+++ b/Mage.Sets/src/mage/cards/r/RampagingGrowth.java
@@ -16,6 +16,7 @@ import mage.game.permanent.token.custom.CreatureToken;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -72,7 +73,7 @@ class RampagingGrowthEffect extends OneShotEffect {
             return true;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             game.addEffect(new BecomesCreatureTargetEffect(
                     new CreatureToken(4, 3, "", SubType.INSECT

--- a/Mage.Sets/src/mage/cards/r/RealmbreakerTheInvasionTree.java
+++ b/Mage.Sets/src/mage/cards/r/RealmbreakerTheInvasionTree.java
@@ -25,6 +25,7 @@ import mage.target.common.TargetCardInGraveyard;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetOpponent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -103,7 +104,7 @@ class RealmbreakerTheInvasionTreeEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/r/ReturnTriumphant.java
+++ b/Mage.Sets/src/mage/cards/r/ReturnTriumphant.java
@@ -15,6 +15,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -72,7 +73,7 @@ class ReturnTriumphantAbility extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/r/ReturnUponTheTide.java
+++ b/Mage.Sets/src/mage/cards/r/ReturnUponTheTide.java
@@ -16,6 +16,7 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.token.ElfWarriorToken;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -70,7 +71,7 @@ class ReturnUponTheTideEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/s/SavageOrder.java
+++ b/Mage.Sets/src/mage/cards/s/SavageOrder.java
@@ -1,36 +1,26 @@
 package mage.cards.s;
 
-import java.util.UUID;
-
-import mage.ObjectColor;
 import mage.abilities.Ability;
-import mage.abilities.DelayedTriggeredAbility;
-import mage.abilities.common.delayed.AtTheBeginOfNextEndStepDelayedTriggeredAbility;
 import mage.abilities.costs.common.SacrificeTargetCost;
 import mage.abilities.effects.ContinuousEffect;
-import mage.abilities.effects.Effect;
 import mage.abilities.effects.SearchEffect;
-import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
-import mage.abilities.effects.common.search.SearchLibraryPutInPlayEffect;
-import mage.abilities.keyword.HasteAbility;
 import mage.abilities.keyword.IndestructibleAbility;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterCard;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterCreatureCard;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.filter.predicate.mageobject.PowerPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
-import mage.util.SubTypes;
+import mage.util.CardUtil;
+
+import java.util.UUID;
 
 /**
  *
@@ -92,7 +82,7 @@ class SavageOrderEffect extends SearchEffect {
                     Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
                     if (card != null) {
                         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                        Permanent permanent = game.getPermanent(card.getId());
+                        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                         if (permanent != null) {
                             ContinuousEffect effect = new GainAbilityTargetEffect(IndestructibleAbility.getInstance(), Duration.UntilYourNextTurn);
                             effect.setTargetPointer(new FixedTarget(permanent.getId(), permanent.getZoneChangeCounter(game)));

--- a/Mage.Sets/src/mage/cards/s/ScrapWelder.java
+++ b/Mage.Sets/src/mage/cards/s/ScrapWelder.java
@@ -25,6 +25,7 @@ import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetadjustment.XManaValueTargetAdjuster;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -84,7 +85,7 @@ class ScrapWelderEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance());
             effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/s/ShadowfaxLordOfHorses.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowfaxLordOfHorses.java
@@ -19,6 +19,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 /**
  *
@@ -99,7 +100,7 @@ class ShadowfaxLordOfHorsesEffect extends OneShotEffect {
         }
 
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             game.getCombat().addAttackingCreature(permanent.getId(), game);
         }

--- a/Mage.Sets/src/mage/cards/s/ShiftingShadow.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftingShadow.java
@@ -16,6 +16,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -135,7 +136,7 @@ class ShiftingShadowEffect extends OneShotEffect {
         Permanent creature;
         if (card != null) {
             player.moveCards(card, Zone.BATTLEFIELD, source, game);
-            creature = game.getPermanent(card.getId());
+            creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         } else {
             creature = null;
         }

--- a/Mage.Sets/src/mage/cards/s/ShiftyDoppelganger.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftyDoppelganger.java
@@ -20,6 +20,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -87,7 +88,7 @@ class ShiftyDoppelgangerExileEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent creature = game.getPermanent(card.getId());
+        Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (creature == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/s/SithMagic.java
+++ b/Mage.Sets/src/mage/cards/s/SithMagic.java
@@ -31,6 +31,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 import mage.watchers.common.LifeLossOtherFromCombatWatcher;
 
 /**
@@ -85,7 +86,7 @@ class SithMagicEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && card != null) {
             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent creature = game.getPermanent(card.getId());
+                Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (creature != null) {
                     // gains haste
                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/s/SithMagic.java
+++ b/Mage.Sets/src/mage/cards/s/SithMagic.java
@@ -138,11 +138,8 @@ class SithMagicReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (event.getTargetId().equals(source.getFirstTarget())
+        return event.getTargetId().equals(source.getFirstTarget())
                 && ((ZoneChangeEvent) event).getFromZone() == Zone.BATTLEFIELD
-                && ((ZoneChangeEvent) event).getToZone() != Zone.EXILED) {
-            return true;
-        }
-        return false;
+                && ((ZoneChangeEvent) event).getToZone() != Zone.EXILED;
     }
 }

--- a/Mage.Sets/src/mage/cards/s/StonehewerGiant.java
+++ b/Mage.Sets/src/mage/cards/s/StonehewerGiant.java
@@ -22,6 +22,7 @@ import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -90,7 +91,7 @@ class StonehewerGiantEffect extends OneShotEffect {
             Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
             if (card != null) {
                 controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                Permanent equipment = game.getPermanent(card.getId());
+                Permanent equipment = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 Target targetCreature = new TargetControlledCreaturePermanent();
                 targetCreature.withNotTarget(true);
                 if (equipment != null && controller.choose(Outcome.BoostCreature, targetCreature, source, game)) {

--- a/Mage.Sets/src/mage/cards/s/StrefanMaurerProgenitor.java
+++ b/Mage.Sets/src/mage/cards/s/StrefanMaurerProgenitor.java
@@ -30,6 +30,7 @@ import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 import mage.watchers.common.PlayerLostLifeWatcher;
 
 import java.util.*;
@@ -121,7 +122,7 @@ class StrefanMaurerProgenitorPlayVampireEffect extends OneShotEffect {
 
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
 
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/s/SurpriseDeployment.java
+++ b/Mage.Sets/src/mage/cards/s/SurpriseDeployment.java
@@ -24,6 +24,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -85,7 +86,7 @@ class SurpriseDeploymentEffect extends OneShotEffect {
                     Card card = game.getCard(target.getFirstTarget());
                     if (card != null) {
                         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                            Permanent permanent = game.getPermanent(card.getId());
+                            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                             if (permanent != null) {
                                 ReturnToHandTargetEffect effect = new ReturnToHandTargetEffect();
                                 effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/t/TeferisTimeTwist.java
+++ b/Mage.Sets/src/mage/cards/t/TeferisTimeTwist.java
@@ -16,6 +16,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetControlledPermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -111,7 +112,7 @@ class TeferisTimeTwistReturnEffect extends OneShotEffect {
         if (!player.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return true;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null && permanent.isCreature(game)) {
             // TODO: This is technically wrong as it should enter with the counters,
             // however there's currently no way to know that for sure

--- a/Mage.Sets/src/mage/cards/t/TheBeamtownBullies.java
+++ b/Mage.Sets/src/mage/cards/t/TheBeamtownBullies.java
@@ -29,6 +29,7 @@ import mage.players.Player;
 import mage.target.TargetPlayer;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -104,7 +105,7 @@ class TheBeamtownBulliesEffect extends OneShotEffect {
             }
 
             // Add continuous effects
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent == null) {
                 return false;
             }

--- a/Mage.Sets/src/mage/cards/t/TheDeckOfManyThings.java
+++ b/Mage.Sets/src/mage/cards/t/TheDeckOfManyThings.java
@@ -23,6 +23,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -122,7 +123,7 @@ class TheDeckOfManyThingsReturnEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/t/TheGrimCaptain.java
+++ b/Mage.Sets/src/mage/cards/t/TheGrimCaptain.java
@@ -102,7 +102,7 @@ class TheGrimCaptainEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, false, null);
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/t/TheNightOfTheDoctor.java
+++ b/Mage.Sets/src/mage/cards/t/TheNightOfTheDoctor.java
@@ -18,6 +18,7 @@ import mage.filter.common.FilterCreatureCard;
 import mage.filter.StaticFilters;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
+import mage.util.CardUtil;
 
 import java.util.*;
 /**
@@ -90,7 +91,7 @@ class TheNightOfTheDoctorEffect extends OneShotEffect {
         if (card == null || !controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/t/TheWarInHeaven.java
+++ b/Mage.Sets/src/mage/cards/t/TheWarInHeaven.java
@@ -97,7 +97,7 @@ class TheWarInHeavenEffect extends OneShotEffect {
             Card card = game.getCard(targetId);
             if (card != null) {
                 card.moveToZone(Zone.BATTLEFIELD, source, game, false);
-                Permanent permanent = game.getPermanent(card.getId());
+                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (permanent != null) {
                     permanent.addCounters(CounterType.NECRODERMIS.createInstance(), source, game);
                     game.addEffect(new AddCardTypeTargetEffect(Duration.Custom, CardType.ARTIFACT)

--- a/Mage.Sets/src/mage/cards/t/TooGreedilyTooDeep.java
+++ b/Mage.Sets/src/mage/cards/t/TooGreedilyTooDeep.java
@@ -8,13 +8,12 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
-import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreatureCard;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInGraveyard;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -66,7 +65,7 @@ class TooGreedilyTooDeepEffect extends OneShotEffect {
         }
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
         game.processAction();
-        Permanent returnedCreature = game.getPermanent(card.getId());
+        Permanent returnedCreature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (returnedCreature != null && returnedCreature.getPower().getValue() > 0) {
             for (Permanent creature : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), source, game)) {
                 if (!creature.getId().equals(returnedCreature.getId())) {

--- a/Mage.Sets/src/mage/cards/t/TreacherousUrge.java
+++ b/Mage.Sets/src/mage/cards/t/TreacherousUrge.java
@@ -24,6 +24,7 @@ import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetOpponent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -81,7 +82,7 @@ class TreacherousUrgeEffect extends OneShotEffect {
                         card = opponent.getHand().get(target.getFirstTarget(), game);
                         if (card != null) {
                             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                                Permanent permanent = game.getPermanent(card.getId());
+                                Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                                 if (permanent != null) {
                                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                                     effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage.Sets/src/mage/cards/u/UltraMagnusTactician.java
+++ b/Mage.Sets/src/mage/cards/u/UltraMagnusTactician.java
@@ -20,6 +20,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -97,7 +98,7 @@ class UltraMagnusTacticianEffect extends OneShotEffect {
                 card, Zone.BATTLEFIELD, source, game, true,
                 false, false, null
         );
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/v/Vault101BirthdayParty.java
+++ b/Mage.Sets/src/mage/cards/v/Vault101BirthdayParty.java
@@ -18,6 +18,7 @@ import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 /**
  *
@@ -103,7 +104,7 @@ class Vault101BirthdayPartyEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent equipment = game.getPermanent(card.getId());
+        Permanent equipment = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (equipment == null || !equipment.hasSubtype(SubType.EQUIPMENT, game)) {
             return true;
         }

--- a/Mage.Sets/src/mage/cards/v/ViviensInvocation.java
+++ b/Mage.Sets/src/mage/cards/v/ViviensInvocation.java
@@ -15,6 +15,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetCard;
 import mage.target.common.TargetOpponentsCreaturePermanent;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -78,7 +79,7 @@ class ViviensInvocationEffect extends OneShotEffect {
         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             cards.remove(card);
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             controller.putCardsOnBottomOfLibrary(cards, game, source, false);
             return true;

--- a/Mage.Sets/src/mage/cards/w/WhipOfErebos.java
+++ b/Mage.Sets/src/mage/cards/w/WhipOfErebos.java
@@ -25,6 +25,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -88,7 +89,7 @@ class WhipOfErebosEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null && card != null) {
             if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
-                Permanent creature = game.getPermanent(card.getId());
+                Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (creature != null) {
                     // gains haste
                     ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/w/WinotaJoinerOfForces.java
+++ b/Mage.Sets/src/mage/cards/w/WinotaJoinerOfForces.java
@@ -17,6 +17,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -98,7 +99,7 @@ class WinotaJoinerOfForcesEffect extends OneShotEffect {
         )) {
             return player.putCardsOnBottomOfLibrary(cards, game, source, false);
         }
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return player.putCardsOnBottomOfLibrary(cards, game, source, false);
         }

--- a/Mage.Sets/src/mage/cards/y/YarusRoarOfTheOldGods.java
+++ b/Mage.Sets/src/mage/cards/y/YarusRoarOfTheOldGods.java
@@ -28,6 +28,7 @@ import mage.filter.predicate.card.FaceDownPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.util.CardUtil;
 
 /**
  *
@@ -109,7 +110,7 @@ class YarusRoarOfTheOldGodsEffect extends OneShotEffect {
                 BecomesFaceDownCreatureEffect.FaceDownType.MANUAL), newSource);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, true, true, null);
 
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent != null) {
             permanent.turnFaceUp(source, game, source.getControllerId());
         }

--- a/Mage.Sets/src/mage/cards/y/YggdrasilRebirthEngine.java
+++ b/Mage.Sets/src/mage/cards/y/YggdrasilRebirthEngine.java
@@ -133,7 +133,7 @@ class YggdrasilRebirthEngineReturnCreatureEffect extends OneShotEffect {
         if (!player.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             return false;
         }
-        Permanent movedCard = game.getPermanent(card.getId());
+        Permanent movedCard = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (movedCard == null){
             return false;
         }

--- a/Mage.Sets/src/mage/cards/z/ZaraRenegadeRecruiter.java
+++ b/Mage.Sets/src/mage/cards/z/ZaraRenegadeRecruiter.java
@@ -21,6 +21,7 @@ import mage.players.Player;
 import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetPlayerOrPlaneswalker;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -94,7 +95,7 @@ class ZaraRenegadeRecruiterEffect extends OneShotEffect {
                 card, Zone.BATTLEFIELD, source, game, true,
                 false, false, null
         );
-        Permanent permanent = game.getPermanent(card.getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/z/ZirilanOfTheClaw.java
+++ b/Mage.Sets/src/mage/cards/z/ZirilanOfTheClaw.java
@@ -24,6 +24,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 /**
  *
@@ -83,7 +84,7 @@ class ZirilanOfTheClawEffect extends OneShotEffect {
                 Card card = controller.getLibrary().getCard(target.getFirstTarget(), game);
                 if (card != null) {
                     controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-                    Permanent permanent = game.getPermanent(card.getId());
+                    Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                     if (permanent != null) {
                         // gains haste
                         ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn);

--- a/Mage/src/main/java/mage/abilities/common/AnimateDeadTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/AnimateDeadTriggeredAbility.java
@@ -192,7 +192,7 @@ class AnimateDeadPutOntoBattlefieldEffect extends OneShotEffect {
         player.moveCards(card, Zone.BATTLEFIELD, source, game, tapped, false, false, null);
         game.processAction();
 
-        Permanent creature = game.getPermanent(CardUtil.getDefaultCardSideForBattlefield(game, card).getId());
+        Permanent creature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (creature == null) {
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/common/BecomesAuraAttachToManifestSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/common/BecomesAuraAttachToManifestSourceEffect.java
@@ -13,6 +13,7 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.common.TargetCreaturePermanent;
+import mage.util.CardUtil;
 
 /**
  * @author LevelX2
@@ -42,7 +43,7 @@ public class BecomesAuraAttachToManifestSourceEffect extends OneShotEffect {
             Card card = controller.getLibrary().getFromTop(game);
             if (card != null) {
                 new ManifestEffect(1).apply(game, source);
-                Permanent enchantedCreature = game.getPermanent(card.getId());
+                Permanent enchantedCreature = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
                 if (enchantedCreature != null) {
                     enchantedCreature.addAttachment(enchantment.getId(), source, game);
                     FilterCreaturePermanent filter = new FilterCreaturePermanent();

--- a/Mage/src/main/java/mage/abilities/effects/common/PutCardIntoPlayWithHasteAndSacrificeEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/PutCardIntoPlayWithHasteAndSacrificeEffect.java
@@ -60,7 +60,7 @@ public class PutCardIntoPlayWithHasteAndSacrificeEffect extends OneShotEffect {
             return false;
         }
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
-        Permanent permanent = game.getPermanent(CardUtil.getDefaultCardSideForBattlefield(game, card).getId());
+        Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
         if (permanent == null) {
             return false;
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/ReturnCreatureFromGraveyardToBattlefieldAndGainHasteEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ReturnCreatureFromGraveyardToBattlefieldAndGainHasteEffect.java
@@ -13,6 +13,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 
 public class ReturnCreatureFromGraveyardToBattlefieldAndGainHasteEffect extends OneShotEffect {
 
@@ -39,7 +40,7 @@ public class ReturnCreatureFromGraveyardToBattlefieldAndGainHasteEffect extends 
         Card card = game.getCard(source.getFirstTarget());
         if (card != null) {
             controller.moveCards(card, Zone.BATTLEFIELD, source, game);
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null) {
                 ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);
                 effect.setTargetPointer(new FixedTarget(permanent, game));

--- a/Mage/src/main/java/mage/game/command/dungeons/UndercityDungeon.java
+++ b/Mage/src/main/java/mage/game/command/dungeons/UndercityDungeon.java
@@ -30,6 +30,7 @@ import mage.target.TargetPlayer;
 import mage.target.common.TargetCardInLibrary;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.CardUtil;
 import mage.util.RandomUtil;
 
 /**
@@ -158,7 +159,7 @@ class ThroneOfTheDeadThreeEffect extends OneShotEffect {
         }
         if (card != null) {
             player.moveCards(card, Zone.BATTLEFIELD, source, game);
-            Permanent permanent = game.getPermanent(card.getId());
+            Permanent permanent = CardUtil.getPermanentFromCardPutToBattlefield(card, game);
             if (permanent != null) {
                 permanent.addCounters(CounterType.P1P1.createInstance(3), source, game);
                 game.addEffect(new GainAbilityTargetEffect(HexproofAbility.getInstance(), Duration.UntilYourNextTurn)

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1316,6 +1316,15 @@ public final class CardUtil {
     }
 
     /**
+     * If a card object is moved to the battlefield, object id can be different (e.g. MDFC).
+     * Use this method to get the permanent object from the card object after move to battlefield.
+     * Can return null if not found on the battlefield.
+     */
+    public static Permanent getPermanentFromCardPutToBattlefield(Card card, Game game) {
+        return game.getPermanent(CardUtil.getDefaultCardSideForBattlefield(game, card).getId());
+    }
+
+    /**
      * Return card name for same name searching
      *
      * @param card


### PR DESCRIPTION
Resolves #13466 by creating a new helper method in CardUtil to handle MDFCs and the like correctly.