### PR TITLE
Conformer Shuriken - switch target and this power on comparition

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ConformerShuriken.java
+++ b/Mage.Sets/src/mage/cards/c/ConformerShuriken.java
@@ -86,7 +86,7 @@ class ConformerShurikenEffect extends OneShotEffect {
                 .map(game::getPermanent)
                 .map(MageObject::getPower)
                 .map(MageInt::getValue)
-                .map(x -> permanent.getPower().getValue() - x)
+                .map(targetsPower -> targetsPower - permanent.getPower().getValue())
                 .filter(x -> x > 0 && permanent.addCounters(CounterType.P1P1.createInstance(x), source, game))
                 .isPresent();
     }


### PR DESCRIPTION
calculation was wrong and only gave +1/+1 counter when the equipped creature had a greater power than the targeted creature.
[[Conformer Shuriken]]