### PR TITLE
Verify card name not in rules

### DIFF
--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -2404,8 +2404,7 @@ public class VerifyCardDataTest {
             if (rule.contains("&mdash ")) {
                 fail(card, "rules", "card's rules contains restricted test [&mdash ] instead [&mdash;]");
             }
-            if (rule.contains(card.getName()) && !rule.contains("named " + card.getName())
-                    && !rule.contains(card.getName()+" {")) {
+            if (Pattern.compile("(?<!named )"+Pattern.quote(card.getName())+"(?! \\{)").matcher(rule).find()) {
                 fail(card, "rules", "card's pre-formatted rules contains its name unexpectedly");
             }
             if (rule.contains("named {this}")) {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -2386,7 +2386,7 @@ public class VerifyCardDataTest {
         }
     }
 
-    private static final String[] wrongSymbols = {"’", "“", "”"};
+    private static final String[] wrongSymbols = {"’", "“", "”", "\n"};
 
     private void checkWrongSymbolsInRules(Card card) {
         for (String s : wrongSymbols) {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -2404,6 +2404,13 @@ public class VerifyCardDataTest {
             if (rule.contains("&mdash ")) {
                 fail(card, "rules", "card's rules contains restricted test [&mdash ] instead [&mdash;]");
             }
+            if (rule.contains(card.getName()) && !rule.contains("named " + card.getName())
+                    && !rule.contains(card.getName()+" {")) {
+                fail(card, "rules", "card's pre-formatted rules contains its name unexpectedly");
+            }
+            if (rule.contains("named {this}")) {
+                fail(card, "rules", "card's rules contains \"named {this}\", should use card's name");
+            }
         }
     }
 


### PR DESCRIPTION
Cards should not be referring to themselves by name directly, they should be using "{this}", except in the situation of checking for cards "named ~" in which case it should *not* be using "{this}", or for Adventure/Omen cards where that SpellAbility is in the rules text.

I also added "\n" to the list of wrongSymbols, as they should not be within an individual ability's rules.

There are 166 cards with the card's name in the text, 10 with "named {this}", and 6 with "\n". That's a lot, but they should all be pretty easy text fixes. I'll do those in master directly, then merge this once that's done.