### PR TITLE
Enable H2R Downloads and Fix Direct/Token Downloads

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -569,6 +569,7 @@ public class ScryfallImageSupportCards {
             add("BIG"); // The Big Score
             add("MH3"); // Modern Horizons 3
             add("M3C"); // Modern Horizons 3 Commander
+            add("H2R"); // Modern Horizons 2 Timeshifts
             add("ACR"); // Assassin's Creed
             add("BLB"); // Bloomburrow
             add("BLC"); // Bloomburrow Commander

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -631,11 +631,11 @@ public class ScryfallImageSupportCards {
             // see test_checkMissingScryfallSettingsAndCardNumbers
 
             // SOI
-            put("SOI/Tamiyo's Journal/265+a", "https://api.scryfall.com/cards/soi/265†a/");
-            put("SOI/Tamiyo's Journal/265+b", "https://api.scryfall.com/cards/soi/265†b/");
-            put("SOI/Tamiyo's Journal/265+c", "https://api.scryfall.com/cards/soi/265†c/");
-            put("SOI/Tamiyo's Journal/265+d", "https://api.scryfall.com/cards/soi/265†d/");
-            put("SOI/Tamiyo's Journal/265+e", "https://api.scryfall.com/cards/soi/265†e/");
+            put("SOI/Tamiyo's Journal/265+a", "https://api.scryfall.com/cards/soi/265%E2%80%A0a/");
+            put("SOI/Tamiyo's Journal/265+b", "https://api.scryfall.com/cards/soi/265%E2%80%A0b/");
+            put("SOI/Tamiyo's Journal/265+c", "https://api.scryfall.com/cards/soi/265%E2%80%A0c/");
+            put("SOI/Tamiyo's Journal/265+d", "https://api.scryfall.com/cards/soi/265%E2%80%A0d/");
+            put("SOI/Tamiyo's Journal/265+e", "https://api.scryfall.com/cards/soi/265%E2%80%A0e/");
             // SLD
             // fake double faced cards
             put("SLD/Adrix and Nev, Twincasters/1544b", "https://api.scryfall.com/cards/sld/1544/en?format=image&face=back");

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -631,11 +631,11 @@ public class ScryfallImageSupportCards {
             // see test_checkMissingScryfallSettingsAndCardNumbers
 
             // SOI
-            put("SOI/Tamiyo's Journal/265+a", "https://api.scryfall.com/cards/soi/265%E2%80%A0a/");
-            put("SOI/Tamiyo's Journal/265+b", "https://api.scryfall.com/cards/soi/265%E2%80%A0b/");
-            put("SOI/Tamiyo's Journal/265+c", "https://api.scryfall.com/cards/soi/265%E2%80%A0c/");
-            put("SOI/Tamiyo's Journal/265+d", "https://api.scryfall.com/cards/soi/265%E2%80%A0d/");
-            put("SOI/Tamiyo's Journal/265+e", "https://api.scryfall.com/cards/soi/265%E2%80%A0e/");
+            put("SOI/Tamiyo's Journal/265+a", "https://cards.scryfall.io/large/front/4/5/45242fd6-6e36-468c-b9ef-140fc969d343.jpg?1602168504");
+            put("SOI/Tamiyo's Journal/265+b", "https://cards.scryfall.io/large/front/e/a/eaae5c06-b8da-4f74-9ee6-dbcba6d638ad.jpg?1602168502");
+            put("SOI/Tamiyo's Journal/265+c", "https://cards.scryfall.io/large/front/7/6/761f4323-525f-440f-b7bd-3363f2180971.jpg?1602168500");
+            put("SOI/Tamiyo's Journal/265+d", "https://cards.scryfall.io/large/front/2/4/240c4920-09a8-452a-8fa3-784f3d00d434.jpg?1602168497");
+            put("SOI/Tamiyo's Journal/265+e", "https://cards.scryfall.io/large/front/f/7/f732c92e-8e0a-4c77-a3c0-d9b9384e363f.jpg?1602168494");
             // SLD
             // fake double faced cards
             put("SLD/Adrix and Nev, Twincasters/1544b", "https://api.scryfall.com/cards/sld/1544/en?format=image&face=back");
@@ -680,7 +680,7 @@ public class ScryfallImageSupportCards {
             put("SLD/Norin the Wary/827b", "https://api.scryfall.com/cards/sld/827/en?format=image&face=back");
             put("SLD/Noxious Ghoul/1459b", "https://api.scryfall.com/cards/sld/1459/en?format=image&face=back");
             put("SLD/Okaun, Eye of Chaos/380b", "https://api.scryfall.com/cards/sld/380/en?format=image&face=back");
-            put("SLD/Okaun, Eye of Chaos/380*b", "https://api.scryfall.com/cards/sld/380%E2%98%85/en?format=image&face=back");
+            put("SLD/Okaun, Eye of Chaos/380*b", "https://cards.scryfall.io/large/back/8/4/8421ad46-dc7f-4b66-800b-e41c30835300.jpg?1670031702");
             put("SLD/Parhelion II/1964b", "https://api.scryfall.com/cards/sld/1964/en?format=image&face=back");
             put("SLD/Peacewalker Colossus/1966b", "https://api.scryfall.com/cards/sld/1966/en?format=image&face=back");
             put("SLD/Propaganda/381b", "https://api.scryfall.com/cards/sld/381/en?format=image&face=back");
@@ -699,7 +699,7 @@ public class ScryfallImageSupportCards {
             put("SLD/Unholy Grotto/1462b", "https://api.scryfall.com/cards/sld/1462/en?format=image&face=back");
             put("SLD/Yargle, Glutton of Urborg/1542b", "https://api.scryfall.com/cards/sld/1542/en?format=image&face=back");
             put("SLD/Zndrsplt, Eye of Wisdom/379b", "https://api.scryfall.com/cards/sld/379/en?format=image&face=back");
-            put("SLD/Zndrsplt, Eye of Wisdom/379*b", "https://api.scryfall.com/cards/sld/379%E2%98%85/en?format=image&face=back");
+            put("SLD/Zndrsplt, Eye of Wisdom/379*b", "https://cards.scryfall.io/large/back/e/2/e25ce640-baf5-442b-8b75-d05dd9fb20dd.jpg?1670031676");
             put("SLD/Zombie Master/1460b", "https://api.scryfall.com/cards/sld/1460/en?format=image&face=back");
             // normal cards
             put("SLD/Counterspell/99999SCTLR", "https://api.scryfall.com/cards/sld/SCTLR/"); // see issue 11157

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -680,7 +680,7 @@ public class ScryfallImageSupportCards {
             put("SLD/Norin the Wary/827b", "https://api.scryfall.com/cards/sld/827/en?format=image&face=back");
             put("SLD/Noxious Ghoul/1459b", "https://api.scryfall.com/cards/sld/1459/en?format=image&face=back");
             put("SLD/Okaun, Eye of Chaos/380b", "https://api.scryfall.com/cards/sld/380/en?format=image&face=back");
-            put("SLD/Okaun, Eye of Chaos/380*b", "https://api.scryfall.com/cards/sld/380★/en?format=image&face=back");
+            put("SLD/Okaun, Eye of Chaos/380*b", "https://api.scryfall.com/cards/sld/380%E2%98%85/en?format=image&face=back");
             put("SLD/Parhelion II/1964b", "https://api.scryfall.com/cards/sld/1964/en?format=image&face=back");
             put("SLD/Peacewalker Colossus/1966b", "https://api.scryfall.com/cards/sld/1966/en?format=image&face=back");
             put("SLD/Propaganda/381b", "https://api.scryfall.com/cards/sld/381/en?format=image&face=back");
@@ -699,7 +699,7 @@ public class ScryfallImageSupportCards {
             put("SLD/Unholy Grotto/1462b", "https://api.scryfall.com/cards/sld/1462/en?format=image&face=back");
             put("SLD/Yargle, Glutton of Urborg/1542b", "https://api.scryfall.com/cards/sld/1542/en?format=image&face=back");
             put("SLD/Zndrsplt, Eye of Wisdom/379b", "https://api.scryfall.com/cards/sld/379/en?format=image&face=back");
-            put("SLD/Zndrsplt, Eye of Wisdom/379*b", "https://api.scryfall.com/cards/sld/379★/en?format=image&face=back");
+            put("SLD/Zndrsplt, Eye of Wisdom/379*b", "https://api.scryfall.com/cards/sld/379%E2%98%85/en?format=image&face=back");
             put("SLD/Zombie Master/1460b", "https://api.scryfall.com/cards/sld/1460/en?format=image&face=back");
             // normal cards
             put("SLD/Counterspell/99999SCTLR", "https://api.scryfall.com/cards/sld/SCTLR/"); // see issue 11157

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2859,7 +2859,7 @@ public class ScryfallImageSupportTokens {
             put("F17/Treasure/3", "https://api.scryfall.com/cards/f17/10?format=image&face=back");
 
             // HHO
-            put("HHO/Treasure", "https://api.scryfall.com/cards/hho/21%E2%98%85?format=image");
+            put("HHO/Treasure", "https://cards.scryfall.io/large/front/5/3/5379b994-5f9e-44ec-a69c-8d58ffb0dbd8.jpg?1749917487");
 
             // J12
             put("J12/Centaur", "https://api.scryfall.com/cards/j12/9?format=image");
@@ -2896,10 +2896,10 @@ public class ScryfallImageSupportTokens {
             put("PEMN/Zombie/2", "https://api.scryfall.com/cards/pemn/1Z?format=image&face=back");
 
             // PHEL
-            put("PHEL/Angel", "https://api.scryfall.com/cards/phel/1%E2%98%85?format=image");
+            put("PHEL/Angel", "https://cards.scryfall.io/large/front/4/a/4ac2b852-92b2-4daf-9d1f-f71d3b27c241.jpg?1561757080");
 
             // PL21
-            put("PL21/Minotaur", "https://api.scryfall.com/cards/pl21/2%E2%98%85?format=image");
+            put("PL21/Minotaur", "https://cards.scryfall.io/large/front/f/e/fe6b9fbc-4060-4ca4-bccb-a631268b57d9.jpg?1681762410");
 
             // PL23
             put("PL23/Food", "https://api.scryfall.com/cards/pl23/2?format=image");

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2859,7 +2859,7 @@ public class ScryfallImageSupportTokens {
             put("F17/Treasure/3", "https://api.scryfall.com/cards/f17/10?format=image&face=back");
 
             // HHO
-            put("HHO/Treasure", "https://api.scryfall.com/cards/hho/21★?format=image");
+            put("HHO/Treasure", "https://api.scryfall.com/cards/hho/21%E2%98%85?format=image");
 
             // J12
             put("J12/Centaur", "https://api.scryfall.com/cards/j12/9?format=image");
@@ -2896,10 +2896,10 @@ public class ScryfallImageSupportTokens {
             put("PEMN/Zombie/2", "https://api.scryfall.com/cards/pemn/1Z?format=image&face=back");
 
             // PHEL
-            put("PHEL/Angel", "https://api.scryfall.com/cards/phel/1★?format=image");
+            put("PHEL/Angel", "https://api.scryfall.com/cards/phel/1%E2%98%85?format=image");
 
             // PL21
-            put("PL21/Minotaur", "https://api.scryfall.com/cards/pl21/2★?format=image");
+            put("PL21/Minotaur", "https://api.scryfall.com/cards/pl21/2%E2%98%85?format=image");
 
             // PL23
             put("PL23/Food", "https://api.scryfall.com/cards/pl23/2?format=image");

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -837,7 +837,7 @@ public class ScryfallImageSupportTokens {
             put("SLD/Hydra", "https://api.scryfall.com/cards/sld/1334?format=image");
             put("SLD/Icingdeath, Frost Tongue", "https://api.scryfall.com/cards/sld/1018?format=image");
             put("SLD/Marit Lage", "https://api.scryfall.com/cards/sld/1681?format=image");
-            put("SLD/Mechtitan", "https://api.scryfall.com/cards/sld/1969?format=image");
+            put("SLD/Mechtitan", "https://api.scryfall.com/cards/sld/1969/en?format=image");
             put("SLD/Myr", "https://api.scryfall.com/cards/sld/2101?format=image");
             put("SLD/Saproling", "https://api.scryfall.com/cards/sld/1139?format=image");
             put("SLD/Shapeshifter/1", "https://api.scryfall.com/cards/sld/1906?format=image");

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -837,7 +837,8 @@ public class ScryfallImageSupportTokens {
             put("SLD/Hydra", "https://api.scryfall.com/cards/sld/1334?format=image");
             put("SLD/Icingdeath, Frost Tongue", "https://api.scryfall.com/cards/sld/1018?format=image");
             put("SLD/Marit Lage", "https://api.scryfall.com/cards/sld/1681?format=image");
-            put("SLD/Mechtitan", "https://api.scryfall.com/cards/sld/1969/en?format=image");
+            put("SLD/Mechtitan/1", "https://api.scryfall.com/cards/sld/1969/en?format=image");
+            put("SLD/Mechtitan/2", "https://api.scryfall.com/cards/sld/1969/en?format=image&face=back");
             put("SLD/Myr", "https://api.scryfall.com/cards/sld/2101?format=image");
             put("SLD/Saproling", "https://api.scryfall.com/cards/sld/1139?format=image");
             put("SLD/Shapeshifter/1", "https://api.scryfall.com/cards/sld/1906?format=image");

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -1532,7 +1532,8 @@
 |Generate|TOK:SLD|Hydra|||ZaxaraTheExemplaryHydraToken|
 |Generate|TOK:SLD|Icingdeath, Frost Tongue|||IcingdeathFrostTongueToken|
 |Generate|TOK:SLD|Marit Lage|||MaritLageToken|
-|Generate|TOK:SLD|Mechtitan|||MechtitanToken|
+|Generate|TOK:SLD|Mechtitan|1||MechtitanToken|
+|Generate|TOK:SLD|Mechtitan|2||MechtitanToken|
 |Generate|TOK:SLD|Myr|||MyrToken|
 |Generate|TOK:SLD|Saproling|||SaprolingToken|
 |Generate|TOK:SLD|Shapeshifter|1||ShapeshifterBlueToken|


### PR DESCRIPTION
H2R (Modern Horizons 2 Timeshifts) were added to XMage but weren't configured in `ScryfallImageSupportCards.java` so the art wasn't being downloaded, I've added it.

Downloads for cards with special characters ★ and † in the URLs were failing even though the URLs work correctly in a browser:
```
INFO  2025-06-30 09:33:55,466 http request 400 Bad Request https://api.scryfall.com/cards/sld/379★/en?format=image&face=back =>[XMAGE images downloader - 4] XmageURLConnection.printHttpResult 
WARN  2025-06-30 09:33:55,466 Image download failed for SLD - Zndrsplt, Eye of Wisdom, http code: 400, url: https://api.scryfall.com/cards/sld/379★/en?format=image&face=back =>[XMAGE images downloader - 4] DownloadPicturesService$DownloadTask.run 
WARN  2025-06-30 09:33:56,039 Image download failed for SOI - Tamiyo's Journal, http code: 400, url: https://api.scryfall.com/cards/soi/265†a/en?format=image =>[XMAGE images downloader - 7] DownloadPicturesService$DownloadTask.run 
WARN  2025-06-30 09:33:56,039 Image download failed for SOI - Tamiyo's Journal, http code: 400, url: https://api.scryfall.com/cards/soi/265†a?format=image =>[XMAGE images downloader - 7] DownloadPicturesService$DownloadTask.run 
```
~~I was able to resolve this by encoding those characters in URLs, I've made those changes for cards and tokens where I saw download errors for during testing.~~ Resolved using direct links instead of the API.

The SLD/Mechtitan token was not downloading and the link was not working without including `/en`: 
```
INFO  2025-06-30 09:33:49,138 http request 404 Not Found https://api.scryfall.com/cards/sld/1969?format=image            =>[XMAGE images downloader - 3] XmageURLConnection.printHttpResult 
WARN  2025-06-30 09:33:49,138 Image download failed for SLD - Mechtitan, http code: 404, url: https://api.scryfall.com/cards/sld/1969?format=image =>[XMAGE images downloader - 3] DownloadPicturesService$DownloadTask.run 
```
I've included that change to resolve the download error and also updated the tokens-database to use both faces.