### PR TITLE
Fix saga first chapter zcc

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GenesisOfTheDaleks.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisOfTheDaleks.java
@@ -2,8 +2,7 @@ package mage.cards.g;
 
 import mage.abilities.Ability;
 import mage.abilities.common.SagaAbility;
-import mage.abilities.dynamicvalue.DynamicValue;
-import mage.abilities.effects.Effect;
+import mage.abilities.dynamicvalue.common.CountersSourceCount;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.DestroyAllEffect;
@@ -19,7 +18,6 @@ import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.Permanent;
 import mage.game.permanent.token.DalekToken;
 import mage.players.Player;
 import mage.target.common.TargetOpponent;
@@ -44,7 +42,7 @@ public final class GenesisOfTheDaleks extends CardImpl {
         // I, II, III -- Create a 3/3 black Dalek artifact creature token with menace for each lore counter on Genesis of the Daleks.
         sagaAbility.addChapterEffect(
                 this, SagaChapter.CHAPTER_I, SagaChapter.CHAPTER_III,
-                new CreateTokenEffect(new DalekToken(), GenesisOfTheDaleksValue.instance)
+                new CreateTokenEffect(new DalekToken(), new CountersSourceCount(CounterType.LORE))
         );
 
         // IV -- Target opponent faces a villainous choice -- Destroy all Dalek creatures and each of your opponents loses life equal to the total power of Daleks that died this turn, or destroy all non-Dalek creatures.
@@ -62,41 +60,6 @@ public final class GenesisOfTheDaleks extends CardImpl {
     @Override
     public GenesisOfTheDaleks copy() {
         return new GenesisOfTheDaleks(this);
-    }
-}
-
-enum GenesisOfTheDaleksValue implements DynamicValue {
-    instance;
-
-    @Override
-    public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        Permanent permanent = sourceAbility.getSourcePermanentOrLKI(game);
-        if (permanent != null) {
-            return permanent
-                    .getCounters(game)
-                    .getCount(CounterType.LORE);
-        }
-        return Optional
-                .ofNullable(sourceAbility)
-                .map(Ability::getSourceId)
-                .map(game::getPermanentOrLKIBattlefield)
-                .map(p -> p.getCounters(game).getCount(CounterType.LORE))
-                .orElse(0);
-    }
-
-    @Override
-    public GenesisOfTheDaleksValue copy() {
-        return this;
-    }
-
-    @Override
-    public String getMessage() {
-        return "lore counter on {this}";
-    }
-
-    @Override
-    public String toString() {
-        return "1";
     }
 }
 

--- a/Mage.Sets/src/mage/cards/l/LongListOfTheEnts.java
+++ b/Mage.Sets/src/mage/cards/l/LongListOfTheEnts.java
@@ -53,8 +53,8 @@ public final class LongListOfTheEnts extends CardImpl {
         return new LongListOfTheEnts(this);
     }
 
-    static String getKey(Game game, Ability source, int offset) {
-        return "EntList_" + source.getSourceId() + "_" + (offset + CardUtil.getActualSourceObjectZoneChangeCounter(game, source));
+    static String getKey(Game game, Ability source) {
+        return "EntList_" + source.getSourceId() + "_" + CardUtil.getActualSourceObjectZoneChangeCounter(game, source);
     }
 
 }
