### PR TITLE
fix: filter exiled cards before free cast

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CollectedConjuring.java
+++ b/Mage.Sets/src/mage/cards/c/CollectedConjuring.java
@@ -76,6 +76,8 @@ class CollectedConjuringEffect extends OneShotEffect {
         }
         Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, 6));
         controller.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, filter, 2);
         controller.putCardsOnBottomOfLibrary(cards, game, source, false);
         return true;

--- a/Mage.Sets/src/mage/cards/d/DanceWithCalamity.java
+++ b/Mage.Sets/src/mage/cards/d/DanceWithCalamity.java
@@ -78,6 +78,8 @@ class DanceWithCalamityEffect extends OneShotEffect {
             player.moveCards(card, Zone.EXILED, source, game);
             cards.add(card);
         }
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         if (cards
                 .getCards(game)
                 .stream()

--- a/Mage.Sets/src/mage/cards/e/EmergentUltimatum.java
+++ b/Mage.Sets/src/mage/cards/e/EmergentUltimatum.java
@@ -79,6 +79,8 @@ class EmergentUltimatumEffect extends OneShotEffect {
         boolean searched = player.searchLibrary(targetCardInLibrary, source, game);
         Cards cards = new CardsImpl(targetCardInLibrary.getTargets());
         player.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         if (cards.isEmpty()) {
             if (searched) {
                 player.shuffleLibrary(source, game);

--- a/Mage.Sets/src/mage/cards/e/EpicExperiment.java
+++ b/Mage.Sets/src/mage/cards/e/EpicExperiment.java
@@ -67,6 +67,8 @@ class EpicExperimentEffect extends OneShotEffect {
         }
         Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, CardUtil.getSourceCostsTag(game, source, "X", 0)));
         controller.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         FilterCard filter = new FilterInstantOrSorceryCard();
         filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, CardUtil.getSourceCostsTag(game, source, "X", 0) + 1));
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, filter);

--- a/Mage.Sets/src/mage/cards/e/EtaliPrimalConqueror.java
+++ b/Mage.Sets/src/mage/cards/e/EtaliPrimalConqueror.java
@@ -91,6 +91,8 @@ class EtaliPrimalConquerorEffect extends OneShotEffect {
                 }
             }
         }
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, StaticFilters.FILTER_CARD);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EtaliPrimalStorm.java
+++ b/Mage.Sets/src/mage/cards/e/EtaliPrimalStorm.java
@@ -78,6 +78,8 @@ class EtaliPrimalStormEffect extends OneShotEffect {
             }
         }
         controller.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, filter);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/f/FeveredSuspicion.java
+++ b/Mage.Sets/src/mage/cards/f/FeveredSuspicion.java
@@ -78,6 +78,7 @@ class FeveredSuspicionEffect extends OneShotEffect {
             }
         }
         controller.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
         nonlands.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(
                 controller, source, game, nonlands,

--- a/Mage.Sets/src/mage/cards/g/GixYawgmothPraetor.java
+++ b/Mage.Sets/src/mage/cards/g/GixYawgmothPraetor.java
@@ -144,6 +144,7 @@ class GixYawgmothPraetorExileEffect extends OneShotEffect {
         int xValue = GetXValue.instance.calculate(game, source, this);
         Set<Card> toExile = opponent.getLibrary().getTopCards(game, xValue);
         controller.moveCards(toExile, Zone.EXILED, source, game);
+        game.processAction();
         Cards cards = new CardsImpl(toExile);
         cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, StaticFilters.FILTER_CARD, Integer.MAX_VALUE, null, true);

--- a/Mage.Sets/src/mage/cards/h/HazoretsUndyingFury.java
+++ b/Mage.Sets/src/mage/cards/h/HazoretsUndyingFury.java
@@ -79,6 +79,8 @@ class HazoretsUndyingFuryEffect extends OneShotEffect {
         // move cards from library to exile
         Cards cards = new CardsImpl(controller.getLibrary().getTopCards(game, 4));
         controller.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         // cast the possible cards without paying the mana
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, filter);
         return true;

--- a/Mage.Sets/src/mage/cards/j/JaceArchitectOfThought.java
+++ b/Mage.Sets/src/mage/cards/j/JaceArchitectOfThought.java
@@ -108,6 +108,7 @@ class JaceArchitectOfThoughtEffect3 extends OneShotEffect {
             controller.moveCards(card, Zone.EXILED, source, game);
             player.shuffleLibrary(source, game);
         }
+        game.processAction();
         cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, StaticFilters.FILTER_CARD);
         return true;

