### PR TITLE
Fix Zenos yae Galvus and Shinryu, Transcendent Rival triggers.

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShinryuTranscendentRival.java
+++ b/Mage.Sets/src/mage/cards/s/ShinryuTranscendentRival.java
@@ -125,9 +125,9 @@ class ShinryuTranscendentRivalTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        this.initSourceObjectZoneChangeCounter(game, false);
+        int zcc = game.getState().getZoneChangeCounter(this.getSourceId());
         return Optional
-                .of(this.getSourceId() + "_" + this.getSourceObjectZoneChangeCounter() + "_opponent")
+                .of(this.getSourceId() + "_" + zcc + "_opponent")
                 .map(game.getState()::getValue)
                 .map(event.getPlayerId()::equals)
                 .orElse(false);

--- a/Mage.Sets/src/mage/cards/s/ShinryuTranscendentRival.java
+++ b/Mage.Sets/src/mage/cards/s/ShinryuTranscendentRival.java
@@ -120,13 +120,14 @@ class ShinryuTranscendentRivalTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.LOSES;
+        return event.getType() == GameEvent.EventType.LOST;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
+        this.initSourceObjectZoneChangeCounter(game, false);
         return Optional
-                .ofNullable(this.getId() + "_" + this.getSourceObjectZoneChangeCounter() + "_opponent")
+                .of(this.getSourceId() + "_" + this.getSourceObjectZoneChangeCounter() + "_opponent")
                 .map(game.getState()::getValue)
                 .map(event.getPlayerId()::equals)
                 .orElse(false);

--- a/Mage.Sets/src/mage/cards/z/ZenosYaeGalvus.java
+++ b/Mage.Sets/src/mage/cards/z/ZenosYaeGalvus.java
@@ -88,8 +88,9 @@ enum ZenosYaeGalvusPredicate implements ObjectSourcePlayerPredicate<Permanent> {
 
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
+        input.getSource().initSourceObjectZoneChangeCounter(game, false);
         return flag == Optional
-                .ofNullable(CardUtil.getObjectZoneString(
+                .of(CardUtil.getObjectZoneString(
                         "chosenCreature", input.getSource().getSourceId(), game,
                         input.getSource().getSourceObjectZoneChangeCounter(), false
                 ))

--- a/Mage.Sets/src/mage/cards/z/ZenosYaeGalvus.java
+++ b/Mage.Sets/src/mage/cards/z/ZenosYaeGalvus.java
@@ -88,11 +88,11 @@ enum ZenosYaeGalvusPredicate implements ObjectSourcePlayerPredicate<Permanent> {
 
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
-        input.getSource().initSourceObjectZoneChangeCounter(game, false);
+        int zcc = game.getState().getZoneChangeCounter(input.getSource().getSourceId());
         return flag == Optional
                 .of(CardUtil.getObjectZoneString(
                         "chosenCreature", input.getSource().getSourceId(), game,
-                        input.getSource().getSourceObjectZoneChangeCounter(), false
+                        zcc, false
                 ))
                 .map(game.getState()::getValue)
                 .filter(MageObjectReference.class::isInstance)


### PR DESCRIPTION
Two weird, hard to track down issues plus one incorrect event type.

I don't understand why I need to call `initSourceObjectZoneChangeCounter` on each ability before the ZCC is properly tracked, but without those calls the second ability on each side of [[Zenos yae Galvus]] sees a ZCC of 0 instead of the ZCC of 4 that he had in my testing, and then it can't find the chosen creature or opponent.

Creating this as a pull request in case it is somehow a larger engine-scale issue that should be fixed rather than wallpapered over with this workaround.