@@ -67,7 +67,7 @@ enum LongListOfTheEntsHint implements Hint {
         if (ability.getSourcePermanentIfItStillExists(game) == null) {
             return null;
         }
-        Set<SubType> subTypes = (Set<SubType>) game.getState().getValue(LongListOfTheEnts.getKey(game, ability, 0));
+        Set<SubType> subTypes = (Set<SubType>) game.getState().getValue(LongListOfTheEnts.getKey(game, ability));
         if (subTypes == null || subTypes.isEmpty()) {
             return "No creature types have been noted yet.";
         }
@@ -109,14 +109,11 @@ class LongListOfTheEntsEffect extends OneShotEffect {
             return false;
         }
 
-        Object existingEntList = game.getState().getValue(LongListOfTheEnts.getKey(game, source, 0));
-        int offset;
+        Object existingEntList = game.getState().getValue(LongListOfTheEnts.getKey(game, source));
         Set<SubType> newEntList;
         if (existingEntList == null) {
-            offset = 1; // zcc is off-by-one due to still entering battlefield
             newEntList = new LinkedHashSet<>();
         } else {
-            offset = 0;
             newEntList = new LinkedHashSet<>((Set<SubType>) existingEntList);
         }
         Set<String> chosenTypes = newEntList
@@ -132,7 +129,7 @@ class LongListOfTheEntsEffect extends OneShotEffect {
         SubType subType = SubType.byDescription(choice.getChoiceKey());
         game.informPlayers(player.getLogName() + " notes the creature type " + subType);
         newEntList.add(subType);
-        game.getState().setValue(LongListOfTheEnts.getKey(game, source, offset), newEntList);
+        game.getState().setValue(LongListOfTheEnts.getKey(game, source), newEntList);
         FilterSpell filter = new FilterCreatureSpell("a creature spell of that type");
         filter.add(subType.getPredicate());
         game.addDelayedTriggeredAbility(new AddCounterNextSpellDelayedTriggeredAbility(filter), source);

--- a/Mage.Sets/src/mage/cards/s/SummonEsperValigarmanda.java
+++ b/Mage.Sets/src/mage/cards/s/SummonEsperValigarmanda.java
@@ -107,7 +107,7 @@ class SummonEsperValigarmandaExileEffect extends OneShotEffect {
         return !cards.isEmpty()
                 && controller.moveCardsToExile(
                 cards.getCards(game), source, game, true,
-                CardUtil.getExileZoneId(game, source, 1),
+                CardUtil.getExileZoneId(game, source),
                 CardUtil.getSourceName(game, source)
         );
     }

--- a/Mage.Sets/src/mage/cards/t/TheAesirEscapeValhalla.java
+++ b/Mage.Sets/src/mage/cards/t/TheAesirEscapeValhalla.java
@@ -1,15 +1,13 @@
 package mage.cards.t;
 
-import java.util.UUID;
-
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SagaAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
-import mage.constants.*;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.*;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.ExileZone;
@@ -19,6 +17,8 @@ import mage.players.Player;
 import mage.target.common.TargetCardInGraveyard;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.util.CardUtil;
+
+import java.util.UUID;
 
 /**
  *
@@ -83,7 +83,7 @@ class TheAesirEscapeValhallaOneEffect extends OneShotEffect {
         controller.choose(outcome, target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {
-            UUID exileId = CardUtil.getExileZoneId(game, source, 1);
+            UUID exileId = CardUtil.getExileZoneId(game, source);
             MageObject sourceObject = source.getSourceObject(game);
             String exileName = sourceObject != null ? sourceObject.getName() : "";
             controller.moveCardsToExile(card, source, game, false, exileId, exileName);

--- a/Mage.Sets/src/mage/cards/t/TheCreationOfAvacyn.java
+++ b/Mage.Sets/src/mage/cards/t/TheCreationOfAvacyn.java
@@ -81,7 +81,7 @@ class TheCreationOfAvacynOneEffect extends OneShotEffect {
             if (card != null) {
                 // exile it face down
                 card.setFaceDown(true, game);
-                UUID exileId = CardUtil.getExileZoneId(game, source, 1);
+                UUID exileId = CardUtil.getExileZoneId(game, source);
                 MageObject sourceObject = source.getSourceObject(game);
                 String exileName = sourceObject != null ? sourceObject.getName() : "";
                 controller.moveCardsToExile(card, source, game, false, exileId, exileName);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/cmm/BattleAtTheHelvaultTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/cmm/BattleAtTheHelvaultTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.cmm;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -19,7 +18,6 @@ public class BattleAtTheHelvaultTest extends CardTestPlayerBase {
      */
     private static final String battle = "Battle at the Helvault";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay() {
         addCard(Zone.HAND, playerA, battle, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/fic/SummonIxionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/fic/SummonIxionTest.java
@@ -3,7 +3,6 @@ package org.mage.test.cards.single.fic;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -23,7 +22,6 @@ public class SummonIxionTest extends CardTestPlayerBase {
      */
     private static final String ixion = "Summon: Ixion";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay() {
         addCard(Zone.HAND, playerA, ixion, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/pip/Vault13DwellersJourneyTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/pip/Vault13DwellersJourneyTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.pip;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -21,7 +20,6 @@ public class Vault13DwellersJourneyTest extends CardTestPlayerBase {
      */
     private static final String vault = "Vault 13: Dweller's Journey";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay_ReturnOne() {
         addCard(Zone.HAND, playerA, vault, 1);
@@ -49,7 +47,6 @@ public class Vault13DwellersJourneyTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Memnite", 1);
         assertLife(playerA, 20 + 2);
     }
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay_Return() {
         addCard(Zone.HAND, playerA, vault, 1);
@@ -81,7 +78,6 @@ public class Vault13DwellersJourneyTest extends CardTestPlayerBase {
         assertLife(playerA, 20 + 2);
     }
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay_NoReturn() {
         addCard(Zone.HAND, playerA, vault, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/who/DayOfTheMoonTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/who/DayOfTheMoonTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.who;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -18,7 +17,6 @@ public class DayOfTheMoonTest extends CardTestPlayerBase {
      */
     private static final String day = "Day of the Moon";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay() {
         addCard(Zone.HAND, playerA, day, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/who/TheWarGamesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/who/TheWarGamesTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.who;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -20,7 +19,6 @@ public class TheWarGamesTest extends CardTestPlayerBase {
      */
     private static final String war = "The War Games";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay_NoExile() {
         addCard(Zone.HAND, playerA, war, 1);
@@ -63,7 +61,6 @@ public class TheWarGamesTest extends CardTestPlayerBase {
         assertLife(playerB, 20 - 6 - 9);
     }
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay_Exile() {
         addCard(Zone.HAND, playerA, war, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/who/TrialOfATimeLordTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/who/TrialOfATimeLordTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.who;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -20,7 +19,6 @@ public class TrialOfATimeLordTest extends CardTestPlayerBase {
      */
     private static final String trial = "Trial of a Time Lord";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay() {
         addCard(Zone.HAND, playerA, trial, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/woe/ThePrincessTakesFlightTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/woe/ThePrincessTakesFlightTest.java
@@ -3,7 +3,6 @@ package org.mage.test.cards.single.woe;
 import mage.abilities.keyword.FlyingAbility;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -21,7 +20,6 @@ public class ThePrincessTakesFlightTest extends CardTestPlayerBase {
      */
     private static final String flight = "The Princess Takes Flight";
 
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void test_SimplePlay() {
         addCard(Zone.HAND, playerA, flight, 1);
@@ -54,7 +52,6 @@ public class ThePrincessTakesFlightTest extends CardTestPlayerBase {
         assertExileCount(playerB, "Memnite", 0);
         assertPermanentCount(playerB, "Memnite", 1);
     }
-    @Ignore // TODO: goal of #11619 is to fix this nicely
     @Test
     public void testFlicker() {
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -1710,15 +1710,14 @@ public abstract class AbilityImpl implements Ability {
 
     private int getCurrentSourceObjectZoneChangeCounter(Game game){
         int zcc = game.getState().getZoneChangeCounter(getSourceId());
-        // TODO: Enable this, #13710
-        /*if (game.getPermanentEntering(getSourceId()) != null){
+        if (game.getPermanentEntering(getSourceId()) != null){
             // If the triggered ability triggered while the permanent is entering the battlefield
             // then add 1 zcc so that it triggers as if the permanent was already on the battlefield
             // So "Enters with counters" causes "Whenever counters are placed" to trigger with battlefield zcc
             // Particularly relevant for Sagas, which always involve both
             // Note that this does NOT apply to "As ~ ETB" effects, those still use the stack zcc
             zcc += 1;
-        }*/
+        }
         return zcc;
     }
 


### PR DESCRIPTION
This is a cleaned version of #11619.

This makes it so that if a permanent is entering as the ability's zcc is being updated, then the zcc is the permanent's instead of the spell's. An ability that happens "as ~ enters" will *not* have a changed zcc, as it isn't put into the entering list until after those abilities have been processed. The new `SigardasSplendorTest` verifies this behavior.

This also centralizes the updating of ability zcc, though `addDelayedTriggeredAbility` is unchanged due to to d8959f1588f0556ba4f4604d5c0dbf98350333b8. The only logic change is in the `getPermanentEntering` check.

Fixes #11728