### PR TITLE
Remove Outdated/Broken Cards and Tokens

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2189,7 +2189,7 @@ public class ScryfallImageSupportTokens {
             put("WOC/Pirate", "https://api.scryfall.com/cards/twoc/12/en?format=image");
             put("WOC/Royal", "https://api.scryfall.com/cards/twoc/2/en?format=image");
             put("WOC/Saproling", "https://api.scryfall.com/cards/twoc/15/en?format=image");
-            put("WOC/Virtuous", "https://api.scryfall.com/cards/twoc/3/en?format=image");
+            put("WOC/Virtuous", "https://api.scryfall.com/cards/twoc/2/en?format=image");
 
             // WHO
             put("WHO/Alien", "https://api.scryfall.com/cards/twho/2?format=image");

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2180,22 +2180,15 @@ public class ScryfallImageSupportTokens {
             put("WOE/Young Hero", "https://api.scryfall.com/cards/twoe/16/en?format=image");
 
             // WOC
-            put("WOC/Cat/1", "https://api.scryfall.com/cards/twoc/6/en?format=image");
-            put("WOC/Cat/2", "https://api.scryfall.com/cards/twoc/5/en?format=image");
-            put("WOC/Elephant", "https://api.scryfall.com/cards/twoc/13/en?format=image");
             put("WOC/Faerie", "https://api.scryfall.com/cards/twoc/10/en?format=image");
             put("WOC/Faerie Rogue/1", "https://api.scryfall.com/cards/twoc/11/en?format=image");
             put("WOC/Faerie Rogue/2", "https://api.scryfall.com/cards/twoc/16/en?format=image");
-            put("WOC/Human Monk", "https://api.scryfall.com/cards/twoc/14/en?format=image");
             put("WOC/Human Soldier", "https://api.scryfall.com/cards/twoc/7/en?format=image");
             put("WOC/Monster", "https://api.scryfall.com/cards/twoc/1/en?format=image");
-            put("WOC/Ox", "https://api.scryfall.com/cards/twoc/8/en?format=image");
             put("WOC/Pegasus", "https://api.scryfall.com/cards/twoc/9/en?format=image");
             put("WOC/Pirate", "https://api.scryfall.com/cards/twoc/12/en?format=image");
             put("WOC/Royal", "https://api.scryfall.com/cards/twoc/2/en?format=image");
             put("WOC/Saproling", "https://api.scryfall.com/cards/twoc/15/en?format=image");
-            put("WOC/Sorcerer", "https://api.scryfall.com/cards/twoc/3/en?format=image");
-            put("WOC/Spirit", "https://api.scryfall.com/cards/twoc/17/en?format=image");
             put("WOC/Virtuous", "https://api.scryfall.com/cards/twoc/3/en?format=image");
 
             // WHO

--- a/Mage.Sets/src/mage/sets/MediaAndCollaborationPromos.java
+++ b/Mage.Sets/src/mage/sets/MediaAndCollaborationPromos.java
@@ -33,7 +33,7 @@ public class MediaAndCollaborationPromos extends ExpansionSet {
         cards.add(new SetCardInfo("Chandra's Outrage", "2010-3", Rarity.COMMON, mage.cards.c.ChandrasOutrage.class));
         cards.add(new SetCardInfo("Chandra's Spitfire", "2010-4", Rarity.UNCOMMON, mage.cards.c.ChandrasSpitfire.class));
         cards.add(new SetCardInfo("Counterspell", "2021-1", Rarity.RARE, mage.cards.c.Counterspell.class));
-        cards.add(new SetCardInfo("Crop Rotation", "2020-7ww", Rarity.RARE, mage.cards.c.CropRotation.class));
+        cards.add(new SetCardInfo("Crop Rotation", "2020-7", Rarity.RARE, mage.cards.c.CropRotation.class));
         cards.add(new SetCardInfo("Culling the Weak", "2023-8", Rarity.RARE, mage.cards.c.CullingTheWeak.class));
         cards.add(new SetCardInfo("Cunning Sparkmage", "2010-2", Rarity.UNCOMMON, mage.cards.c.CunningSparkmage.class));
         cards.add(new SetCardInfo("Dark Ritual", "2020-4", Rarity.RARE, mage.cards.d.DarkRitual.class));

--- a/Mage.Sets/src/mage/sets/SecretLairShowdown.java
+++ b/Mage.Sets/src/mage/sets/SecretLairShowdown.java
@@ -25,7 +25,6 @@ public class SecretLairShowdown extends ExpansionSet {
         cards.add(new SetCardInfo("Dark Ritual", 16, Rarity.RARE, mage.cards.d.DarkRitual.class));
         cards.add(new SetCardInfo("Death's Shadow", 8, Rarity.RARE, mage.cards.d.DeathsShadow.class));
         cards.add(new SetCardInfo("Dragonlord Silumgar", 9, Rarity.MYTHIC, mage.cards.d.DragonlordSilumgar.class));
-        cards.add(new SetCardInfo("Echo of Death's Wail", 356, Rarity.RARE, mage.cards.e.EchoOfDeathsWail.class));
         cards.add(new SetCardInfo("Eldritch Evolution", 5, Rarity.RARE, mage.cards.e.EldritchEvolution.class));
         cards.add(new SetCardInfo("Explore", 12, Rarity.RARE, mage.cards.e.Explore.class));
         cards.add(new SetCardInfo("Expressive Iteration", 13, Rarity.RARE, mage.cards.e.ExpressiveIteration.class));
@@ -60,7 +59,6 @@ public class SecretLairShowdown extends ExpansionSet {
         cards.add(new SetCardInfo("Supreme Verdict", 26, Rarity.RARE, mage.cards.s.SupremeVerdict.class));
         cards.add(new SetCardInfo("Swamp", 33, Rarity.LAND, mage.cards.basiclands.Swamp.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Swords to Plowshares", 20, Rarity.RARE, mage.cards.s.SwordsToPlowshares.class));
-        cards.add(new SetCardInfo("Tribute to Horobi", 356, Rarity.RARE, mage.cards.t.TributeToHorobi.class));
         cards.add(new SetCardInfo("Ugin, the Spirit Dragon", 6, Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class));
         cards.add(new SetCardInfo("Unholy Heat", 4, Rarity.RARE, mage.cards.u.UnholyHeat.class));
         cards.add(new SetCardInfo("Valakut, the Molten Pinnacle", 14, Rarity.RARE, mage.cards.v.ValakutTheMoltenPinnacle.class));

--- a/Mage.Sets/src/mage/sets/Warhammer40000Commander.java
+++ b/Mage.Sets/src/mage/sets/Warhammer40000Commander.java
@@ -30,7 +30,6 @@ public final class Warhammer40000Commander extends ExpansionSet {
         cards.add(new SetCardInfo("Abundance", 210, Rarity.RARE, mage.cards.a.Abundance.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Acolyte Hybrid", "70*", Rarity.UNCOMMON, mage.cards.a.AcolyteHybrid.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Acolyte Hybrid", 70, Rarity.UNCOMMON, mage.cards.a.AcolyteHybrid.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Adaptive Automaton", 322, Rarity.RARE, mage.cards.a.AdaptiveAutomaton.class));
         cards.add(new SetCardInfo("Aetherize", "191*", Rarity.UNCOMMON, mage.cards.a.Aetherize.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Aetherize", 191, Rarity.UNCOMMON, mage.cards.a.Aetherize.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("And They Shall Know No Fear", "9*", Rarity.UNCOMMON, mage.cards.a.AndTheyShallKnowNoFear.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -2235,22 +2235,15 @@
 |Generate|TOK:WOE|Young Hero|||YoungHeroRoleToken|
 
 # WOC
-|Generate|TOK:WOC|Cat|1||CatToken2|
-|Generate|TOK:WOC|Cat|2||CatToken|
-|Generate|TOK:WOC|Elephant|||ElephantToken|
 |Generate|TOK:WOC|Faerie|||FaerieToken|
 |Generate|TOK:WOC|Faerie Rogue|1||FaerieRogueToken|
 |Generate|TOK:WOC|Faerie Rogue|2||OonaQueenFaerieRogueToken|
-|Generate|TOK:WOC|Human Monk|||HumanMonkToken|
 |Generate|TOK:WOC|Human Soldier|||HumanSoldierToken|
 |Generate|TOK:WOC|Monster|||MonsterRoleToken|
-|Generate|TOK:WOC|Ox|||OxToken|
 |Generate|TOK:WOC|Pegasus|||PegasusToken2|
 |Generate|TOK:WOC|Pirate|||NettlingNuisancePirateToken|
 |Generate|TOK:WOC|Royal|||RoyalRoleToken|
 |Generate|TOK:WOC|Saproling|||SaprolingToken|
-|Generate|TOK:WOC|Sorcerer|||SorcererRoleToken|
-|Generate|TOK:WOC|Spirit|||WhiteBlackSpiritToken|
 |Generate|TOK:WOC|Virtuous|||VirtuousRoleToken|
 
 # WHO


### PR DESCRIPTION
- Fixes PMEI Crop Rotation URL
- Removes SLP Showdown Echo of Death's Wail & Tribute to Horobi, does not exist on scryfall and I can't find anything that says they were printed as part of the showdown series.
- Removes a bunch of WOC/TWOC tokens that were never printed and are not on scryfall.
- Updates URL for WOC/TWOC Virtuous token to point to a working card.
- Remove 40K Adaptive Automaton.

40K Adaptive Automaton is an interesting one, it does exist on gatherer but not on scryfall. After reaching out to scryfall to report it as missing they have responded that it was never physically printed so it was removed from scryfall. The scryfall team has also reported it themselves to gatherer to ask for it to be removed there. Considering that, I've removed it as part of this PR.