### PR TITLE
Add Freeform Unlimited deck type

### DIFF
--- a/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesPanel.java
@@ -896,7 +896,7 @@ public class TablesPanel extends javax.swing.JPanel {
             formatFilterList.add(RowFilter.regexFilter("^Limited", TablesTableModel.COLUMN_DECK_TYPE));
         }
         if (btnFormatOther.isSelected()) {
-            formatFilterList.add(RowFilter.regexFilter("^Momir Basic|^Constructed - Pauper|^Constructed - Frontier|^Constructed - Extended|^Constructed - Eternal|^Constructed - Historical|^Constructed - Super|^Constructed - Freeform|^Australian Highlander|^European Highlander|^Canadian Highlander|^Constructed - Old|^Constructed - Historic", TablesTableModel.COLUMN_DECK_TYPE));
+            formatFilterList.add(RowFilter.regexFilter("^Momir Basic|^Constructed - Pauper|^Constructed - Frontier|^Constructed - Extended|^Constructed - Eternal|^Constructed - Historical|^Constructed - Super|^Constructed - Freeform|^Constructed - Freeform Unlimited|^Australian Highlander|^European Highlander|^Canadian Highlander|^Constructed - Old|^Constructed - Historic", TablesTableModel.COLUMN_DECK_TYPE));
         }
 
         // skill

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/FreeformUnlimited.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/FreeformUnlimited.java
@@ -1,0 +1,34 @@
+package mage.deck;
+
+import mage.cards.decks.Deck;
+import mage.cards.decks.DeckValidator;
+import mage.cards.decks.DeckValidatorErrorType;
+
+/**
+ * @author resech
+ */
+public class FreeformUnlimited extends DeckValidator {
+
+    public FreeformUnlimited() {
+        this("Constructed - Freeform Unlimited", null);
+    }
+
+    public FreeformUnlimited(String name, String shortName) {
+        super(name, shortName);
+    }
+
+    @Override
+    public int getDeckMinSize() {
+        return 0;
+    }
+
+    @Override
+    public int getSideboardMinSize() {
+        return 0;
+    }
+
+    @Override
+    public boolean validate(Deck deck) {
+        return true;
+    }
+}

--- a/Mage.Server/config/config.xml
+++ b/Mage.Server/config/config.xml
@@ -196,6 +196,7 @@
         <deckType name="Constructed - Old School 93/94 - EC Rules" jar="mage-deck-constructed.jar" className="mage.deck.OldSchool9394EC"/>
         <deckType name="Constructed - Premodern" jar="mage-deck-constructed.jar" className="mage.deck.Premodern"/>
         <deckType name="Constructed - Freeform" jar="mage-deck-constructed.jar" className="mage.deck.Freeform"/>
+        <deckType name="Constructed - Freeform Unlimited" jar="mage-deck-constructed.jar" className="mage.deck.FreeformUnlimited"/>
         <deckType name="Variant Magic - Commander" jar="mage-deck-constructed.jar" className="mage.deck.Commander"/>
         <deckType name="Variant Magic - Duel Commander" jar="mage-deck-constructed.jar" className="mage.deck.DuelCommander"/>
         <deckType name="Variant Magic - MTGO 1v1 Commander" jar="mage-deck-constructed.jar" className="mage.deck.MTGO1v1Commander"/>

--- a/Mage.Server/release/config/config.xml
+++ b/Mage.Server/release/config/config.xml
@@ -190,6 +190,7 @@
         <deckType name="Constructed - Old School 93/94 - EC Rules" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.OldSchool9394EC"/>
         <deckType name="Constructed - Premodern" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.Premodern"/>
         <deckType name="Constructed - Freeform" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.Freeform"/>
+        <deckType name="Constructed - Freeform Unlimited" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.FreeformUnlimited"/>
         <deckType name="Variant Magic - Commander" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.Commander"/>
         <deckType name="Variant Magic - Duel Commander" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.DuelCommander"/>
         <deckType name="Variant Magic - MTGO 1v1 Commander" jar="mage-deck-constructed-${project.version}.jar" className="mage.deck.MTGO1v1Commander"/>


### PR DESCRIPTION
There was a question in Discord about being able to play minimasters/pack battles or having the option to create a table with no deck building restrictions. The only decktype I could find that was unrestricted without a minimum decksize was freeform unlimited commander, the constructed - freeform type had a minimum size of 40 which is too high for minimasters and doesn't handle the goal of a table with no restrictions.

This is a copy of the Constructed - Freeform Deck type but using 0 as the minimum deck size and having the validation logic return true, similar to how Freeform Unlimited Commander is handled.