### PR TITLE
Fix Station wrongly showing as activatable

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/StationAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/StationAbility.java
@@ -8,7 +8,10 @@ import mage.constants.Outcome;
 import mage.constants.TimingRule;
 import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.filter.predicate.permanent.TappedPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -20,8 +23,15 @@ import java.util.List;
  */
 public class StationAbility extends SimpleActivatedAbility {
 
+    private static final FilterControlledPermanent filter = new FilterControlledCreaturePermanent("another creature you control");
+
+    static {
+        filter.add(AnotherPredicate.instance);
+        filter.add(TappedPredicate.UNTAPPED);
+    }
+
     public StationAbility() {
-        super(Zone.BATTLEFIELD, new StationAbilityEffect(), new TapTargetCost(StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE));
+        super(Zone.BATTLEFIELD, new StationAbilityEffect(), new TapTargetCost(filter));
         this.timing = TimingRule.SORCERY;
     }
 
@@ -36,7 +46,7 @@ public class StationAbility extends SimpleActivatedAbility {
 
     @Override
     public String getRule() {
-        return "station <i>(Tap another creature you control: Put charge counters equal to its power on {this}. Station only as a sorcery.)</i>";
+        return "Station <i>(Tap another creature you control: Put charge counters equal to its power on {this}. Station only as a sorcery.)</i>";
     }
 }
 


### PR DESCRIPTION
Significant QOL improvement for station which causes the keyword to work like all other abilities with a tap cost. That is to say, there is an implicit "Tap another <**untapped**> creature you control..." in station's cost. Every other card in the game explicitly states the permanent must be untapped in the cost but they omitted the word in the hint text of station for brevity. See screenshots below of before and after this fix:

<details><summary>Before</summary>
Base board state (normal):
<img width="899" height="643" alt="image" src="https://github.com/user-attachments/assets/1ed433d8-9fb1-45dc-828f-2083622e49e6" />
Activating. Note how ALL creatures are highlighted as an option to tap as part of the cost, even the creature which is already tapped. Selecting the tapped creature causes the paying of the ability to instantly end prematurely, because it isn't a valid option.
<img width="904" height="650" alt="image" src="https://github.com/user-attachments/assets/c84cc8da-6a86-43da-a630-0a053e0ae4fe" />
With no creatures available to activate Station. Note that the spacecraft remains highlighted purple to communicate that it can be activated - but it can't.
<img width="744" height="645" alt="image" src="https://github.com/user-attachments/assets/1d23d049-c78e-44cd-92e8-1e414655c5e6" />
</details>

<details><summary>After</summary>
Base board state (normal):
<img width="850" height="647" alt="image" src="https://github.com/user-attachments/assets/1758b241-7d5b-4c8f-a98a-b060f253d10c" />
Activating. Note that the tapped creature isn't shown as an option to tap.
<img width="888" height="646" alt="image" src="https://github.com/user-attachments/assets/d3da29e3-034e-49d6-8304-a49dfc4a22ff" />
With no creatures available to activate Station. Note that the spacecraft has no purple highlight - there are no creatures available to tap to pay the cost.
<img width="892" height="634" alt="image" src="https://github.com/user-attachments/assets/7c2253ee-1428-4f18-a589-4a5586e11b06" />


</details>