### PR TITLE
Clipboard Import Improvements

### DIFF
--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportClipboardDialog.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportClipboardDialog.java
@@ -23,8 +23,12 @@ public class DeckImportClipboardDialog extends MageDialog {
             "// Example:\n" +
                     "//1 Library of Congress\n" +
                     "//1 Cryptic Gateway\n" +
-                    "//1 Azami, Lady of Scrolls\n" +
                     "// NB: This is slow as, and will lock your screen :)\n" +
+                    "// Decks are processed as plain text format\n" +
+                    "// To process as mtga format, use a first line of\n" +
+                    "// Commander or Deck. Example:\n" +
+                    "// Deck\n" +
+                    "// 1 Runehorn Hellkite (SCD) 155\n" +
                     "\n" +
                     "// Your current clipboard:\n" +
                     "\n";
@@ -73,7 +77,7 @@ public class DeckImportClipboardDialog extends MageDialog {
 
         String tempDeckPath;
         // This dialog also accepts a paste in .mtga format
-        if (decklist.startsWith("Deck\n")) {  // An .mtga list always starts with the first line being "Deck". This kind of paste is processed as .mtga
+        if (decklist.startsWith("Deck\n") || decklist.startsWith("Commander\n")) {  // An .mtga list always starts with the first line being "Deck" or "Commander". This kind of paste is processed as .mtga
             tempDeckPath = DeckUtil.writeTextToTempFile("cbimportdeck", ".mtga", decklist);
         } else {
             // If the paste is not .mtga format, it's processed as plaintext

--- a/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportClipboardDialog.java
+++ b/Mage.Client/src/main/java/mage/client/deckeditor/DeckImportClipboardDialog.java
@@ -5,6 +5,9 @@ import mage.client.dialog.MageDialog;
 import mage.util.DeckUtil;
 
 import javax.swing.*;
+
+import org.apache.commons.lang3.StringUtils;
+
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -77,7 +80,8 @@ public class DeckImportClipboardDialog extends MageDialog {
 
         String tempDeckPath;
         // This dialog also accepts a paste in .mtga format
-        if (decklist.startsWith("Deck\n") || decklist.startsWith("Commander\n")) {  // An .mtga list always starts with the first line being "Deck" or "Commander". This kind of paste is processed as .mtga
+        if (StringUtils.startsWithIgnoreCase(decklist, "Deck\n") || StringUtils.startsWithIgnoreCase(decklist, "Commander\n")) { 
+            // An .mtga list always starts with the first line being "Deck" or "Commander". This kind of paste is processed as .mtga
             tempDeckPath = DeckUtil.writeTextToTempFile("cbimportdeck", ".mtga", decklist);
         } else {
             // If the paste is not .mtga format, it's processed as plaintext

--- a/Mage/src/main/java/mage/cards/decks/importer/MtgaImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/MtgaImporter.java
@@ -36,10 +36,11 @@ public class MtgaImporter extends PlainTextDeckImporter {
         line = line.trim();
 
         if (line.equals("Deck")) {
+            sideboard = false;
             return;
         }
 
-        if (line.equals("Sideboard") || line.equals("")) {
+        if (line.equals("Sideboard") || line.equals("") || line.equals("Commander")) {
             sideboard = true;
             return;
         }

--- a/Mage/src/main/java/mage/cards/decks/importer/MtgaImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/MtgaImporter.java
@@ -35,12 +35,12 @@ public class MtgaImporter extends PlainTextDeckImporter {
 
         line = line.trim();
 
-        if (line.equals("Deck")) {
+        if (line.equalsIgnoreCase("Deck")) {
             sideboard = false;
             return;
         }
 
-        if (line.equals("Sideboard") || line.equals("") || line.equals("Commander")) {
+        if (line.equalsIgnoreCase("Sideboard") || line.equalsIgnoreCase("") || line.equalsIgnoreCase("Commander")) {
             sideboard = true;
             return;
         }


### PR DESCRIPTION
- Added example text to the clipboard import for getting the list parsed as mtga format
- Modified the check in DeckImportClipboardDialog to treat lists starting with Commander or Deck as mtga formatted.
- Added support in the MtgaImporter to handle the Commander line that is used for Brawl