### PR TITLE
Fix bugs associated with Foretell ability

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BohnBeguilingBalladeer.java
+++ b/Mage.Sets/src/mage/cards/b/BohnBeguilingBalladeer.java
@@ -4,18 +4,14 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.CastSecondSpellTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.combat.GoadTargetEffect;
 import mage.abilities.keyword.ForetellAbility;
-import mage.cards.*;
-import mage.constants.*;
-import mage.filter.common.FilterNonlandCard;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.mageobject.AbilityPredicate;
-import mage.game.Game;
-import mage.players.Player;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.target.common.TargetOpponentsCreaturePermanent;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -34,7 +30,7 @@ public final class BohnBeguilingBalladeer extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}.
-        this.addAbility(new SimpleStaticAbility(new EdginLarcenousLutenistEffect()));
+        this.addAbility(new SimpleStaticAbility(ForetellAbility.makeAddForetellEffect()));
 
         // Whenever you cast your second spell each turn, goad target creature an opponent controls.
         Ability ability = new CastSecondSpellTriggeredAbility(new GoadTargetEffect());
@@ -49,71 +45,5 @@ public final class BohnBeguilingBalladeer extends CardImpl {
     @Override
     public BohnBeguilingBalladeer copy() {
         return new BohnBeguilingBalladeer(this);
-    }
-}
-
-class EdginLarcenousLutenistEffect extends ContinuousEffectImpl {
-
-    private static final FilterNonlandCard filter = new FilterNonlandCard();
-
-    static {
-        filter.add(Predicates.not(new AbilityPredicate(ForetellAbility.class)));
-    }
-
-    EdginLarcenousLutenistEffect() {
-        super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
-        this.staticText = "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}";
-    }
-
-    private EdginLarcenousLutenistEffect(final EdginLarcenousLutenistEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public EdginLarcenousLutenistEffect copy() {
-        return new EdginLarcenousLutenistEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null) {
-            return false;
-        }
-        for (Card card : controller.getHand().getCards(filter, game)) {
-            ForetellAbility foretellAbility = null;
-            if (card instanceof SplitCard) {
-                String leftHalfCost = CardUtil.reduceCost(((SplitCard) card).getLeftHalfCard().getManaCost(), 2).getText();
-                String rightHalfCost = CardUtil.reduceCost(((SplitCard) card).getRightHalfCard().getManaCost(), 2).getText();
-                foretellAbility = new ForetellAbility(card, leftHalfCost, rightHalfCost);
-            } else if (card instanceof ModalDoubleFacedCard) {
-                ModalDoubleFacedCardHalf leftHalfCard = ((ModalDoubleFacedCard) card).getLeftHalfCard();
-                // If front side of MDFC is land, do nothing as Dream Devourer does not apply to lands
-                // MDFC cards in hand are considered lands if front side is land
-                if (!leftHalfCard.isLand(game)) {
-                    String leftHalfCost = CardUtil.reduceCost(leftHalfCard.getManaCost(), 2).getText();
-                    ModalDoubleFacedCardHalf rightHalfCard = ((ModalDoubleFacedCard) card).getRightHalfCard();
-                    if (rightHalfCard.isLand(game)) {
-                        foretellAbility = new ForetellAbility(card, leftHalfCost);
-                    } else {
-                        String rightHalfCost = CardUtil.reduceCost(rightHalfCard.getManaCost(), 2).getText();
-                        foretellAbility = new ForetellAbility(card, leftHalfCost, rightHalfCost);
-                    }
-                }
-            } else if (card instanceof CardWithSpellOption) {
-                String creatureCost = CardUtil.reduceCost(card.getMainCard().getManaCost(), 2).getText();
-                String spellCost = CardUtil.reduceCost(((CardWithSpellOption) card).getSpellCard().getManaCost(), 2).getText();
-                foretellAbility = new ForetellAbility(card, creatureCost, spellCost);
-            } else {
-                String costText = CardUtil.reduceCost(card.getManaCost(), 2).getText();
-                foretellAbility = new ForetellAbility(card, costText);
-            }
-            if (foretellAbility != null) {
-                foretellAbility.setSourceId(card.getId());
-                foretellAbility.setControllerId(card.getOwnerId());
-                game.getState().addOtherAbility(card, foretellAbility);
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DreamDevourer.java
+++ b/Mage.Sets/src/mage/cards/d/DreamDevourer.java
@@ -1,27 +1,17 @@
 package mage.cards.d;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.ForetellSourceControllerTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
 import mage.abilities.keyword.ForetellAbility;
-import mage.cards.*;
-import mage.constants.SubType;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Layer;
-import mage.constants.Outcome;
-import mage.constants.SubLayer;
-import mage.constants.Zone;
-import mage.filter.common.FilterNonlandCard;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.mageobject.AbilityPredicate;
-import mage.game.Game;
-import mage.players.Player;
-import mage.util.CardUtil;
+import mage.constants.SubType;
+
+import java.util.UUID;
 
 /**
  *
@@ -38,7 +28,7 @@ public final class DreamDevourer extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by 2.
-        this.addAbility(new SimpleStaticAbility(new DreamDevourerAddAbilityEffect()));
+        this.addAbility(new SimpleStaticAbility(ForetellAbility.makeAddForetellEffect()));
 
         // Whenever you foretell a card, Dream Devourer gets +2/+0 until end of turn.
         this.addAbility(new ForetellSourceControllerTriggeredAbility(new BoostSourceEffect(2, 0, Duration.EndOfTurn)));
@@ -52,71 +42,5 @@ public final class DreamDevourer extends CardImpl {
     @Override
     public DreamDevourer copy() {
         return new DreamDevourer(this);
-    }
-}
-
-class DreamDevourerAddAbilityEffect extends ContinuousEffectImpl {
-
-    private static final FilterNonlandCard filter = new FilterNonlandCard();
-
-    static {
-        filter.add(Predicates.not(new AbilityPredicate(ForetellAbility.class)));
-    }
-
-    DreamDevourerAddAbilityEffect() {
-        super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
-        this.staticText = "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}";
-    }
-
-    private DreamDevourerAddAbilityEffect(final DreamDevourerAddAbilityEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public DreamDevourerAddAbilityEffect copy() {
-        return new DreamDevourerAddAbilityEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null) {
-            return false;
-        }
-        for (Card card : controller.getHand().getCards(filter, game)) {
-            ForetellAbility foretellAbility = null;
-            if (card instanceof SplitCard) {
-                String leftHalfCost = CardUtil.reduceCost(((SplitCard) card).getLeftHalfCard().getManaCost(), 2).getText();
-                String rightHalfCost = CardUtil.reduceCost(((SplitCard) card).getRightHalfCard().getManaCost(), 2).getText();
-                foretellAbility = new ForetellAbility(card, leftHalfCost, rightHalfCost);
-            } else if (card instanceof ModalDoubleFacedCard) {
-                ModalDoubleFacedCardHalf leftHalfCard = ((ModalDoubleFacedCard) card).getLeftHalfCard();
-                // If front side of MDFC is land, do nothing as Dream Devourer does not apply to lands
-                // MDFC cards in hand are considered lands if front side is land
-                if (!leftHalfCard.isLand(game)) {
-                    String leftHalfCost = CardUtil.reduceCost(leftHalfCard.getManaCost(), 2).getText();
-                    ModalDoubleFacedCardHalf rightHalfCard = ((ModalDoubleFacedCard) card).getRightHalfCard();
-                    if (rightHalfCard.isLand(game)) {
-                        foretellAbility = new ForetellAbility(card, leftHalfCost);
-                    } else {
-                        String rightHalfCost = CardUtil.reduceCost(rightHalfCard.getManaCost(), 2).getText();
-                        foretellAbility = new ForetellAbility(card, leftHalfCost, rightHalfCost);
-                    }
-                }
-            } else if (card instanceof CardWithSpellOption) {
-                String creatureCost = CardUtil.reduceCost(card.getMainCard().getManaCost(), 2).getText();
-                String spellCost = CardUtil.reduceCost(((CardWithSpellOption) card).getSpellCard().getManaCost(), 2).getText();
-                foretellAbility = new ForetellAbility(card, creatureCost, spellCost);
-            } else {
-                String costText = CardUtil.reduceCost(card.getManaCost(), 2).getText();
-                foretellAbility = new ForetellAbility(card, costText);
-            }
-            if (foretellAbility != null) {
-                foretellAbility.setSourceId(card.getId());
-                foretellAbility.setControllerId(card.getOwnerId());
-                game.getState().addOtherAbility(card, foretellAbility);
-            }
-        }
-        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
@@ -1,23 +1,21 @@
 package mage.cards.e;
 
 import mage.MageInt;
-import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldOrAttacksSourceTriggeredAbility;
-import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.ForetellAbility;
-import mage.cards.*;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.game.Game;
-import mage.game.events.GameEvent;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -75,77 +73,15 @@ class EtherealValkyrieEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-
         controller.drawCards(1, source, game);
-        TargetCardInHand targetCard = new TargetCardInHand(new FilterCard("card to exile face down. It becomes foretold."));
+        TargetCardInHand targetCard = new TargetCardInHand(StaticFilters.FILTER_CARD).withChooseHint("to exile face down; it becomes foretold");
         if (!controller.chooseTarget(Outcome.Benefit, targetCard, source, game)) {
             return false;
         }
-
-        Card exileCard = game.getCard(targetCard.getFirstTarget());
-        if (exileCard == null) {
+        Card card = game.getCard(targetCard.getFirstTarget());
+        if (card == null) {
             return false;
         }
-
-        // process Split, MDFC, and Adventure cards first
-        // note that 'Foretell Cost' refers to the main card (left) and 'Foretell Split Cost' refers to the (right) card if it exists
-        ForetellAbility foretellAbility = null;
-        if (exileCard instanceof SplitCard) {
-            String leftHalfCost = CardUtil.reduceCost(((SplitCard) exileCard).getLeftHalfCard().getManaCost(), 2).getText();
-            String rightHalfCost = CardUtil.reduceCost(((SplitCard) exileCard).getRightHalfCard().getManaCost(), 2).getText();
-            game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Cost", leftHalfCost);
-            game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Split Cost", rightHalfCost);
-            foretellAbility = new ForetellAbility(exileCard, leftHalfCost, rightHalfCost);
-        } else if (exileCard instanceof ModalDoubleFacedCard) {
-            ModalDoubleFacedCardHalf leftHalfCard = ((ModalDoubleFacedCard) exileCard).getLeftHalfCard();
-            if (!leftHalfCard.isLand(game)) {  // Only MDFC cards with a left side a land have a land on the right side too
-                String leftHalfCost = CardUtil.reduceCost(leftHalfCard.getManaCost(), 2).getText();
-                game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Cost", leftHalfCost);
-                ModalDoubleFacedCardHalf rightHalfCard = ((ModalDoubleFacedCard) exileCard).getRightHalfCard();
-                if (rightHalfCard.isLand(game)) {
-                    foretellAbility = new ForetellAbility(exileCard, leftHalfCost);
-                } else {
-                    String rightHalfCost = CardUtil.reduceCost(rightHalfCard.getManaCost(), 2).getText();
-                    game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Split Cost", rightHalfCost);
-                    foretellAbility = new ForetellAbility(exileCard, leftHalfCost, rightHalfCost);
-                }
-            }
-        } else if (exileCard instanceof CardWithSpellOption) {
-            String creatureCost = CardUtil.reduceCost(exileCard.getMainCard().getManaCost(), 2).getText();
-            String spellCost = CardUtil.reduceCost(((CardWithSpellOption) exileCard).getSpellCard().getManaCost(), 2).getText();
-            game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Cost", creatureCost);
-            game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Split Cost", spellCost);
-            foretellAbility = new ForetellAbility(exileCard, creatureCost, spellCost);
-        } else if (!exileCard.isLand(game)) {
-            // normal card
-            String costText = CardUtil.reduceCost(exileCard.getManaCost(), 2).getText();
-            game.getState().setValue(exileCard.getId().toString() + "Foretell Cost", costText);
-            foretellAbility = new ForetellAbility(exileCard, costText);
-        }
-
-        // All card types (including lands) must be exiled
-        UUID exileId = CardUtil.getExileZoneId(exileCard.getMainCard().getId().toString() + "foretellAbility", game);
-        controller.moveCardsToExile(exileCard, source, game, true, exileId, " Foretell Turn Number: " + game.getTurnNum());
-        exileCard.setFaceDown(true, game);
-
-        // all done pre-processing so stick the foretell cost effect onto the main card
-        // note that the card is not foretell'd into exile, it is put into exile and made foretold
-        // If the card is a non-land, it will not be exiled.
-        if (foretellAbility != null) {
-            // copy source and use it for the foretold effect on the exiled card
-            // bug #8673
-            Ability copiedSource = source.copy();
-            copiedSource.newId();
-            copiedSource.setSourceId(exileCard.getId());
-            game.getState().setValue(exileCard.getMainCard().getId().toString() + "Foretell Turn Number", game.getTurnNum());
-            foretellAbility.setSourceId(exileCard.getId());
-            foretellAbility.setControllerId(exileCard.getOwnerId());
-            game.getState().addOtherAbility(exileCard, foretellAbility);
-            foretellAbility.activate(game, true);
-            ContinuousEffect effect = ForetellAbility.getForetellAddCostEffect(new MageObjectReference(exileCard, game));
-            game.addEffect(effect, copiedSource);
-            game.fireEvent(new GameEvent(GameEvent.EventType.CARD_FORETOLD, exileCard.getId(), copiedSource, copiedSource.getControllerId(), 0, false));
-        }
-        return true;
+        return ForetellAbility.doExileBecomesForetold(card, game, source, 2);
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
@@ -144,7 +144,7 @@ class EtherealValkyrieEffect extends OneShotEffect {
             foretellAbility.activate(game, true);
             ContinuousEffect effect = new ForetellAbility.ForetellAddCostEffect(new MageObjectReference(exileCard, game));
             game.addEffect(effect, copiedSource);
-            game.fireEvent(GameEvent.getEvent(GameEvent.EventType.FORETOLD, exileCard.getId(), null, null));
+            game.fireEvent(new GameEvent(GameEvent.EventType.CARD_FORETOLD, exileCard.getId(), copiedSource, copiedSource.getControllerId(), 0, false));
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
@@ -142,7 +142,7 @@ class EtherealValkyrieEffect extends OneShotEffect {
             foretellAbility.setControllerId(exileCard.getOwnerId());
             game.getState().addOtherAbility(exileCard, foretellAbility);
             foretellAbility.activate(game, true);
-            ContinuousEffect effect = new ForetellAbility.ForetellAddCostEffect(new MageObjectReference(exileCard, game));
+            ContinuousEffect effect = ForetellAbility.getForetellAddCostEffect(new MageObjectReference(exileCard, game));
             game.addEffect(effect, copiedSource);
             game.fireEvent(new GameEvent(GameEvent.EventType.CARD_FORETOLD, exileCard.getId(), copiedSource, copiedSource.getControllerId(), 0, false));
         }

--- a/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
+++ b/Mage.Sets/src/mage/cards/e/EtherealValkyrie.java
@@ -16,6 +16,7 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.common.TargetCardInHand;
+import mage.watchers.common.ForetoldWatcher;
 
 import java.util.UUID;
 
@@ -36,7 +37,7 @@ public final class EtherealValkyrie extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever Ethereal Valkyrie enters the battlefield or attacks, draw a card, then exile a card from your hand face down. It becomes foretold. Its foretell cost is its mana cost reduced by {2}.
-        this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(new EtherealValkyrieEffect()));
+        this.addAbility(new EntersBattlefieldOrAttacksSourceTriggeredAbility(new EtherealValkyrieEffect()), new ForetoldWatcher());
     }
 
     private EtherealValkyrie(final EtherealValkyrie card) {

--- a/Mage.Sets/src/mage/cards/r/RanarTheEverWatchful.java
+++ b/Mage.Sets/src/mage/cards/r/RanarTheEverWatchful.java
@@ -89,7 +89,7 @@ class RanarTheEverWatchfulCostReductionEffect extends CostModificationEffectImpl
     public boolean applies(Ability abilityToModify, Ability source, Game game) {
         ForetoldWatcher watcher = game.getState().getWatcher(ForetoldWatcher.class);
         return (watcher != null
-                && watcher.countNumberForetellThisTurn() == 0
+                && watcher.getPlayerForetellCountThisTurn(source.getControllerId()) == 0
                 && abilityToModify.isControlledBy(source.getControllerId())
                 && abilityToModify instanceof ForetellAbility);
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ForetellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ForetellTest.java
@@ -155,7 +155,7 @@ public class ForetellTest extends CardTestPlayerBase {
         // turn 4, draw card B
         activateAbility(4, PhaseStep.PRECOMBAT_MAIN, playerB, "Foretell {1}{B}", flamespeaker);
         // foretold, so scry 2 (cards C and D)
-        addTarget(playerA, cardD); // scrying D bottom (C remains on top)
+        addTarget(playerB, cardD); // scrying D bottom (C remains on top)
 
         setStrictChooseMode(true);
         setStopAt(4, PhaseStep.END_TURN);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ForetellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ForetellTest.java
@@ -81,4 +81,91 @@ public class ForetellTest extends CardTestPlayerBase {
         assertExileCount(playerA, "Lightning Bolt", 1); // foretold card in exile
         assertPowerToughness(playerA, "Dream Devourer", 2, 3);  // +2 power boost from trigger due to foretell of Lightning Bolt
     }
+
+
+    // Tests needed to check watcher scope issue (see issue #7493 and issue #13774)
+
+    private static final String scornEffigy = "Scorn Effigy"; // {3} 2/3 foretell {0}
+    private static final String poisonCup = "Poison the Cup"; // {1}{B}{B} instant destroy target creature
+    // Foretell {1}{B}, if spell was foretold, scry 2
+    private static final String flamespeaker = "Flamespeaker Adept"; // {2}{R} 2/3
+    // Whenever you scry, gets +2/+0 and first strike until end of turn
+    private static final String chancemetElves = "Chance-Met Elves"; // {2}{G} 3/2
+    // Whenever you scry, gets a +1/+1 counter, triggers once per turn
+
+    private static final String cardE = "Elite Vanguard";
+    private static final String cardD = "Devilthorn Fox";
+    private static final String cardC = "Canopy Gorger";
+    private static final String cardB = "Barbtooth Wurm";
+    private static final String cardA = "Alaborn Trooper";
+
+    private void setupLibrariesEtc() {
+        // make a library of 5 cards, bottom : E D C B A : top
+        skipInitShuffling();
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, cardE);
+        addCard(Zone.LIBRARY, playerA, cardD);
+        addCard(Zone.LIBRARY, playerA, cardC);
+        addCard(Zone.LIBRARY, playerA, cardB);
+        addCard(Zone.LIBRARY, playerA, cardA);
+        removeAllCardsFromLibrary(playerB);
+        addCard(Zone.LIBRARY, playerB, cardE);
+        addCard(Zone.LIBRARY, playerB, cardD);
+        addCard(Zone.LIBRARY, playerB, cardC);
+        addCard(Zone.LIBRARY, playerB, cardB);
+        addCard(Zone.LIBRARY, playerB, cardA);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+        addCard(Zone.BATTLEFIELD, playerB, "Swamp", 5);
+        addCard(Zone.BATTLEFIELD, playerA, flamespeaker);
+        addCard(Zone.BATTLEFIELD, playerB, chancemetElves);
+        addCard(Zone.HAND, playerA, scornEffigy);
+    }
+
+    @Test
+    public void testForetellWatcherPlayerA() {
+        setupLibrariesEtc();
+        addCard(Zone.HAND, playerA, poisonCup);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, scornEffigy);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Foretell");
+        checkExileCount("foretold in exile", 2, PhaseStep.PRECOMBAT_MAIN, playerA, poisonCup, 1);
+        // turn 3, draw card A
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Foretell {1}{B}", chancemetElves);
+        // foretold, so scry 2 (cards B and C)
+        addTarget(playerA, cardB); // scrying B bottom (C remains on top)
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertPowerToughness(playerA, scornEffigy, 2, 3);
+        assertGraveyardCount(playerA, poisonCup, 1);
+        assertGraveyardCount(playerB, chancemetElves, 1);
+        assertPowerToughness(playerA, flamespeaker, 4, 3);
+    }
+
+    @Test
+    public void testForetellWatcherPlayerB() {
+        setupLibrariesEtc();
+        addCard(Zone.HAND, playerB, poisonCup);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, scornEffigy);
+        // turn 2, draw card A
+        activateAbility(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Foretell");
+        checkExileCount("foretold in exile", 2, PhaseStep.PRECOMBAT_MAIN, playerB, poisonCup, 1);
+        // turn 4, draw card B
+        activateAbility(4, PhaseStep.PRECOMBAT_MAIN, playerB, "Foretell {1}{B}", flamespeaker);
+        // foretold, so scry 2 (cards C and D)
+        addTarget(playerA, cardD); // scrying D bottom (C remains on top)
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.END_TURN);
+        execute();
+
+        assertPowerToughness(playerA, scornEffigy, 2, 3);
+        assertGraveyardCount(playerB, poisonCup, 1);
+        assertGraveyardCount(playerA, flamespeaker, 1);
+        assertPowerToughness(playerB, chancemetElves, 4, 3);
+    }
+
+
+
 }

--- a/Mage/src/main/java/mage/abilities/common/ForetellSourceControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/ForetellSourceControllerTriggeredAbility.java
@@ -24,16 +24,14 @@ public class ForetellSourceControllerTriggeredAbility extends TriggeredAbilityIm
 
     @Override
     public boolean checkEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.FORETELL;
+        return event.getType() == GameEvent.EventType.CARD_FORETOLD;
     }
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         Card card = game.getCard(event.getTargetId());
         Player player = game.getPlayer(event.getPlayerId());
-        return (card != null
-                && player != null
-                && isControlledBy(player.getId()));
+        return event.getFlag() && card != null && player != null && isControlledBy(player.getId());
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/common/ForetellSourceControllerTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/ForetellSourceControllerTriggeredAbility.java
@@ -7,6 +7,7 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
+import mage.watchers.common.ForetoldWatcher;
 
 /**
  * @author jeffwadsworth
@@ -16,6 +17,7 @@ public class ForetellSourceControllerTriggeredAbility extends TriggeredAbilityIm
     public ForetellSourceControllerTriggeredAbility(Effect effect) {
         super(Zone.BATTLEFIELD, effect, false);
         setTriggerPhrase("Whenever you foretell a card, ");
+        addWatcher(new ForetoldWatcher());
     }
 
     protected ForetellSourceControllerTriggeredAbility(final ForetellSourceControllerTriggeredAbility ability) {

--- a/Mage/src/main/java/mage/abilities/condition/common/ForetoldCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/ForetoldCondition.java
@@ -17,7 +17,7 @@ public enum ForetoldCondition implements Condition {
     public boolean apply(Game game, Ability source) {
         ForetoldWatcher watcher = game.getState().getWatcher(ForetoldWatcher.class);
         if (watcher != null) {
-            return watcher.cardWasForetold(source.getSourceId());
+            return watcher.checkForetold(source.getSourceId(), game);
         }
         return false;
     }

--- a/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
@@ -143,7 +143,7 @@ public class ForetellAbility extends SpecialAction {
                 effect.apply(game, source);
                 card.setFaceDown(true, game);
                 game.addEffect(new ForetellAddCostEffect(new MageObjectReference(card, game)), source);
-                game.fireEvent(GameEvent.getEvent(GameEvent.EventType.FORETELL, card.getId(), null, source.getControllerId()));
+                game.fireEvent(new GameEvent(GameEvent.EventType.CARD_FORETOLD, card.getId(), source, source.getControllerId(), 0, true));
                 return true;
             }
             return false;

--- a/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
@@ -182,7 +182,7 @@ class ForetellExileEffect extends OneShotEffect {
         this.foretellSplitCost = foretellSplitCost;
     }
 
-    protected ForetellExileEffect(final ForetellExileEffect effect) {
+    private ForetellExileEffect(final ForetellExileEffect effect) {
         super(effect);
         this.card = effect.card;
         this.foretellCost = effect.foretellCost;
@@ -235,7 +235,7 @@ class ForetellLookAtCardEffect extends AsThoughEffectImpl {
         super(AsThoughEffectType.LOOK_AT_FACE_DOWN, Duration.EndOfGame, Outcome.AIDontUseIt);
     }
 
-    protected ForetellLookAtCardEffect(final ForetellLookAtCardEffect effect) {
+    private ForetellLookAtCardEffect(final ForetellLookAtCardEffect effect) {
         super(effect);
     }
 
@@ -273,13 +273,13 @@ class ForetellAddCostEffect extends ContinuousEffectImpl {
 
     private final MageObjectReference mor;
 
-    public ForetellAddCostEffect(MageObjectReference mor) {
+    ForetellAddCostEffect(MageObjectReference mor) {
         super(Duration.EndOfGame, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
         this.mor = mor;
         staticText = "Foretold card";
     }
 
-    protected ForetellAddCostEffect(final ForetellAddCostEffect effect) {
+    private ForetellAddCostEffect(final ForetellAddCostEffect effect) {
         super(effect);
         this.mor = effect.mor;
     }
@@ -394,7 +394,7 @@ class ForetellCostAbility extends SpellAbility {
         this.addCost(new ManaCostsImpl<>(foretellCost));
     }
 
-    protected ForetellCostAbility(final ForetellCostAbility ability) {
+    private ForetellCostAbility(final ForetellCostAbility ability) {
         super(ability);
         this.spellAbilityType = ability.spellAbilityType;
         this.abilityName = ability.abilityName;
@@ -537,7 +537,7 @@ class ForetellCostAbility extends SpellAbility {
      * Used for split card in PlayerImpl method:
      * getOtherUseableActivatedAbilities
      */
-    public void setAbilityName(String abilityName) {
+    void setAbilityName(String abilityName) {
         this.abilityName = abilityName;
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
@@ -11,6 +11,7 @@ import mage.abilities.costs.Costs;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.AsThoughEffectImpl;
+import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ExileTargetEffect;
@@ -88,6 +89,10 @@ public class ForetellAbility extends SpecialAction {
     @Override
     public String getGameLogMessage(Game game) {
         return " foretells a card from hand";
+    }
+
+    public static ContinuousEffect getForetellAddCostEffect(MageObjectReference mor) {
+        return new ForetellAddCostEffect(mor);
     }
 
     static class ForetellExileEffect extends OneShotEffect {
@@ -190,7 +195,7 @@ public class ForetellAbility extends SpecialAction {
         }
     }
 
-    public static class ForetellAddCostEffect extends ContinuousEffectImpl {
+    static class ForetellAddCostEffect extends ContinuousEffectImpl {
 
         private final MageObjectReference mor;
 

--- a/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ForetellAbility.java
@@ -144,7 +144,7 @@ public class ForetellAbility extends SpecialAction {
 
         // All card types (including lands) must be exiled
         UUID exileId = CardUtil.getExileZoneId(card.getMainCard().getId().toString() + "foretellAbility", game);
-        controller.moveCardsToExile(card, source, game, true, exileId, " Foretell Turn Number: " + game.getTurnNum());
+        controller.moveCardsToExile(card, source, game, false, exileId, " Foretell Turn Number: " + game.getTurnNum());
         card.setFaceDown(true, game);
 
         // all done pre-processing so stick the foretell cost effect onto the main card

--- a/Mage/src/main/java/mage/game/events/GameEvent.java
+++ b/Mage/src/main/java/mage/game/events/GameEvent.java
@@ -615,8 +615,12 @@ public class GameEvent implements Serializable {
         DUNGEON_COMPLETED,
         TEMPTED_BY_RING, RING_BEARER_CHOSEN,
         REMOVED_FROM_COMBAT, // targetId    id of permanent removed from combat
-        FORETOLD, // targetId   id of card foretold
-        FORETELL, // targetId   id of card foretell  playerId   id of the controller
+        /* card foretold
+        targetId    id of card foretold
+        playerId    id of player foretelling card
+        flag        true if player did foretell, false if became foretold without foretell
+         */
+        CARD_FORETOLD,
         /* villainous choice
          targetId    player making the choice
          sourceId    sourceId of the ability forcing the choice


### PR DESCRIPTION
As I suspected when researching https://github.com/magefree/mage/issues/13774#issuecomment-2993379224, the source of the intermittent bugs with "if this spell was foretold" was indeed a bad implementation of ForetoldWatcher.

https://github.com/magefree/mage/blob/379a3b504d32cb393349f80755b5892c8e193fd2/Mage/src/main/java/mage/watchers/common/ForetoldWatcher.java#L28-L35

Note the nonsense check of "controllerId" , the watcher has scope GAME. So this check would work for the first player (who initiated the watcher) but not for the second player. Multiple devs tried to investigate this without being able to reproduce. But it can indeed be reproduced by the unit test framework, once you know what to look for.

While reworking the watcher, I also cleaned up the game events... FORETELL and FORETOLD looked like a standard pair (present tense replacement check, past tense fired) but weren't (both only fired, which one depending on whether the card became foretold by a foretell ability or by some other effect), and no reason they needed to be separate anyway, so now there's just CARD_FORETOLD, using the flag for the distinction. Probably fixed some other edge cases by adding the watcher to a couple more cards, checking zcc, etc.

ForetellAbility is still a frustratingly messy implementation, but since it's passing all the tests I wrote I'll leave it where it is for now. (I also attempted to implement The Foretold Soldier, but couldn't get it fully working (when it exiles itself to become foretold, I couldn't seem to make it castable (nor face down, strangely))... not going to hold up this fix for that.)

fix #7493 (with tests added), fix #7539, fix #7677, fix #8419
