### PR TITLE
Card Number and Name fixes

### DIFF
--- a/Mage.Sets/src/mage/sets/MagicFest2025.java
+++ b/Mage.Sets/src/mage/sets/MagicFest2025.java
@@ -25,6 +25,12 @@ public class MagicFest2025 extends ExpansionSet {
         cards.add(new SetCardInfo("Ponder", 2, Rarity.RARE, mage.cards.p.Ponder.class));
         cards.add(new SetCardInfo("Serra the Benevolent", 1, Rarity.MYTHIC, mage.cards.s.SerraTheBenevolent.class, RETRO_ART));
         cards.add(new SetCardInfo("The First Sliver", 3, Rarity.MYTHIC, mage.cards.t.TheFirstSliver.class));
-        cards.add(new SetCardInfo("Yoshimaru, Ever Faithful", 4, Rarity.MYTHIC, mage.cards.y.YoshimaruEverFaithful.class));
+        cards.add(new SetCardInfo("Yoshimaru, Ever Faithful", 5, Rarity.MYTHIC, mage.cards.y.YoshimaruEverFaithful.class));
+        cards.add(new SetCardInfo("Ugin, the Spirit Dragon", 6, Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class, RETRO_ART));
+        cards.add(new SetCardInfo("Sliver Hive", 7, Rarity.RARE, mage.cards.s.SliverHive.class, RETRO_ART));
+        cards.add(new SetCardInfo("Tifa Lockhart", 9, Rarity.RARE, mage.cards.t.TifaLockhart.class));
+        cards.add(new SetCardInfo("Arcane Signet", 10, Rarity.RARE, mage.cards.a.ArcaneSignet.class));
+        cards.add(new SetCardInfo("Rograkh, Son of Rohgahh", 11, Rarity.RARE, mage.cards.r.RograkhSonOfRohgahh.class));
+        cards.add(new SetCardInfo("Swords to Plowshares", 13, Rarity.RARE, mage.cards.s.SwordsToPlowshares.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/MagicOnlinePromos.java
+++ b/Mage.Sets/src/mage/sets/MagicOnlinePromos.java
@@ -1209,7 +1209,7 @@ public class MagicOnlinePromos extends ExpansionSet {
         cards.add(new SetCardInfo("Helm of Kaldra", 31989, Rarity.RARE, mage.cards.h.HelmOfKaldra.class));
         cards.add(new SetCardInfo("Helm of Obedience", 65642, Rarity.RARE, mage.cards.h.HelmOfObedience.class));
         cards.add(new SetCardInfo("Hengegate Pathway", 88408, Rarity.RARE, mage.cards.h.HengegatePathway.class));
-        cards.add(new SetCardInfo("Henzie Toolbox Torre", 99789, Rarity.MYTHIC, mage.cards.h.HenzieToolboxTorre.class));
+        cards.add(new SetCardInfo("Henzie \"Toolbox\" Torre", 99789, Rarity.MYTHIC, mage.cards.h.HenzieToolboxTorre.class));
         cards.add(new SetCardInfo("Herd Migration", 103470, Rarity.RARE, mage.cards.h.HerdMigration.class));
         cards.add(new SetCardInfo("Hermit Druid", 36080, Rarity.RARE, mage.cards.h.HermitDruid.class));
         cards.add(new SetCardInfo("Hero of Bladehold", 39646, Rarity.MYTHIC, mage.cards.h.HeroOfBladehold.class));

--- a/Mage.Sets/src/mage/sets/MagicOnlinePromos.java
+++ b/Mage.Sets/src/mage/sets/MagicOnlinePromos.java
@@ -1486,7 +1486,7 @@ public class MagicOnlinePromos extends ExpansionSet {
         cards.add(new SetCardInfo("Kolvori, God of Kinship", 88348, Rarity.RARE, mage.cards.k.KolvoriGodOfKinship.class));
         cards.add(new SetCardInfo("Koma, Cosmos Serpent", 88356, Rarity.MYTHIC, mage.cards.k.KomaCosmosSerpent.class));
         cards.add(new SetCardInfo("Komainu Battle Armor", 97995, Rarity.RARE, mage.cards.k.KomainuBattleArmor.class));
-        cards.add(new SetCardInfo("Kongming, Sleeping Dragon", 33442, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class, RETRO_ART));
+        cards.add(new SetCardInfo("Kongming, \"Sleeping Dragon\"", 33442, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class, RETRO_ART));
         cards.add(new SetCardInfo("Kor Duelist", 36212, Rarity.UNCOMMON, mage.cards.k.KorDuelist.class));
         cards.add(new SetCardInfo("Kor Firewalker", 43574, Rarity.UNCOMMON, mage.cards.k.KorFirewalker.class));
         cards.add(new SetCardInfo("Kor Skyfisher", 43548, Rarity.COMMON, mage.cards.k.KorSkyfisher.class));

--- a/Mage.Sets/src/mage/sets/MastersEditionIII.java
+++ b/Mage.Sets/src/mage/sets/MastersEditionIII.java
@@ -140,7 +140,7 @@ public final class MastersEditionIII extends ExpansionSet {
         cards.add(new SetCardInfo("Kobold Overlord", 105, Rarity.UNCOMMON, mage.cards.k.KoboldOverlord.class, RETRO_ART));
         cards.add(new SetCardInfo("Kobold Taskmaster", 106, Rarity.COMMON, mage.cards.k.KoboldTaskmaster.class, RETRO_ART));
         cards.add(new SetCardInfo("Kobolds of Kher Keep", 107, Rarity.COMMON, mage.cards.k.KoboldsOfKherKeep.class, RETRO_ART));
-        cards.add(new SetCardInfo("Kongming, Sleeping Dragon", 16, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class, RETRO_ART));
+        cards.add(new SetCardInfo("Kongming, \"Sleeping Dragon\"", 16, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class, RETRO_ART));
         cards.add(new SetCardInfo("Labyrinth Minotaur", 39, Rarity.COMMON, mage.cards.l.LabyrinthMinotaur.class, RETRO_ART));
         cards.add(new SetCardInfo("Lady Caleria", 157, Rarity.UNCOMMON, mage.cards.l.LadyCaleria.class, RETRO_ART));
         cards.add(new SetCardInfo("Lady Evangela", 158, Rarity.UNCOMMON, mage.cards.l.LadyEvangela.class, RETRO_ART));

--- a/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
+++ b/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
@@ -85,7 +85,7 @@ public final class PortalThreeKingdoms extends ExpansionSet {
         cards.add(new SetCardInfo("Island", 170, Rarity.LAND, mage.cards.basiclands.Island.class, RETRO_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Island", 171, Rarity.LAND, mage.cards.basiclands.Island.class, RETRO_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Kongming's Contraptions", 10, Rarity.RARE, mage.cards.k.KongmingsContraptions.class, RETRO_ART));
-        cards.add(new SetCardInfo("Kongming, Sleeping Dragon", 9, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class, RETRO_ART));
+        cards.add(new SetCardInfo("Kongming, \"Sleeping Dragon\"", 9, Rarity.RARE, mage.cards.k.KongmingSleepingDragon.class, RETRO_ART));
         cards.add(new SetCardInfo("Lady Sun", 45, Rarity.RARE, mage.cards.l.LadySun.class, RETRO_ART));
         cards.add(new SetCardInfo("Lady Zhurong, Warrior Queen", 139, Rarity.RARE, mage.cards.l.LadyZhurongWarriorQueen.class, RETRO_ART));
         cards.add(new SetCardInfo("Liu Bei, Lord of Shu", 11, Rarity.RARE, mage.cards.l.LiuBeiLordOfShu.class, RETRO_ART));

--- a/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
+++ b/Mage.Sets/src/mage/sets/PortalThreeKingdoms.java
@@ -106,7 +106,7 @@ public final class PortalThreeKingdoms extends ExpansionSet {
         cards.add(new SetCardInfo("Mountain Bandit", 117, Rarity.COMMON, mage.cards.m.MountainBandit.class, RETRO_ART));
         cards.add(new SetCardInfo("Mystic Denial", 49, Rarity.UNCOMMON, mage.cards.m.MysticDenial.class, RETRO_ART));
         cards.add(new SetCardInfo("Overwhelming Forces", 79, Rarity.RARE, mage.cards.o.OverwhelmingForces.class, RETRO_ART));
-        cards.add(new SetCardInfo("Pang Tong, Young Phoenix", 14, Rarity.RARE, mage.cards.p.PangTongYoungPhoenix.class, RETRO_ART));
+        cards.add(new SetCardInfo("Pang Tong, \"Young Phoenix\"", 14, Rarity.RARE, mage.cards.p.PangTongYoungPhoenix.class, RETRO_ART));
         cards.add(new SetCardInfo("Peach Garden Oath", 15, Rarity.UNCOMMON, mage.cards.p.PeachGardenOath.class, RETRO_ART));
         cards.add(new SetCardInfo("Plains", 166, Rarity.LAND, mage.cards.basiclands.Plains.class, RETRO_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Plains", 167, Rarity.LAND, mage.cards.basiclands.Plains.class, RETRO_ART_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/SecretLairDrop.java
+++ b/Mage.Sets/src/mage/sets/SecretLairDrop.java
@@ -1946,8 +1946,6 @@ public class SecretLairDrop extends ExpansionSet {
         cards.add(new SetCardInfo("Reckoner Bankbuster", "1967b", Rarity.RARE, mage.cards.r.ReckonerBankbuster.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Smuggler's Copter", 1968, Rarity.RARE, mage.cards.s.SmugglersCopter.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Smuggler's Copter", "1968b", Rarity.RARE, mage.cards.s.SmugglersCopter.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Mechtitan Core", 1969, Rarity.COMMON, mage.cards.m.MechtitanCore.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Mechtitan Core", "1969b", Rarity.COMMON, mage.cards.m.MechtitanCore.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Dragonlord Atarka", 1970, Rarity.MYTHIC, mage.cards.d.DragonlordAtarka.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Dragonlord Atarka", "1970b", Rarity.MYTHIC, mage.cards.d.DragonlordAtarka.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Dragonlord Dromoka", 1971, Rarity.MYTHIC, mage.cards.d.DragonlordDromoka.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/URLConventionPromos.java
+++ b/Mage.Sets/src/mage/sets/URLConventionPromos.java
@@ -23,7 +23,7 @@ public class URLConventionPromos extends ExpansionSet {
         cards.add(new SetCardInfo("Aeronaut Tinkerer", 8, Rarity.COMMON, mage.cards.a.AeronautTinkerer.class));
         cards.add(new SetCardInfo("Bloodthrone Vampire", 3, Rarity.RARE, mage.cards.b.BloodthroneVampire.class));
         cards.add(new SetCardInfo("Chandra's Fury", 5, Rarity.RARE, mage.cards.c.ChandrasFury.class));
-        cards.add(new SetCardInfo("Kor Skyfisher", 2, Rarity.RARE, mage.cards.k.KorSkyfisher.class));
+        cards.add(new SetCardInfo("Kor Skyfisher", 23, Rarity.RARE, mage.cards.k.KorSkyfisher.class));
         cards.add(new SetCardInfo("Merfolk Mesmerist", 4, Rarity.RARE, mage.cards.m.MerfolkMesmerist.class));
         // Italian-only printing
         //cards.add(new SetCardInfo("Relentless Rats", 9, Rarity.RARE, mage.cards.r.RelentlessRats.class));
@@ -31,5 +31,6 @@ public class URLConventionPromos extends ExpansionSet {
         //cards.add(new SetCardInfo("Shepherd of the Lost", "34*", Rarity.UNCOMMON, mage.cards.s.ShepherdOfTheLost.class));
         cards.add(new SetCardInfo("Stealer of Secrets", 7, Rarity.RARE, mage.cards.s.StealerOfSecrets.class));
         cards.add(new SetCardInfo("Steward of Valeron", 1, Rarity.RARE, mage.cards.s.StewardOfValeron.class));
+        cards.add(new SetCardInfo("Counterspell", 2, Rarity.RARE, mage.cards.c.Counterspell.class));
      }
 }


### PR DESCRIPTION
- Fix PF25 Yoshimaru card number and add missing cards.
- Fix inconsistent naming for `Kongming, "Sleeping Dragon"` across sets.
- Fix inconsistent naming for `Henzie "Toolbox" Torre` across sets.
- Fix inconsistent naming for `Pang Tong "Young Phoenix"` across sets.
- Fix PURL Kor Skyfisher card number and add Counterspell.
- Remove Second Mechtitan Core entry from SLD, it's a Mechtitan token not Mechtitan Core.