### PR TITLE
Effect withTargetDescription, other fixes for discrepencies with "target" text with reference

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CircleOfFlame.java
+++ b/Mage.Sets/src/mage/cards/c/CircleOfFlame.java
@@ -30,7 +30,7 @@ public final class CircleOfFlame extends CardImpl {
 
 
         // Whenever a creature without flying attacks you or a planeswalker you control, Circle of Flame deals 1 damage to that creature.
-        this.addAbility(new AttacksAllTriggeredAbility(new DamageTargetEffect(1), false,
+        this.addAbility(new AttacksAllTriggeredAbility(new DamageTargetEffect(1).withTargetDescription("that creature"), false,
                 filter, SetTargetPointer.PERMANENT, true));
     }
 

--- a/Mage.Sets/src/mage/cards/d/DrownInFilth.java
+++ b/Mage.Sets/src/mage/cards/d/DrownInFilth.java
@@ -32,7 +32,7 @@ public final class DrownInFilth extends CardImpl {
         effect.setText("Choose target creature. Mill four cards");
         this.getSpellAbility().addEffect(effect);
         DynamicValue landCards = new SignInversionDynamicValue(new CardsInControllerGraveyardCount(new FilterLandCard()));
-        this.getSpellAbility().addEffect(new BoostTargetEffect(landCards, landCards, Duration.EndOfTurn).withTargetDescription("that creature"));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(landCards, landCards, Duration.EndOfTurn).withTargetDescription(", then that creature"));
     }
 
     private DrownInFilth(final DrownInFilth card) {

--- a/Mage.Sets/src/mage/cards/d/DrownInFilth.java
+++ b/Mage.Sets/src/mage/cards/d/DrownInFilth.java
@@ -1,7 +1,6 @@
 
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.CardsInControllerGraveyardCount;
 import mage.abilities.dynamicvalue.common.SignInversionDynamicValue;
@@ -14,6 +13,8 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.filter.common.FilterLandCard;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -31,7 +32,7 @@ public final class DrownInFilth extends CardImpl {
         effect.setText("Choose target creature. Mill four cards");
         this.getSpellAbility().addEffect(effect);
         DynamicValue landCards = new SignInversionDynamicValue(new CardsInControllerGraveyardCount(new FilterLandCard()));
-        this.getSpellAbility().addEffect(new BoostTargetEffect(landCards, landCards, Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new BoostTargetEffect(landCards, landCards, Duration.EndOfTurn).withTargetDescription("that creature"));
     }
 
     private DrownInFilth(final DrownInFilth card) {

--- a/Mage.Sets/src/mage/cards/e/EchoStorm.java
+++ b/Mage.Sets/src/mage/cards/e/EchoStorm.java
@@ -1,12 +1,13 @@
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
 import mage.abilities.keyword.CommanderStormAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.target.common.TargetArtifactPermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -18,7 +19,7 @@ public final class EchoStorm extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}{U}");
 
         // When you cast this spell, copy it for each time you've cast your commander from the command zone this game. You may choose new targets for the copies.
-        this.addAbility(new CommanderStormAbility());
+        this.addAbility(new CommanderStormAbility(true));
 
         // Create a token that's a copy of target artifact.
         this.getSpellAbility().addEffect(new CreateTokenCopyTargetEffect());

--- a/Mage.Sets/src/mage/cards/e/EmpyrialStorm.java
+++ b/Mage.Sets/src/mage/cards/e/EmpyrialStorm.java
@@ -1,12 +1,13 @@
 package mage.cards.e;
 
-import java.util.UUID;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.keyword.CommanderStormAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.game.permanent.token.AngelToken;
+
+import java.util.UUID;
 
 /**
  *
@@ -18,7 +19,7 @@ public final class EmpyrialStorm extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{W}{W}");
 
         // When you cast this spell, copy it for each time you've cast your commander from the command zone this game.
-        this.addAbility(new CommanderStormAbility());
+        this.addAbility(new CommanderStormAbility(false));
 
         // Create a 4/4 white Angel creature token with flying.
         this.getSpellAbility().addEffect(new CreateTokenEffect(new AngelToken()));

--- a/Mage.Sets/src/mage/cards/f/FuryStorm.java
+++ b/Mage.Sets/src/mage/cards/f/FuryStorm.java
@@ -1,6 +1,5 @@
 package mage.cards.f;
 
-import java.util.UUID;
 import mage.abilities.effects.common.CopyTargetStackObjectEffect;
 import mage.abilities.keyword.CommanderStormAbility;
 import mage.cards.CardImpl;
@@ -8,6 +7,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.StaticFilters;
 import mage.target.TargetSpell;
+
+import java.util.UUID;
 
 /**
  *
@@ -19,7 +20,7 @@ public final class FuryStorm extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{2}{R}{R}");
 
         // When you cast this spell, copy it for each time you've cast your commander from the command zone this game. You may choose new targets for the copies.
-        this.addAbility(new CommanderStormAbility());
+        this.addAbility(new CommanderStormAbility(true));
 
         // Copy target instant or sorcery spell. You may choose new targets for the copy.
         this.getSpellAbility().addEffect(new CopyTargetStackObjectEffect());

--- a/Mage.Sets/src/mage/cards/g/GenesisStorm.java
+++ b/Mage.Sets/src/mage/cards/g/GenesisStorm.java
@@ -1,19 +1,16 @@
 package mage.cards.g;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.CommanderStormAbility;
-import mage.cards.Card;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.cards.Cards;
-import mage.cards.CardsImpl;
+import mage.cards.*;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.players.Player;
+
+import java.util.UUID;
 
 /**
  *
@@ -25,7 +22,7 @@ public final class GenesisStorm extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}{G}");
 
         // When you cast this spell, copy it for each time you've cast your commander from the command zone this game.
-        this.addAbility(new CommanderStormAbility());
+        this.addAbility(new CommanderStormAbility(false));
 
         // Reveal cards from the top of your library until you reveal a nonland permanent card. You may put that card onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield on the bottom of your library in a random order.
         this.getSpellAbility().addEffect(new GenesisStormEffect());

--- a/Mage.Sets/src/mage/cards/h/HeliodsEmissary.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsEmissary.java
@@ -1,7 +1,6 @@
 
 package mage.cards.h;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.AttacksAttachedTriggeredAbility;
@@ -10,17 +9,13 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.TapTargetEffect;
 import mage.abilities.effects.common.continuous.BoostEnchantedEffect;
 import mage.abilities.keyword.BestowAbility;
+import mage.abilities.meta.OrTriggeredAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Duration;
-import mage.constants.Zone;
-import mage.filter.StaticFilters;
-import mage.target.Target;
+import mage.constants.*;
 import mage.target.TargetPermanent;
-import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 import static mage.filter.StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE;
 
@@ -31,7 +26,7 @@ import static mage.filter.StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE;
 public final class HeliodsEmissary extends CardImpl {
 
     public HeliodsEmissary(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT,CardType.CREATURE},"{3}{W}");
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT, CardType.CREATURE}, "{3}{W}");
         this.subtype.add(SubType.ELK);
 
         this.power = new MageInt(3);
@@ -40,16 +35,13 @@ public final class HeliodsEmissary extends CardImpl {
         // Bestow {6}{W}
         this.addAbility(new BestowAbility(this, "{6}{W}"));
         // Whenever Heliod's Emissary or enchanted creature attacks, tap target creature an opponent controls.
-        Ability ability = new AttacksTriggeredAbility(new TapTargetEffect(), false);
-        Target target = new TargetPermanent(FILTER_OPPONENTS_PERMANENT_CREATURE);
-        ability.addTarget(target);
-        this.addAbility(ability);
-        ability = new AttacksAttachedTriggeredAbility(new TapTargetEffect(), AttachmentType.AURA, false);
-        target = new TargetPermanent(FILTER_OPPONENTS_PERMANENT_CREATURE);
-        ability.addTarget(target);
+        Ability ability = new OrTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(),
+                new AttacksTriggeredAbility(null, false),
+                new AttacksAttachedTriggeredAbility(null, AttachmentType.AURA, false));
+        ability.addTarget(new TargetPermanent(FILTER_OPPONENTS_PERMANENT_CREATURE));
         this.addAbility(ability);
         // Enchanted creature gets +3/+3.
-        this.addAbility(new SimpleStaticAbility(new BoostEnchantedEffect(3,3, Duration.WhileOnBattlefield)));
+        this.addAbility(new SimpleStaticAbility(new BoostEnchantedEffect(3, 3, Duration.WhileOnBattlefield)));
     }
 
     private HeliodsEmissary(final HeliodsEmissary card) {

--- a/Mage.Sets/src/mage/cards/h/HeliodsEmissary.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsEmissary.java
@@ -36,6 +36,7 @@ public final class HeliodsEmissary extends CardImpl {
         this.addAbility(new BestowAbility(this, "{6}{W}"));
         // Whenever Heliod's Emissary or enchanted creature attacks, tap target creature an opponent controls.
         Ability ability = new OrTriggeredAbility(Zone.BATTLEFIELD, new TapTargetEffect(),
+                false, "Whenever {this} or enchanted creature attacks, ",
                 new AttacksTriggeredAbility(null, false),
                 new AttacksAttachedTriggeredAbility(null, AttachmentType.AURA, false));
         ability.addTarget(new TargetPermanent(FILTER_OPPONENTS_PERMANENT_CREATURE));

--- a/Mage.Sets/src/mage/cards/k/KothOfTheHammer.java
+++ b/Mage.Sets/src/mage/cards/k/KothOfTheHammer.java
@@ -41,7 +41,7 @@ public final class KothOfTheHammer extends CardImpl {
 
         // +1: Untap target Mountain. It becomes a 4/4 red Elemental creature until end of turn. It's still a land.
         Ability ability = new LoyaltyAbility(new UntapTargetEffect(), 1);
-        ability.addEffect(new BecomesCreatureTargetEffect(new KothOfTheHammerToken(), false, true, Duration.EndOfTurn));
+        ability.addEffect(new BecomesCreatureTargetEffect(new KothOfTheHammerToken(), false, true, Duration.EndOfTurn).withTargetDescription("It"));
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/k/KothOfTheHammer.java
+++ b/Mage.Sets/src/mage/cards/k/KothOfTheHammer.java
@@ -65,7 +65,7 @@ public final class KothOfTheHammer extends CardImpl {
 class KothOfTheHammerToken extends TokenImpl {
 
     public KothOfTheHammerToken() {
-        super("Elemental", "4/4 red Elemental");
+        super("Elemental", "4/4 red Elemental creature");
         this.cardType.add(CardType.CREATURE);
         this.subtype.add(SubType.ELEMENTAL);
 

--- a/Mage.Sets/src/mage/cards/l/LeapOfFaith.java
+++ b/Mage.Sets/src/mage/cards/l/LeapOfFaith.java
@@ -1,7 +1,6 @@
 
 package mage.cards.l;
 
-import java.util.UUID;
 import mage.abilities.effects.common.PreventDamageToTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -10,6 +9,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -23,7 +24,7 @@ public final class LeapOfFaith extends CardImpl {
 
         // Target creature gains flying until end of turn. Prevent all damage that would be dealt to that creature this turn.
         this.getSpellAbility().addEffect(new GainAbilityTargetEffect(FlyingAbility.getInstance(), Duration.EndOfTurn));
-        this.getSpellAbility().addEffect(new PreventDamageToTargetEffect(Duration.EndOfTurn, Integer.MAX_VALUE));
+        this.getSpellAbility().addEffect(new PreventDamageToTargetEffect(Duration.EndOfTurn, Integer.MAX_VALUE).withTargetDescription("that creature"));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 

--- a/Mage.Sets/src/mage/cards/m/MirrodinBesieged.java
+++ b/Mage.Sets/src/mage/cards/m/MirrodinBesieged.java
@@ -61,6 +61,7 @@ class MirrodinBesiegedEffect extends OneShotEffect {
 
     MirrodinBesiegedEffect() {
         super(Outcome.Benefit);
+        this.setText("draw a card, then discard a card. Then if there are fifteen or more artifact cards in your graveyard, target opponent loses the game.");
     }
 
     private MirrodinBesiegedEffect(final MirrodinBesiegedEffect effect) {

--- a/Mage.Sets/src/mage/cards/p/PalazzoArchers.java
+++ b/Mage.Sets/src/mage/cards/p/PalazzoArchers.java
@@ -39,7 +39,7 @@ public final class PalazzoArchers extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
 
         // Whenever a creature with flying attacks you or a planeswalker you control, Palazzo Archers deals damage equal to its power to that creature.
-        this.addAbility(new AttacksAllTriggeredAbility(new DamageTargetEffect(SourcePermanentPowerValue.NOT_NEGATIVE),
+        this.addAbility(new AttacksAllTriggeredAbility(new DamageTargetEffect(SourcePermanentPowerValue.NOT_NEGATIVE).withTargetDescription("that creature"),
                 false, filter, SetTargetPointer.PERMANENT, true));
     }
 

--- a/Mage.Sets/src/mage/cards/p/PippinsBravery.java
+++ b/Mage.Sets/src/mage/cards/p/PippinsBravery.java
@@ -25,7 +25,7 @@ public final class PippinsBravery extends CardImpl {
         // You may sacrifice a Food. If you do, target creature gets +4/+4 until end of turn. Otherwise, that creature gets +2/+2 until end of turn.
         this.getSpellAbility().addEffect(new DoIfCostPaid(
                 new BoostTargetEffect(4, 4),
-                new BoostTargetEffect(2, 2),
+                new BoostTargetEffect(2, 2).withTargetDescription("that creature"),
                 new SacrificeTargetCost(filter)
         ));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/p/PowerOfPersuasion.java
+++ b/Mage.Sets/src/mage/cards/p/PowerOfPersuasion.java
@@ -28,17 +28,17 @@ public final class PowerOfPersuasion extends CardImpl {
         this.getSpellAbility().addTarget(new TargetOpponentsCreaturePermanent());
 
         // 1-9 | Return it to its owner's hand.
-        effect.addTableEntry(1, 9, new ReturnToHandTargetEffect().setText("return it to its owner's hand"));
+        effect.addTableEntry(1, 9, new ReturnToHandTargetEffect().withTargetDescription("it"));
 
         // 10-19 | Its owner puts it on the top of bottom of their library.
         effect.addTableEntry(10, 19, new PutOnTopOrBottomLibraryTargetEffect(false).setText(
-                "its owner puts it on the top or bottom of their library"
+                "its owner puts it on their choice of the top or bottom of their library"
         ));
 
         // 20 | Gain control of it until the end of your next turn.
         effect.addTableEntry(20, 20, new GainControlTargetEffect(
                 Duration.UntilEndOfYourNextTurn, true
-        ).setText("gain control of it until the end of your next turn"));
+        ).withTargetDescription("it"));
     }
 
     private PowerOfPersuasion(final PowerOfPersuasion card) {

--- a/Mage.Sets/src/mage/cards/r/RevengeOfTheHunted.java
+++ b/Mage.Sets/src/mage/cards/r/RevengeOfTheHunted.java
@@ -25,7 +25,7 @@ public final class RevengeOfTheHunted extends CardImpl {
         // Until end of turn, target creature gets +6/+6 and gains trample, and all creatures able to block it this turn do so.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new BoostTargetEffect(6, 6, Duration.EndOfTurn));
-        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(TrampleAbility.getInstance(), Duration.EndOfTurn).withTargetDescription("and"));
         Effect effect = new MustBeBlockedByAllTargetEffect(Duration.EndOfTurn);
         effect.setText("and all creatures able to block it this turn do so");
         this.getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/s/ScionOfStygia.java
+++ b/Mage.Sets/src/mage/cards/s/ScionOfStygia.java
@@ -40,13 +40,14 @@ public final class ScionOfStygia extends CardImpl {
         this.addAbility(ability.withFlavorWord("Cone of Cold"));
 
         // 1-9 | Tap that creature.
-        effect.addTableEntry(1, 9, new TapTargetEffect("tap that creature"));
+        effect.addTableEntry(1, 9, new TapTargetEffect());
 
         // 10-20 | Tap that creature. It doesn't untap during its controller's next untap step.
         effect.addTableEntry(
-                10, 20, new TapTargetEffect("tap that creature"),
+                10, 20, new TapTargetEffect(),
                 new DontUntapInControllersNextUntapStepTargetEffect("it")
         );
+        effect.withTargetDescription("that creature");
     }
 
     private ScionOfStygia(final ScionOfStygia card) {

--- a/Mage.Sets/src/mage/cards/s/SkullStorm.java
+++ b/Mage.Sets/src/mage/cards/s/SkullStorm.java
@@ -49,7 +49,7 @@ class SkullStormEffect extends OneShotEffect {
 
     SkullStormEffect() {
         super(Outcome.Benefit);
-        this.staticText = "Each opponent sacrifices a creature. "
+        this.staticText = "Each opponent sacrifices a creature of their choice. "
                 + "Each opponent who can't loses half their life, rounded up.";
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkullStorm.java
+++ b/Mage.Sets/src/mage/cards/s/SkullStorm.java
@@ -1,6 +1,5 @@
 package mage.cards.s;
 
-import java.util.UUID;
 import mage.abilities.Ability;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.OneShotEffect;
@@ -18,6 +17,8 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
 
+import java.util.UUID;
+
 /**
  *
  * @author TheElk801
@@ -28,7 +29,7 @@ public final class SkullStorm extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{7}{B}{B}");
 
         // When you cast this spell, copy it for each time you've cast your commander from the command zone this game.
-        this.addAbility(new CommanderStormAbility());
+        this.addAbility(new CommanderStormAbility(false));
 
         // Each opponent sacrifices a creature. Each opponent who can't loses half their life, rounded up.
         this.getSpellAbility().addEffect(new SkullStormEffect());

--- a/Mage.Sets/src/mage/cards/t/TurnAgainst.java
+++ b/Mage.Sets/src/mage/cards/t/TurnAgainst.java
@@ -1,7 +1,6 @@
 
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.abilities.effects.common.UntapTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.effects.common.continuous.GainControlTargetEffect;
@@ -12,6 +11,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -28,8 +29,8 @@ public final class TurnAgainst extends CardImpl {
         // Gain control of target creature until end of turn. Untap that creature. It gains haste until end of turn.
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
         this.getSpellAbility().addEffect(new GainControlTargetEffect(Duration.EndOfTurn));
-        this.getSpellAbility().addEffect(new UntapTargetEffect());
-        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn));
+        this.getSpellAbility().addEffect(new UntapTargetEffect().withTargetDescription("that creature"));
+        this.getSpellAbility().addEffect(new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.EndOfTurn).withTargetDescription("It"));
     }
 
     private TurnAgainst(final TurnAgainst card) {

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalOneShotEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalOneShotEffect.java
@@ -134,7 +134,9 @@ public class ConditionalOneShotEffect extends OneShotEffect {
 
     @Override
     public ConditionalOneShotEffect withTargetDescription(String target) {
-        throw new UnsupportedOperationException("Cannot overwrite target descriptions for ConditionalOneShotEffect (Adjust the inner effects' pointers instead)");
+        effects.forEach(effect -> effect.withTargetDescription(target));
+        otherwiseEffects.forEach(effect -> effect.withTargetDescription(target));
+        return this;
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/decorator/ConditionalOneShotEffect.java
+++ b/Mage/src/main/java/mage/abilities/decorator/ConditionalOneShotEffect.java
@@ -133,6 +133,11 @@ public class ConditionalOneShotEffect extends OneShotEffect {
     }
 
     @Override
+    public ConditionalOneShotEffect withTargetDescription(String target) {
+        throw new UnsupportedOperationException("Cannot overwrite target descriptions for ConditionalOneShotEffect (Adjust the inner effects' pointers instead)");
+    }
+
+    @Override
     public Condition getCondition() {
         return condition;
     }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffectImpl.java
@@ -448,6 +448,12 @@ public abstract class ContinuousEffectImpl extends EffectImpl implements Continu
         return this;
     }
 
+    @Override
+    public ContinuousEffect withTargetDescription(String target) {
+        super.withTargetDescription(target);
+        return this;
+    }
+
     /**
      * Auto-generates dependencies on different effects (what's apply first and
      * what's apply second)

--- a/Mage/src/main/java/mage/abilities/effects/Effect.java
+++ b/Mage/src/main/java/mage/abilities/effects/Effect.java
@@ -61,7 +61,6 @@ public interface Effect extends Serializable, Copyable<Effect> {
 
     /**
      * Sets the target pointer's description to the given string.
-     * WARNING: won't apply if target pointer is set afterwards
      */
     Effect withTargetDescription(String target);
 

--- a/Mage/src/main/java/mage/abilities/effects/Effect.java
+++ b/Mage/src/main/java/mage/abilities/effects/Effect.java
@@ -59,6 +59,12 @@ public interface Effect extends Serializable, Copyable<Effect> {
 
     TargetPointer getTargetPointer();
 
+    /**
+     * Sets the target pointer's description to the given string.
+     * WARNING: won't apply if target pointer is set afterwards
+     */
+    Effect withTargetDescription(String target);
+
     void setValue(String key, Object value);
 
     Object getValue(String key);

--- a/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
@@ -93,7 +93,7 @@ public abstract class EffectImpl implements Effect {
             // first target pointer is default
             throw new IllegalArgumentException("Wrong code usage: target pointer can't be set to null: " + this);
         }
-
+        targetPointer.setTargetDescription(this.targetPointer.getTargetDescription()); // copies the null if not set
         this.targetPointer = targetPointer;
         initNewTargetPointer();
         return this;

--- a/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
@@ -105,6 +105,12 @@ public abstract class EffectImpl implements Effect {
     }
 
     @Override
+    public Effect withTargetDescription(String target) {
+        this.targetPointer.setTargetDescription(target);
+        return this;
+    }
+
+    @Override
     public void newId() {
         if (!(this instanceof MageSingleton)) {
             this.id = UUID.randomUUID();

--- a/Mage/src/main/java/mage/abilities/effects/OneShotEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/OneShotEffect.java
@@ -43,5 +43,11 @@ public abstract class OneShotEffect extends EffectImpl {
     }
 
     @Override
+    public OneShotEffect withTargetDescription(String target) {
+        super.withTargetDescription(target);
+        return this;
+    }
+
+    @Override
     abstract public OneShotEffect copy();
 }

--- a/Mage/src/main/java/mage/abilities/effects/OneShotNonTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/OneShotNonTargetEffect.java
@@ -73,6 +73,12 @@ public class OneShotNonTargetEffect extends OneShotEffect {
     }
 
     @Override
+    public OneShotEffect withTargetDescription(String target) {
+        effect.withTargetDescription(target);
+        return super.withTargetDescription(target);
+    }
+
+    @Override
     public void setValue(String key, Object value) {
         effect.setValue(key, value);
         super.setValue(key, value);

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateDelayedTriggeredAbilityEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateDelayedTriggeredAbilityEffect.java
@@ -96,4 +96,9 @@ public class CreateDelayedTriggeredAbilityEffect extends OneShotEffect {
         this.copyToPointer = copyToPointer;
         return this;
     }
+
+    @Override
+    public CreateDelayedTriggeredAbilityEffect withTargetDescription(String target) {
+        throw new UnsupportedOperationException("Cannot overwrite target descriptions for CreateDelayedTriggeredAbilityEffect (Adjust the inner effects' pointers instead)");
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/CreateDelayedTriggeredAbilityEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/CreateDelayedTriggeredAbilityEffect.java
@@ -99,6 +99,8 @@ public class CreateDelayedTriggeredAbilityEffect extends OneShotEffect {
 
     @Override
     public CreateDelayedTriggeredAbilityEffect withTargetDescription(String target) {
-        throw new UnsupportedOperationException("Cannot overwrite target descriptions for CreateDelayedTriggeredAbilityEffect (Adjust the inner effects' pointers instead)");
+        ability.getEffects().forEach(effect -> effect.withTargetDescription(target));
+        super.withTargetDescription(target);
+        return this;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/RollDieWithResultTableEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RollDieWithResultTableEffect.java
@@ -160,4 +160,9 @@ public class RollDieWithResultTableEffect extends OneShotEffect {
         super.setTargetPointer(targetPointer);
         return this;
     }
+
+    @Override
+    public RollDieWithResultTableEffect withTargetDescription(String target) {
+        throw new UnsupportedOperationException("Cannot overwrite target descriptions for RollDieWithResultTableEffect (Adjust the inner effects' pointers instead)");
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/RollDieWithResultTableEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RollDieWithResultTableEffect.java
@@ -161,8 +161,12 @@ public class RollDieWithResultTableEffect extends OneShotEffect {
         return this;
     }
 
+
     @Override
     public RollDieWithResultTableEffect withTargetDescription(String target) {
-        throw new UnsupportedOperationException("Cannot overwrite target descriptions for RollDieWithResultTableEffect (Adjust the inner effects' pointers instead)");
+        resultsTable.forEach(tableEntry -> tableEntry.effects.forEach(
+                effect -> effect.withTargetDescription(target)));
+        super.withTargetDescription(target);
+        return this;
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/CommanderStormAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CommanderStormAbility.java
@@ -20,8 +20,11 @@ import mage.watchers.common.CommanderPlaysCountWatcher;
  */
 public class CommanderStormAbility extends TriggeredAbilityImpl {
 
-    public CommanderStormAbility() {
-        super(Zone.STACK, new CommanderStormEffect());
+    public CommanderStormAbility(boolean newTargetsText) {
+        super(Zone.STACK, new CommanderStormEffect().setText("copy it for each time you've "
+                + "cast your commander from the command zone this game."
+                + (newTargetsText ? " You may choose new targets for the copies." : "")));
+        this.setTriggerPhrase("When you cast this spell, ");
         this.setRuleAtTheTop(true);
     }
 
@@ -53,13 +56,6 @@ public class CommanderStormAbility extends TriggeredAbilityImpl {
             effect.setValue("StormSpellRef", new MageObjectReference(spell.getId(), game));
         }
         return true;
-    }
-
-    @Override
-    public String getRule() {
-        return "When you cast this spell, copy it for each time you've "
-                + "cast your commander from the command zone this game. "
-                + "You may choose new targets for the copies.";
     }
 }
 

--- a/Mage/src/main/java/mage/constants/ModeChoice.java
+++ b/Mage/src/main/java/mage/constants/ModeChoice.java
@@ -18,7 +18,7 @@ public enum ModeChoice {
     SULTAI("Sultai"),
 
     MIRRAN("Mirran"),
-    PHYREXIAN("Phyrexian "),
+    PHYREXIAN("Phyrexian"),
 
     ODD("odd"),
     EVEN("even"),

--- a/Mage/src/main/java/mage/target/targetpointer/EachTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/EachTargetPointer.java
@@ -120,6 +120,7 @@ public class EachTargetPointer extends TargetPointerImpl {
 
     @Override
     public String describeTargets(Targets targets, String defaultDescription) {
+        if (overwriteTargetDescription != null) return overwriteTargetDescription;
         if (targets.isEmpty()) {
             return defaultDescription;
         }

--- a/Mage/src/main/java/mage/target/targetpointer/EachTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/EachTargetPointer.java
@@ -120,7 +120,7 @@ public class EachTargetPointer extends TargetPointerImpl {
 
     @Override
     public String describeTargets(Targets targets, String defaultDescription) {
-        if (overwriteTargetDescription != null) return overwriteTargetDescription;
+        if (targetDescription != null) return targetDescription;
         if (targets.isEmpty()) {
             return defaultDescription;
         }

--- a/Mage/src/main/java/mage/target/targetpointer/NthTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/NthTargetPointer.java
@@ -148,6 +148,7 @@ public abstract class NthTargetPointer extends TargetPointerImpl {
 
     @Override
     public String describeTargets(Targets targets, String defaultDescription) {
+        if (overwriteTargetDescription != null) return overwriteTargetDescription;
         if (targets.size() <= this.targetIndex) {
             // TODO: need research, is it used for non setup targets ?!
             // Typical usage example: trigger sets fixed target pointer

--- a/Mage/src/main/java/mage/target/targetpointer/NthTargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/NthTargetPointer.java
@@ -148,7 +148,7 @@ public abstract class NthTargetPointer extends TargetPointerImpl {
 
     @Override
     public String describeTargets(Targets targets, String defaultDescription) {
-        if (overwriteTargetDescription != null) return overwriteTargetDescription;
+        if (targetDescription != null) return targetDescription;
         if (targets.size() <= this.targetIndex) {
             // TODO: need research, is it used for non setup targets ?!
             // Typical usage example: trigger sets fixed target pointer

--- a/Mage/src/main/java/mage/target/targetpointer/TargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/TargetPointer.java
@@ -62,7 +62,8 @@ public interface TargetPointer extends Serializable, Copyable<TargetPointer> {
     /**
      * Overwrite the default target description
      */
-    void setTargetDescription(String defaultDescription);
+    void setTargetDescription(String description);
+    String getTargetDescription();
 
     default boolean isPlural(Targets targets) {
         return false;

--- a/Mage/src/main/java/mage/target/targetpointer/TargetPointer.java
+++ b/Mage/src/main/java/mage/target/targetpointer/TargetPointer.java
@@ -57,9 +57,12 @@ public interface TargetPointer extends Serializable, Copyable<TargetPointer> {
     /**
      * Describes the appropriate subset of targets for ability text.
      */
-    default String describeTargets(Targets targets, String defaultDescription) {
-        return defaultDescription;
-    }
+    String describeTargets(Targets targets, String defaultDescription);
+
+    /**
+     * Overwrite the default target description
+     */
+    void setTargetDescription(String defaultDescription);
 
     default boolean isPlural(Targets targets) {
         return false;

--- a/Mage/src/main/java/mage/target/targetpointer/TargetPointerImpl.java
+++ b/Mage/src/main/java/mage/target/targetpointer/TargetPointerImpl.java
@@ -83,8 +83,12 @@ public abstract class TargetPointerImpl implements TargetPointer {
     }
 
     @Override
-    public void setTargetDescription(String defaultDescription) {
-        targetDescription = defaultDescription;
+    public void setTargetDescription(String description) {
+        targetDescription = description;
+    }
+    @Override
+    public String getTargetDescription() {
+        return targetDescription;
     }
 
 }

--- a/Mage/src/main/java/mage/target/targetpointer/TargetPointerImpl.java
+++ b/Mage/src/main/java/mage/target/targetpointer/TargetPointerImpl.java
@@ -19,7 +19,7 @@ public abstract class TargetPointerImpl implements TargetPointer {
     private Map<String, String> data;
 
     private boolean initialized = false;
-    protected String overwriteTargetDescription;
+    protected String targetDescription = null;
 
     protected TargetPointerImpl() {
         super();
@@ -32,7 +32,7 @@ public abstract class TargetPointerImpl implements TargetPointer {
             this.data.putAll(targetPointer.data);
         }
         this.initialized = targetPointer.initialized;
-        this.overwriteTargetDescription = targetPointer.overwriteTargetDescription;
+        this.targetDescription = targetPointer.targetDescription;
     }
 
     @Override
@@ -79,12 +79,12 @@ public abstract class TargetPointerImpl implements TargetPointer {
 
     @Override
     public String describeTargets(Targets targets, String defaultDescription) {
-        return overwriteTargetDescription != null ? overwriteTargetDescription : defaultDescription;
+        return targetDescription != null ? targetDescription : defaultDescription;
     }
 
     @Override
     public void setTargetDescription(String defaultDescription) {
-        overwriteTargetDescription = defaultDescription;
+        targetDescription = defaultDescription;
     }
 
 }

--- a/Mage/src/main/java/mage/target/targetpointer/TargetPointerImpl.java
+++ b/Mage/src/main/java/mage/target/targetpointer/TargetPointerImpl.java
@@ -5,6 +5,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.players.Player;
+import mage.target.Targets;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +19,7 @@ public abstract class TargetPointerImpl implements TargetPointer {
     private Map<String, String> data;
 
     private boolean initialized = false;
+    protected String overwriteTargetDescription;
 
     protected TargetPointerImpl() {
         super();
@@ -30,6 +32,7 @@ public abstract class TargetPointerImpl implements TargetPointer {
             this.data.putAll(targetPointer.data);
         }
         this.initialized = targetPointer.initialized;
+        this.overwriteTargetDescription = targetPointer.overwriteTargetDescription;
     }
 
     @Override
@@ -72,6 +75,16 @@ public abstract class TargetPointerImpl implements TargetPointer {
         }
         data.put(key, value);
         return this;
+    }
+
+    @Override
+    public String describeTargets(Targets targets, String defaultDescription) {
+        return overwriteTargetDescription != null ? overwriteTargetDescription : defaultDescription;
+    }
+
+    @Override
+    public void setTargetDescription(String defaultDescription) {
+        overwriteTargetDescription = defaultDescription;
     }
 
 }


### PR DESCRIPTION
The word "target" should appear the same number of times both in the reference card text and the XMage card (I will soon be adding that check to #13647). This PR fixes many of these issues, primarily by adding support for `withTargetDescription` to all effects by making it able to be overwritten in `TargetPointer`. It also has a few other smaller fixes for cards that had duplicate "target" words.

There are two cards remaining that this PR does not attempt to fix: [[Blink]], which has nonconsecutive chapters in a way that XMage does not currently support, and [[Artifact Ward]] whose implementation needs radical reworking if we want it to correctly match the card text.

I do not change `DamageTargetEffect`'s original implementation of `withTargetDescription`, as that seems to be doing something weird with the target descriptions anyway.