--- a/Mage.Sets/src/mage/cards/k/KefkaDancingMad.java
+++ b/Mage.Sets/src/mage/cards/k/KefkaDancingMad.java
@@ -114,6 +114,7 @@ class KefkaDancingMadEffect extends OneShotEffect {
             return false;
         }
         controller.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
         cards.retainZone(Zone.EXILED, game);
         KefkaDancingMadTracker tracker = new KefkaDancingMadTracker();
         CardUtil.castMultipleWithAttributeForFree(

--- a/Mage.Sets/src/mage/cards/k/KotisTheFangkeeper.java
+++ b/Mage.Sets/src/mage/cards/k/KotisTheFangkeeper.java
@@ -80,6 +80,8 @@ class KotisTheFangkeeperEffect extends OneShotEffect {
         controller.moveCards(cards, Zone.EXILED, source, game);
         FilterCard filter = new FilterCard();
         filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, xValue + 1));
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, filter);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/k/KyloxVisionaryInventor.java
+++ b/Mage.Sets/src/mage/cards/k/KyloxVisionaryInventor.java
@@ -110,6 +110,8 @@ class KyloxVisionaryInventorEffect extends OneShotEffect {
             return true;
         }
         player.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(
                 player, source, game, cards,
                 StaticFilters.FILTER_CARD_INSTANT_OR_SORCERY

--- a/Mage.Sets/src/mage/cards/p/PrimevalSpawn.java
+++ b/Mage.Sets/src/mage/cards/p/PrimevalSpawn.java
@@ -132,6 +132,8 @@ class PrimevalSpawnSpellEffect extends OneShotEffect {
         }
         Cards cards = new CardsImpl(player.getLibrary().getTopCards(game, 10));
         player.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         CardUtil.castMultipleWithAttributeForFree(
                 player, source, game, cards, StaticFilters.FILTER_CARD,
                 Integer.MAX_VALUE, new PrimevalSpawnTracker()

--- a/Mage.Sets/src/mage/cards/v/VillainousWealth.java
+++ b/Mage.Sets/src/mage/cards/v/VillainousWealth.java
@@ -71,6 +71,8 @@ class VillainousWealthEffect extends OneShotEffect {
         }
         Cards cards = new CardsImpl(opponent.getLibrary().getTopCards(game, xValue));
         opponent.moveCards(cards, Zone.EXILED, source, game);
+        game.processAction();
+        cards.retainZone(Zone.EXILED, game);
         FilterCard filter = new FilterCard();
         filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, CardUtil.getSourceCostsTag(game, source, "X", 0) + 1));
         CardUtil.castMultipleWithAttributeForFree(controller, source, game, cards, filter);


### PR DESCRIPTION
This PR close #13788 by ensuring that all cards moved to exile are properly processed and filtered before being cast with `castMultipleWithAttributeForFree`.

The following card classes were updated to include the necessary calls to `game.processAction()` and `retainZone(...)`:

- `CollectedConjuring.java`
- `DanceWithCalamity.java`
- `EmergentUltimatum.java`
- `EpicExperiment.java`
- `EtaliPrimalConqueror.java`
- `EtaliPrimalStorm.java`
- `FeveredSuspicion.java`
- `GixYawgmothPraetor.java`
- `HazoretsUndyingFury.java`
- `JaceArchitectOfThought.java`
- `KefkaDancingMad.java`
- `KotisTheFangkeeper.java`
- `KyloxVisionaryInventor.java`
- `PrimevalSpawn.java`
- `VillainousWealth.java`