### PR TITLE
Reworked targeting, possible targets and AI

### DIFF
--- a/Mage.Client/src/main/java/mage/client/cards/CardArea.java
+++ b/Mage.Client/src/main/java/mage/client/cards/CardArea.java
@@ -18,10 +18,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.*;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -258,7 +256,7 @@ public class CardArea extends JPanel implements CardEventProducer {
         this.reloaded = false;
     }
 
-    public void selectCards(List<UUID> selected) {
+    public void selectCards(Set<UUID> selected) {
         for (Component component : cardArea.getComponents()) {
             if (component instanceof MageCard) {
                 MageCard mageCard = (MageCard) component;
@@ -269,7 +267,7 @@ public class CardArea extends JPanel implements CardEventProducer {
         }
     }
 
-    public void markCards(List<UUID> marked) {
+    public void markCards(Set<UUID> marked) {
         for (Component component : cardArea.getComponents()) {
             if (component instanceof MageCard) {
                 MageCard mageCard = (MageCard) component;

--- a/Mage.Client/src/main/java/mage/client/dialog/ShowCardsDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/ShowCardsDialog.java
@@ -100,11 +100,11 @@
          cardArea.loadCards(showCards, bigCard, gameId);
          if (options != null) {
              if (options.containsKey("chosenTargets")) {
-                 java.util.List<UUID> chosenCards = (java.util.List<UUID>) options.get("chosenTargets");
+                 java.util.Set<UUID> chosenCards = (java.util.Set<UUID>) options.get("chosenTargets");
                  cardArea.selectCards(chosenCards);
              }
              if (options.containsKey("possibleTargets")) {
-                 java.util.List<UUID> choosableCards = (java.util.List<UUID>) options.get("possibleTargets");
+                 java.util.Set<UUID> choosableCards = (java.util.Set<UUID>) options.get("possibleTargets");
                  cardArea.markCards(choosableCards);
              }
              if (options.containsKey("queryType") && options.get("queryType") == QueryType.PICK_ABILITY) {

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -216,17 +216,9 @@ public final class GamePanel extends javax.swing.JPanel {
             });
         }
 
-        public List<UUID> getPossibleTargets() {
-            if (options != null && options.containsKey("possibleTargets")) {
-                return (List<UUID>) options.get("possibleTargets");
-            } else {
-                return Collections.emptyList();
-            }
-        }
-
         public Set<UUID> getChosenTargets() {
             if (options != null && options.containsKey("chosenTargets")) {
-                return new HashSet<>((List<UUID>) options.get("chosenTargets"));
+                return (Set<UUID>) options.get("chosenTargets");
             } else {
                 return Collections.emptySet();
             }

--- a/Mage.Common/src/main/java/mage/utils/testers/BaseTestableDialog.java
+++ b/Mage.Common/src/main/java/mage/utils/testers/BaseTestableDialog.java
@@ -7,6 +7,7 @@ import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.TargetPermanent;
+import mage.target.TargetPlayer;
 import mage.target.common.TargetPermanentOrPlayer;
 
 /**
@@ -74,6 +75,10 @@ abstract class BaseTestableDialog implements TestableDialog {
 
     static Target createAnyTarget(int min, int max) {
         return createAnyTarget(min, max, false);
+    }
+
+    static Target createPlayerTarget(int min, int max, boolean notTarget) {
+        return new TargetPlayer(min, max, notTarget);
     }
 
     private static Target createAnyTarget(int min, int max, boolean notTarget) {

--- a/Mage.Common/src/main/java/mage/utils/testers/ChooseTargetTestableDialog.java
+++ b/Mage.Common/src/main/java/mage/utils/testers/ChooseTargetTestableDialog.java
@@ -126,6 +126,19 @@ class ChooseTargetTestableDialog extends BaseTestableDialog {
                         runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "impossible 1-3", createImpossibleTarget(1, 3)).aiMustChoose(false, 0));
                         runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "impossible 2-3", createImpossibleTarget(2, 3)).aiMustChoose(false, 0));
                         runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "impossible max", createImpossibleTarget(0, Integer.MAX_VALUE)).aiMustChoose(false, 0));
+                        //
+                        // additional tests for 2 possible options limitation
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 0", createPlayerTarget(0, 0, notTarget)).aiMustChoose(false, 0));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 0-1", createPlayerTarget(0, 1, notTarget)).aiMustChoose(true, 1));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 0-2", createPlayerTarget(0, 2, notTarget)).aiMustChoose(true, 1));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 0-5", createPlayerTarget(0, 5, notTarget)).aiMustChoose(true, 1));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 1", createPlayerTarget(1, 1, notTarget)).aiMustChoose(true, 1));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 1-2", createPlayerTarget(1, 2, notTarget)).aiMustChoose(true, 1));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 1-5", createPlayerTarget(1, 5, notTarget)).aiMustChoose(true, 1));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 2", createPlayerTarget(2, 2, notTarget)).aiMustChoose(true, 2));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 2-5", createPlayerTarget(2, 5, notTarget)).aiMustChoose(true, 2));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 3", createPlayerTarget(3, 3, notTarget)).aiMustChoose(false, 0));
+                        runner.registerDialog(new ChooseTargetTestableDialog(isPlayerChoice, isTargetChoice, notTarget, isYou, "player 3-5", createPlayerTarget(3, 5, notTarget)).aiMustChoose(false, 0));
                     }
                 }
             }

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ComputerPlayer6.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/ComputerPlayer6.java
@@ -405,13 +405,13 @@ public class ComputerPlayer6 extends ComputerPlayer {
             if (effect != null
                     && stackObject.getControllerId().equals(playerId)) {
                 Target target = effect.getTarget();
-                if (!target.isChoiceCompleted(getId(), (StackAbility) stackObject, game)) {
+                if (!target.isChoiceCompleted(getId(), (StackAbility) stackObject, game, null)) {
                     for (UUID targetId : target.possibleTargets(stackObject.getControllerId(), stackObject.getStackAbility(), game)) {
                         Game sim = game.createSimulationForAI();
                         StackAbility newAbility = (StackAbility) stackObject.copy();
                         SearchEffect newEffect = getSearchEffect(newAbility);
                         newEffect.getTarget().addTarget(targetId, newAbility, sim);
-                        sim.getStack().push(newAbility);
+                        sim.getStack().push(sim, newAbility);
                         SimulationNode2 newNode = new SimulationNode2(node, sim, depth, stackObject.getControllerId());
                         node.children.add(newNode);
                         newNode.getTargets().add(targetId);
@@ -886,10 +886,10 @@ public class ComputerPlayer6 extends ComputerPlayer {
         }
 
         UUID abilityControllerId = target.getAffectedAbilityControllerId(getId());
-        if (!target.isChoiceCompleted(abilityControllerId, source, game)) {
+        if (!target.isChoiceCompleted(abilityControllerId, source, game, cards)) {
             for (UUID targetId : targets) {
                 target.addTarget(targetId, source, game);
-                if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                if (target.isChoiceCompleted(abilityControllerId, source, game, cards)) {
                     targets.clear();
                     return true;
                 }
@@ -906,10 +906,10 @@ public class ComputerPlayer6 extends ComputerPlayer {
         }
 
         UUID abilityControllerId = target.getAffectedAbilityControllerId(getId());
-        if (!target.isChoiceCompleted(abilityControllerId, source, game)) {
+        if (!target.isChoiceCompleted(abilityControllerId, source, game, cards)) {
             for (UUID targetId : targets) {
                 target.add(targetId, game);
-                if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                if (target.isChoiceCompleted(abilityControllerId, source, game, cards)) {
                     targets.clear();
                     return true;
                 }

--- a/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MA/src/mage/player/ai/SimulatedPlayer2.java
@@ -105,7 +105,7 @@ public final class SimulatedPlayer2 extends ComputerPlayer {
         return list;
     }
 
-    protected void simulateOptions(Game game) {
+    private void simulateOptions(Game game) {
         List<ActivatedAbility> playables = game.getPlayer(playerId).getPlayable(game, isSimulatedPlayer);
         for (ActivatedAbility ability : playables) {
             if (ability.isManaAbility()) {
@@ -175,6 +175,10 @@ public final class SimulatedPlayer2 extends ComputerPlayer {
         if (options.isEmpty()) {
             return options;
         }
+
+        // remove invalid targets
+        // TODO: is it useless cause it already filtered before?
+        options.removeIf(option -> !option.getTargets().isChosen(game));
 
         if (AI_SIMULATE_ALL_BAD_AND_GOOD_TARGETS) {
             return options;
@@ -315,7 +319,7 @@ public final class SimulatedPlayer2 extends ComputerPlayer {
         List<Ability> options = getPlayableOptions(ability, game);
         if (options.isEmpty()) {
             logger.debug("simulating -- triggered ability:" + ability);
-            game.getStack().push(new StackAbility(ability, playerId));
+            game.getStack().push(game, new StackAbility(ability, playerId));
             if (ability.activate(game, false) && ability.isUsesStack()) {
                 game.fireEvent(new GameEvent(GameEvent.EventType.TRIGGERED_ABILITY, ability.getId(), ability, ability.getControllerId()));
             }
@@ -337,9 +341,9 @@ public final class SimulatedPlayer2 extends ComputerPlayer {
 
     protected void addAbilityNode(SimulationNode2 parent, Ability ability, int depth, Game game) {
         Game sim = game.createSimulationForAI();
-        sim.getStack().push(new StackAbility(ability, playerId));
+        sim.getStack().push(sim, new StackAbility(ability, playerId));
         if (ability.activate(sim, false) && ability.isUsesStack()) {
-            game.fireEvent(new GameEvent(GameEvent.EventType.TRIGGERED_ABILITY, ability.getId(), ability, ability.getControllerId()));
+            sim.fireEvent(new GameEvent(GameEvent.EventType.TRIGGERED_ABILITY, ability.getId(), ability, ability.getControllerId()));
         }
         sim.applyEffects();
         SimulationNode2 newNode = new SimulationNode2(parent, sim, depth, playerId);

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -142,17 +142,27 @@ public class ComputerPlayer extends PlayerImpl {
         UUID abilityControllerId = target.getAffectedAbilityControllerId(getId());
 
         // nothing to choose, e.g. X=0
-        if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+        if (target.isChoiceCompleted(abilityControllerId, source, game, fromCards)) {
             return false;
         }
 
-        // default logic for any targets
         PossibleTargetsSelector possibleTargetsSelector = new PossibleTargetsSelector(outcome, target, abilityControllerId, source, game);
         possibleTargetsSelector.findNewTargets(fromCards);
+
+        // nothing to choose, e.g. no valid targets
+        if (!possibleTargetsSelector.hasAnyTargets()) {
+            return false;
+        }
+
+        // can't choose
+        if (!possibleTargetsSelector.hasMinNumberOfTargets()) {
+            return false;
+        }
+
         // good targets -- choose as much as possible
         for (MageItem item : possibleTargetsSelector.getGoodTargets()) {
             target.add(item.getId(), game);
-            if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+            if (target.isChoiceCompleted(abilityControllerId, source, game, fromCards)) {
                 return true;
             }
         }
@@ -226,7 +236,7 @@ public class ComputerPlayer extends PlayerImpl {
         UUID abilityControllerId = target.getAffectedAbilityControllerId(getId());
 
         // nothing to choose, e.g. X=0
-        if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+        if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
             return false;
         }
 
@@ -235,6 +245,11 @@ public class ComputerPlayer extends PlayerImpl {
 
         // nothing to choose, e.g. no valid targets
         if (!possibleTargetsSelector.hasAnyTargets()) {
+            return false;
+        }
+
+        // can't choose
+        if (!possibleTargetsSelector.hasMinNumberOfTargets()) {
             return false;
         }
 
@@ -251,7 +266,7 @@ public class ComputerPlayer extends PlayerImpl {
                 int leftLife = PossibleTargetsComparator.getLifeForDamage(item, game);
                 if (leftLife > 0 && leftLife <= target.getAmountRemaining()) {
                     target.addTarget(item.getId(), leftLife, source, game);
-                    if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                    if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                         return true;
                     }
                 }
@@ -268,7 +283,7 @@ public class ComputerPlayer extends PlayerImpl {
                 int leftLife = PossibleTargetsComparator.getLifeForDamage(item, game);
                 if (leftLife > 0 && leftLife <= target.getAmountRemaining()) {
                     target.addTarget(item.getId(), leftLife, source, game);
-                    if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                    if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                         return true;
                     }
                 }
@@ -283,7 +298,7 @@ public class ComputerPlayer extends PlayerImpl {
                     continue;
                 }
                 target.addTarget(item.getId(), target.getAmountRemaining(), source, game);
-                if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                     return true;
                 }
             }
@@ -303,7 +318,7 @@ public class ComputerPlayer extends PlayerImpl {
                 int leftLife = PossibleTargetsComparator.getLifeForDamage(item, game);
                 if (leftLife > 1) {
                     target.addTarget(item.getId(), Math.min(leftLife - 1, target.getAmountRemaining()), source, game);
-                    if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                    if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                         return true;
                     }
                 }
@@ -322,7 +337,7 @@ public class ComputerPlayer extends PlayerImpl {
                     return !target.getTargets().isEmpty();
                 }
                 target.addTarget(item.getId(), target.getAmountRemaining(), source, game);
-                if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                     return true;
                 }
             }
@@ -339,7 +354,7 @@ public class ComputerPlayer extends PlayerImpl {
                 continue;
             }
             target.addTarget(item.getId(), target.getAmountRemaining(), source, game);
-            if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+            if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                 return true;
             }
         }
@@ -355,7 +370,7 @@ public class ComputerPlayer extends PlayerImpl {
                 return !target.getTargets().isEmpty();
             }
             target.addTarget(item.getId(), target.getAmountRemaining(), source, game);
-            if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+            if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                 return true;
             }
         }

--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/PossibleTargetsSelector.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/PossibleTargetsSelector.java
@@ -47,7 +47,6 @@ public class PossibleTargetsSelector {
         // collect new valid targets
         List<MageItem> found = target.possibleTargets(abilityControllerId, source, game, fromTargetsList).stream()
                 .filter(id -> !target.contains(id))
-                .filter(id -> target.canTarget(abilityControllerId, id, source, game))
                 .map(id -> {
                     Player player = game.getPlayer(id);
                     if (player != null) {
@@ -137,6 +136,10 @@ public class PossibleTargetsSelector {
         }
     }
 
+    public List<MageItem> getAny() {
+        return this.any;
+    }
+
     public static boolean isMyItem(UUID abilityControllerId, MageItem item) {
         if (item instanceof Player) {
             return item.getId().equals(abilityControllerId);
@@ -181,7 +184,12 @@ public class PossibleTargetsSelector {
         return false;
     }
 
-    boolean hasAnyTargets() {
+    public boolean hasAnyTargets() {
         return !this.any.isEmpty();
+    }
+
+    public boolean hasMinNumberOfTargets() {
+        return this.target.getMinNumberOfTargets() == 0
+                || this.any.size() >= this.target.getMinNumberOfTargets();
     }
 }

--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/SimulatedPlayerMCTS.java
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/SimulatedPlayerMCTS.java
@@ -121,7 +121,7 @@ public final class SimulatedPlayerMCTS extends MCTSPlayer {
                 }
             }
             if (ability.isUsesStack()) {
-                game.getStack().push(new StackAbility(ability, playerId));
+                game.getStack().push(game, new StackAbility(ability, playerId));
                 if (ability.activate(game, false)) {
                     game.fireEvent(new GameEvent(GameEvent.EventType.TRIGGERED_ABILITY, ability.getId(), ability, ability.getControllerId()));
                     actionCount++;
@@ -187,8 +187,8 @@ public final class SimulatedPlayerMCTS extends MCTSPlayer {
         abort = true;
     }
 
-    protected boolean chooseRandom(Target target, Game game) {
-        Set<UUID> possibleTargets = target.possibleTargets(playerId, game);
+    private boolean chooseRandom(Target target, Ability source, Game game) {
+        Set<UUID> possibleTargets = target.possibleTargets(playerId, source, game);
         if (possibleTargets.isEmpty()) {
             return false;
         }
@@ -233,7 +233,7 @@ public final class SimulatedPlayerMCTS extends MCTSPlayer {
     @Override
     public boolean choose(Outcome outcome, Target target, Ability source, Game game) {
         if (this.isHuman()) {
-            return chooseRandom(target, game);
+            return chooseRandom(target, source, game);
         }
         return super.choose(outcome, target, source, game);
     }
@@ -241,7 +241,7 @@ public final class SimulatedPlayerMCTS extends MCTSPlayer {
     @Override
     public boolean choose(Outcome outcome, Target target, Ability source, Game game, Map<String, Serializable> options) {
         if (this.isHuman()) {
-            return chooseRandom(target, game);
+            return chooseRandom(target, source, game);
         }
         return super.choose(outcome, target, source, game, options);
     }
@@ -252,7 +252,7 @@ public final class SimulatedPlayerMCTS extends MCTSPlayer {
             if (cards.isEmpty()) {
                 return false;
             }
-            Set<UUID> possibleTargets = target.possibleTargets(playerId, cards, source, game);
+            Set<UUID> possibleTargets = target.possibleTargets(playerId, source, game, cards);
             if (possibleTargets.isEmpty()) {
                 return false;
             }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -3,7 +3,6 @@ package mage.player.human;
 import mage.MageIdentifier;
 import mage.MageObject;
 import mage.abilities.*;
-import mage.abilities.costs.VariableCost;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCost;
@@ -697,7 +696,7 @@ public class HumanPlayer extends PlayerImpl {
         }
 
         // stop on completed, e.g. X=0
-        if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+        if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
             return false;
         }
 
@@ -729,7 +728,7 @@ public class HumanPlayer extends PlayerImpl {
                 // continue to next target (example: auto-choose must fill min/max = 2 from 2 possible cards)
             } else {
                 // manual choose
-                options.put("chosenTargets", (Serializable) target.getTargets());
+                options.put("chosenTargets", new HashSet<>(target.getTargets()));
 
                 prepareForResponse(game);
                 if (!isExecutingMacro()) {
@@ -747,9 +746,9 @@ public class HumanPlayer extends PlayerImpl {
                         continue;
                     }
 
-                    if (possibleTargets.contains(responseId) && target.canTarget(getId(), responseId, source, game)) {
+                    if (possibleTargets.contains(responseId)) {
                         target.add(responseId, game);
-                        if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                        if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
                             break;
                         }
                     }
@@ -794,7 +793,7 @@ public class HumanPlayer extends PlayerImpl {
 
             // manual choice
             if (responseId == null) {
-                options.put("chosenTargets", (Serializable) target.getTargets());
+                options.put("chosenTargets", new HashSet<>(target.getTargets()));
 
                 prepareForResponse(game);
                 if (!isExecutingMacro()) {
@@ -814,11 +813,9 @@ public class HumanPlayer extends PlayerImpl {
 
                 // add new target
                 if (possibleTargets.contains(responseId)) {
-                    if (target.canTarget(abilityControllerId, responseId, source, game)) {
-                        target.addTarget(responseId, source, game);
-                        if (target.isChoiceCompleted(abilityControllerId, source, game)) {
-                            return true;
-                        }
+                    target.addTarget(responseId, source, game);
+                    if (target.isChoiceCompleted(abilityControllerId, source, game, null)) {
+                        return true;
                     }
                 }
             } else {
@@ -864,13 +861,7 @@ public class HumanPlayer extends PlayerImpl {
         UUID abilityControllerId = target.getAffectedAbilityControllerId(this.getId());
 
         while (canRespond()) {
-
-            List<UUID> possibleTargets = new ArrayList<>();
-            for (UUID cardId : cards) {
-                if (target.canTarget(abilityControllerId, cardId, source, cards, game)) {
-                    possibleTargets.add(cardId);
-                }
-            }
+            Set<UUID> possibleTargets = target.possibleTargets(abilityControllerId, source, game, cards);
 
             boolean required = target.isRequired(source != null ? source.getSourceId() : null, game);
             int count = cards.count(target.getFilter(), abilityControllerId, source, game);
@@ -880,7 +871,7 @@ public class HumanPlayer extends PlayerImpl {
             }
 
             // if nothing to choose then show dialog (user must see non selectable items and click on any of them)
-            // TODO: need research - is it used?
+            // TODO: need research - is it used (test player and AI player don't see empty dialogs)?
             if (required && possibleTargets.isEmpty()) {
                 required = false;
             }
@@ -894,7 +885,7 @@ public class HumanPlayer extends PlayerImpl {
             } else {
                 // manual choose
                 Map<String, Serializable> options = getOptions(target, null);
-                options.put("chosenTargets", (Serializable) target.getTargets());
+                options.put("chosenTargets", new HashSet<>(target.getTargets()));
                 if (!possibleTargets.isEmpty()) {
                     options.put("possibleTargets", (Serializable) possibleTargets);
                 }
@@ -916,9 +907,9 @@ public class HumanPlayer extends PlayerImpl {
                         continue;
                     }
 
-                    if (possibleTargets.contains(responseId) && target.canTarget(getId(), responseId, source, cards, game)) {
+                    if (possibleTargets.contains(responseId)) {
                         target.add(responseId, game);
-                        if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                        if (target.isChoiceCompleted(abilityControllerId, source, game, cards)) {
                             return true;
                         }
                     }
@@ -962,12 +953,8 @@ public class HumanPlayer extends PlayerImpl {
                 required = false;
             }
 
-            List<UUID> possibleTargets = new ArrayList<>();
-            for (UUID cardId : cards) {
-                if (target.canTarget(abilityControllerId, cardId, source, cards, game)) {
-                    possibleTargets.add(cardId);
-                }
-            }
+            Set<UUID> possibleTargets = target.possibleTargets(abilityControllerId, source, game, cards);
+
             // if nothing to choose then show dialog (user must see non-selectable items and click on any of them)
             if (possibleTargets.isEmpty()) {
                 required = false;
@@ -977,7 +964,7 @@ public class HumanPlayer extends PlayerImpl {
 
             if (responseId == null) {
                 Map<String, Serializable> options = getOptions(target, null);
-                options.put("chosenTargets", (Serializable) target.getTargets());
+                options.put("chosenTargets", new HashSet<>(target.getTargets()));
 
                 if (!possibleTargets.isEmpty()) {
                     options.put("possibleTargets", (Serializable) possibleTargets);
@@ -995,9 +982,9 @@ public class HumanPlayer extends PlayerImpl {
             if (responseId != null) {
                 if (target.contains(responseId)) { // if already included remove it
                     target.remove(responseId);
-                } else if (target.canTarget(abilityControllerId, responseId, source, cards, game)) {
+                } else if (possibleTargets.contains(responseId)) {
                     target.addTarget(responseId, source, game);
-                    if (target.isChoiceCompleted(abilityControllerId, source, game)) {
+                    if (target.isChoiceCompleted(abilityControllerId, source, game, cards)) {
                         return true;
                     }
                 }
@@ -1054,9 +1041,9 @@ public class HumanPlayer extends PlayerImpl {
         // 1. Select targets
         // TODO: rework to use existing chooseTarget instead custom select?
         while (canRespond()) {
-            Set<UUID> possibleTargetIds = target.possibleTargets(abilityControllerId, source, game);
+            Set<UUID> possibleTargets = target.possibleTargets(abilityControllerId, source, game);
             boolean required = target.isRequired(source.getSourceId(), game);
-            if (possibleTargetIds.isEmpty()
+            if (possibleTargets.isEmpty()
                     || target.getSize() >= target.getMinNumberOfTargets()) {
                 required = false;
             }
@@ -1065,12 +1052,6 @@ public class HumanPlayer extends PlayerImpl {
 
             // responseId is null if a choice couldn't be automatically made
             if (responseId == null) {
-                List<UUID> possibleTargets = new ArrayList<>();
-                for (UUID targetId : possibleTargetIds) {
-                    if (target.canTarget(abilityControllerId, targetId, source, game)) {
-                        possibleTargets.add(targetId);
-                    }
-                }
                 // if nothing to choose then show dialog (user must see non selectable items and click on any of them)
                 if (required && possibleTargets.isEmpty()) {
                     required = false;
@@ -1078,7 +1059,7 @@ public class HumanPlayer extends PlayerImpl {
 
                 // selected
                 Map<String, Serializable> options = getOptions(target, null);
-                options.put("chosenTargets", (Serializable) target.getTargets());
+                options.put("chosenTargets", new HashSet<>(target.getTargets()));
                 if (!possibleTargets.isEmpty()) {
                     options.put("possibleTargets", (Serializable) possibleTargets);
                 }
@@ -1087,7 +1068,7 @@ public class HumanPlayer extends PlayerImpl {
                 if (!isExecutingMacro()) {
                     String multiType = multiAmountType == MultiAmountType.DAMAGE ? " to divide %d damage" : " to distribute %d counters";
                     String message = target.getMessage(game) + String.format(multiType, amountTotal);
-                    game.fireSelectTargetEvent(playerId, new MessageToClient(message, getRelatedObjectName(source, game)), possibleTargetIds, required, options);
+                    game.fireSelectTargetEvent(playerId, new MessageToClient(message, getRelatedObjectName(source, game)), possibleTargets, required, options);
                 }
                 waitForResponse(game);
 
@@ -1098,9 +1079,7 @@ public class HumanPlayer extends PlayerImpl {
                 if (target.contains(responseId)) {
                     // unselect
                     target.remove(responseId);
-                } else if (possibleTargetIds.contains(responseId)
-                        && target.canTarget(abilityControllerId, responseId, source, game)
-                        && target.getSize() < amountTotal) {
+                } else if (possibleTargets.contains(responseId) && target.getSize() < amountTotal) {
                     // select
                     target.addTarget(responseId, source, game);
                 }
@@ -2094,32 +2073,33 @@ public class HumanPlayer extends PlayerImpl {
         if (!canCallFeedback(game)) {
             return;
         }
-        TargetAttackingCreature target = new TargetAttackingCreature();
 
-        // TODO: add canRespond cycle?
+        // no need in cycle, cause parent selectBlockers used it already
         if (!canRespond()) {
             return;
         }
 
         UUID responseId = null;
 
-        prepareForResponse(game);
         if (!isExecutingMacro()) {
             // possible attackers to block
-            Set<UUID> attackers = target.possibleTargets(playerId, null, game);
+            TargetAttackingCreature target = new TargetAttackingCreature();
             Permanent blocker = game.getPermanent(blockerId);
-            Set<UUID> possibleTargets = new HashSet<>();
-            for (UUID attackerId : attackers) {
+            Set<UUID> allAttackers = target.possibleTargets(playerId, null, game);
+            Set<UUID> possibleAttackersToBlock = new HashSet<>();
+            for (UUID attackerId : allAttackers) {
                 CombatGroup group = game.getCombat().findGroup(attackerId);
                 if (group != null && blocker != null && group.canBlock(blocker, game)) {
-                    possibleTargets.add(attackerId);
+                    possibleAttackersToBlock.add(attackerId);
                 }
             }
-            if (possibleTargets.size() == 1) {
-                responseId = possibleTargets.stream().iterator().next();
+            if (possibleAttackersToBlock.size() == 1) {
+                // auto-choice
+                responseId = possibleAttackersToBlock.stream().iterator().next();
             } else {
+                prepareForResponse(game);
                 game.fireSelectTargetEvent(playerId, new MessageToClient("Select attacker to block", getRelatedObjectName(blockerId, game)),
-                        possibleTargets, false, getOptions(target, null));
+                        possibleAttackersToBlock, false, getOptions(target, null));
                 waitForResponse(game);
             }
         }
@@ -2174,7 +2154,7 @@ public class HumanPlayer extends PlayerImpl {
             break;
         }
 
-        return  xValue;
+        return xValue;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AjanisChosen.java
+++ b/Mage.Sets/src/mage/cards/a/AjanisChosen.java
@@ -77,7 +77,7 @@ class AjanisChosenEffect extends OneShotEffect {
                             Permanent oldCreature = game.getPermanent(enchantment.getAttachedTo());
                             if (oldCreature != null) {
                                 boolean canAttach = enchantment.getSpellAbility() == null
-                                        || (!enchantment.getSpellAbility().getTargets().isEmpty() && enchantment.getSpellAbility().getTargets().get(0).canTarget(tokenPermanent.getId(), game));
+                                        || (!enchantment.getSpellAbility().getTargets().isEmpty() && enchantment.getSpellAbility().getTargets().get(0).canTarget(tokenPermanent.getId(), source, game));
                                 if (canAttach && controller.chooseUse(Outcome.Neutral, "Attach " + enchantment.getName() + " to the token ?", source, game)) {
                                     if (oldCreature.removeAttachment(enchantment.getId(), source, game)) {
                                         tokenPermanent.addAttachment(enchantment.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/a/AncientBrassDragon.java
+++ b/Mage.Sets/src/mage/cards/a/AncientBrassDragon.java
@@ -108,8 +108,8 @@ class AncientBrassDragonTarget extends TargetCardInGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, xValue, game);
     }

--- a/Mage.Sets/src/mage/cards/a/AnuridScavenger.java
+++ b/Mage.Sets/src/mage/cards/a/AnuridScavenger.java
@@ -84,7 +84,7 @@ class AnuridScavengerCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/a/AoTheDawnSky.java
+++ b/Mage.Sets/src/mage/cards/a/AoTheDawnSky.java
@@ -134,8 +134,8 @@ class AoTheDawnSkyTarget extends TargetCardInLibrary {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 4, game);
     }

--- a/Mage.Sets/src/mage/cards/a/ArdentDustspeaker.java
+++ b/Mage.Sets/src/mage/cards/a/ArdentDustspeaker.java
@@ -79,7 +79,7 @@ class ArdentDustspeakerCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BackFromTheBrink.java
+++ b/Mage.Sets/src/mage/cards/b/BackFromTheBrink.java
@@ -67,7 +67,7 @@ class BackFromTheBrinkCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BattleForBretagard.java
+++ b/Mage.Sets/src/mage/cards/b/BattleForBretagard.java
@@ -147,6 +147,7 @@ class BattleForBretagardTarget extends TargetPermanent {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
+
         Set<String> names = this.getTargets()
                 .stream()
                 .map(game::getPermanent)
@@ -159,6 +160,7 @@ class BattleForBretagardTarget extends TargetPermanent {
             Permanent permanent = game.getPermanent(uuid);
             return permanent == null || names.contains(permanent.getName());
         });
+
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BattlefieldScrounger.java
+++ b/Mage.Sets/src/mage/cards/b/BattlefieldScrounger.java
@@ -79,7 +79,7 @@ class BattlefieldScroungerCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/b/BeguilerOfWills.java
+++ b/Mage.Sets/src/mage/cards/b/BeguilerOfWills.java
@@ -66,12 +66,12 @@ class BeguilerOfWillsTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Permanent permanent = game.getPermanent(id);
         int count = game.getBattlefield().countAll(this.filter, source.getControllerId(), game);
 
         if (permanent != null && permanent.getPower().getValue() <= count) {
-            return super.canTarget(controllerId, id, source, game);
+            return super.canTarget(playerId, id, source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/b/BlazingHope.java
+++ b/Mage.Sets/src/mage/cards/b/BlazingHope.java
@@ -49,18 +49,18 @@ class BlazingHopeTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Permanent permanent = game.getPermanent(id);
         if (permanent != null) {
             if (!isNotTarget()) {
-                if (!permanent.canBeTargetedBy(game.getObject(source.getId()), controllerId, source, game)
-                        || !permanent.canBeTargetedBy(game.getObject(source), controllerId, source, game)) {
+                if (!permanent.canBeTargetedBy(game.getObject(source.getId()), playerId, source, game)
+                        || !permanent.canBeTargetedBy(game.getObject(source), playerId, source, game)) {
                     return false;
                 }
             }
             Player controller = game.getPlayer(source.getControllerId());
             if (controller != null && permanent.getPower().getValue() >= controller.getLife()) {
-                return filter.match(permanent, controllerId, source, game);
+                return filter.match(permanent, playerId, source, game);
             }
         }
         return false;

--- a/Mage.Sets/src/mage/cards/b/BreakingOfTheFellowship.java
+++ b/Mage.Sets/src/mage/cards/b/BreakingOfTheFellowship.java
@@ -1,6 +1,5 @@
 package mage.cards.b;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.keyword.TheRingTemptsYouEffect;
@@ -8,20 +7,20 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.filter.predicate.permanent.PermanentIdPredicate;
+import mage.filter.common.FilterOpponentsCreaturePermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.target.common.TargetCreaturePermanent;
 
+import java.util.Set;
 import java.util.UUID;
 
 /**
+ * TODO: combine with Mutiny
+ *
  * @author Susucr
  */
 public final class BreakingOfTheFellowship extends CardImpl {
@@ -31,8 +30,8 @@ public final class BreakingOfTheFellowship extends CardImpl {
 
         // Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
         this.getSpellAbility().addEffect(new BreakingOfTheFellowshipEffect());
-        this.getSpellAbility().addTarget(new BreakingOfTheFellowshipFirstTarget());
-        this.getSpellAbility().addTarget(new TargetPermanent(new FilterCreaturePermanent("another target creature that player controls")));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
+        this.getSpellAbility().addTarget(new BreakingOfTheFellowshipSecondTarget());
 
         // The Ring tempts you.
         this.getSpellAbility().addEffect(new TheRingTemptsYouEffect());
@@ -76,74 +75,45 @@ class BreakingOfTheFellowshipEffect extends OneShotEffect {
         }
         return true;
     }
-
 }
 
-class BreakingOfTheFellowshipFirstTarget extends TargetPermanent {
+class BreakingOfTheFellowshipSecondTarget extends TargetPermanent {
 
-    public BreakingOfTheFellowshipFirstTarget() {
-        super(1, 1, StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE, false);
+    public BreakingOfTheFellowshipSecondTarget() {
+        super(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
     }
 
-    private BreakingOfTheFellowshipFirstTarget(final BreakingOfTheFellowshipFirstTarget target) {
+    private BreakingOfTheFellowshipSecondTarget(final BreakingOfTheFellowshipSecondTarget target) {
         super(target);
     }
 
     @Override
-    public void addTarget(UUID id, Ability source, Game game, boolean skipEvent) {
-        super.addTarget(id, source, game, skipEvent);
-        // Update the second target
-        UUID firstController = game.getControllerId(id);
-        if (firstController != null && source.getTargets().size() > 1) {
-            Player controllingPlayer = game.getPlayer(firstController);
-            TargetCreaturePermanent targetCreaturePermanent = (TargetCreaturePermanent) source.getTargets().get(1);
-            // Set a new filter to the second target with the needed restrictions
-            FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature that player " + controllingPlayer.getName() + " controls");
-            filter.add(new ControllerIdPredicate(firstController));
-            filter.add(Predicates.not(new PermanentIdPredicate(id)));
-            targetCreaturePermanent.replaceFilter(filter);
-        }
-    }
+    public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
+        Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
 
-    @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (super.canTarget(controllerId, id, source, game)) {
-            // can only target, if the controller has at least two targetable creatures
-            UUID controllingPlayerId = game.getControllerId(id);
-            int possibleTargets = 0;
-            MageObject sourceObject = game.getObject(source.getId());
-            for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, controllingPlayerId, game)) {
-                if (permanent.canBeTargetedBy(sourceObject, controllerId, source, game)) {
-                    possibleTargets++;
-                }
+        Permanent firstTarget = game.getPermanent(source.getFirstTarget());
+        if (firstTarget == null) {
+            // playable or first target not yet selected
+            // use all
+            if (possibleTargets.size() == 1) {
+                // workaround to make 1 target invalid
+                possibleTargets.clear();
             }
-            return possibleTargets > 1;
+        } else {
+            // real
+            // filter by same player
+            possibleTargets.removeIf(id -> {
+                Permanent permanent = game.getPermanent(id);
+                return permanent == null || !permanent.isControlledBy(firstTarget.getControllerId());
+            });
         }
-        return false;
+        possibleTargets.removeIf(id -> firstTarget != null && firstTarget.getId().equals(id));
+
+        return possibleTargets;
     }
 
     @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        if (super.canChoose(sourceControllerId, source, game)) {
-            UUID controllingPlayerId = game.getControllerId(source.getSourceId());
-            for (UUID playerId : game.getOpponents(controllingPlayerId)) {
-                int possibleTargets = 0;
-                MageObject sourceObject = game.getObject(source);
-                for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, playerId, game)) {
-                    if (permanent.canBeTargetedBy(sourceObject, controllingPlayerId, source, game)) {
-                        possibleTargets++;
-                    }
-                }
-                if (possibleTargets > 1) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public BreakingOfTheFellowshipFirstTarget copy() {
-        return new BreakingOfTheFellowshipFirstTarget(this);
+    public BreakingOfTheFellowshipSecondTarget copy() {
+        return new BreakingOfTheFellowshipSecondTarget(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CallOfTheDeathDweller.java
+++ b/Mage.Sets/src/mage/cards/c/CallOfTheDeathDweller.java
@@ -141,8 +141,8 @@ class CallOfTheDeathDwellerTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 3, game);
     }

--- a/Mage.Sets/src/mage/cards/c/ChaosMutation.java
+++ b/Mage.Sets/src/mage/cards/c/ChaosMutation.java
@@ -124,8 +124,8 @@ class ChaosMutationTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/c/CloudsLimitBreak.java
+++ b/Mage.Sets/src/mage/cards/c/CloudsLimitBreak.java
@@ -85,8 +85,8 @@ class CloudsLimitBreakTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
+++ b/Mage.Sets/src/mage/cards/c/ConspiracyTheorist.java
@@ -119,8 +119,7 @@ class ConspiracyTheoristEffect extends OneShotEffect {
         if (controller != null) {
             CardsImpl cards = new CardsImpl(discardedCards);
             TargetCard target = new TargetCard(Zone.GRAVEYARD, new FilterCard("card to exile"));
-            boolean validTarget = cards.stream()
-                    .anyMatch(card -> target.canTarget(card, game));
+            boolean validTarget = cards.stream().anyMatch(card -> target.canTarget(card, source, game));
             if (validTarget && controller.chooseUse(Outcome.Benefit, "Exile a card?", source, game)) {
                 if (controller.choose(Outcome.Benefit, cards, target, source, game)) {
                     Card card = cards.get(target.getFirstTarget(), game);

--- a/Mage.Sets/src/mage/cards/d/DaringThief.java
+++ b/Mage.Sets/src/mage/cards/d/DaringThief.java
@@ -9,6 +9,7 @@ import mage.abilities.keyword.InspiredAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -35,8 +36,12 @@ public final class DaringThief extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Inspired - Whenever Daring Thief becomes untapped, you may exchange control of target nonland permanent you control and target permanent an opponent controls that shares a card type with it.
-        Ability ability = new InspiredAbility(new ExchangeControlTargetEffect(Duration.EndOfGame,
-                "you may exchange control of target nonland permanent you control and target permanent an opponent controls that shares a card type with it", false, true), true);
+        Ability ability = new InspiredAbility(new ExchangeControlTargetEffect(
+                Duration.EndOfGame,
+                "you may exchange control of target nonland permanent you control and target permanent an opponent controls that shares a card type with it",
+                false,
+                true
+        ), true);
         ability.addTarget(new TargetControlledPermanentSharingOpponentPermanentCardType());
         ability.addTarget(new DaringThiefSecondTarget());
         this.addAbility(ability);
@@ -66,9 +71,10 @@ class TargetControlledPermanentSharingOpponentPermanentCardType extends TargetCo
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (super.canTarget(controllerId, id, source, game)) {
-            Set<CardType> cardTypes = getOpponentPermanentCardTypes(controllerId, game);
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        Set<CardType> cardTypes = getOpponentPermanentCardTypes(playerId, game);
+
+        if (super.canTarget(playerId, id, source, game)) {
             Permanent permanent = game.getPermanent(id);
             for (CardType type : permanent.getCardType(game)) {
                 if (cardTypes.contains(type)) {
@@ -81,23 +87,21 @@ class TargetControlledPermanentSharingOpponentPermanentCardType extends TargetCo
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        // get all cardtypes from opponents permanents 
         Set<CardType> cardTypes = getOpponentPermanentCardTypes(sourceControllerId, game);
+
         Set<UUID> possibleTargets = new HashSet<>();
         MageObject targetSource = game.getObject(source);
         if (targetSource != null) {
             for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, sourceControllerId, source, game)) {
-                if (!targets.containsKey(permanent.getId()) && permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                    for (CardType type : permanent.getCardType(game)) {
-                        if (cardTypes.contains(type)) {
-                            possibleTargets.add(permanent.getId());
-                            break;
-                        }
+                for (CardType type : permanent.getCardType(game)) {
+                    if (cardTypes.contains(type)) {
+                        possibleTargets.add(permanent.getId());
+                        break;
                     }
                 }
             }
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
@@ -119,58 +123,54 @@ class TargetControlledPermanentSharingOpponentPermanentCardType extends TargetCo
     }
 }
 
-
 class DaringThiefSecondTarget extends TargetPermanent {
 
-    private Permanent firstTarget = null;
-
     public DaringThiefSecondTarget() {
-        super();
-        this.filter = this.filter.copy();
-        filter.add(TargetController.OPPONENT.getControllerPredicate());
+        super(StaticFilters.FILTER_OPPONENTS_PERMANENT);
         withTargetName("permanent an opponent controls that shares a card type with it");
     }
 
     private DaringThiefSecondTarget(final DaringThiefSecondTarget target) {
         super(target);
-        this.firstTarget = target.firstTarget;
     }
-
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
-        if (super.canTarget(id, source, game)) {
-            Permanent target1 = game.getPermanent(source.getFirstTarget());
-            Permanent opponentPermanent = game.getPermanent(id);
-            if (target1 != null && opponentPermanent != null) {
-                return target1.shareTypes(opponentPermanent, game);
-            }
+        Permanent ownPermanent = game.getPermanent(source.getFirstTarget());
+        Permanent possiblePermanent = game.getPermanent(id);
+        if (ownPermanent == null || possiblePermanent == null) {
+            return false;
         }
-        return false;
+        return super.canTarget(id, source, game) && ownPermanent.shareTypes(possiblePermanent, game);
     }
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
-        if (firstTarget != null) {
-            MageObject targetSource = game.getObject(source);
-            if (targetSource != null) {
-                for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, sourceControllerId, source, game)) {
-                    if (!targets.containsKey(permanent.getId()) && permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                        if (permanent.shareTypes(firstTarget, game)) {
-                            possibleTargets.add(permanent.getId());
-                        }
-                    }
+
+        Permanent ownPermanent = game.getPermanent(source.getFirstTarget());
+        for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, sourceControllerId, source, game)) {
+            if (ownPermanent == null) {
+                // playable or first target not yet selected
+                // use all
+                possibleTargets.add(permanent.getId());
+            } else {
+                // real
+                // filter by shared type
+                if (permanent.shareTypes(ownPermanent, game)) {
+                    possibleTargets.add(permanent.getId());
                 }
             }
         }
-        return possibleTargets;
+        possibleTargets.removeIf(id -> ownPermanent != null && ownPermanent.getId().equals(id));
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
     public boolean chooseTarget(Outcome outcome, UUID playerId, Ability source, Game game) {
-        firstTarget = game.getPermanent(source.getFirstTarget());
-        return super.chooseTarget(Outcome.Damage, playerId, source, game);
+        // AI hint with better outcome
+        return super.chooseTarget(Outcome.GainControl, playerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/DeepCavernBat.java
+++ b/Mage.Sets/src/mage/cards/d/DeepCavernBat.java
@@ -91,9 +91,7 @@ class DeepCaverBatEffect extends OneShotEffect {
             return true;
         }
 
-        TargetCard target = new TargetCardInHand(
-                0, 1, StaticFilters.FILTER_CARD_A_NON_LAND
-        );
+        TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_A_NON_LAND);
         controller.choose(outcome, opponent.getHand(), target, source, game);
         Card card = opponent.getHand().get(target.getFirstTarget(), game);
         if (card == null) {

--- a/Mage.Sets/src/mage/cards/d/DesperateGambit.java
+++ b/Mage.Sets/src/mage/cards/d/DesperateGambit.java
@@ -137,49 +137,12 @@ class TargetControlledSource extends TargetSource {
     }
 
     @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        int count = 0;
-        for (StackObject stackObject : game.getStack()) {
-            if (game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
-                    && Objects.equals(stackObject.getControllerId(), sourceControllerId)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(sourceControllerId, game)) {
-            if (Objects.equals(permanent.getControllerId(), sourceControllerId)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        for (Player player : game.getPlayers().values()) {
-            if (Objects.equals(player, game.getPlayer(sourceControllerId))) {
-                for (Card card : player.getGraveyard().getCards(game)) {
-                    count++;
-                    if (count >= this.minNumberOfTargets) {
-                        return true;
-                    }
-                }
-                // 108.4a If anything asks for the controller of a card that doesn't have one (because it's not a permanent or spell), use its owner instead.
-                for (Card card : game.getExile().getAllCards(game)) {
-                    if (Objects.equals(card.getOwnerId(), sourceControllerId)) {
-                        count++;
-                        if (count >= this.minNumberOfTargets) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        return false;
+    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
+    public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
         for (StackObject stackObject : game.getStack()) {
             if (game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
@@ -205,7 +168,7 @@ class TargetControlledSource extends TargetSource {
                 }
             }
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/DistendedMindbender.java
+++ b/Mage.Sets/src/mage/cards/d/DistendedMindbender.java
@@ -90,10 +90,10 @@ class DistendedMindbenderEffect extends OneShotEffect {
         TargetCard targetThreeOrLess = new TargetCard(1, Zone.HAND, filterThreeOrLess);
         TargetCard targetFourOrGreater = new TargetCard(1, Zone.HAND, filterFourOrGreater);
         Cards toDiscard = new CardsImpl();
-        if (controller.chooseTarget(Outcome.Benefit, opponent.getHand(), targetThreeOrLess, source, game)) {
+        if (controller.choose(Outcome.Benefit, opponent.getHand(), targetThreeOrLess, source, game)) {
             toDiscard.addAll(targetThreeOrLess.getTargets());
         }
-        if (controller.chooseTarget(Outcome.Benefit, opponent.getHand(), targetFourOrGreater, source, game)) {
+        if (controller.choose(Outcome.Benefit, opponent.getHand(), targetFourOrGreater, source, game)) {
             toDiscard.addAll(targetFourOrGreater.getTargets());
         }
         opponent.discard(toDiscard, false, source, game);

--- a/Mage.Sets/src/mage/cards/d/DrafnasRestoration.java
+++ b/Mage.Sets/src/mage/cards/d/DrafnasRestoration.java
@@ -1,25 +1,26 @@
 
 package mage.cards.d;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
-import mage.cards.*;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.filter.common.FilterArtifactCard;
 import mage.game.Game;
-import mage.game.events.TargetEvent;
-import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.target.TargetPlayer;
 import mage.target.common.TargetCardInGraveyard;
 
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author emerald000
  */
 public final class DrafnasRestoration extends CardImpl {
@@ -54,26 +55,32 @@ class DrafnasRestorationTarget extends TargetCardInGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        Player targetPlayer = game.getPlayer(source.getFirstTarget());
-        return targetPlayer != null && targetPlayer.getGraveyard().contains(id) && super.canTarget(id, source, game);
-    }
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
-        MageObject object = game.getObject(source);
-        if (object instanceof StackObject) {
-            Player targetPlayer = game.getPlayer(((StackObject) object).getStackAbility().getFirstTarget());
-            if (targetPlayer != null) {
-                for (Card card : targetPlayer.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-                    if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                        possibleTargets.add(card.getId());
-                    }
-                }
-            }
+
+        Player controller = game.getPlayer(sourceControllerId);
+        if (controller == null) {
+            return possibleTargets;
         }
-        return possibleTargets;
+
+        Player targetPlayer = game.getPlayer(source.getFirstTarget());
+        game.getState().getPlayersInRange(sourceControllerId, game, true).stream()
+                .map(game::getPlayer)
+                .filter(Objects::nonNull)
+                .flatMap(player -> player.getGraveyard().getCards(filter, sourceControllerId, source, game).stream())
+                .forEach(card -> {
+                    if (targetPlayer == null) {
+                        // playable or not selected - use any
+                        possibleTargets.add(card.getId());
+                    } else {
+                        // selected, filter by player
+                        if (targetPlayer.getId().equals(card.getControllerOrOwnerId())) {
+                            possibleTargets.add(card.getId());
+                        }
+                    }
+                });
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/d/DreamsOfSteelAndOil.java
+++ b/Mage.Sets/src/mage/cards/d/DreamsOfSteelAndOil.java
@@ -72,7 +72,7 @@ class DreamsOfSteelAndOilEffect extends OneShotEffect {
         filter.add(Predicates.or(CardType.ARTIFACT.getPredicate(), CardType.CREATURE.getPredicate()));
         TargetCard target = new TargetCard(Zone.HAND, filter);
         target.withNotTarget(true);
-        controller.chooseTarget(Outcome.Discard, opponent.getHand(), target, source, game);
+        controller.choose(Outcome.Discard, opponent.getHand(), target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {
             toExile.add(card);
@@ -81,7 +81,7 @@ class DreamsOfSteelAndOilEffect extends OneShotEffect {
         filter.setMessage("artifact or creature card from " + opponent.getName() + "'s graveyard");
         target = new TargetCard(Zone.GRAVEYARD, filter);
         target.withNotTarget(true);
-        controller.chooseTarget(Outcome.Exile, opponent.getGraveyard(), target, source, game);
+        controller.choose(Outcome.Exile, opponent.getGraveyard(), target, source, game);
         card = game.getCard(target.getFirstTarget());
         if (card != null) {
             toExile.add(card);

--- a/Mage.Sets/src/mage/cards/d/DruidicRitual.java
+++ b/Mage.Sets/src/mage/cards/d/DruidicRitual.java
@@ -105,11 +105,10 @@ class RevivalExperimentTarget extends TargetCardInYourGraveyard {
         return cardTypeAssigner.getRoleCount(cards, game) >= cards.size();
     }
 
-
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, null, game));
+        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EliteSpellbinder.java
+++ b/Mage.Sets/src/mage/cards/e/EliteSpellbinder.java
@@ -79,9 +79,7 @@ class EliteSpellbinderEffect extends OneShotEffect {
         if (controller == null || opponent == null || opponent.getHand().isEmpty()) {
             return false;
         }
-        TargetCard target = new TargetCardInHand(
-                0, 1, StaticFilters.FILTER_CARD_A_NON_LAND
-        );
+        TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_A_NON_LAND);
         controller.choose(outcome, opponent.getHand(), target, source, game);
         Card card = opponent.getHand().get(target.getFirstTarget(), game);
         if (card == null) {

--- a/Mage.Sets/src/mage/cards/e/EnchantmentAlteration.java
+++ b/Mage.Sets/src/mage/cards/e/EnchantmentAlteration.java
@@ -129,7 +129,7 @@ class EnchantmentAlterationEffect extends OneShotEffect {
                 if (oldPermanent != null
                         && !oldPermanent.equals(permanentToBeAttachedTo)) {
                     Target auraTarget = aura.getSpellAbility().getTargets().get(0);
-                    if (!auraTarget.canTarget(permanentToBeAttachedTo.getId(), game)) {
+                    if (!auraTarget.canTarget(permanentToBeAttachedTo.getId(), source, game)) {
                         game.informPlayers(aura.getLogName() + " was not attched to " + permanentToBeAttachedTo.getLogName() + " because it's no legal target for the aura");
                     } else if (oldPermanent.removeAttachment(aura.getId(), source, game)) {
                         game.informPlayers(aura.getLogName() + " was unattached from " + oldPermanent.getLogName() + " and attached to " + permanentToBeAttachedTo.getLogName());

--- a/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
+++ b/Mage.Sets/src/mage/cards/e/EverythingComesToDust.java
@@ -58,7 +58,7 @@ enum EverythingComesToDustPredicate implements ObjectSourcePlayerPredicate<Perma
         if (!p.isCreature(game)){
             return false;
         }
-        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
+        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>());
         for (MageObjectReference mor : set){
             Permanent convoked = game.getPermanentOrLKIBattlefield(mor);
             if (convoked.shareCreatureTypes(game, p)){

--- a/Mage.Sets/src/mage/cards/e/ExtractBrain.java
+++ b/Mage.Sets/src/mage/cards/e/ExtractBrain.java
@@ -8,9 +8,11 @@ import mage.cards.Cards;
 import mage.cards.CardsImpl;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
+import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetOpponent;
 import mage.util.CardUtil;
@@ -65,9 +67,7 @@ class ExtractBrainEffect extends OneShotEffect {
         if (controller == null || opponent == null || opponent.getHand().isEmpty() || xValue < 1) {
             return false;
         }
-        TargetCardInHand target = new TargetCardInHand(
-                Math.min(opponent.getHand().size(), xValue), StaticFilters.FILTER_CARD
-        );
+        TargetCard target = new TargetCard(Math.min(opponent.getHand().size(), xValue), Integer.MAX_VALUE, Zone.HAND, StaticFilters.FILTER_CARD);
         opponent.choose(Outcome.Detriment, opponent.getHand(), target, source, game);
         Cards cards = new CardsImpl(target.getTargets());
         controller.lookAtCards(source, null, cards, game);

--- a/Mage.Sets/src/mage/cards/f/Fireball.java
+++ b/Mage.Sets/src/mage/cards/f/Fireball.java
@@ -134,7 +134,6 @@ class FireballTargetCreatureOrPlayer extends TargetAnyTarget {
                 continue;
             }
 
-            possibleTargets.removeAll(getTargets());
             for (UUID targetId : possibleTargets) {
                 TargetAnyTarget target = this.copy();
                 target.clearChosen();

--- a/Mage.Sets/src/mage/cards/f/FrogkinKidnapper.java
+++ b/Mage.Sets/src/mage/cards/f/FrogkinKidnapper.java
@@ -85,7 +85,7 @@ class FrogkinKidnapperEffect extends OneShotEffect {
         opponent.revealCards(source, opponent.getHand(), game);
         TargetCard target = new TargetCard(1, Zone.HAND, StaticFilters.FILTER_CARD_A_NON_LAND);
         Cards toRansom = new CardsImpl();
-        if (controller.chooseTarget(outcome, opponent.getHand(), target, source, game)) {
+        if (controller.choose(outcome, opponent.getHand(), target, source, game)) {
             toRansom.addAll(target.getTargets());
 
             String exileName = "Ransomed (owned by " + opponent.getName() + ")";

--- a/Mage.Sets/src/mage/cards/g/GateSmasher.java
+++ b/Mage.Sets/src/mage/cards/g/GateSmasher.java
@@ -9,13 +9,12 @@ import mage.abilities.keyword.EquipAbility;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
-import mage.constants.CardType;
-import mage.constants.ComparisonType;
-import mage.constants.SubType;
+import mage.constants.*;
 import mage.filter.FilterPermanent;
+import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.ToughnessPredicate;
+import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;

--- a/Mage.Sets/src/mage/cards/g/GhastlordOfFugue.java
+++ b/Mage.Sets/src/mage/cards/g/GhastlordOfFugue.java
@@ -82,7 +82,7 @@ class GhastlordOfFugueEffect extends OneShotEffect {
             TargetCard target = new TargetCard(Zone.HAND, new FilterCard());
             target.withNotTarget(true);
             Card chosenCard = null;
-            if (controller.chooseTarget(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
+            if (controller.choose(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
                 chosenCard = game.getCard(target.getFirstTarget());
             }
             if (chosenCard != null) {

--- a/Mage.Sets/src/mage/cards/g/GlyphOfDelusion.java
+++ b/Mage.Sets/src/mage/cards/g/GlyphOfDelusion.java
@@ -1,9 +1,7 @@
 package mage.cards.g;
 
-import mage.MageObject;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
-import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.SourceHasCounterCondition;
 import mage.abilities.decorator.ConditionalContinuousRuleModifyingEffect;
@@ -11,11 +9,14 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DontUntapInControllersUntapStepSourceEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
 import mage.abilities.effects.common.counter.RemoveCounterSourceEffect;
+import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.counters.CounterType;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -59,8 +60,6 @@ public final class GlyphOfDelusion extends CardImpl {
 
 class GlyphOfDelusionSecondTarget extends TargetPermanent {
 
-    private Permanent firstTarget = null;
-
     public GlyphOfDelusionSecondTarget() {
         super();
         withTargetName("target creature that target Wall blocked this turn");
@@ -68,33 +67,39 @@ class GlyphOfDelusionSecondTarget extends TargetPermanent {
 
     private GlyphOfDelusionSecondTarget(final GlyphOfDelusionSecondTarget target) {
         super(target);
-        this.firstTarget = target.firstTarget;
     }
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
-        if (firstTarget != null) {
-            BlockedAttackerWatcher watcher = game.getState().getWatcher(BlockedAttackerWatcher.class);
-            if (watcher != null) {
-                MageObject targetSource = game.getObject(source);
-                if (targetSource != null) {
-                    for (Permanent creature : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, sourceControllerId, source, game)) {
-                        if (!targets.containsKey(creature.getId()) && creature.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                            if (watcher.creatureHasBlockedAttacker(new MageObjectReference(creature, game), new MageObjectReference(firstTarget, game))) {
-                                possibleTargets.add(creature.getId());
-                            }
-                        }
-                    }
+
+        BlockedAttackerWatcher watcher = game.getState().getWatcher(BlockedAttackerWatcher.class);
+        if (watcher == null) {
+            return possibleTargets;
+        }
+
+        Permanent targetWall = game.getPermanent(source.getFirstTarget());
+        for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, sourceControllerId, source, game)) {
+            if (targetWall == null) {
+                // playable or first target not yet selected
+                // use all
+                possibleTargets.add(permanent.getId());
+            } else {
+                // real
+                // filter by blocked
+                if (watcher.creatureHasBlockedAttacker(new MageObjectReference(permanent, game), new MageObjectReference(targetWall, game))) {
+                    possibleTargets.add(permanent.getId());
                 }
             }
         }
-        return possibleTargets;
+        possibleTargets.removeIf(id -> targetWall != null && targetWall.getId().equals(id));
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
     public boolean chooseTarget(Outcome outcome, UUID playerId, Ability source, Game game) {
-        firstTarget = game.getPermanent(source.getFirstTarget());
+        // AI hint with better outcome
         return super.chooseTarget(Outcome.Tap, playerId, source, game);
     }
 
@@ -133,8 +138,7 @@ class GlyphOfDelusionEffect extends OneShotEffect {
                 effect.setTargetPointer(new FixedTarget(targetPermanent.getId(), game));
                 game.addEffect(effect, source);
 
-                BeginningOfUpkeepTriggeredAbility ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.GLYPH.createInstance())
-                );
+                BeginningOfUpkeepTriggeredAbility ability2 = new BeginningOfUpkeepTriggeredAbility(new RemoveCounterSourceEffect(CounterType.GLYPH.createInstance()));
                 GainAbilityTargetEffect effect2 = new GainAbilityTargetEffect(ability2, Duration.Custom);
                 effect2.setTargetPointer(new FixedTarget(targetPermanent.getId(), game));
                 game.addEffect(effect2, source);

--- a/Mage.Sets/src/mage/cards/g/GoblinArtisans.java
+++ b/Mage.Sets/src/mage/cards/g/GoblinArtisans.java
@@ -81,8 +81,8 @@ class GoblinArtisansTarget extends TargetSpell {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         MageObjectReference sourceRef = new MageObjectReference(source.getSourceObject(game), game);

--- a/Mage.Sets/src/mage/cards/g/GracefulTakedown.java
+++ b/Mage.Sets/src/mage/cards/g/GracefulTakedown.java
@@ -61,8 +61,8 @@ class GracefulTakedownTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent permanent = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/g/GrimeGorger.java
+++ b/Mage.Sets/src/mage/cards/g/GrimeGorger.java
@@ -129,7 +129,7 @@ class GrimeGorgerTarget extends TargetCardInGraveyard {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, null, game));
+        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
         return possibleTargets;
     }
 

--- a/Mage.Sets/src/mage/cards/g/Gurzigost.java
+++ b/Mage.Sets/src/mage/cards/g/Gurzigost.java
@@ -92,7 +92,7 @@ class GurzigostCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/i/ImpelledGiant.java
+++ b/Mage.Sets/src/mage/cards/i/ImpelledGiant.java
@@ -99,7 +99,7 @@ class ImpelledGiantCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/i/InvasionOfGobakhan.java
+++ b/Mage.Sets/src/mage/cards/i/InvasionOfGobakhan.java
@@ -79,9 +79,7 @@ class InvasionOfGobakhanEffect extends OneShotEffect {
         if (controller == null || opponent == null || opponent.getHand().isEmpty()) {
             return false;
         }
-        TargetCard target = new TargetCardInHand(
-                0, 1, StaticFilters.FILTER_CARD_A_NON_LAND
-        );
+        TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_A_NON_LAND);
         controller.choose(outcome, opponent.getHand(), target, source, game);
         Card card = opponent.getHand().get(target.getFirstTarget(), game);
         if (card == null) {

--- a/Mage.Sets/src/mage/cards/i/IwamoriOfTheOpenFist.java
+++ b/Mage.Sets/src/mage/cards/i/IwamoriOfTheOpenFist.java
@@ -1,32 +1,27 @@
-
 package mage.cards.i;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.*;
-import mage.constants.CardType;
-import mage.constants.SubType;
-import mage.constants.Outcome;
-import mage.constants.SuperType;
-import mage.constants.Zone;
+import mage.constants.*;
 import mage.filter.FilterCard;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
-import mage.target.common.TargetCardInHand;
+import mage.target.TargetCard;
+
+import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public final class IwamoriOfTheOpenFist extends CardImpl {
 
     public IwamoriOfTheOpenFist(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{G}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{G}{G}");
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);
         this.subtype.add(SubType.MONK);
@@ -80,15 +75,11 @@ class IwamoriOfTheOpenFistEffect extends OneShotEffect {
             Cards cards = new CardsImpl();
             for (UUID playerId : game.getOpponents(controller.getId())) {
                 Player opponent = game.getPlayer(playerId);
-                Target target = new TargetCardInHand(filter);
-                if (opponent != null && target.canChoose(opponent.getId(), source, game)) {
-                    if (opponent.chooseUse(Outcome.PutCreatureInPlay, "Put a legendary creature card from your hand onto the battlefield?", source, game)) {
-                        if (target.chooseTarget(Outcome.PutCreatureInPlay, opponent.getId(), source, game)) {
-                            Card card = game.getCard(target.getFirstTarget());
-                            if (card != null) {
-                                cards.add(card);
-                            }
-                        }
+                Target target = new TargetCard(0, 1, Zone.HAND, filter).withChooseHint("put from hand to battlefield");
+                if (target.choose(Outcome.PutCreatureInPlay, opponent.getId(), source, game)) {
+                    Card card = game.getCard(target.getFirstTarget());
+                    if (card != null) {
+                        cards.add(card);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/j/JotunGrunt.java
+++ b/Mage.Sets/src/mage/cards/j/JotunGrunt.java
@@ -78,7 +78,7 @@ class JotunGruntCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/k/KairiTheSwirlingSky.java
+++ b/Mage.Sets/src/mage/cards/k/KairiTheSwirlingSky.java
@@ -88,8 +88,8 @@ class KairiTheSwirlingSkyTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 6, game);
     }

--- a/Mage.Sets/src/mage/cards/k/KeeperOfTheLight.java
+++ b/Mage.Sets/src/mage/cards/k/KeeperOfTheLight.java
@@ -1,8 +1,6 @@
-
 package mage.cards.k;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -12,13 +10,11 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.filter.FilterOpponent;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetPlayer;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -67,43 +63,19 @@ class KeeperOfTheLightTarget extends TargetPlayer {
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        Set<UUID> availablePossibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        Set<UUID> possibleTargets = new HashSet<>();
-        int lifeController = game.getPlayer(sourceControllerId).getLife();
+        Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
 
-        for (UUID targetId : availablePossibleTargets) {
-            Player opponent = game.getPlayer(targetId);
-            if (opponent != null) {
-                int lifeOpponent = opponent.getLife();
-                if (lifeOpponent > lifeController) {
-                    possibleTargets.add(targetId);
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        int count = 0;
-        MageObject targetSource = game.getObject(source);
         Player controller = game.getPlayer(sourceControllerId);
-        if (controller != null && targetSource != null) {
-            for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-                Player player = game.getPlayer(playerId);
-                if (player != null
-                        && controller.getLife() < player.getLife()
-                        && !player.hasLeft()
-                        && filter.match(player, sourceControllerId, source, game)
-                        && player.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                    count++;
-                    if (count >= this.minNumberOfTargets) {
-                        return true;
-                    }
-                }
-            }
+        if (controller == null) {
+            return possibleTargets;
         }
-        return false;
+
+        possibleTargets.removeIf(playerId -> {
+            Player player = game.getPlayer(playerId);
+            return player == null || player.getLife() >= controller.getLife();
+        });
+
+        return possibleTargets;
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/k/KeldonBattlewagon.java
+++ b/Mage.Sets/src/mage/cards/k/KeldonBattlewagon.java
@@ -105,7 +105,7 @@ class KeldonBattlewagonCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/k/KondasBanner.java
+++ b/Mage.Sets/src/mage/cards/k/KondasBanner.java
@@ -7,15 +7,14 @@ import mage.abilities.effects.common.continuous.BoostAllEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.SubType;
-import mage.constants.SuperType;
+import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
+import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;

--- a/Mage.Sets/src/mage/cards/k/KotoseTheSilentSpider.java
+++ b/Mage.Sets/src/mage/cards/k/KotoseTheSilentSpider.java
@@ -15,6 +15,7 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
 import mage.players.Player;
+import mage.target.TargetCard;
 import mage.target.common.TargetCardInGraveyard;
 import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetCardInLibrary;
@@ -107,9 +108,9 @@ class KotoseTheSilentSpiderEffect extends OneShotEffect {
         cards.addAll(targetCardInGraveyard.getTargets());
 
         filter.setMessage("cards named " + card.getName() + " from " + opponent.getName() + "'s hand");
-        TargetCardInHand targetCardInHand = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
-        controller.choose(outcome, opponent.getHand(), targetCardInHand, source, game);
-        cards.addAll(targetCardInHand.getTargets());
+        TargetCard targetCard = new TargetCard(0, Integer.MAX_VALUE, Zone.HAND, filter);
+        controller.choose(outcome, opponent.getHand(), targetCard, source, game);
+        cards.addAll(targetCard.getTargets());
 
         filter.setMessage("cards named " + card.getName() + " from " + opponent.getName() + "'s library");
         TargetCardInLibrary target = new TargetCardInLibrary(0, Integer.MAX_VALUE, filter);

--- a/Mage.Sets/src/mage/cards/l/LagrellaTheMagpie.java
+++ b/Mage.Sets/src/mage/cards/l/LagrellaTheMagpie.java
@@ -130,8 +130,8 @@ class LagrellaTheMagpieTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/l/LethalScheme.java
+++ b/Mage.Sets/src/mage/cards/l/LethalScheme.java
@@ -69,7 +69,7 @@ class LethalSchemeEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         HashSet<MageObjectReference> convokingCreatures = CardUtil.getSourceCostsTag(game, source,
-                ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
+                ConvokeAbility.convokingCreaturesKey, new HashSet<>());
         Set<AbstractMap.SimpleEntry<UUID, Permanent>> playerPermanentsPairs =
                 convokingCreatures
                         .stream()

--- a/Mage.Sets/src/mage/cards/l/LivelyDirge.java
+++ b/Mage.Sets/src/mage/cards/l/LivelyDirge.java
@@ -103,8 +103,8 @@ class LivelyDirgeTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 4, game);
     }

--- a/Mage.Sets/src/mage/cards/l/Lobotomy.java
+++ b/Mage.Sets/src/mage/cards/l/Lobotomy.java
@@ -74,7 +74,7 @@ class LobotomyEffect extends SearchTargetGraveyardHandLibraryForCardNameAndExile
             TargetCard target = new TargetCard(Zone.HAND, filter);
             target.withNotTarget(true);
             Card chosenCard = null;
-            if (controller.chooseTarget(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
+            if (controller.choose(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
                 chosenCard = game.getCard(target.getFirstTarget());
             }
 

--- a/Mage.Sets/src/mage/cards/l/LongRest.java
+++ b/Mage.Sets/src/mage/cards/l/LongRest.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author weirddan455
  */
 public final class LongRest extends CardImpl {
@@ -67,19 +66,22 @@ class LongRestTarget extends TargetCardInYourGraveyard {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
-        Set<Integer> manaValues = new HashSet<>();
+
+        Set<Integer> usedManaValues = new HashSet<>();
         for (UUID targetId : this.getTargets()) {
             Card card = game.getCard(targetId);
             if (card != null) {
-                manaValues.add(card.getManaValue());
+                usedManaValues.add(card.getManaValue());
             }
         }
+
         for (UUID possibleTargetId : super.possibleTargets(sourceControllerId, source, game)) {
             Card card = game.getCard(possibleTargetId);
-            if (card != null && !manaValues.contains(card.getManaValue())) {
+            if (card != null && !usedManaValues.contains(card.getManaValue())) {
                 possibleTargets.add(possibleTargetId);
             }
         }
+
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MarchFromTheTomb.java
+++ b/Mage.Sets/src/mage/cards/m/MarchFromTheTomb.java
@@ -56,8 +56,8 @@ class MarchFromTheTombTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 8, game);
     }

--- a/Mage.Sets/src/mage/cards/m/ModifyMemory.java
+++ b/Mage.Sets/src/mage/cards/m/ModifyMemory.java
@@ -86,8 +86,8 @@ class ModifyMemoryTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/m/MoorlandRescuer.java
+++ b/Mage.Sets/src/mage/cards/m/MoorlandRescuer.java
@@ -112,8 +112,8 @@ class MoorlandRescuerTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, m -> m.getPower().getValue(), xValue, game);
     }

--- a/Mage.Sets/src/mage/cards/m/Mutiny.java
+++ b/Mage.Sets/src/mage/cards/m/Mutiny.java
@@ -1,6 +1,5 @@
 package mage.cards.m;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
@@ -9,18 +8,16 @@ import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.Predicates;
-import mage.filter.predicate.permanent.ControllerIdPredicate;
-import mage.filter.predicate.permanent.PermanentIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.target.common.TargetCreaturePermanent;
 
+import java.util.Set;
 import java.util.UUID;
 
 /**
+ * TODO: combine with BreakingOfTheFellowship
+ *
  * @author LevelX2
  */
 public final class Mutiny extends CardImpl {
@@ -30,7 +27,8 @@ public final class Mutiny extends CardImpl {
 
         // Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
         this.getSpellAbility().addEffect(new MutinyEffect());
-        this.getSpellAbility().addTarget(new MutinyFirstTarget(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
+        this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE));
+        this.getSpellAbility().addTarget(new MutinySecondTarget());
         this.getSpellAbility().addTarget(new TargetPermanent(new FilterCreaturePermanent("another target creature that player controls")));
     }
 
@@ -72,74 +70,45 @@ class MutinyEffect extends OneShotEffect {
         }
         return true;
     }
-
 }
 
-class MutinyFirstTarget extends TargetPermanent {
+class MutinySecondTarget extends TargetPermanent {
 
-    public MutinyFirstTarget(FilterCreaturePermanent filter) {
-        super(1, 1, filter, false);
+    public MutinySecondTarget() {
+        super(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURE);
     }
 
-    private MutinyFirstTarget(final MutinyFirstTarget target) {
+    private MutinySecondTarget(final MutinySecondTarget target) {
         super(target);
     }
 
     @Override
-    public void addTarget(UUID id, Ability source, Game game, boolean skipEvent) {
-        super.addTarget(id, source, game, skipEvent);
-        // Update the second target
-        UUID firstController = game.getControllerId(id);
-        if (firstController != null && source.getTargets().size() > 1) {
-            Player controllingPlayer = game.getPlayer(firstController);
-            TargetCreaturePermanent targetCreaturePermanent = (TargetCreaturePermanent) source.getTargets().get(1);
-            // Set a new filter to the second target with the needed restrictions
-            FilterCreaturePermanent filter = new FilterCreaturePermanent("another creature that player " + controllingPlayer.getName() + " controls");
-            filter.add(new ControllerIdPredicate(firstController));
-            filter.add(Predicates.not(new PermanentIdPredicate(id)));
-            targetCreaturePermanent.replaceFilter(filter);
-        }
-    }
+    public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
+        Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
 
-    @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (super.canTarget(controllerId, id, source, game)) {
-            // can only target, if the controller has at least two targetable creatures
-            UUID controllingPlayerId = game.getControllerId(id);
-            int possibleTargets = 0;
-            MageObject sourceObject = game.getObject(source.getId());
-            for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, controllingPlayerId, game)) {
-                if (permanent.canBeTargetedBy(sourceObject, controllerId, source, game)) {
-                    possibleTargets++;
-                }
+        Permanent firstTarget = game.getPermanent(source.getFirstTarget());
+        if (firstTarget == null) {
+            // playable or first target not yet selected
+            // use all
+            if (possibleTargets.size() == 1) {
+                // workaround to make 1 target invalid
+                possibleTargets.clear();
             }
-            return possibleTargets > 1;
+        } else {
+            // real
+            // filter by same player
+            possibleTargets.removeIf(id -> {
+                Permanent permanent = game.getPermanent(id);
+                return permanent == null || !permanent.isControlledBy(firstTarget.getControllerId());
+            });
         }
-        return false;
+        possibleTargets.removeIf(id -> firstTarget != null && firstTarget.getId().equals(id));
+
+        return possibleTargets;
     }
 
     @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        if (super.canChoose(sourceControllerId, source, game)) {
-            UUID controllingPlayerId = game.getControllerId(source.getSourceId());
-            for (UUID playerId : game.getOpponents(controllingPlayerId)) {
-                int possibleTargets = 0;
-                MageObject sourceObject = game.getObject(source);
-                for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, playerId, game)) {
-                    if (permanent.canBeTargetedBy(sourceObject, controllingPlayerId, source, game)) {
-                        possibleTargets++;
-                    }
-                }
-                if (possibleTargets > 1) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public MutinyFirstTarget copy() {
-        return new MutinyFirstTarget(this);
+    public MutinySecondTarget copy() {
+        return new MutinySecondTarget(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/n/Nethergoyf.java
+++ b/Mage.Sets/src/mage/cards/n/Nethergoyf.java
@@ -22,10 +22,7 @@ import mage.target.common.TargetCardInYourGraveyard;
 import mage.util.CardUtil;
 
 import java.awt.*;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -113,7 +110,10 @@ class NethergoyfTarget extends TargetCardInYourGraveyard {
             return false;
         }
         // Check that exiling all the possible cards would have >= 4 different card types
-        return metCondition(this.possibleTargets(sourceControllerId, source, game), game);
+        Set<UUID> idsToCheck = new HashSet<>();
+        idsToCheck.addAll(this.getTargets());
+        idsToCheck.addAll(this.possibleTargets(sourceControllerId, source, game));
+        return metCondition(idsToCheck, game);
     }
 
     private static Set<CardType> typesAmongSelection(Collection<UUID> cardsIds, Game game) {

--- a/Mage.Sets/src/mage/cards/n/NethroiApexOfDeath.java
+++ b/Mage.Sets/src/mage/cards/n/NethroiApexOfDeath.java
@@ -83,8 +83,8 @@ class NethroiApexOfDeathTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, m -> m.getPower().getValue(), 10, game);
     }

--- a/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
+++ b/Mage.Sets/src/mage/cards/n/NicolBolasDragonGod.java
@@ -150,7 +150,7 @@ class NicolBolasDragonGodPlusOneEffect extends OneShotEffect {
             TargetPermanent targetPermanent = new TargetControlledPermanent();
             targetPermanent.withNotTarget(true);
             targetPermanent.setTargetController(opponentId);
-            if (!targetPermanent.possibleTargets(opponentId, game).isEmpty()) {
+            if (!targetPermanent.possibleTargets(opponentId, source, game).isEmpty()) {
                 possibleTargetTypes.add(targetPermanent);
             }
 

--- a/Mage.Sets/src/mage/cards/n/NivmagusElemental.java
+++ b/Mage.Sets/src/mage/cards/n/NivmagusElemental.java
@@ -91,7 +91,7 @@ class NivmagusElementalCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/o/OKagachiVengefulKami.java
+++ b/Mage.Sets/src/mage/cards/o/OKagachiVengefulKami.java
@@ -52,7 +52,8 @@ public final class OKagachiVengefulKami extends CardImpl {
         ability.addTarget(new TargetPermanent(filter));
         ability.setTargetAdjuster(new ThatPlayerControlsTargetAdjuster());
         ability.withInterveningIf(KagachiVengefulKamiCondition.instance);
-        this.addAbility(ability);
+
+        this.addAbility(ability, new OKagachiVengefulKamiWatcher());
     }
 
     private OKagachiVengefulKami(final OKagachiVengefulKami card) {

--- a/Mage.Sets/src/mage/cards/o/ONaginata.java
+++ b/Mage.Sets/src/mage/cards/o/ONaginata.java
@@ -9,12 +9,12 @@ import mage.abilities.keyword.EquipAbility;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.AttachmentType;
-import mage.constants.CardType;
-import mage.constants.ComparisonType;
-import mage.constants.SubType;
+import mage.constants.*;
 import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterCreatureCard;
+import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
+import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -24,7 +24,7 @@ import java.util.UUID;
  */
 public final class ONaginata extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("creature with power 3 or greater");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature with power 3 or greater");
 
     static {
         filter.add(new PowerPredicate(ComparisonType.MORE_THAN, 2));

--- a/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
+++ b/Mage.Sets/src/mage/cards/o/OildeepGearhulk.java
@@ -13,6 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
+import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.game.Game;
 import mage.players.Player;
@@ -81,7 +82,7 @@ class OildeepGearhulkEffect extends OneShotEffect {
         }
 
         controller.lookAtCards(targetPlayer.getName() + " Hand", targetPlayer.getHand(), game);
-        TargetCard chosenCard = new TargetCardInHand(0, 1, new FilterCard("card to discard"));
+        TargetCard chosenCard = new TargetCard(0, 1, Zone.HAND, new FilterCard("card to discard"));
         if (!controller.choose(Outcome.Discard, targetPlayer.getHand(), chosenCard, source, game)) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/o/OrcusPrinceOfUndeath.java
+++ b/Mage.Sets/src/mage/cards/o/OrcusPrinceOfUndeath.java
@@ -119,8 +119,8 @@ class OrcusPrinceOfUndeathTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, xValue, game);
     }

--- a/Mage.Sets/src/mage/cards/p/PairODiceLost.java
+++ b/Mage.Sets/src/mage/cards/p/PairODiceLost.java
@@ -101,8 +101,8 @@ class PairODiceLostTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, xValue, game);
     }

--- a/Mage.Sets/src/mage/cards/p/PatchUp.java
+++ b/Mage.Sets/src/mage/cards/p/PatchUp.java
@@ -58,8 +58,8 @@ class PatchUpTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 3, game);
     }

--- a/Mage.Sets/src/mage/cards/p/PhenomenonInvestigators.java
+++ b/Mage.Sets/src/mage/cards/p/PhenomenonInvestigators.java
@@ -105,7 +105,7 @@ class PhenomenonInvestigatorsReturnCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/p/PhoenixWardenOfFire.java
+++ b/Mage.Sets/src/mage/cards/p/PhoenixWardenOfFire.java
@@ -94,8 +94,8 @@ class PhoenixWardenOfFireTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 6, game
         );

--- a/Mage.Sets/src/mage/cards/p/PrimordialMist.java
+++ b/Mage.Sets/src/mage/cards/p/PrimordialMist.java
@@ -78,7 +78,7 @@ class PrimordialMistCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/p/ProteanHulk.java
+++ b/Mage.Sets/src/mage/cards/p/ProteanHulk.java
@@ -64,8 +64,8 @@ class ProteanHulkTarget extends TargetCardInLibrary {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 6, game);
     }

--- a/Mage.Sets/src/mage/cards/q/QueenKaylaBinKroog.java
+++ b/Mage.Sets/src/mage/cards/q/QueenKaylaBinKroog.java
@@ -110,25 +110,10 @@ class QueenKaylaBinKroogTarget extends TargetCard {
     }
 
     @Override
-    public boolean canTarget(UUID playerId, UUID id, Ability ability, Game game) {
-        if (!super.canTarget(playerId, id, ability, game)) {
-            return false;
-        }
-        Card card = game.getCard(id);
-        return card != null && 1 <= card.getManaValue() && card.getManaValue() <= 3 && this
-                .getTargets()
-                .stream()
-                .map(game::getCard)
-                .filter(Objects::nonNull)
-                .mapToInt(MageObject::getManaValue)
-                .noneMatch(x -> card.getManaValue() == x);
-    }
-
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        Set<Integer> manaValues = this
+
+        Set<Integer> usedManaValues = this
                 .getTargets()
                 .stream()
                 .map(game::getCard)
@@ -137,8 +122,9 @@ class QueenKaylaBinKroogTarget extends TargetCard {
                 .collect(Collectors.toSet());
         possibleTargets.removeIf(uuid -> {
             Card card = game.getCard(uuid);
-            return card != null && manaValues.contains(card.getManaValue());
+            return card == null || usedManaValues.contains(card.getManaValue());
         });
+
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RaiseTheDraugr.java
+++ b/Mage.Sets/src/mage/cards/r/RaiseTheDraugr.java
@@ -58,8 +58,8 @@ class RaiseTheDraugrTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         if (getTargets().isEmpty()) {

--- a/Mage.Sets/src/mage/cards/r/RampagingYaoGuai.java
+++ b/Mage.Sets/src/mage/cards/r/RampagingYaoGuai.java
@@ -82,8 +82,8 @@ class RampagingYaoGuaiTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, GetXValue.instance.calculate(game, source, null), game);
     }

--- a/Mage.Sets/src/mage/cards/r/RasputinDreamweaver.java
+++ b/Mage.Sets/src/mage/cards/r/RasputinDreamweaver.java
@@ -102,7 +102,7 @@ class RasputinDreamweaverWatcher extends Watcher {
         filter.add(TappedPredicate.UNTAPPED);
     }
 
-    private final Set<UUID> startedUntapped = new HashSet<>(0);
+    private final Set<UUID> startedUntapped = new HashSet<>();
 
     RasputinDreamweaverWatcher() {
         super(WatcherScope.GAME);

--- a/Mage.Sets/src/mage/cards/r/RavagerOfTheFells.java
+++ b/Mage.Sets/src/mage/cards/r/RavagerOfTheFells.java
@@ -1,7 +1,6 @@
 package mage.cards.r;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.TransformIntoSourceTriggeredAbility;
 import mage.abilities.common.WerewolfBackTriggeredAbility;
@@ -15,13 +14,11 @@ import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetOpponentOrPlaneswalker;
 import mage.target.targetpointer.EachTargetPointer;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -100,7 +97,7 @@ class RavagerOfTheFellsEffect extends OneShotEffect {
 class RavagerOfTheFellsTarget extends TargetPermanent {
 
     RavagerOfTheFellsTarget() {
-        super(0, 1, StaticFilters.FILTER_PERMANENT_CREATURE, false);
+        super(0, 1, StaticFilters.FILTER_PERMANENT_CREATURE);
     }
 
     private RavagerOfTheFellsTarget(final RavagerOfTheFellsTarget target) {
@@ -108,46 +105,22 @@ class RavagerOfTheFellsTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        Player player = game.getPlayerOrPlaneswalkerController(source.getFirstTarget());
-        if (player == null) {
-            return false;
-        }
-        UUID firstTarget = player.getId();
-        Permanent permanent = game.getPermanent(id);
-        if (firstTarget != null && permanent != null && permanent.isControlledBy(firstTarget)) {
-            return super.canTarget(id, source, game);
-        }
-        return false;
-    }
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        Set<UUID> availablePossibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        Set<UUID> possibleTargets = new HashSet<>();
-        MageObject object = game.getObject(source);
+        Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
 
-        for (StackObject item : game.getState().getStack()) {
-            if (item.getId().equals(source.getSourceId())) {
-                object = item;
-            }
-            if (item.getSourceId().equals(source.getSourceId())) {
-                object = item;
-            }
+        Player needPlayer = game.getPlayerOrPlaneswalkerController(source.getFirstTarget());
+        if (needPlayer == null) {
+            // playable or not selected - use any
+        } else {
+            // filter by controller
+            possibleTargets.removeIf(id -> {
+                Permanent permanent = game.getPermanent(id);
+                return permanent == null
+                        || permanent.getId().equals(source.getFirstTarget())
+                        || !permanent.isControlledBy(needPlayer.getId());
+            });
         }
 
-        if (object instanceof StackObject) {
-            UUID playerId = ((StackObject) object).getStackAbility().getFirstTarget();
-            Player player = game.getPlayerOrPlaneswalkerController(playerId);
-            if (player != null) {
-                for (UUID targetId : availablePossibleTargets) {
-                    Permanent permanent = game.getPermanent(targetId);
-                    if (permanent != null && permanent.isControlledBy(player.getId())) {
-                        possibleTargets.add(targetId);
-                    }
-                }
-            }
-        }
         return possibleTargets;
     }
 

--- a/Mage.Sets/src/mage/cards/r/ReapIntellect.java
+++ b/Mage.Sets/src/mage/cards/r/ReapIntellect.java
@@ -85,7 +85,7 @@ class ReapIntellectEffect extends OneShotEffect {
             int xCost = Math.min(CardUtil.getSourceCostsTag(game, source, "X", 0), targetPlayer.getHand().size());
             TargetCard target = new TargetCard(0, xCost, Zone.HAND, filterNonLands);
             target.withNotTarget(true);
-            controller.chooseTarget(Outcome.Benefit, targetPlayer.getHand(), target, source, game);
+            controller.choose(Outcome.Benefit, targetPlayer.getHand(), target, source, game);
             for (UUID cardId : target.getTargets()) {
                 Card chosenCard = game.getCard(cardId);
                 if (chosenCard != null) {

--- a/Mage.Sets/src/mage/cards/r/ReckonerShakedown.java
+++ b/Mage.Sets/src/mage/cards/r/ReckonerShakedown.java
@@ -7,6 +7,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
@@ -68,7 +69,7 @@ class ReckonerShakedownEffect extends OneShotEffect {
             return false;
         }
         player.revealCards(source, player.getHand(), game);
-        TargetCard target = new TargetCardInHand(0, 1, StaticFilters.FILTER_CARD_A_NON_LAND);
+        TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_A_NON_LAND);
         controller.choose(Outcome.Discard, player.getHand(), target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         if (card != null) {

--- a/Mage.Sets/src/mage/cards/r/Retether.java
+++ b/Mage.Sets/src/mage/cards/r/Retether.java
@@ -87,7 +87,7 @@ class RetetherEffect extends OneShotEffect {
                                 for (Ability ability : aura.getAbilities()) {
                                     if (ability instanceof SpellAbility) {
                                         for (Target abilityTarget : ability.getTargets()) {
-                                            if (abilityTarget.possibleTargets(controller.getId(), game).contains(permanent.getId())) {
+                                            if (abilityTarget.possibleTargets(controller.getId(), source, game).contains(permanent.getId())) {
                                                 target = abilityTarget.copy();
                                                 break auraLegalitySearch;
                                             }

--- a/Mage.Sets/src/mage/cards/r/ReturnFromExtinction.java
+++ b/Mage.Sets/src/mage/cards/r/ReturnFromExtinction.java
@@ -58,8 +58,8 @@ class ReturnFromExtinctionTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         if (getTargets().isEmpty()) {

--- a/Mage.Sets/src/mage/cards/r/ReunionOfTheHouse.java
+++ b/Mage.Sets/src/mage/cards/r/ReunionOfTheHouse.java
@@ -61,8 +61,8 @@ class ReunionOfTheHouseTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, m -> m.getPower().getValue(), 10, game);
     }

--- a/Mage.Sets/src/mage/cards/r/RevealingEye.java
+++ b/Mage.Sets/src/mage/cards/r/RevealingEye.java
@@ -11,6 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
+import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
@@ -82,7 +83,7 @@ class RevealingEyeEffect extends OneShotEffect {
         if (opponent.getHand().count(StaticFilters.FILTER_CARD_NON_LAND, game) < 1) {
             return true;
         }
-        TargetCard target = new TargetCardInHand(0, 1, StaticFilters.FILTER_CARD_NON_LAND);
+        TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_NON_LAND);
         controller.choose(outcome, opponent.getHand(), target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         if (card == null) {

--- a/Mage.Sets/src/mage/cards/r/RevivalExperiment.java
+++ b/Mage.Sets/src/mage/cards/r/RevivalExperiment.java
@@ -120,7 +120,7 @@ class RevivalExperimentTarget extends TargetCardInYourGraveyard {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, null, game));
+        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RiftElemental.java
+++ b/Mage.Sets/src/mage/cards/r/RiftElemental.java
@@ -99,7 +99,7 @@ class RiftElementalCost extends CostImpl {
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
         Target target = new TargetPermanentOrSuspendedCard(filter, true);
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/r/RivalsDuel.java
+++ b/Mage.Sets/src/mage/cards/r/RivalsDuel.java
@@ -90,8 +90,8 @@ class RivalsDuelTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/r/RoguesGallery.java
+++ b/Mage.Sets/src/mage/cards/r/RoguesGallery.java
@@ -84,7 +84,7 @@ class RoguesGalleryTarget extends TargetCardInYourGraveyard {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, null, game));
+        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RoleReversal.java
+++ b/Mage.Sets/src/mage/cards/r/RoleReversal.java
@@ -53,8 +53,8 @@ class TargetPermanentsThatShareCardType extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (super.canTarget(playerId, id, source, game)) {
             if (!getTargets().isEmpty()) {
                 Permanent targetOne = game.getPermanent(getTargets().get(0));
                 Permanent targetTwo = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/r/RunAwayTogether.java
+++ b/Mage.Sets/src/mage/cards/r/RunAwayTogether.java
@@ -59,8 +59,8 @@ class RunAwayTogetherTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/s/ScoutForSurvivors.java
+++ b/Mage.Sets/src/mage/cards/s/ScoutForSurvivors.java
@@ -96,8 +96,8 @@ class ScoutForSurvivorsTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 3, game
         );

--- a/Mage.Sets/src/mage/cards/s/ScreamsFromWithin.java
+++ b/Mage.Sets/src/mage/cards/s/ScreamsFromWithin.java
@@ -77,7 +77,7 @@ class ScreamsFromWithinEffect extends OneShotEffect {
         if (aura != null && game.getState().getZone(source.getSourceId()) == Zone.GRAVEYARD && player != null && player.getGraveyard().contains(source.getSourceId())) {
             for (Permanent creaturePermanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), source, game)) {
                 for (Target target : aura.getSpellAbility().getTargets()) {
-                    if (target.canTarget(creaturePermanent.getId(), game)) {
+                    if (target.canTarget(creaturePermanent.getId(), source, game)) {
                         return player.moveCards(aura, Zone.BATTLEFIELD, source, game);
                     }
                 }

--- a/Mage.Sets/src/mage/cards/s/SearingBlaze.java
+++ b/Mage.Sets/src/mage/cards/s/SearingBlaze.java
@@ -1,6 +1,5 @@
 package mage.cards.s;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
@@ -11,19 +10,16 @@ import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.stack.StackObject;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetPlayerOrPlaneswalker;
 import mage.watchers.common.LandfallWatcher;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
 /**
- * @author BetaSteward_at_googlemail.com
- * @author North
+ * @author BetaSteward_at_googlemail.com, North
  */
 public final class SearingBlaze extends CardImpl {
 
@@ -111,21 +107,21 @@ class SearingBlazeTarget extends TargetPermanent {
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        Set<UUID> availablePossibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        Set<UUID> possibleTargets = new HashSet<>();
-        MageObject object = game.getObject(source);
-        if (object instanceof StackObject) {
-            UUID playerId = ((StackObject) object).getStackAbility().getFirstTarget();
-            Player player = game.getPlayerOrPlaneswalkerController(playerId);
-            if (player != null) {
-                for (UUID targetId : availablePossibleTargets) {
-                    Permanent permanent = game.getPermanent(targetId);
-                    if (permanent != null && permanent.isControlledBy(player.getId())) {
-                        possibleTargets.add(targetId);
-                    }
-                }
-            }
+        Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
+
+        Player needPlayer = game.getPlayerOrPlaneswalkerController(source.getFirstTarget());
+        if (needPlayer == null) {
+            // playable or not selected - use any
+        } else {
+            // filter by controller
+            possibleTargets.removeIf(id -> {
+                Permanent permanent = game.getPermanent(id);
+                return permanent == null
+                        || permanent.getId().equals(source.getFirstTarget())
+                        || !permanent.isControlledBy(needPlayer.getId());
+            });
         }
+
         return possibleTargets;
     }
 

--- a/Mage.Sets/src/mage/cards/s/SeverancePriest.java
+++ b/Mage.Sets/src/mage/cards/s/SeverancePriest.java
@@ -13,6 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.SubType;
+import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.token.SpiritXXToken;
@@ -86,7 +87,7 @@ class SeverancePriestEffect extends OneShotEffect {
             return false;
         }
         opponent.revealCards(source, opponent.getHand(), game);
-        TargetCard target = new TargetCardInHand(0, 1, StaticFilters.FILTER_CARD_NON_LAND);
+        TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_NON_LAND);
         controller.choose(Outcome.Discard, opponent.getHand(), target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         return card != null && controller.moveCardsToExile(

--- a/Mage.Sets/src/mage/cards/s/ShiftingLoyalties.java
+++ b/Mage.Sets/src/mage/cards/s/ShiftingLoyalties.java
@@ -53,8 +53,8 @@ class TargetPermanentsThatShareCardType extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (super.canTarget(playerId, id, source, game)) {
             if (!getTargets().isEmpty()) {
                 Permanent targetOne = game.getPermanent(getTargets().get(0));
                 Permanent targetTwo = game.getPermanent(id);

--- a/Mage.Sets/src/mage/cards/s/ShimianSpecter.java
+++ b/Mage.Sets/src/mage/cards/s/ShimianSpecter.java
@@ -88,9 +88,7 @@ class ShimianSpecterEffect extends SearchTargetGraveyardHandLibraryForCardNameAn
 
             // You choose a nonland card from it
             TargetCard target = new TargetCard(Zone.HAND, new FilterNonlandCard());
-            target.withNotTarget(true);
-            if (target.canChoose(controller.getId(), source, game)
-                    && controller.chooseTarget(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
+            if (controller.choose(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
                 return applySearchAndExile(game, source, CardUtil.getCardNameForSameNameSearch(game.getCard(target.getFirstTarget())), getTargetPointer().getFirst(game, source));
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SirenStormtamer.java
+++ b/Mage.Sets/src/mage/cards/s/SirenStormtamer.java
@@ -1,9 +1,6 @@
 
 package mage.cards.s;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -15,19 +12,18 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
-import mage.constants.Zone;
-import mage.filter.Filter;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
-import mage.game.stack.StackAbility;
 import mage.game.stack.StackObject;
 import mage.target.Target;
-import mage.target.TargetObject;
+import mage.target.TargetStackObject;
 import mage.target.Targets;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 /**
- *
  * @author spjspj
  */
 public final class SirenStormtamer extends CardImpl {
@@ -46,7 +42,7 @@ public final class SirenStormtamer extends CardImpl {
 
         // {U}, Sacrifice Siren Stormtamer: Counter target spell or ability that targets you or a creature you control.
         Ability ability = new SimpleActivatedAbility(new CounterTargetEffect(), new ManaCostsImpl<>("{U}"));
-        ability.addTarget(new SirenStormtamerTargetObject());
+        ability.addTarget(new SirenStormtamerTarget());
         ability.addCost(new SacrificeSourceCost());
 
         this.addAbility(ability);
@@ -62,97 +58,45 @@ public final class SirenStormtamer extends CardImpl {
     }
 }
 
-class SirenStormtamerTargetObject extends TargetObject {
+class SirenStormtamerTarget extends TargetStackObject {
 
-    public SirenStormtamerTargetObject() {
-        this.minNumberOfTargets = 1;
-        this.maxNumberOfTargets = 1;
-        this.zone = Zone.STACK;
-        this.targetName = "spell or ability that targets you or a creature you control";
+    public SirenStormtamerTarget() {
+        super();
+        withTargetName("spell or ability that targets you or a creature you control");
     }
 
-    private SirenStormtamerTargetObject(final SirenStormtamerTargetObject target) {
+    private SirenStormtamerTarget(final SirenStormtamerTarget target) {
         super(target);
     }
 
     @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        StackObject stackObject = game.getStack().getStackObject(id);
-        return (stackObject instanceof Spell) || (stackObject instanceof StackAbility);
-    }
+    public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
+        Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
 
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        return canChoose(sourceControllerId, game);
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
+        Set<UUID> targetsMe = new HashSet<>();
         for (StackObject stackObject : game.getStack()) {
-            if ((stackObject instanceof Spell) || (stackObject instanceof StackAbility)) {
-                Targets objectTargets = stackObject.getStackAbility().getTargets();
-                if (!objectTargets.isEmpty()) {
-                    for (Target target : objectTargets) {
-                        for (UUID targetId : target.getTargets()) {
-                            Permanent targetedPermanent = game.getPermanentOrLKIBattlefield(targetId);
-                            if (targetedPermanent != null
-                                    && targetedPermanent.isControlledBy(sourceControllerId)
-                                    && targetedPermanent.isCreature(game)) {
-                                return true;
-                            }
-
-                            if (sourceControllerId.equals(targetId)) {
-                                return true;
-                            }
-
-                        }
+            Targets objectTargets = stackObject.getStackAbility().getTargets();
+            for (Target target : objectTargets) {
+                for (UUID targetId : target.getTargets()) {
+                    Permanent targetedPermanent = game.getPermanentOrLKIBattlefield(targetId);
+                    if (targetedPermanent != null
+                            && targetedPermanent.isControlledBy(sourceControllerId)
+                            && targetedPermanent.isCreature(game)) {
+                        targetsMe.add(stackObject.getId());
+                    }
+                    if (sourceControllerId.equals(targetId)) {
+                        targetsMe.add(stackObject.getId());
                     }
                 }
             }
         }
-        return false;
-    }
+        possibleTargets.removeIf(id -> !targetsMe.contains(id));
 
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId,
-                                     Ability source, Game game) {
-        return possibleTargets(sourceControllerId, game);
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        Set<UUID> possibleTargets = new HashSet<>();
-        for (StackObject stackObject : game.getStack()) {
-            if ((stackObject instanceof Spell) || (stackObject instanceof StackAbility)) {
-                Targets objectTargets = stackObject.getStackAbility().getTargets();
-                if (!objectTargets.isEmpty()) {
-                    for (Target target : objectTargets) {
-                        for (UUID targetId : target.getTargets()) {
-                            Permanent targetedPermanent = game.getPermanentOrLKIBattlefield(targetId);
-                            if (targetedPermanent != null
-                                    && targetedPermanent.isControlledBy(sourceControllerId)
-                                    && targetedPermanent.isCreature(game)) {
-                                possibleTargets.add(stackObject.getId());
-                            }
-
-                            if (sourceControllerId.equals(targetId)) {
-                                possibleTargets.add(stackObject.getId());
-                            }
-                        }
-                    }
-                }
-            }
-        }
         return possibleTargets;
     }
 
     @Override
-    public SirenStormtamerTargetObject copy() {
-        return new SirenStormtamerTargetObject(this);
-    }
-
-    @Override
-    public Filter getFilter() {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public SirenStormtamerTarget copy() {
+        return new SirenStormtamerTarget(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SoulSearch.java
+++ b/Mage.Sets/src/mage/cards/s/SoulSearch.java
@@ -69,7 +69,7 @@ class SoulSearchEffect extends OneShotEffect {
         if (opponent.getHand().count(StaticFilters.FILTER_CARD_NON_LAND, game) < 1) {
             return true;
         }
-        TargetCard target = new TargetCardInHand(StaticFilters.FILTER_CARD_NON_LAND);
+        TargetCard target = new TargetCard(1, Zone.HAND, StaticFilters.FILTER_CARD_NON_LAND);
         controller.choose(Outcome.Discard, opponent.getHand(), target, source, game);
         Card card = game.getCard(target.getFirstTarget());
         if (card == null) {

--- a/Mage.Sets/src/mage/cards/s/SpearOfHeliod.java
+++ b/Mage.Sets/src/mage/cards/s/SpearOfHeliod.java
@@ -18,7 +18,6 @@ import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.other.DamagedPlayerThisTurnPredicate;
 import mage.target.Target;
 import mage.target.TargetPermanent;
-import mage.target.common.TargetCreaturePermanent;
 
 import java.util.UUID;
 
@@ -27,8 +26,7 @@ import java.util.UUID;
  */
 public final class SpearOfHeliod extends CardImpl {
 
-    private static final FilterCreaturePermanent filter
-            = new FilterCreaturePermanent("creature that dealt damage to you this turn");
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creature that dealt damage to you this turn");
 
     static {
         filter.add(new DamagedPlayerThisTurnPredicate(TargetController.YOU));
@@ -38,15 +36,13 @@ public final class SpearOfHeliod extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT, CardType.ARTIFACT}, "{1}{W}{W}");
         this.supertype.add(SuperType.LEGENDARY);
 
-
         // Creatures you control get +1/+1.
         this.addAbility(new SimpleStaticAbility(new BoostControlledEffect(1, 1, Duration.WhileOnBattlefield)));
 
         // {1}{W}{W}, {T}: Destroy target creature that dealt damage to you this turn.
         Ability ability = new SimpleActivatedAbility(new DestroyTargetEffect(), new ManaCostsImpl<>("{1}{W}{W}"));
         ability.addCost(new TapSourceCost());
-        Target target = new TargetPermanent(filter);
-        ability.addTarget(target);
+        ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SpectersShriek.java
+++ b/Mage.Sets/src/mage/cards/s/SpectersShriek.java
@@ -77,8 +77,7 @@ class SpectersShriekEffect extends OneShotEffect {
             return false;
         }
         TargetCard target = new TargetCard(0, 1, Zone.HAND, new FilterNonlandCard());
-        target.withNotTarget(true);
-        if (!controller.chooseTarget(Outcome.Benefit, player.getHand(), target, source, game)) {
+        if (!controller.choose(Outcome.Benefit, player.getHand(), target, source, game)) {
             return false;
         }
         Card card = game.getCard(target.getFirstTarget());

--- a/Mage.Sets/src/mage/cards/s/StickTogether.java
+++ b/Mage.Sets/src/mage/cards/s/StickTogether.java
@@ -139,14 +139,7 @@ class StickTogetherTarget extends TargetPermanent {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, null, game));
+        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
         return possibleTargets;
-    }
-
-    static int checkTargetCount(Ability source, Game game) {
-        List<Permanent> permanents = game
-                .getBattlefield()
-                .getActivePermanents(filterParty, source.getControllerId(), source, game);
-        return subTypeAssigner.getRoleCount(new CardsImpl(permanents), game);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/StoneGiant.java
+++ b/Mage.Sets/src/mage/cards/s/StoneGiant.java
@@ -68,13 +68,13 @@ class StoneGiantTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Permanent sourceCreature = game.getPermanent(source.getSourceId());
         Permanent targetCreature = game.getPermanent(id);
 
         if (targetCreature != null && sourceCreature != null
                 && targetCreature.getToughness().getValue() < sourceCreature.getPower().getValue()) {
-            return super.canTarget(controllerId, id, source, game);
+            return super.canTarget(playerId, id, source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/s/SynthesisPod.java
+++ b/Mage.Sets/src/mage/cards/s/SynthesisPod.java
@@ -93,7 +93,7 @@ class SynthesisPodCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/t/Technomancer.java
+++ b/Mage.Sets/src/mage/cards/t/Technomancer.java
@@ -107,8 +107,8 @@ class TechnomancerTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 6, game);
     }

--- a/Mage.Sets/src/mage/cards/t/TemptingWurm.java
+++ b/Mage.Sets/src/mage/cards/t/TemptingWurm.java
@@ -1,34 +1,30 @@
 package mage.cards.t;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
-import mage.cards.CardImpl;
-import mage.cards.CardSetInfo;
-import mage.cards.Cards;
-import mage.cards.CardsImpl;
+import mage.cards.*;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.Target;
-import mage.target.common.TargetCardInHand;
+import mage.target.TargetCard;
+
+import java.util.UUID;
 
 /**
- *
  * @author Eirkei
  */
 public final class TemptingWurm extends CardImpl {
 
     public TemptingWurm(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{G}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{G}");
         this.subtype.add(SubType.WURM);
         this.power = new MageInt(5);
         this.toughness = new MageInt(5);
@@ -59,43 +55,36 @@ class TemptingWurmEffect extends OneShotEffect {
                 CardType.LAND.getPredicate()
         ));
     }
-    
+
     TemptingWurmEffect() {
         super(Outcome.Detriment);
         this.staticText = "each opponent may put any number of artifact, creature, enchantment, and/or land cards from their hand onto the battlefield.";
     }
-    
+
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        
+
         if (controller != null) {
             Cards cards = new CardsImpl();
-            
+
             for (UUID playerId : game.getOpponents(controller.getId())) {
                 Player opponent = game.getPlayer(playerId);
-                
-                if (opponent != null){
-                    Target target = new TargetCardInHand(0, Integer.MAX_VALUE, filter);
-                    
-                    if (target.canChoose(opponent.getId(), source, game)) {
-                        if (opponent.chooseUse(Outcome.PutCardInPlay , "Put any artifact, creature, enchantment, and/or land cards cards from your hand onto the battlefield?", source, game)) {
-                            if (target.chooseTarget(Outcome.PutCardInPlay, opponent.getId(), source, game)) {
-                                for (UUID cardId: target.getTargets()){
-                                    Card card = game.getCard(cardId);
-                                    
-                                    if (card != null) {
-                                        cards.add(card);
-                                    }
-                                }
+                if (opponent != null) {
+                    Target target = new TargetCard(0, Integer.MAX_VALUE, Zone.HAND, filter).withChooseHint("put from hand to battlefield");
+                    if (target.chooseTarget(Outcome.PutCardInPlay, opponent.getId(), source, game)) {
+                        for (UUID cardId : target.getTargets()) {
+                            Card card = game.getCard(cardId);
+                            if (card != null) {
+                                cards.add(card);
                             }
                         }
                     }
                 }
             }
-            
+
             controller.moveCards(cards.getCards(game), Zone.BATTLEFIELD, source, game, false, false, true, null);
-            
+
             return true;
         }
 
@@ -105,7 +94,7 @@ class TemptingWurmEffect extends OneShotEffect {
     private TemptingWurmEffect(final TemptingWurmEffect effect) {
         super(effect);
     }
-    
+
     @Override
     public TemptingWurmEffect copy() {
         return new TemptingWurmEffect(this);

--- a/Mage.Sets/src/mage/cards/t/TheCapitolineTriad.java
+++ b/Mage.Sets/src/mage/cards/t/TheCapitolineTriad.java
@@ -1,9 +1,7 @@
 package mage.cards.t;
 
 import java.awt.*;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 import mage.MageInt;
 import mage.MageObject;
@@ -170,7 +168,10 @@ class TheCapitolineTriadTarget extends TargetCardInYourGraveyard {
             return false;
         }
         // Check that exiling all the possible cards would have >= 4 different card types
-        return metCondition(this.possibleTargets(sourceControllerId, source, game), game);
+        Set<UUID> idsToCheck = new HashSet<>();
+        idsToCheck.addAll(this.getTargets());
+        idsToCheck.addAll(this.possibleTargets(sourceControllerId, source, game));
+        return metCondition(idsToCheck, game);
     }
 
     private static int manaValueOfSelection(Collection<UUID> cardsIds, Game game) {

--- a/Mage.Sets/src/mage/cards/t/TheTricksterGodsHeist.java
+++ b/Mage.Sets/src/mage/cards/t/TheTricksterGodsHeist.java
@@ -95,8 +95,8 @@ class TheTricksterGodsHeistTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         if (getTargets().isEmpty()) {
@@ -118,7 +118,7 @@ class TheTricksterGodsHeistTarget extends TargetPermanent {
             return false;
         }
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, sourceControllerId, source, game)) {
-            if (!permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
+            if (!isNotTarget() && !permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
                 continue;
             }
             for (CardType cardType : permanent.getCardType(game)) {

--- a/Mage.Sets/src/mage/cards/t/TheWarInHeaven.java
+++ b/Mage.Sets/src/mage/cards/t/TheWarInHeaven.java
@@ -128,8 +128,8 @@ class TheWarInHeavenTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 8, game);
     }

--- a/Mage.Sets/src/mage/cards/t/TocasiaDigSiteMentor.java
+++ b/Mage.Sets/src/mage/cards/t/TocasiaDigSiteMentor.java
@@ -93,8 +93,8 @@ class TocasiaDigSiteMentorTarget extends TargetCardInYourGraveyard {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        return super.canTarget(controllerId, id, source, game)
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        return super.canTarget(playerId, id, source, game)
                 && CardUtil.checkCanTargetTotalValueLimit(
                 this.getTargets(), id, MageObject::getManaValue, 10, game);
     }

--- a/Mage.Sets/src/mage/cards/v/VATS.java
+++ b/Mage.Sets/src/mage/cards/v/VATS.java
@@ -62,8 +62,8 @@ class VATSTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         if (this.getTargets().isEmpty()) {

--- a/Mage.Sets/src/mage/cards/v/ValkiGodOfLies.java
+++ b/Mage.Sets/src/mage/cards/v/ValkiGodOfLies.java
@@ -123,8 +123,7 @@ class ValkiGodOfLiesRevealExileEffect extends OneShotEffect {
                 TargetCard targetToExile = new TargetCard(Zone.HAND, StaticFilters.FILTER_CARD_CREATURE);
                 targetToExile.withChooseHint("card to exile");
                 targetToExile.withNotTarget(true);
-                if (opponent.getHand().count(StaticFilters.FILTER_CARD_CREATURE, game) > 0 &&
-                        controller.choose(Outcome.Exile, opponent.getHand(), targetToExile, source, game)) {
+                if (controller.choose(Outcome.Exile, opponent.getHand(), targetToExile, source, game)) {
                     Card targetedCardToExile = game.getCard(targetToExile.getFirstTarget());
                     if (targetedCardToExile != null
                             && game.getState().getZone(source.getSourceId()) == Zone.BATTLEFIELD) {

--- a/Mage.Sets/src/mage/cards/w/WeightOfConscience.java
+++ b/Mage.Sets/src/mage/cards/w/WeightOfConscience.java
@@ -1,6 +1,5 @@
 package mage.cards.w;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -11,11 +10,13 @@ import mage.abilities.effects.common.combat.CantAttackAttachedEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.AttachmentType;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.common.FilterControlledPermanent;
-import mage.filter.predicate.Predicate;
 import mage.filter.predicate.mageobject.SharesCreatureTypePredicate;
 import mage.filter.predicate.permanent.TappedPredicate;
 import mage.game.Game;
@@ -25,7 +26,10 @@ import mage.target.TargetPermanent;
 import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author emerald000
@@ -66,7 +70,6 @@ class WeightOfConscienceTarget extends TargetControlledPermanent {
 
     static {
         filterUntapped.add(TappedPredicate.UNTAPPED);
-        filterUntapped.add(WeightOfConsciencePredicate.instance);
     }
 
     WeightOfConscienceTarget() {
@@ -79,13 +82,15 @@ class WeightOfConscienceTarget extends TargetControlledPermanent {
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
+        Set<UUID> possibleTargets = new HashSet<>();
+
         Player player = game.getPlayer(sourceControllerId);
-        Set<UUID> possibleTargets = new HashSet<>(0);
         if (player == null) {
             return possibleTargets;
         }
-        // Choosing first target
+
         if (this.getTargets().isEmpty()) {
+            // choosing first target - use any permanent with shared types
             List<Permanent> permanentList = game.getBattlefield().getActivePermanents(filterUntapped, sourceControllerId, source, game);
             if (permanentList.size() < 2) {
                 return possibleTargets;
@@ -101,8 +106,8 @@ class WeightOfConscienceTarget extends TargetControlledPermanent {
                     possibleTargets.add(permanent.getId());
                 }
             }
-        } // Choosing second target
-        else {
+        } else {
+            // choosing second target - must have shared type with first target
             Permanent firstTargetCreature = game.getPermanent(this.getFirstTarget());
             if (firstTargetCreature == null) {
                 return possibleTargets;
@@ -115,68 +120,12 @@ class WeightOfConscienceTarget extends TargetControlledPermanent {
                 }
             }
         }
-        return possibleTargets;
-    }
 
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        for (Permanent permanent1 : game.getBattlefield().getActivePermanents(filterUntapped, sourceControllerId, source, game)) {
-            for (Permanent permanent2 : game.getBattlefield().getActivePermanents(filterUntapped, sourceControllerId, source, game)) {
-                if (!Objects.equals(permanent1, permanent2) && permanent1.shareCreatureTypes(game, permanent2)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        if (!super.canTarget(id, game)) {
-            return false;
-        }
-        Permanent targetPermanent = game.getPermanent(id);
-        if (targetPermanent == null) {
-            return false;
-        }
-        if (this.getTargets().isEmpty()) {
-            List<Permanent> permanentList = game.getBattlefield().getActivePermanents(filterUntapped, source.getControllerId(), source, game);
-            if (permanentList.size() < 2) {
-                return false;
-            }
-            for (Permanent permanent : permanentList) {
-                if (permanent.isAllCreatureTypes(game)) {
-                    return true;
-                }
-                FilterPermanent filter = filterUntapped.copy();
-                filter.add(new SharesCreatureTypePredicate(permanent));
-                if (game.getBattlefield().count(filter, source.getControllerId(), source, game) > 1) {
-                    return true;
-                }
-            }
-        } else {
-            Permanent firstTarget = game.getPermanent(this.getTargets().get(0));
-            return firstTarget != null && firstTarget.shareCreatureTypes(game, targetPermanent);
-        }
-        return false;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
     public WeightOfConscienceTarget copy() {
         return new WeightOfConscienceTarget(this);
-    }
-}
-
-enum WeightOfConsciencePredicate implements Predicate<MageObject> {
-    instance;
-
-    @Override
-    public boolean apply(MageObject input, Game game) {
-        return input.isAllCreatureTypes(game)
-                || input
-                .getSubtype(game)
-                .stream()
-                .map(SubType::getSubTypeSet)
-                .anyMatch(SubTypeSet.CreatureType::equals);
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WhimsOfTheFates.java
+++ b/Mage.Sets/src/mage/cards/w/WhimsOfTheFates.java
@@ -175,20 +175,17 @@ class TargetSecondPilePermanent extends TargetPermanent {
         this.firstPile = firstPile;
     }
 
-    @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game, boolean flag) {
-        if (firstPile.contains(id)) {
-            return false;
-        }
-        return super.canTarget(controllerId, id, source, game, flag);
+    public TargetSecondPilePermanent(final TargetSecondPilePermanent target) {
+        super(target);
+        this.firstPile = new HashSet<>(target.firstPile);
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         if (firstPile.contains(id)) {
             return false;
         }
-        return super.canTarget(controllerId, id, source, game);
+        return super.canTarget(playerId, id, source, game);
     }
 
     @Override
@@ -199,4 +196,8 @@ class TargetSecondPilePermanent extends TargetPermanent {
         return super.canTarget(id, source, game);
     }
 
+    @Override
+    public TargetSecondPilePermanent copy() {
+        return new TargetSecondPilePermanent(this);
+    }
 }

--- a/Mage.Sets/src/mage/cards/y/YorionSkyNomad.java
+++ b/Mage.Sets/src/mage/cards/y/YorionSkyNomad.java
@@ -52,8 +52,7 @@ public final class YorionSkyNomad extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
 
-        // When Yorion enters the battlefield, exile any number of other nonland permanents you own
-        // and control. Return those cards to the battlefield at the beginning of the next end step.
+        // When Yorion enters the battlefield, exile any number of other nonland permanents you own and control. Return those cards to the battlefield at the beginning of the next end step.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new OneShotNonTargetEffect(
                 new ExileReturnBattlefieldNextEndStepTargetEffect().setText(ruleText),
                 new TargetPermanent(0, Integer.MAX_VALUE, filter, true))));

--- a/Mage.Sets/src/mage/cards/y/YoseiTheMorningStar.java
+++ b/Mage.Sets/src/mage/cards/y/YoseiTheMorningStar.java
@@ -69,12 +69,12 @@ class YoseiTheMorningStarTarget extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Player player = game.getPlayer(source.getFirstTarget());
         if (player != null) {
             this.filter = filterTemplate.copy();
             this.filter.add(new ControllerIdPredicate(player.getId()));
-            return super.canTarget(controllerId, id, source, game);
+            return super.canTarget(playerId, id, source, game);
         }
         return false;
     }

--- a/Mage.Sets/src/mage/cards/y/YunasDecision.java
+++ b/Mage.Sets/src/mage/cards/y/YunasDecision.java
@@ -127,7 +127,7 @@ class YunasDecisionTarget extends TargetCardInHand {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, null, game));
+        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
         return possibleTargets;
     }
 }

--- a/Mage.Sets/src/mage/cards/z/ZamWesell.java
+++ b/Mage.Sets/src/mage/cards/z/ZamWesell.java
@@ -74,7 +74,7 @@ class ZamWesselEffect extends OneShotEffect {
             if (targetPlayer != null && you != null) {
                 if (!targetPlayer.getHand().isEmpty()) {
                     TargetCard target = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_CREATURE);
-                    if (you.chooseTarget(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
+                    if (you.choose(Outcome.Benefit, targetPlayer.getHand(), target, source, game)) {
                         Card card = game.getCard(target.getFirstTarget());
                         if (card != null) {
                             ContinuousEffect copyEffect = new CopyEffect(Duration.EndOfGame, card.getMainCard(), source.getSourceId());

--- a/Mage.Sets/src/mage/cards/z/ZaraRenegadeRecruiter.java
+++ b/Mage.Sets/src/mage/cards/z/ZaraRenegadeRecruiter.java
@@ -18,6 +18,7 @@ import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
+import mage.target.TargetCard;
 import mage.target.common.TargetCardInHand;
 import mage.target.common.TargetPlayerOrPlaneswalker;
 import mage.target.targetpointer.FixedTarget;
@@ -83,10 +84,8 @@ class ZaraRenegadeRecruiterEffect extends OneShotEffect {
         if (controller == null || player == null || player.getHand().isEmpty()) {
             return false;
         }
-        TargetCardInHand targetCard = new TargetCardInHand(
-                0, 1, StaticFilters.FILTER_CARD_CREATURE
-        );
-        controller.choose(outcome, player.getHand(), targetCard, source, game);
+        TargetCard targetCard = new TargetCard(0, 1, Zone.HAND, StaticFilters.FILTER_CARD_CREATURE);
+        controller.choose(Outcome.Detriment, player.getHand(), targetCard, source, game);
         Card card = game.getCard(targetCard.getFirstTarget());
         if (card == null) {
             return false;

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/CopyAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/CopyAITest.java
@@ -116,7 +116,7 @@ public class CopyAITest extends CardTestPlayerBaseWithAIHelps {
         //
         addCard(Zone.GRAVEYARD, playerB, "Balduvian Bears", 1); // 2/2
 
-        // copy (AI must choose most valueable permanent - own)
+        // copy (AI must choose most valuable permanent - own)
         aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
 
         setStopAt(1, PhaseStep.END_TURN);

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/SimulationStabilityAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/SimulationStabilityAITest.java
@@ -28,6 +28,8 @@ public class SimulationStabilityAITest extends CardTestPlayerBaseWithAIHelps {
 
     @Before
     public void prepare() {
+        // WARNING, for some reason java 8 sometime can't compile and run test with updated AI settings, so it's ok to freeze on it
+
         // comment it to enable AI code debug
         Assert.assertFalse("AI stability tests must be run under release config", ComputerPlayer.COMPUTER_DISABLE_TIMEOUT_IN_GAME_SIMULATIONS);
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/ValakutTheMoltenPinnacleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/enters/ValakutTheMoltenPinnacleTest.java
@@ -69,6 +69,7 @@ public class ValakutTheMoltenPinnacleTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Scapeshift");
         setChoice(playerA, "Forest^Forest^Forest^Forest^Forest^Forest"); // to sac
+        setChoice(playerA, TestPlayer.CHOICE_SKIP);
         addTarget(playerA, "Mountain^Mountain^Mountain^Mountain^Mountain^Mountain"); // to search
         setChoice(playerA, "Whenever a Mountain", 6 - 1); // x6 triggers from valakut
         addTarget(playerA, playerB, 6); // to deal damage

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CumulativeUpkeepTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CumulativeUpkeepTest.java
@@ -61,32 +61,37 @@ public class CumulativeUpkeepTest extends CardTestPlayerBase {
         // Whenever Kor Celebrant or another creature you control enters, you gain 1 life.
         addCard(Zone.HAND, playerB, "Kor Celebrant", 1); // Creature {2}{W}
         addCard(Zone.BATTLEFIELD, playerB, "Plains", 3);
-        
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 6);
+        //
         // Cumulative upkeep {2}
-        // When Illusions of Grandeur enters the battlefield, you gain 20 life.
+        // At the beginning of your upkeep, put an age counter on this permanent,
+        // then sacrifice it unless you pay its upkeep cost for each age counter on it.
         // When Illusions of Grandeur leaves the battlefield, you lose 20 life.
         addCard(Zone.HAND, playerA, "Illusions of Grandeur"); // Enchantment {3}{U}
-        
-        // At the beginning of your upkeep, you may exchange control of target nonland permanent you control and target nonland permanent an opponent controls with an equal or lesser converted mana cost.        
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 6);
+        //
+        // At the beginning of your upkeep, you may exchange control of target nonland permanent you control
+        // and target nonland permanent an opponent controls with an equal or lesser converted mana cost.
         addCard(Zone.HAND, playerA, "Puca's Mischief"); // Enchantment {3}{U}
 
-        
+        // turn 1, 2 - prepare cumulative upkeep and gain life triggers
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Illusions of Grandeur");
-             
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Kor Celebrant");
-        
-        // Illusions of Grandeur - CumulativeUpkeepAbility: Cumulative upkeep {2}
-        setChoice(playerA, true); // Pay {2}?
-        
+
+        // turn 3 - upkeep trigger and prepare control card
+        setChoice(playerA, true); // use upkeep cost {2}
         castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Puca's Mischief");
-        
-        setChoice(playerA, "Cumulative upkeep"); // Triggered list (total 2) which trigger goes first on the stack
-        addTarget(playerA, "Illusions of Grandeur"); // Own target permanent of Puca's Mischief
-        addTarget(playerA, "Kor Celebrant"); // Opponent's target permanent of Puca's Mischief
-        
-        setChoice(playerA, true); // At the beginning of your upkeep, you may exchange control of target nonland permanent you control and target nonland permanent an opponent controls with an equal or lesser converted mana cost.
-        setChoice(playerA, false); // Pay {2}{2}?
+
+        // turn 5 - multiple upkeep triggers
+        // first put upkeep, then put change control - so control will be resolved before upkeep cost
+        setChoice(playerA, "Cumulative upkeep");
+
+        // resolve change control first
+        addTarget(playerA, "Illusions of Grandeur"); // own target
+        addTarget(playerA, "Kor Celebrant"); // opponent target
+        setChoice(playerA, true); // yes, resolve change control
+
+        // resolve upkeep
+        setChoice(playerA, false); // no, do not pay upkeep cost
         
         checkPermanentCounters("Age counters", 5, PhaseStep.PRECOMBAT_MAIN, playerB, "Illusions of Grandeur", CounterType.AGE, 2);
         

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EscalateTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EscalateTest.java
@@ -4,6 +4,7 @@ package org.mage.test.cards.abilities.keywords;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -27,7 +28,9 @@ public class EscalateTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Savage Alliance", "mode=2Silvercoat Lion");
         setModeChoice(playerA, "2");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();
 
@@ -52,7 +55,9 @@ public class EscalateTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Collective Defiance", playerB);
         setModeChoice(playerA, "3"); // deal 3 dmg to opponent
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -78,10 +83,12 @@ public class EscalateTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Collective Defiance"); // {1}{R}{R} sorcery
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Collective Defiance", "mode=2Gaddock Teeg");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Collective Defiance", "mode=2Gaddock Teeg^mode=3targetPlayer=PlayerB");
         setModeChoice(playerA, "2"); // deal 4 dmg to target creature (gaddock teeg)
         setModeChoice(playerA, "3"); // deal 3 dmg to opponent
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -109,8 +116,6 @@ public class EscalateTest extends CardTestPlayerBase {
         addCard(Zone.HAND, playerA, "Collective Defiance"); // {1}{R}{R} sorcery
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
 
-        setStrictChooseMode(true);
-
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Collective Defiance", "mode=2Wall of Omens");
         setModeChoice(playerA, "1"); // opponent discards hand and draws that many
         setModeChoice(playerA, "2"); // deal 4 dmg to target creature (Wall of Omens)
@@ -120,6 +125,8 @@ public class EscalateTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Spell Queller");
         addTarget(playerB, "Collective Defiance");
+
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerWithAnyNumberModesAbilityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/KickerWithAnyNumberModesAbilityTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.abilities.keywords;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -50,6 +51,7 @@ public class KickerWithAnyNumberModesAbilityTest extends CardTestPlayerBase {
         setChoice(playerA, true); // use kicker
         setModeChoice(playerA, "2");
         setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, playerA); // gain x life
         addTarget(playerA, "Balduvian Bears"); // get counters
 
@@ -79,6 +81,7 @@ public class KickerWithAnyNumberModesAbilityTest extends CardTestPlayerBase {
         setChoice(playerA, true); // use kicker
         setModeChoice(playerA, "2");
         setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, playerA); // gain x life
         addTarget(playerA, "Balduvian Bears"); // get counters
 
@@ -108,6 +111,7 @@ public class KickerWithAnyNumberModesAbilityTest extends CardTestPlayerBase {
         setChoice(playerA, true); // use kicker
         setModeChoice(playerA, "2");
         setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, playerA); // gain x life
         addTarget(playerA, "Balduvian Bears"); // get counters
 
@@ -139,6 +143,7 @@ public class KickerWithAnyNumberModesAbilityTest extends CardTestPlayerBase {
         setChoice(playerA, true); // use kicker
         setModeChoice(playerA, "2");
         setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, playerA); // gain x life
         addTarget(playerA, "Balduvian Bears"); // get counters
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/LandfallTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/LandfallTest.java
@@ -1,15 +1,12 @@
-
 package org.mage.test.cards.abilities.keywords;
 
 import mage.abilities.keyword.IntimidateAbility;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
- *
  * @author LevelX2
  */
 public class LandfallTest extends CardTestPlayerBase {
@@ -26,9 +23,12 @@ public class LandfallTest extends CardTestPlayerBase {
 
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Plains");
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rest for the Weary");
+        addTarget(playerA, playerA);
 
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerA, "Rest for the Weary");
+        addTarget(playerA, playerA);
 
+        setStrictChooseMode(true);
         setStopAt(2, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -43,7 +43,6 @@ public class LandfallTest extends CardTestPlayerBase {
      * If you Hive Mind an opponent's Rest for the Weary and redirect its target
      * to yourself when it's not your turn, the game spits out this message and
      * rolls back to before Rest for the Weary was cast.
-     *
      */
     @Test
     public void testHiveMind() {
@@ -57,15 +56,17 @@ public class LandfallTest extends CardTestPlayerBase {
         // Landfall - If you had a land enter the battlefield under your control this turn, that player gains 8 life instead.
         addCard(Zone.HAND, playerA, "Rest for the Weary", 1);
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rest for the Weary");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Rest for the Weary", playerA);
+        setChoice(playerB, true); // change target of copied spell
+        addTarget(playerB, playerB);
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
         assertGraveyardCount(playerA, "Rest for the Weary", 1);
         assertLife(playerA, 24);
         assertLife(playerB, 24);
-
     }
 
     @Test
@@ -76,6 +77,7 @@ public class LandfallTest extends CardTestPlayerBase {
 
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Plains");
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -104,10 +106,14 @@ public class LandfallTest extends CardTestPlayerBase {
 
         addCard(Zone.BATTLEFIELD, playerB, "Silvercoat Lion", 1);
 
+        // prepare landfall
         playLand(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Mountain");
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Searing Blaze");
+        addTarget(playerA, playerB);
+        addTarget(playerA, "Silvercoat Lion");
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
 
@@ -133,6 +139,7 @@ public class LandfallTest extends CardTestPlayerBase {
         attack(2, playerB, "Silvercoat Lion");
         castSpell(2, PhaseStep.DECLARE_ATTACKERS, playerB, "Groundswell", "Silvercoat Lion");
 
+        setStrictChooseMode(true);
         setStopAt(2, PhaseStep.END_COMBAT);
         execute();
 
@@ -179,6 +186,7 @@ public class LandfallTest extends CardTestPlayerBase {
         attack(2, playerB, "Silvercoat Lion");
         castSpell(2, PhaseStep.DECLARE_ATTACKERS, playerB, "Groundswell", "Silvercoat Lion");
 
+        setStrictChooseMode(true);
         setStopAt(2, PhaseStep.END_COMBAT);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/PrototypeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/PrototypeTest.java
@@ -16,6 +16,7 @@ import mage.filter.predicate.mageobject.*;
 import mage.game.permanent.Permanent;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -319,6 +320,7 @@ public class PrototypeTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, epiphany);
         setModeChoice(playerA, "3"); // Return target nonland permanent to its owner's hand.
         setModeChoice(playerA, "4"); // Create a token that's a copy of target creature you control.
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, automaton);
         addTarget(playerA, automaton);
 
@@ -340,6 +342,7 @@ public class PrototypeTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, epiphany);
         setModeChoice(playerA, "3"); // Return target nonland permanent to its owner's hand.
         setModeChoice(playerA, "4"); // Create a token that's a copy of target creature you control.
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, automaton);
         addTarget(playerA, automaton);
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SaddleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SaddleTest.java
@@ -8,6 +8,7 @@ import mage.game.permanent.Permanent;
 import mage.watchers.common.SaddledMountWatcher;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -90,6 +91,7 @@ public class SaddleTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Saddle");
         setChoice(playerA, bear); // to saddle cost
+        setChoice(playerA, TestPlayer.CHOICE_SKIP);
 
         attack(1, playerA, possum, playerB);
         setChoice(playerA, bear); // to return
@@ -116,6 +118,7 @@ public class SaddleTest extends CardTestPlayerBase {
         // turn 1 - saddle x2 and trigger on attack
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Saddle");
         setChoice(playerA, bear + "^" + lion);
+        setChoice(playerA, TestPlayer.CHOICE_SKIP);
 
         attack(1, playerA, possum, playerB);
         setChoice(playerA, elf); // to return (try to choose a wrong creature, so game must not allow to choose it)

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SpreeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SpreeTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.abilities.keywords;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -24,8 +25,9 @@ public class SpreeTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, bear, 1);
         addCard(Zone.HAND, playerA, accident);
 
-        setModeChoice(playerA, "1");
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, accident, bear);
+        setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -41,8 +43,9 @@ public class SpreeTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 1 + 1);
         addCard(Zone.HAND, playerA, accident);
 
-        setModeChoice(playerA, "2");
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, accident);
+        setModeChoice(playerA, "2");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -58,9 +61,10 @@ public class SpreeTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, bear, 1);
         addCard(Zone.HAND, playerA, accident);
 
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, accident, bear);
         setModeChoice(playerA, "1");
         setModeChoice(playerA, "2");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, accident, bear);
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -80,9 +84,10 @@ public class SpreeTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, electromancer, 1);
         addCard(Zone.HAND, playerA, accident);
 
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, accident, bear);
         setModeChoice(playerA, "1");
         setModeChoice(playerA, "2");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, accident, bear);
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/OneShotNonTargetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/oneshot/OneShotNonTargetTest.java
@@ -5,22 +5,31 @@ import mage.constants.Zone;
 import org.junit.Test;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
+
 /**
- *
  * @author notgreat
  */
 public class OneShotNonTargetTest extends CardTestPlayerBase {
+
     @Test
     public void YorionChooseAfterTriggerTest() {
+        // When Yorion enters the battlefield, exile any number of other nonland permanents you own and control.
+        // Return those cards to the battlefield at the beginning of the next end step.
         addCard(Zone.HAND, playerA, "Yorion, Sky Nomad");
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 7);
+        //
+        // When Resolute Reinforcements enters the battlefield, create a 1/1 white Soldier creature token.
         addCard(Zone.HAND, playerA, "Resolute Reinforcements");
 
+        // prepare yori and put trigger on stack
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Yorion, Sky Nomad");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, true);
         checkPermanentCount("Yorion on battlefield", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Yorion, Sky Nomad", 1);
+
+        // prepare another create before yori trigger resolve
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Resolute Reinforcements");
-        setChoice(playerA, "Resolute Reinforcements");
+        setChoice(playerA, "Resolute Reinforcements"); // 1 of 2 target for yori trigger
+        setChoice(playerA, TestPlayer.CHOICE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
@@ -30,6 +39,7 @@ public class OneShotNonTargetTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Resolute Reinforcements", 1);
         assertTappedCount("Plains", true, 7);
     }
+
     @Test
     public void NonTargetAdjusterTest() {
         addCard(Zone.HAND, playerA, "Temporal Firestorm");
@@ -52,21 +62,30 @@ public class OneShotNonTargetTest extends CardTestPlayerBase {
         assertGraveyardCount(playerA, "Python", 0);
         assertGraveyardCount(playerA, "Watchwolf", 1);
     }
+
     @Test
     public void ModeSelectionTest() {
-        addCard(Zone.HAND, playerA, "SOLDIER Military Program");
+        // At the beginning of combat on your turn, choose one. If you control a commander, you may choose both instead.
+        // * Create a 1/1 white Soldier creature token.
+        // * Put a +1/+1 counter on each of up to two Soldiers you control.
+        addCard(Zone.HAND, playerA, "SOLDIER Military Program"); // {2}{W}
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
-        addCard(Zone.BATTLEFIELD, playerA, "Squire", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Squire", 1); // 1/2
 
+        // prepare mode ability
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "SOLDIER Military Program");
+
+        // turn 1 combat - put counter
         setModeChoice(playerA, "2");
         setChoice(playerA, "Squire");
-        setChoice(playerA, TestPlayer.CHOICE_SKIP);
 
+        // turn 3 combat - create token
         setModeChoice(playerA, "1");
 
+        // turn 5 combat - put counter
         setModeChoice(playerA, "2");
-        setChoice(playerA, "Squire^Soldier Token");
+        setChoice(playerA, "Squire");
+        setChoice(playerA, "Soldier Token");
 
         setStrictChooseMode(true);
         setStopAt(5, PhaseStep.END_TURN);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/continuous/OracleEnVecNextTurnTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/continuous/OracleEnVecNextTurnTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.continuous;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -22,7 +23,9 @@ public class OracleEnVecNextTurnTest extends CardTestPlayerBase {
 
         // 1 - activate
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Target opponent", playerB);
-        setChoice(playerB, "Balduvian Bears^Angelic Wall");
+        setChoice(playerB, "Balduvian Bears");
+        setChoice(playerB, "Angelic Wall");
+        setChoice(playerB, TestPlayer.CHOICE_SKIP);
         //
         checkLife("turn 1", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, 20);
         checkPermanentCount("turn 1", 1, PhaseStep.POSTCOMBAT_MAIN, playerB, "Balduvian Bears", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/control/TakeControlWhileSearchingLibraryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/control/TakeControlWhileSearchingLibraryTest.java
@@ -235,7 +235,7 @@ public class TakeControlWhileSearchingLibraryTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Buried Alive");
         setChoice(playerB, true); // continue after new control
         addTarget(playerB, "Balduvian Bears");
-        addTarget(playerB, TestPlayer.TARGET_SKIP);
+        //addTarget(playerB, TestPlayer.TARGET_SKIP);
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         checkGraveyardCount("after grave a", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears", 0);
         checkGraveyardCount("after grave b", 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Balduvian Bears", 0);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/RemoveCounterCostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/additional/RemoveCounterCostTest.java
@@ -23,7 +23,6 @@ public class RemoveCounterCostTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}, Remove two +1/+1 counters");
         setChoice(playerA, "Novijen Sages"); // counters to remove
-        setChoice(playerA, TestPlayer.CHOICE_SKIP);
         setChoice(playerA, "X=2"); // counters to remove
 
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/alternate/CastFromHandWithoutPayingManaCostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/alternate/CastFromHandWithoutPayingManaCostTest.java
@@ -427,18 +427,20 @@ public class CastFromHandWithoutPayingManaCostTest extends CardTestPlayerBase {
         String savageBeating = "Savage Beating";
 
         skipInitShuffling();
-        addCard(Zone.LIBRARY, playerA, savageBeating, 2);
+        addCard(Zone.LIBRARY, playerA, savageBeating, 2); // to free cast
         addCard(Zone.HAND, playerA, jeleva);
         addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
         addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
 
+        // prepare and exile cards from libs
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, jeleva);
 
+        // attack and use free cast from exile
         attack(3, playerA, jeleva);
-        setChoice(playerA, true); // opt to use Jeleva ability
-        setChoice(playerA, savageBeating); // choose to cast Savage Beating for free
-        setChoice(playerA, false); // opt not to pay entwine cost
+        setChoice(playerA, savageBeating); // to free cast
+        setChoice(playerA, true); // confirm free cast
+        setChoice(playerA, false); // ignore entwine cost
         setModeChoice(playerA, "1"); // use first mode of Savage Beating granting double strike
 
         setStopAt(3, PhaseStep.END_COMBAT);
@@ -448,6 +450,5 @@ public class CastFromHandWithoutPayingManaCostTest extends CardTestPlayerBase {
         assertTapped(jeleva, true);
         assertLife(playerB, 18);
         assertAbility(playerA, jeleva, DoubleStrikeAbility.getInstance(), true);
-
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/modaldoublefaced/ModalDoubleFacedCardsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/modaldoublefaced/ModalDoubleFacedCardsTest.java
@@ -945,7 +945,7 @@ public class ModalDoubleFacedCardsTest extends CardTestPlayerBase {
         // cast as copy of mdf card
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Zam Wesell");
         addTarget(playerA, playerB); // target opponent
-        addTarget(playerA, "Akoum Warrior"); // creature card to copy
+        setChoice(playerA, "Akoum Warrior"); // creature card to copy
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
         checkPermanentCount("after", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Akoum Warrior", 1);
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/dungeons/DungeonTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/dungeons/DungeonTest.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
  */
 public class DungeonTest extends CardTestPlayerBase {
 
-    private static final String TOMB_OF_ANNIHILATION = "Tomb of Annihilation";
+    private static final String TOMB_OF_ANNIHILATION = "Tomb of Annihilation"; // TODO: miss test
     private static final String LOST_MINE_OF_PHANDELVER = "Lost Mine of Phandelver";
     private static final String DUNGEON_OF_THE_MAD_MAGE = "Dungeon of the Mad Mage";
     private static final String FLAMESPEAKER_ADEPT = "Flamespeaker Adept";

--- a/Mage.Tests/src/test/java/org/mage/test/cards/modal/OneOrBothTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/modal/OneOrBothTest.java
@@ -4,6 +4,7 @@ package org.mage.test.cards.modal;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -25,7 +26,7 @@ public class OneOrBothTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Subtle Strike", "Pillarfield Ox");
         setModeChoice(playerA, "1");
-        setModeChoice(playerA, null);
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();
@@ -47,7 +48,7 @@ public class OneOrBothTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Subtle Strike", "Pillarfield Ox");
         setModeChoice(playerA, "2");
-        setModeChoice(playerA, null);
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/modal/OneOrMoreTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/modal/OneOrMoreTest.java
@@ -6,6 +6,7 @@ import mage.game.permanent.Permanent;
 import mage.game.permanent.PermanentToken;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -39,7 +40,7 @@ public class OneOrMoreTest extends CardTestPlayerBase {
         addTarget(playerA, "Silvercoat Lion"); // for 3
         addTarget(playerA, "Silvercoat Lion"); // for 4
         addTarget(playerA, playerB); // for 5
-        setModeChoice(playerA, null);
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
@@ -76,7 +77,7 @@ public class OneOrMoreTest extends CardTestPlayerBase {
         addTarget(playerA, "Silvercoat Lion"); // for 3
         addTarget(playerA, "Silvercoat Lion"); // for 4
         addTarget(playerA, playerB); // for 5
-        setModeChoice(playerA, null);
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/modal/PawPrintsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/modal/PawPrintsTest.java
@@ -3,7 +3,9 @@ package org.mage.test.cards.modal;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.counters.CounterType;
+import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -61,25 +63,17 @@ public class PawPrintsTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Season of Gathering");
         setModeChoice(playerA, "1");
         setModeChoice(playerA, "2");
-        setModeChoice(playerA, "3"); // Will be unused
+        setModeChoice(playerA, "3"); // no more paws for mode 3, see exception below
         addTarget(playerA, "Memnite"); // for 1
         setChoice(playerA, "Enchantment");
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
-        execute();
-
-        // Add one more counter from Hardened Scales, which was still on the battlefield when the counter placing effect triggered
-        assertPowerToughness(playerA, "Memnite", 3, 3);
-        assertCounterCount("Memnite", CounterType.P1P1, 2);
-
-        // But not anymore...
-        assertPermanentCount(playerA, "Hardened Scales", 0);
-        assertGraveyardCount(playerA, "Hardened Scales", 1);
-
-        // Draw effect didnt trigger
-        assertHandCount(playerA, 0);
-
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertTrue("mode 3 must not be able to choose due total paws cost", e.getMessage().contains("Can't use mode: 3"));
+        }
     }
 
     @Test

--- a/Mage.Tests/src/test/java/org/mage/test/cards/rules/AttachmentTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/rules/AttachmentTest.java
@@ -282,9 +282,9 @@ public class AttachmentTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Show and Tell");
-        setChoice(playerA, true);
-        setChoice(playerB, false);
+        setChoice(playerA, true); // yes, put from hand to battle
         addTarget(playerA, "Aether Tunnel");
+        setChoice(playerB, false); // no, do not put
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/MantleOfTheAncientsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/MantleOfTheAncientsTest.java
@@ -50,6 +50,9 @@ public class MantleOfTheAncientsTest extends CardTestPlayerBase {
         addTarget(playerA, "Gate Smasher^Aether Tunnel");
         addTarget(playerA, TestPlayer.TARGET_SKIP);
 
+
+        showBattlefield("after", 1, PhaseStep.END_TURN, playerA);
+
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/ShareTheSpoilsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/afc/ShareTheSpoilsTest.java
@@ -314,15 +314,14 @@ public class ShareTheSpoilsTest extends CardTestCommander4Players {
         // Cast an adventure card from hand
         castSpell(5, PhaseStep.PRECOMBAT_MAIN, playerA, "Dizzying Swoop");
         addTarget(playerA, "Prosper, Tome-Bound");
-        addTarget(playerA, TestPlayer.TARGET_SKIP); // tap 1 of 2 targets
+        //addTarget(playerA, TestPlayer.TARGET_SKIP); // only 1 creature, so tap 1 of 2, no need in skip
         waitStackResolved(5, PhaseStep.PRECOMBAT_MAIN);
 
         // Make sure the creature card can't be played from exile since there isn't the {W}{W} for it
         checkPlayableAbility("creature cast", 5, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Ardenvale Tactician", false);
 
-        setStopAt(5, PhaseStep.POSTCOMBAT_MAIN);
-
         setStrictChooseMode(true);
+        setStopAt(5, PhaseStep.POSTCOMBAT_MAIN);
         execute();
 
         // 1 exiled with Share the Spoils

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/ApproachOfTheSecondSunTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/akh/ApproachOfTheSecondSunTest.java
@@ -189,9 +189,9 @@ public class ApproachOfTheSecondSunTest extends CardTestPlayerBase {
         // first may have been cast from anywhere.
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Finale of Promise", true);
         setChoice(playerA, "X=7"); // each with mana value X or less
+        addTarget(playerA, TARGET_SKIP); // skip instant target
+        addTarget(playerA, "Approach of the Second Sun"); // use sorcery target
         setChoice(playerA, "Yes"); // You may cast
-        addTarget(playerA, TARGET_SKIP); // up to one target instant card
-        addTarget(playerA, "Approach of the Second Sun"); // and/or up to one target sorcery card from your graveyard
         checkLife("Approach of the Second Sun cast from graveyard gains life", 1, PhaseStep.PRECOMBAT_MAIN, playerA, 27);
         checkLibraryCount("Approach of the Second Sun cast from graveyard goes to library",
                 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Approach of the Second Sun", 1);
@@ -200,9 +200,9 @@ public class ApproachOfTheSecondSunTest extends CardTestPlayerBase {
         // The second Approach of the Second Sun that you cast must be cast from your hand,
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Finale of Promise", true);
         setChoice(playerA, "X=7"); // each with mana value X or less
-        setChoice(playerA, "Yes"); // You may cast
         addTarget(playerA, TARGET_SKIP); // up to one target instant card
         addTarget(playerA, "Approach of the Second Sun"); // and/or up to one target sorcery card from your graveyard
+        setChoice(playerA, "Yes"); // You may cast
         checkLife("Approach of the Second Sun cast from graveyard gains life", 1, PhaseStep.PRECOMBAT_MAIN, playerA, 34);
         checkLibraryCount("Approach of the Second Sun cast from graveyard goes to library",
                 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Approach of the Second Sun", 2);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/bfz/BrutalExpulsionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/bfz/BrutalExpulsionTest.java
@@ -4,6 +4,7 @@ package org.mage.test.cards.single.bfz;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -27,7 +28,7 @@ public class BrutalExpulsionTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Brutal Expulsion", "mode=2Augmenting Automaton");
         setModeChoice(playerA, "2");
-        setModeChoice(playerA, null); // ignore last one mode
+        setModeChoice(playerA, TestPlayer.MODE_SKIP); // ignore last one mode
         //addTarget(playerA, "mode=2Augmenting Automaton"); // doesn't work with mode
 
         setStopAt(1, PhaseStep.END_COMBAT);
@@ -56,7 +57,7 @@ public class BrutalExpulsionTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Brutal Expulsion", "mode=2Kiora, the Crashing Wave");
         setModeChoice(playerA, "2");
-        setModeChoice(playerA, null); // ignore last one mode
+        setModeChoice(playerA, TestPlayer.MODE_SKIP); // ignore last one mode
 
         setStopAt(1, PhaseStep.END_COMBAT);
         execute();
@@ -116,7 +117,7 @@ public class BrutalExpulsionTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Brutal Expulsion", "mode=2Gideon, Ally of Zendikar");
         setModeChoice(playerA, "2");
-        setModeChoice(playerA, null); // ignore last one mode
+        setModeChoice(playerA, TestPlayer.MODE_SKIP); // ignore last one mode
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Shock", "Gideon, Ally of Zendikar");
 
         setStopAt(1, PhaseStep.END_COMBAT);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c18/GeodeGolemTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c18/GeodeGolemTest.java
@@ -27,8 +27,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
 
         // attack and cast first time (free)
         attack(1, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Grizzly Bears"); // commander choice
+        setChoice(playerA, true); // cast commander
         waitStackResolved(1, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 1", 1, PhaseStep.COMBAT_DAMAGE, playerA, "Grizzly Bears", 1);
         checkPermanentTapped("after 1", 1, PhaseStep.COMBAT_DAMAGE, playerA, "Forest", true, 0);
@@ -40,8 +40,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 3 - second cast (1x tax)
 
         attack(3, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Grizzly Bears"); // commander choice
+        setChoice(playerA, true); // cast commander
         waitStackResolved(3, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 2", 3, PhaseStep.COMBAT_DAMAGE, playerA, "Grizzly Bears", 1);
         checkPermanentTapped("after 2", 3, PhaseStep.COMBAT_DAMAGE, playerA, "Forest", true, 2); // 1x tax
@@ -53,8 +53,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 5 - third cast (2x tax)
 
         attack(5, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Grizzly Bears"); // commander choice
+        setChoice(playerA, true); // cast commander
         waitStackResolved(5, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 3", 5, PhaseStep.COMBAT_DAMAGE, playerA, "Grizzly Bears", 1);
         checkPermanentTapped("after 3", 5, PhaseStep.COMBAT_DAMAGE, playerA, "Forest", true, 2 * 2); // 2x tax
@@ -85,8 +85,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
 
         // attack and cast first time (free)
         attack(1, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Akoum Warrior"); // commander choice
+        setChoice(playerA, true); // cast commander
         waitStackResolved(1, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 1", 1, PhaseStep.COMBAT_DAMAGE, playerA, "Akoum Warrior", 1);
         checkPermanentTapped("after 1", 1, PhaseStep.COMBAT_DAMAGE, playerA, "Mountain", true, 0);
@@ -98,8 +98,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 3 - second cast (1x tax)
 
         attack(3, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Akoum Warrior"); // commander choice
+        setChoice(playerA, true); // cast commander
         waitStackResolved(3, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 2", 3, PhaseStep.COMBAT_DAMAGE, playerA, "Akoum Warrior", 1);
         checkPermanentTapped("after 2", 3, PhaseStep.COMBAT_DAMAGE, playerA, "Mountain", true, 2); // 1x tax
@@ -111,8 +111,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 5 - third cast (2x tax)
 
         attack(5, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Akoum Warrior"); // commander choice
+        setChoice(playerA, true); // cast commander
         waitStackResolved(5, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 3", 5, PhaseStep.COMBAT_DAMAGE, playerA, "Akoum Warrior", 1);
         checkPermanentTapped("after 3", 5, PhaseStep.COMBAT_DAMAGE, playerA, "Mountain", true, 2 * 2); // 2x tax
@@ -144,8 +144,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
 
         // attack and cast first time (free)
         attack(1, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Birgi, God of Storytelling"); // commander choice
+        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Cast Birgi, God of Storytelling"); // spell choice
         waitStackResolved(1, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 1", 1, PhaseStep.COMBAT_DAMAGE, playerA, "Birgi, God of Storytelling", 1);
@@ -158,8 +158,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 3 - second cast, LEFT side (1x tax)
 
         attack(3, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Birgi, God of Storytelling"); // commander choice
+        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Cast Birgi, God of Storytelling"); // spell choice
         waitStackResolved(3, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 2", 3, PhaseStep.COMBAT_DAMAGE, playerA, "Birgi, God of Storytelling", 1);
@@ -172,8 +172,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 5 - third cast, RIGHT side (2x tax)
 
         attack(5, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Birgi, God of Storytelling"); // commander choice
+        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Cast Harnfel, Horn of Bounty"); // spell choice
         waitStackResolved(5, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 3", 5, PhaseStep.COMBAT_DAMAGE, playerA, "Harnfel, Horn of Bounty", 1);
@@ -186,8 +186,8 @@ public class GeodeGolemTest extends CardTestCommanderDuelBase {
         // turn 7 - fourth cast, RIGHT side (3x tax)
 
         attack(7, playerA, "Geode Golem");
-        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Birgi, God of Storytelling"); // commander choice
+        setChoice(playerA, true); // cast commander
         setChoice(playerA, "Cast Harnfel, Horn of Bounty"); // spell choice
         waitStackResolved(7, PhaseStep.COMBAT_DAMAGE);
         checkPermanentCount("after 4", 7, PhaseStep.COMBAT_DAMAGE, playerA, "Harnfel, Horn of Bounty", 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/clu/SludgeTitanTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/clu/SludgeTitanTest.java
@@ -1,4 +1,3 @@
-
 package org.mage.test.cards.single.clu;
 
 import mage.constants.PhaseStep;
@@ -6,6 +5,7 @@ import mage.constants.Zone;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -41,35 +41,11 @@ public class SludgeTitanTest extends CardTestPlayerBase {
         addCard(Zone.LIBRARY, playerA, divination, 5);
 
         attack(1, playerA, titan, playerB);
-        setChoice(playerA, playerA.CHOICE_SKIP);
 
         setStopAt(1, PhaseStep.DECLARE_BLOCKERS);
         execute();
 
         assertGraveyardCount(playerA, divination, 5);
-    }
-
-    @Test
-    public void testNoValidChoiceInvalid() {
-        setStrictChooseMode(true);
-        skipInitShuffling();
-
-        addCard(Zone.BATTLEFIELD, playerA, titan);
-        addCard(Zone.LIBRARY, playerA, divination, 5);
-
-        attack(1, playerA, titan, playerB);
-        setChoice(playerA, divination); // invalid, titan doesn't allow for choosing sorcery
-
-        setStopAt(1, PhaseStep.DECLARE_BLOCKERS);
-
-        try {
-            execute();
-            Assert.fail("must throw exception on execute");
-        } catch (Throwable e) {
-            if (!e.getMessage().startsWith("Missing CHOICE def")) {
-                Assert.fail("Unexpected exception " + e.getMessage());
-            }
-        }
     }
 
     @Test
@@ -81,7 +57,7 @@ public class SludgeTitanTest extends CardTestPlayerBase {
         addCard(Zone.LIBRARY, playerA, piker, 5);
 
         attack(1, playerA, titan, playerB);
-        setChoice(playerA, playerA.CHOICE_SKIP);
+        setChoice(playerA, TestPlayer.CHOICE_SKIP);
 
         setStopAt(1, PhaseStep.DECLARE_BLOCKERS);
         execute();
@@ -207,6 +183,8 @@ public class SludgeTitanTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, titan);
         addCard(Zone.LIBRARY, playerA, brownscale, 5);
 
+        // must able to select only 1 creature, so after first choice it must auto-finish
+        // if you see miss choice here then something broken in TestPlayer's choose method
         attack(1, playerA, titan, playerB);
         setChoice(playerA, brownscale);
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/emn/TamiyoFieldResearcherTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/emn/TamiyoFieldResearcherTest.java
@@ -78,7 +78,7 @@ public class TamiyoFieldResearcherTest extends CardTestPlayerBase {
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+1: Choose up to two");
         addTarget(playerA, "Bronze Sable");
-        addTarget(playerA, TestPlayer.TARGET_SKIP);
+        //addTarget(playerA, TestPlayer.TARGET_SKIP); // there are only 1 creature, so choose 1 of 2, no need in skip
 
         attack(1, playerA, "Bronze Sable");
 
@@ -240,7 +240,7 @@ public class TamiyoFieldResearcherTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Tamiyo, Field Researcher", true);
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+1: Choose up to two");
         addTarget(playerA, "Bronze Sable");
-        addTarget(playerA, TestPlayer.TARGET_SKIP);
+        //addTarget(playerA, TestPlayer.TARGET_SKIP); // there are only 1 creature, so choose 1 of 2, no need in skip
 
         attack(2, playerB, "Bronze Sable");
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/fin/GarnetPrincessOfAlexandriaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/fin/GarnetPrincessOfAlexandriaTest.java
@@ -1,0 +1,91 @@
+package org.mage.test.cards.single.fin;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author JayDi85
+ */
+public class GarnetPrincessOfAlexandriaTest extends CardTestPlayerBase {
+
+    @Test
+    public void test_Targets_0() {
+        // 2/2
+        // Whenever Garnet attacks, you may remove a lore counter from each of any number of Sagas you control.
+        // Put a +1/+1 counter on Garnet for each lore counter removed this way.
+        addCard(Zone.BATTLEFIELD, playerA, "Garnet, Princess of Alexandria");
+
+        // nothing to select after attack
+        attack(1, playerA, "Garnet, Princess of Alexandria", playerB);
+        //setChoice(playerA, TestPlayer.CHOICE_SKIP); // no valid choices, so do not show choose dialog
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 20 - 2);
+    }
+
+    @Test
+    public void test_Targets_1() {
+        // 2/2
+        // Whenever Garnet attacks, you may remove a lore counter from each of any number of Sagas you control.
+        // Put a +1/+1 counter on Garnet for each lore counter removed this way.
+        addCard(Zone.BATTLEFIELD, playerA, "Garnet, Princess of Alexandria");
+        //
+        // (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+        // I, II, III, IV -- Stampede! -- Other creatures you control get +1/+0 until end of turn.
+        addCard(Zone.HAND, playerA, "Summon: Choco/Mog"); // {2}{W}
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+
+        // prepare x1 saga
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Summon: Choco/Mog");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        // can select 1 target only
+        attack(1, playerA, "Garnet, Princess of Alexandria", playerB);
+        setChoice(playerA, "Summon: Choco/Mog");
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        // 2/2 attack + 1/1 saga's boost + 1/0 counter remove boost
+        assertCounterCount(playerA, "Summon: Choco/Mog", CounterType.LORE, 0);
+        assertLife(playerB, 20 - 2 - 1 - 1);
+    }
+
+    @Test
+    public void test_Targets_2() {
+        // 2/2
+        // Whenever Garnet attacks, you may remove a lore counter from each of any number of Sagas you control.
+        // Put a +1/+1 counter on Garnet for each lore counter removed this way.
+        addCard(Zone.BATTLEFIELD, playerA, "Garnet, Princess of Alexandria");
+        //
+        // (As this Saga enters and after your draw step, add a lore counter. Sacrifice after IV.)
+        // I, II, III, IV -- Stampede! -- Other creatures you control get +1/+0 until end of turn.
+        addCard(Zone.HAND, playerA, "Summon: Choco/Mog", 2); // {2}{W}
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3 * 2);
+
+        // prepare x2 sagas
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Summon: Choco/Mog");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Summon: Choco/Mog");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        // can select 2 targets
+        attack(1, playerA, "Garnet, Princess of Alexandria", playerB);
+        setChoice(playerA, "Summon: Choco/Mog", 2); // x2 targets
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        // 2/2 attack + x2 1/1 saga's boost + x2 1/0 counter remove boost
+        assertCounterCount(playerA, "Summon: Choco/Mog", CounterType.LORE, 0);
+        assertLife(playerB, 20 - 2 - 2 - 2);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/grn/WandOfVertebraeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/grn/WandOfVertebraeTest.java
@@ -27,13 +27,13 @@ public class WandOfVertebraeTest extends CardTestPlayerBase {
         addCard(Zone.BATTLEFIELD, playerA, wandOfVertebrae);
         addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
         addCard(Zone.GRAVEYARD, playerA, lavaCoil);
-
-        setStrictChooseMode(true);
+        addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears", 10);
 
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}, {T}");
         addTarget(playerA, lavaCoil);
         addTarget(playerA, TestPlayer.TARGET_SKIP); // must choose 1 of 5
 
+        setStrictChooseMode(true);
         setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/gtc/DiluvianPrimordialTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/gtc/DiluvianPrimordialTest.java
@@ -20,9 +20,9 @@ public class DiluvianPrimordialTest extends CardTestPlayerBase {
      */
     private static final String primordial = "Diluvian Primordial";
 
-    // Bug: NPE on casting Valakut Awakening
     @Test
     public void test_MDFC() {
+        // possible bug: NPE on casting Valakut Awakening
         setStrictChooseMode(true);
 
         addCard(Zone.HAND, playerA, primordial);
@@ -32,7 +32,7 @@ public class DiluvianPrimordialTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, primordial);
         addTarget(playerA, "Valakut Awakening");
         setChoice(playerA, true); // Yes to "You may"
-        setChoice(playerA, TestPlayer.CHOICE_SKIP); // No choice for Awakening's effect
+        //setChoice(playerA, TestPlayer.CHOICE_SKIP); // no need in skip, cause no valid choices for Awakening's effect
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/lcc/RipplesOfPotentialTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/lcc/RipplesOfPotentialTest.java
@@ -4,6 +4,7 @@ import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.counters.CounterType;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -32,9 +33,10 @@ public class RipplesOfPotentialTest extends CardTestPlayerBase {
         setChoice(playerA, "Blast Zone^Arcbound Javelineer^Chandra, Pyromaster^Atraxa's Skitterfang");
         // Phase out choice
         setChoice(playerA, "Blast Zone^Arcbound Javelineer^Chandra, Pyromaster");
+        setChoice(playerA, TestPlayer.CHOICE_SKIP); // keep Atraxa's Skitterfang
+        setChoice(playerA, false); // Atraxa's Skitterfang ability - do not remove oil
 
         setStrictChooseMode(true);
-        setChoice(playerA, false); // Atraxa's Skitterfang ability
         setStopAt(1, PhaseStep.END_TURN);
         execute();
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/BreakingOfTheFellowshipTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/BreakingOfTheFellowshipTest.java
@@ -1,0 +1,83 @@
+package org.mage.test.cards.single.ltr;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ * @author JayDi85
+ */
+
+public class BreakingOfTheFellowshipTest extends CardTestPlayerBaseWithAIHelps {
+
+    @Test
+    public void test_PossibleTargets() {
+        // Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
+        addCard(Zone.HAND, playerA, "Breaking of the Fellowship"); // {1}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        //
+        addCard(Zone.HAND, playerB, "Grizzly Bears"); // 2/2, {1}{G}
+        addCard(Zone.HAND, playerB, "Spectral Bears"); // 3/3, {1}{G}
+        addCard(Zone.BATTLEFIELD, playerB, "Forest", 2 * 2);
+
+        // turn 1 - no targets, can't play
+        checkPlayableAbility("no targets - can't cast", 2, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Breaking of the Fellowship", false);
+
+        // turn 3 - 1 of 2 targets, can't play
+        castSpell(3 - 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Grizzly Bears");
+        checkPlayableAbility("1 of 2 targets - can't cast", 3, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Breaking of the Fellowship", false);
+
+        // turn 5 - 2 of 2 targets, can play
+        castSpell(5 - 1, PhaseStep.PRECOMBAT_MAIN, playerB, "Spectral Bears");
+        checkPlayableAbility("2 of 2 targets - can cast", 5, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Breaking of the Fellowship", true);
+
+        castSpell(5, PhaseStep.PRECOMBAT_MAIN, playerA, "Breaking of the Fellowship", "Grizzly Bears^Spectral Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(5, PhaseStep.END_TURN);
+        execute();
+
+        assertDamageReceived(playerB, "Spectral Bears", 2);
+    }
+
+    @Test
+    public void test_Normal_AI() {
+        // Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
+        addCard(Zone.HAND, playerA, "Breaking of the Fellowship"); // {1}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        //
+        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears"); // 2/2
+        addCard(Zone.BATTLEFIELD, playerB, "Spectral Bears"); // 3/3
+
+        // AI must choose 3/3 to kill 2/2
+        aiPlayStep(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Grizzly Bears", 1);
+    }
+
+    @Test
+    public void test_Protection_AI() {
+        // Target creature an opponent controls deals damage equal to its power to another target creature that player controls.
+        addCard(Zone.HAND, playerA, "Breaking of the Fellowship"); // {1}{R}
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+        //
+        addCard(Zone.BATTLEFIELD, playerB, "Grizzly Bears"); // 2/2
+        addCard(Zone.BATTLEFIELD, playerB, "Spectral Bears"); // 3/3
+        addCard(Zone.BATTLEFIELD, playerB, "Lavinia of the Tenth"); // 4/4, Protection from red
+
+        // can't choose 4/4 to kill 3/3 due protection from red
+        // AI must choose 3/3 to kill 2/2
+        aiPlayStep(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, "Grizzly Bears", 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/GlamdringTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ltr/GlamdringTest.java
@@ -2,6 +2,7 @@ package org.mage.test.cards.single.ltr;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -29,14 +30,16 @@ public class GlamdringTest extends CardTestPlayerBase {
 
         attack(1, playerA, "Blur Sliver");
         setChoice(playerA, "In Garruk's Wake"); // 9 mana, so we shouldn't be able to choose it
-        setChoice(playerA, "Yes");
 
         try {
             setStopAt(1, PhaseStep.FIRST_COMBAT_DAMAGE);
             execute();
         }
         catch (AssertionError e) {
-            assert(e.getMessage().contains("Missing CHOICE def for turn 1, step FIRST_COMBAT_DAMAGE, PlayerA"));
+            Assert.assertTrue(
+                    "catch wrong exception: " + e.getMessage(),
+                    e.getMessage().contains("Found wrong choice command") && e.getMessage().contains("In Garruk's Wake")
+            );
             return;
         }
         fail("Was able to pick [[In Garruk's Wake]] but it costs more than 2");

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m21/EnthrallingHoldTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m21/EnthrallingHoldTest.java
@@ -10,6 +10,14 @@ public class EnthrallingHoldTest extends CardTestPlayerBase {
     @Test
     public void testTappedTarget_untapped_doesNotFizzle() {
         // Traxos, Scourge of Kroog enters the battlefield tapped and doesn't untap during your untap step.
+
+        // The middle ability of Enthralling Hold affects only the choice of target as the spell is cast.
+        // If the creature becomes untapped before the spell resolves, it still resolves. If a player is
+        // allowed to change the spell's target while it's on the stack, they may choose an untapped
+        // creature. If you put Enthralling Hold onto the battlefield without casting it, you may attach
+        // it to an untapped creature.
+        // (2020-06-23)
+
         addCard(Zone.BATTLEFIELD, playerB, "Traxos, Scourge of Kroog");
 
         addCard(Zone.BATTLEFIELD, playerA, "Island", 6);
@@ -26,10 +34,11 @@ public class EnthrallingHoldTest extends CardTestPlayerBase {
          */
         addCard(Zone.HAND, playerA, "Twiddle");
 
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Enthralling Hold", "Traxos, Scourge of Kroog");
-        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Twiddle", "Traxos, Scourge of Kroog");
-
-        setChoice(playerA, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Enthralling Hold");
+        addTarget(playerA, "Traxos, Scourge of Kroog");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Twiddle");
+        addTarget(playerA, "Traxos, Scourge of Kroog");
+        setChoice(playerA, true); // untap traxos
 
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_COMBAT);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/BarrowgoyfTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/m3c/BarrowgoyfTest.java
@@ -100,7 +100,6 @@ public class BarrowgoyfTest extends CardTestPlayerBase {
 
         attack(1, playerA, barrowgoyf, playerB);
         setChoice(playerA, true);
-        setChoice(playerA, TestPlayer.CHOICE_SKIP); // decide to not return. There was no choice anyway.
 
         setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/IzzetGeneratoriumTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/IzzetGeneratoriumTest.java
@@ -6,6 +6,7 @@ import mage.counters.CounterType;
 import mage.players.Player;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -82,6 +83,7 @@ public class IzzetGeneratoriumTest extends CardTestPlayerBase {
         checkPlayableAbility("1: condition not met before losing counters", 2, PhaseStep.UPKEEP, playerA, "{T}: Draw", false);
         castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Final Act");
         setModeChoice(playerB, "5"); // each opponent loses all counters.
+        setModeChoice(playerB, TestPlayer.MODE_SKIP);
         waitStackResolved(2, PhaseStep.PRECOMBAT_MAIN);
         runCode("energy counter is 0", 2, PhaseStep.PRECOMBAT_MAIN, playerA, (info, player, game) -> checkEnergyCount(info, player, 0));
         checkPlayableAbility("2: condition met after losing counters", 2, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Draw", true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/NethergoyfTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh3/NethergoyfTest.java
@@ -183,6 +183,7 @@ public class NethergoyfTest extends CardTestPlayerBaseWithAIHelps {
         // The same is true for permanent spells you control and nonland permanent cards you own that aren’t on the battlefield.
         addCard(Zone.HAND, playerA, "Encroaching Mycosynth");
 
+        // AI must be able to choose good targets combination
         aiPlayStep(1, PhaseStep.PRECOMBAT_MAIN, playerA);
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mkm/KayaSpiritsJusticeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mkm/KayaSpiritsJusticeTest.java
@@ -1,9 +1,13 @@
 package org.mage.test.cards.single.mkm;
 
+import mage.abilities.Mode;
+import mage.abilities.effects.common.ExileAllEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -21,6 +25,11 @@ public class KayaSpiritsJusticeTest extends CardTestPlayerBase {
         addCard(Zone.GRAVEYARD, playerA, "Fyndhorn Elves");
         addCard(Zone.HAND, playerA, "Thraben Inspector");
         addCard(Zone.HAND, playerA, "Astrid Peth");
+        // Choose one or more —
+        // • Exile all artifacts.
+        // • Exile all creatures.
+        // • Exile all enchantments.
+        // • Exile all graveyards.
         addCard(Zone.HAND, playerA, "Farewell");
 
         // Creates a Clue token
@@ -35,6 +44,7 @@ public class KayaSpiritsJusticeTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Farewell");
         setModeChoice(playerA, "2");
         setModeChoice(playerA, "4");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, 1);
 
         // Kaya's first ability triggers twice, so choose which is put on the stack:

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mom/InvasionOfFioraTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mom/InvasionOfFioraTest.java
@@ -1,6 +1,7 @@
 package org.mage.test.cards.single.mom;
 
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 import mage.constants.PhaseStep;
@@ -47,6 +48,7 @@ public class InvasionOfFioraTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, invasion);
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, 1);
         setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, 1);
 
         checkPermanentCount("Battle on battlefield", 1, PhaseStep.PRECOMBAT_MAIN, playerA, invasion, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/targets/TargetsSelectionBaseTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/targets/TargetsSelectionBaseTest.java
@@ -54,11 +54,10 @@ public class TargetsSelectionBaseTest extends CardTestPlayerBaseWithAIHelps {
         checkHandCardCount("prepare", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Swamp", availableCardsCount);
         checkExileCount("prepare", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Swamp", 0);
 
+        // cause minTarget = 0, so ability can be activated at any time
+        checkPlayableAbility("can activate on any targets", 1, PhaseStep.PRECOMBAT_MAIN, playerA, startingText, true);
         if (availableCardsCount > 0) {
-            checkPlayableAbility("can activate on non-zero targets", 1, PhaseStep.PRECOMBAT_MAIN, playerA, startingText, true);
             activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, startingText);
-        } else {
-            checkPlayableAbility("can't activate on zero targets", 1, PhaseStep.PRECOMBAT_MAIN, playerA, startingText, false);
         }
 
         if (chooseCardsCount > 0) {
@@ -74,7 +73,8 @@ public class TargetsSelectionBaseTest extends CardTestPlayerBaseWithAIHelps {
             // - 2 of 3 - yes
             // - 3 of 3 - no, it's auto-finish on last select
             // - 3 of 5 - no, it's auto-finish on last select
-            if (chooseCardsCount < maxTarget) {
+            int maxPossibleChoose = Math.min(availableCardsCount, maxTarget);
+            if (chooseCardsCount < maxPossibleChoose) {
                 addTarget(playerA, TestPlayer.TARGET_SKIP);
             }
         } else {
@@ -128,20 +128,18 @@ public class TargetsSelectionBaseTest extends CardTestPlayerBaseWithAIHelps {
                 targetCards.add("Swamp");
             });
             setChoice(playerA, String.join("^", targetCards));
-        } else {
-            // need skip
-            // on 0 cards there are must be dialog with done button anyway
+        }
 
-            // end selection:
-            // - x of 0 - yes
-            // - 1 of 3 - yes
-            // - 2 of 3 - yes
-            // - 3 of 3 - no, it's auto-finish on last select
-            // - 3 of 5 - no, it's auto-finish on last select
-            if (chooseCardsCount < maxTarget) {
-                setChoice(playerA, TestPlayer.CHOICE_SKIP);
-            }
-
+        // choose skip
+        // end selection condition:
+        // - x of 0 - yes
+        // - 1 of 3 - yes
+        // - 2 of 3 - yes
+        // - 3 of 3 - no, it's auto-finish on last select
+        // - 3 of 5 - no, it's auto-finish on last select and nothing to choose
+        int canSelectCount = Math.min(maxTarget, availableCardsCount);
+        if (canSelectCount > 0 && chooseCardsCount < canSelectCount) {
+            setChoice(playerA, TestPlayer.CHOICE_SKIP);
         }
 
         if (DEBUG_ENABLE_DETAIL_LOGS) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/BecomesTargetTriggerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/BecomesTargetTriggerTest.java
@@ -7,6 +7,7 @@ import mage.constants.Zone;
 import mage.counters.CounterType;
 import mage.filter.Filter;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -478,6 +479,7 @@ public class BecomesTargetTriggerTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, hostility);
         setModeChoice(playerA, "1");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, protector);
 
         setStrictChooseMode(true);
@@ -502,6 +504,7 @@ public class BecomesTargetTriggerTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, hostility);
         setModeChoice(playerA, "2");
+        setModeChoice(playerA, TestPlayer.MODE_SKIP);
         addTarget(playerA, dragon);
 
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/EnterLeaveBattlefieldExileTargetTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/EnterLeaveBattlefieldExileTargetTest.java
@@ -24,7 +24,6 @@ public class EnterLeaveBattlefieldExileTargetTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Angel of Serenity");
         addTarget(playerA, "Silvercoat Lion^Pillarfield Ox");
-        addTarget(playerA, TestPlayer.TARGET_SKIP);
         setChoice(playerA, true);
 
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/dialogs/TestableDialogsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/dialogs/TestableDialogsTest.java
@@ -6,6 +6,7 @@ import mage.abilities.effects.common.InfoEffect;
 import mage.abilities.effects.common.continuous.PlayAdditionalLandsAllEffect;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.util.ConsoleUtil;
 import mage.utils.testers.TestableDialog;
 import mage.utils.testers.TestableDialogsRunner;
 import org.junit.Assert;
@@ -107,7 +108,7 @@ public class TestableDialogsTest extends CardTestPlayerBaseWithAIHelps {
     @Test
     @Ignore // debug only - run single dialog by reg number
     public void test_RunSingle_Debugging() {
-        int needRegNumber = 557;
+        int needRegNumber = 5;
 
         prepareCards();
 
@@ -233,15 +234,15 @@ public class TestableDialogsTest extends CardTestPlayerBaseWithAIHelps {
             if (resAssert == null) {
                 totalUnknown++;
                 status = "?";
-                coloredTexts.put("?", asYellow("?"));
+                coloredTexts.put("?", ConsoleUtil.asYellow("?"));
             } else if (resAssert.isEmpty()) {
                 totalGood++;
                 status = "OK";
-                coloredTexts.put("OK", asGreen("OK"));
+                coloredTexts.put("OK", ConsoleUtil.asGreen("OK"));
             } else {
                 totalBad++;
                 status = "FAIL";
-                coloredTexts.put("FAIL", asRed("FAIL"));
+                coloredTexts.put("FAIL", ConsoleUtil.asRed("FAIL"));
                 assertError = resAssert;
             }
             if (!assertError.isEmpty()) {
@@ -256,8 +257,8 @@ public class TestableDialogsTest extends CardTestPlayerBaseWithAIHelps {
             // print dialog error
             if (!assertError.isEmpty()) {
                 coloredTexts.clear();
-                coloredTexts.put(resAssert, asRed(resAssert));
-                coloredTexts.put(resDebugSource, asRed(resDebugSource));
+                coloredTexts.put(resAssert, ConsoleUtil.asRed(resAssert));
+                coloredTexts.put(resDebugSource, ConsoleUtil.asRed(resDebugSource));
                 String badAssert = getColoredRow(totalsRightFormat, coloredTexts, resAssert);
                 String badDebugSource = getColoredRow(totalsRightFormat, coloredTexts, resDebugSource);
                 if (firstBadDialog == null) {
@@ -283,15 +284,15 @@ public class TestableDialogsTest extends CardTestPlayerBaseWithAIHelps {
         String badStats = String.format("%d bad", totalBad);
         String unknownStats = String.format("%d unknown", totalUnknown);
         coloredTexts.clear();
-        coloredTexts.put(goodStats, String.format("%s good", asGreen(String.valueOf(totalGood))));
-        coloredTexts.put(badStats, String.format("%s bad", asRed(String.valueOf(totalBad))));
-        coloredTexts.put(unknownStats, String.format("%s unknown", asYellow(String.valueOf(totalUnknown))));
+        coloredTexts.put(goodStats, String.format("%s good", ConsoleUtil.asGreen(String.valueOf(totalGood))));
+        coloredTexts.put(badStats, String.format("%s bad", ConsoleUtil.asRed(String.valueOf(totalBad))));
+        coloredTexts.put(unknownStats, String.format("%s unknown", ConsoleUtil.asYellow(String.valueOf(totalUnknown))));
         System.out.print(getColoredRow(totalsLeftFormat, coloredTexts, String.format("Total results: %s, %s, %s",
                 goodStats, badStats, unknownStats)));
         // first error for fast access in big list
         if (totalDialogs > 1 && firstBadDialog != null) {
             System.out.println(horizontalBorder);
-            System.out.print(getColoredRow(totalsRightFormat, coloredTexts, "First bad dialog: " + firstBadDialog.getRegNumber()));
+            System.out.print(getColoredRow(totalsRightFormat, coloredTexts, "First bad dialog: " + firstBadDialog.getRegNumber() + " (debug it by test_RunSingle_Debugging)"));
             System.out.print(getColoredRow(totalsRightFormat, coloredTexts, firstBadDialog.getName() + " - " + firstBadDialog.getDescription()));
             System.out.print(firstBadAssert);
             System.out.print(firstBadDebugSource);
@@ -312,17 +313,5 @@ public class TestableDialogsTest extends CardTestPlayerBaseWithAIHelps {
             line = line.replace(coloredText, coloredTexts.get(coloredText));
         }
         return line;
-    }
-
-    private String asRed(String text) {
-        return "\u001B[31m" + text + "\u001B[0m";
-    }
-
-    private String asGreen(String text) {
-        return "\u001B[32m" + text + "\u001B[0m";
-    }
-
-    private String asYellow(String text) {
-        return "\u001B[33m" + text + "\u001B[0m";
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
+++ b/Mage.Tests/src/test/java/org/mage/test/serverside/base/impl/CardTestPlayerAPIImpl.java
@@ -1706,6 +1706,11 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
     private void assertAllCommandsUsed() throws AssertionError {
         for (Player player : currentGame.getPlayers().values()) {
             TestPlayer testPlayer = (TestPlayer) player;
+
+            if (testPlayer.isSkipAllNextChooseCommands()) {
+                Assert.fail(testPlayer.getName() + " used skip next choose commands, but game do not call any choose dialog after it. Skip must be removed after debug.");
+            }
+
             assertActionsMustBeEmpty(testPlayer);
             assertChoicesCount(testPlayer, 0);
             assertTargetsCount(testPlayer, 0);
@@ -2008,7 +2013,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      * @param step
      * @param player
      * @param cardName
-     * @param targetName for modes you can add "mode=3" before target name;
+     * @param targetName for non default mode you can add target by "mode=3target_name" style;
      *                   multiple targets can be separated by ^;
      *                   no target marks as TestPlayer.NO_TARGET;
      *                   warning, do not support cards with target adjusters - use addTarget instead
@@ -2315,6 +2320,7 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
      *               spell mode can be used only once like Demonic Pact, the
      *               value has to be set to the number of the remaining modes
      *               (e.g. if only 2 are left the number need to be 1 or 2).
+     *               If you need to partly select then use TestPlayer.MODE_SKIP
      */
     public void setModeChoice(TestPlayer player, String choice) {
         player.addModeChoice(choice);
@@ -2437,6 +2443,26 @@ public abstract class CardTestPlayerAPIImpl extends MageTestPlayerBase implement
 
     protected void skipInitShuffling() {
         gameOptions.skipInitShuffling = true;
+    }
+
+    /**
+     * Debug only: skip all choose commands after that command.
+     * <p>
+     * Alternative to comment/uncomment all test commands:
+     * - insert skip before first choice command;
+     * - run test and look at error message about miss choice;
+     * - make sure test use correct choice;
+     * - move skip command to next test's choice and repeat;
+     */
+    protected void skipAllNextChooseCommands() {
+        playerA.skipAllNextChooseCommands();
+        playerB.skipAllNextChooseCommands();
+        if (playerC != null) {
+            playerC.skipAllNextChooseCommands();
+        }
+        if (playerD != null) {
+            playerD.skipAllNextChooseCommands();
+        }
     }
 
     public void assertDamageReceived(Player player, String cardName, int expected) {

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -1227,7 +1227,7 @@ public abstract class AbilityImpl implements Ability {
             boolean validTargets = true;
             for (Target target : mode.getTargets()) {
                 UUID abilityControllerId = target.getAffectedAbilityControllerId(controllerId);
-                if (!target.canChoose(abilityControllerId, ability, game)) {
+                if (!target.canChooseOrAlreadyChosen(abilityControllerId, ability, game)) {
                     validTargets = false;
                     break;
                 }

--- a/Mage/src/main/java/mage/abilities/Mode.java
+++ b/Mage/src/main/java/mage/abilities/Mode.java
@@ -130,4 +130,9 @@ public class Mode implements Serializable {
     public int getPawPrintValue() {
         return pawPrintValue;
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s", this.getEffects().getText(this));
+    }
 }

--- a/Mage/src/main/java/mage/abilities/common/AttachableToRestrictedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/AttachableToRestrictedAbility.java
@@ -1,33 +1,43 @@
 package mage.abilities.common;
 
-import mage.abilities.Ability;
 import mage.abilities.effects.common.InfoEffect;
+import mage.constants.TargetController;
 import mage.constants.Zone;
+import mage.filter.predicate.Predicate;
+import mage.filter.predicate.Predicates;
 import mage.game.Game;
 import mage.target.Target;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public class AttachableToRestrictedAbility extends SimpleStaticAbility {
+
     private final Target attachable;
+
     public AttachableToRestrictedAbility(Target target) {
         super(Zone.BATTLEFIELD, new InfoEffect("{this} can be attached only to a " + target.getTargetName()));
         this.attachable = target.copy();
+
+        // verify check: make sure filter don't have controller predicate cause it used in code without controller info
+        List<Predicate> list = new ArrayList<>();
+        Predicates.collectAllComponents(target.getFilter().getPredicates(), target.getFilter().getExtraPredicates(), list);
+        if (list.stream().anyMatch(TargetController.ControllerPredicate.class::isInstance)) {
+            throw new IllegalArgumentException("Wrong code usage: attachable restriction filter must not contain controller predicate");
+        }
     }
 
     private AttachableToRestrictedAbility(AttachableToRestrictedAbility ability) {
         super(ability);
-        this.attachable = ability.attachable; // Since we never modify the target, we don't need to re-copy it
+        this.attachable = ability.attachable.copy();
     }
 
-    public boolean canEquip(UUID toEquip, Ability source, Game game) {
-        if (source == null) {
-            return attachable.canTarget(toEquip, game);
-        } else return attachable.canTarget(toEquip, source, game);
+    public boolean canEquip(UUID toEquip, Game game) {
+        return attachable.canTarget(toEquip, null, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/Cost.java
+++ b/Mage/src/main/java/mage/abilities/costs/Cost.java
@@ -19,8 +19,19 @@ public interface Cost extends Serializable, Copyable<Cost> {
     /**
      * Check is it possible to pay
      * For mana it checks only single color and amount available, not total mana cost
+     * <p>
+     * Warning, if you want to use canChoose, then don't forget about already selected targets (important for AI sims).
      */
     boolean canPay(Ability ability, Ability source, UUID controllerId, Game game);
+
+    /**
+     * Simple canPay logic implementation with targets - cost has possible targets or already selected it, e.g. by AI sims
+     * <p>
+     * Do not override
+     */
+    default boolean canChooseOrAlreadyChosen(Ability ability, Ability source, UUID controllerId, Game game) {
+        return this.getTargets().stream().allMatch(target -> target.isChosen(game) || target.canChoose(controllerId, source, game));
+    }
 
     boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana);
 

--- a/Mage/src/main/java/mage/abilities/costs/common/DiscardTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/DiscardTargetCost.java
@@ -70,7 +70,7 @@ public class DiscardTargetCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/ExileFromGraveCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ExileFromGraveCost.java
@@ -120,7 +120,7 @@ public class ExileFromGraveCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/ExileFromHandCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ExileFromHandCost.java
@@ -82,7 +82,7 @@ public class ExileFromHandCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/ExileTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ExileTargetCost.java
@@ -68,7 +68,7 @@ public class ExileTargetCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCardFromHandOnTopOfLibraryCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCardFromHandOnTopOfLibraryCost.java
@@ -32,8 +32,7 @@ public class PutCardFromHandOnTopOfLibraryCost extends CostImpl {
         TargetCardInHand targetCardInHand = new TargetCardInHand();
         targetCardInHand.setRequired(false);
         Card card;
-        if (targetCardInHand.canChoose(controllerId, source, game)
-                && controller.choose(Outcome.PreventDamage, targetCardInHand, source, game)) {
+        if (controller.choose(Outcome.PreventDamage, targetCardInHand, source, game)) {
             card = game.getCard(targetCardInHand.getFirstTarget());
             paid = card != null && controller.moveCardToLibraryWithInfo(card, source, game, Zone.HAND, true, true);
         }

--- a/Mage/src/main/java/mage/abilities/costs/common/PutCountersTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/PutCountersTargetCost.java
@@ -58,6 +58,6 @@ public class PutCountersTargetCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 }

--- a/Mage/src/main/java/mage/abilities/costs/common/RemoveCounterCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/RemoveCounterCost.java
@@ -159,7 +159,7 @@ public class RemoveCounterCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     private String setText() {

--- a/Mage/src/main/java/mage/abilities/costs/common/ReturnToHandChosenControlledPermanentCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ReturnToHandChosenControlledPermanentCost.java
@@ -71,7 +71,7 @@ public class ReturnToHandChosenControlledPermanentCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/ReturnToHandFromGraveyardCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ReturnToHandFromGraveyardCost.java
@@ -52,7 +52,7 @@ public class ReturnToHandFromGraveyardCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/RevealTargetFromHandCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/RevealTargetFromHandCost.java
@@ -89,7 +89,7 @@ public class RevealTargetFromHandCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return allowNoReveal || this.getTargets().canChoose(controllerId, source, game);
+        return allowNoReveal || canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/costs/common/TapTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/TapTargetCost.java
@@ -69,7 +69,7 @@ public class TapTargetCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     public TargetControlledPermanent getTarget() {

--- a/Mage/src/main/java/mage/abilities/costs/common/UntapTargetCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/UntapTargetCost.java
@@ -63,7 +63,7 @@ public class UntapTargetCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/ConvokedSourceCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/ConvokedSourceCount.java
@@ -20,7 +20,7 @@ public enum ConvokedSourceCount implements DynamicValue {
 
     @Override
     public int calculate(Game game, Ability sourceAbility, Effect effect) {
-        return CardUtil.getSourceCostsTag(game, sourceAbility, ConvokeAbility.convokingCreaturesKey, new HashSet<>(0)).size();
+        return CardUtil.getSourceCostsTag(game, sourceAbility, ConvokeAbility.convokingCreaturesKey, new HashSet<>()).size();
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/effects/common/SacrificeOpponentsUnlessPayEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/SacrificeOpponentsUnlessPayEffect.java
@@ -74,8 +74,7 @@ public class SacrificeOpponentsUnlessPayEffect extends OneShotEffect {
 
                 if (game.getBattlefield().count(TargetSacrifice.makeFilter(filter), player.getId(), source, game) > 0) {
                     TargetSacrifice target = new TargetSacrifice(1, filter);
-                    if (target.canChoose(player.getId(), source, game)) {
-                        player.choose(Outcome.Sacrifice, target, source, game);
+                    if (player.choose(Outcome.Sacrifice, target, source, game)) {
                         permsToSacrifice.addAll(target.getTargets());
                     }
                 }

--- a/Mage/src/main/java/mage/abilities/effects/common/discard/LookTargetHandChooseDiscardEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/discard/LookTargetHandChooseDiscardEffect.java
@@ -7,6 +7,7 @@ import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardsImpl;
 import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
 import mage.game.Game;
@@ -60,7 +61,7 @@ public class LookTargetHandChooseDiscardEffect extends OneShotEffect {
             }
             return true;
         }
-        TargetCard target = new TargetCardInHand(upTo ? 0 : num, num, filter);
+        TargetCard target = new TargetCard(upTo ? 0 : num, num, Zone.HAND, filter);
         if (controller.choose(Outcome.Discard, player.getHand(), target, source, game)) {
             // TODO: must fizzle discard effect on not full choice
             // - tests: affected (allow to choose and discard 1 instead 2)

--- a/Mage/src/main/java/mage/abilities/keyword/ChampionAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ChampionAbility.java
@@ -160,7 +160,7 @@ class ChampionExileCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/keyword/CraftAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CraftAbility.java
@@ -115,7 +115,7 @@ class CraftCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return target.canChoose(controllerId, source, game);
+        return target.canChooseOrAlreadyChosen(controllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/keyword/NinjutsuAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/NinjutsuAbility.java
@@ -171,7 +171,7 @@ class ReturnAttackerToHandTargetCost extends CostImpl {
 
     @Override
     public boolean canPay(Ability ability, Ability source, UUID controllerId, Game game) {
-        return this.getTargets().canChoose(controllerId, source, game);
+        return canChooseOrAlreadyChosen(ability, source, controllerId, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/collectors/DataCollector.java
+++ b/Mage/src/main/java/mage/collectors/DataCollector.java
@@ -2,6 +2,7 @@ package mage.collectors;
 
 import mage.game.Game;
 import mage.game.Table;
+import mage.players.Player;
 
 import java.util.UUID;
 
@@ -11,10 +12,12 @@ import java.util.UUID;
  * Supported features:
  * - [x] collect and print game logs in server output, including unit tests
  * - [x] collect and save full games history and decks
- * - [ ] collect and print performance metrics like ApplyEffects calc time or inform players time (pings)
- * - [ ] collect and send metrics to third party tools like prometheus + grafana
- * - [ ] prepare "attachable" game data for bug reports
- * - [ ] record game replays data (GameView history)
+ * - [ ] TODO: collect and print performance metrics like ApplyEffects calc time or inform players time (pings)
+ * - [ ] TODO: collect and send metrics to third party tools like prometheus + grafana
+ * - [x] tests: print used selections (choices, targets, modes, skips) TODO: add yes/no, replacement effect, coins, other choices
+ * - [ ] TODO: tests: print additional info like current resolve ability?
+ * - [ ] TODO: prepare "attachable" game data for bug reports
+ * - [ ] TODO: record game replays data (GameView history)
  * <p>
  * How-to enable or disable:
  * - use java params like -Dxmage.dataCollectors.saveGameHistory=true
@@ -62,7 +65,27 @@ public interface DataCollector {
     void onChatTable(UUID tableId, String userName, String message);
 
     /**
-     * @param gameId chat sessings don't have full game access, so use onGameStart event to find game's ID before chat
+     * @param gameId chat session don't have full game access, so use onGameStart event to find game's ID before chat
      */
     void onChatGame(UUID gameId, String userName, String message);
+
+    /**
+     * Tests only: on any non-target choice like yes/no, mode, etc
+     */
+    void onTestsChoiceUse(Game game, Player player, String usingChoice, String reason);
+
+    /**
+     * Tests only: on any target choice
+     */
+    void onTestsTargetUse(Game game, Player player, String usingTarget, String reason);
+
+    /**
+     * Tests only: on push object to stack (calls before activate and make any choice/announce)
+     */
+    void onTestsStackPush(Game game);
+
+    /**
+     * Tests only: on stack object resolve (calls before starting resolve)
+     */
+    void onTestsStackResolve(Game game);
 }

--- a/Mage/src/main/java/mage/collectors/DataCollectorServices.java
+++ b/Mage/src/main/java/mage/collectors/DataCollectorServices.java
@@ -4,6 +4,7 @@ import mage.collectors.services.PrintGameLogsDataCollector;
 import mage.collectors.services.SaveGameHistoryDataCollector;
 import mage.game.Game;
 import mage.game.Table;
+import mage.players.Player;
 import org.apache.log4j.Logger;
 
 import java.util.LinkedHashSet;
@@ -139,5 +140,29 @@ final public class DataCollectorServices implements DataCollector {
     @Override
     public void onChatGame(UUID gameId, String userName, String message) {
         activeServices.forEach(c -> c.onChatGame(gameId, userName, message));
+    }
+
+    @Override
+    public void onTestsChoiceUse(Game game, Player player, String usingChoice, String reason) {
+        if (game.isSimulation()) return;
+        activeServices.forEach(c -> c.onTestsChoiceUse(game, player, usingChoice, reason));
+    }
+
+    @Override
+    public void onTestsTargetUse(Game game, Player player, String usingTarget, String reason) {
+        if (game.isSimulation()) return;
+        activeServices.forEach(c -> c.onTestsTargetUse(game, player, usingTarget, reason));
+    }
+
+    @Override
+    public void onTestsStackPush(Game game) {
+        if (game.isSimulation()) return;
+        activeServices.forEach(c -> c.onTestsStackPush(game));
+    }
+
+    @Override
+    public void onTestsStackResolve(Game game) {
+        if (game.isSimulation()) return;
+        activeServices.forEach(c -> c.onTestsStackResolve(game));
     }
 }

--- a/Mage/src/main/java/mage/collectors/services/EmptyDataCollector.java
+++ b/Mage/src/main/java/mage/collectors/services/EmptyDataCollector.java
@@ -3,6 +3,7 @@ package mage.collectors.services;
 import mage.collectors.DataCollector;
 import mage.game.Game;
 import mage.game.Table;
+import mage.players.Player;
 
 import java.util.UUID;
 
@@ -65,6 +66,26 @@ public abstract class EmptyDataCollector implements DataCollector {
 
     @Override
     public void onChatGame(UUID gameId, String userName, String message) {
+        // nothing
+    }
+
+    @Override
+    public void onTestsChoiceUse(Game game, Player player, String usingChoice, String reason) {
+        // nothing
+    }
+
+    @Override
+    public void onTestsTargetUse(Game game, Player player, String usingTarget, String reason) {
+        // nothing
+    }
+
+    @Override
+    public void onTestsStackPush(Game game) {
+        // nothing
+    }
+
+    @Override
+    public void onTestsStackResolve(Game game) {
         // nothing
     }
 }

--- a/Mage/src/main/java/mage/collectors/services/PrintGameLogsDataCollector.java
+++ b/Mage/src/main/java/mage/collectors/services/PrintGameLogsDataCollector.java
@@ -1,7 +1,9 @@
 package mage.collectors.services;
 
 import mage.game.Game;
+import mage.players.Player;
 import mage.util.CardUtil;
+import mage.util.ConsoleUtil;
 import org.apache.log4j.Logger;
 import org.jsoup.Jsoup;
 
@@ -40,9 +42,47 @@ public class PrintGameLogsDataCollector extends EmptyDataCollector {
     @Override
     public void onGameLog(Game game, String message) {
         String needMessage = Jsoup.parse(message).text();
-        writeLog("GAME", "LOG", String.format("%s: %s",
+        writeLog("LOG", "GAME", String.format("%s: %s",
                 CardUtil.getTurnInfo(game),
                 needMessage
+        ));
+    }
+
+    @Override
+    public void onTestsChoiceUse(Game game, Player player, String choice, String reason) {
+        String needReason = Jsoup.parse(reason).text();
+        writeLog("LOG", "GAME", ConsoleUtil.asYellow(String.format("%s: %s using choice: %s%s",
+                CardUtil.getTurnInfo(game),
+                player.getName(),
+                choice,
+                reason.isEmpty() ? "" : " (" + needReason + ")"
+        )));
+    }
+
+    @Override
+    public void onTestsTargetUse(Game game, Player player, String target, String reason) {
+        String needReason = Jsoup.parse(reason).text();
+        writeLog("LOG", "GAME", ConsoleUtil.asYellow(String.format("%s: %s using target: %s%s",
+                CardUtil.getTurnInfo(game),
+                player.getName(),
+                target,
+                reason.isEmpty() ? "" : " (" + needReason + ")"
+        )));
+    }
+
+    @Override
+    public void onTestsStackPush(Game game) {
+        writeLog("LOG", "GAME", String.format("%s: Stack push: %s",
+                CardUtil.getTurnInfo(game),
+                game.getStack().toString()
+        ));
+    }
+
+    @Override
+    public void onTestsStackResolve(Game game) {
+        writeLog("LOG", "GAME", String.format("%s: Stack resolve: %s",
+                CardUtil.getTurnInfo(game),
+                game.getStack().toString()
         ));
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/ConvokedSourcePredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/ConvokedSourcePredicate.java
@@ -17,7 +17,7 @@ public enum ConvokedSourcePredicate implements ObjectSourcePlayerPredicate<Perma
     instance;
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
-        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>(0));
+        HashSet<MageObjectReference> set = CardUtil.getSourceCostsTag(game, input.getSource(), ConvokeAbility.convokingCreaturesKey, new HashSet<>());
         return set.contains(new MageObjectReference(input.getObject(), game));
     }
 }

--- a/Mage/src/main/java/mage/game/Game.java
+++ b/Mage/src/main/java/mage/game/Game.java
@@ -162,7 +162,7 @@ public interface Game extends MageItem, Serializable, Copyable<Game> {
     // Result must be checked for null. Possible errors search pattern: (\S*) = game.getPlayer.+\n(?!.+\1 != null)
     Player getPlayer(UUID playerId);
 
-    Player getPlayerOrPlaneswalkerController(UUID playerId);
+    Player getPlayerOrPlaneswalkerController(UUID targetId);
 
     /**
      * Static players list from start of the game. Use it to find player by ID or in game engine.

--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -412,12 +412,12 @@ public abstract class GameImpl implements Game {
     }
 
     @Override
-    public Player getPlayerOrPlaneswalkerController(UUID playerId) {
-        Player player = getPlayer(playerId);
+    public Player getPlayerOrPlaneswalkerController(UUID targetId) {
+        Player player = getPlayer(targetId);
         if (player != null) {
             return player;
         }
-        Permanent permanent = getPermanent(playerId);
+        Permanent permanent = getPermanent(targetId);
         if (permanent == null) {
             return null;
         }
@@ -1841,6 +1841,7 @@ public abstract class GameImpl implements Game {
         boolean wasError = false;
         try {
             top = state.getStack().peek();
+            DataCollectorServices.getInstance().onTestsStackResolve(this);
             top.resolve(this);
             resetControlAfterSpellResolve(top.getId());
         } catch (Throwable e) {
@@ -2819,7 +2820,7 @@ public abstract class GameImpl implements Game {
                     if (attachedTo != null) {
                         for (Ability ability : perm.getAbilities(this)) {
                             if (ability instanceof AttachableToRestrictedAbility) {
-                                if (!((AttachableToRestrictedAbility) ability).canEquip(attachedTo.getId(), null, this)) {
+                                if (!((AttachableToRestrictedAbility) ability).canEquip(attachedTo.getId(), this)) {
                                     attachedTo = null;
                                     break;
                                 }

--- a/Mage/src/main/java/mage/game/ZonesHandler.java
+++ b/Mage/src/main/java/mage/game/ZonesHandler.java
@@ -253,9 +253,9 @@ public final class ZonesHandler {
                             spell = new Spell(card, card.getSpellAbility().copy(), card.getOwnerId(), event.getFromZone(), game);
                         }
                         spell.syncZoneChangeCounterOnStack(card, game);
-                        game.getStack().push(spell);
                         game.getState().setZone(spell.getId(), Zone.STACK);
                         game.getState().setZone(card.getId(), Zone.STACK);
+                        game.getStack().push(game, spell);
                     }
                     break;
                 case BATTLEFIELD:

--- a/Mage/src/main/java/mage/game/command/dungeons/TombOfAnnihilationDungeon.java
+++ b/Mage/src/main/java/mage/game/command/dungeons/TombOfAnnihilationDungeon.java
@@ -189,27 +189,21 @@ class OublietteTarget extends TargetSacrifice {
     }
 
     @Override
-    public boolean canTarget(UUID playerId, UUID id, Ability ability, Game game) {
-        if (!super.canTarget(playerId, id, ability, game)) {
-            return false;
-        }
-        Permanent permanent = game.getPermanent(id);
-        if (permanent == null) {
-            return false;
-        }
-        if (this.getTargets().isEmpty()) {
-            return true;
-        }
-        Cards cards = new CardsImpl(this.getTargets());
-        cards.add(permanent);
-        return cardTypeAssigner.getRoleCount(cards, game) >= cards.size();
-    }
-
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        possibleTargets.removeIf(uuid -> !this.canTarget(sourceControllerId, uuid, source, game));
+
+        // only valid roles
+        Cards existingTargets = new CardsImpl(this.getTargets());
+        possibleTargets.removeIf(id -> {
+            Permanent permanent = game.getPermanent(id);
+            if (permanent == null) {
+                return true;
+            }
+            Cards newTargets = existingTargets.copy();
+            newTargets.add(permanent);
+            return cardTypeAssigner.getRoleCount(newTargets, game) < newTargets.size();
+        });
+
         return possibleTargets;
     }
 

--- a/Mage/src/main/java/mage/game/events/TargetEvent.java
+++ b/Mage/src/main/java/mage/game/events/TargetEvent.java
@@ -12,24 +12,21 @@ import java.util.UUID;
 public class TargetEvent extends GameEvent {
 
     /**
-     * @param target
-     * @param sourceId
      * @param sourceControllerId can be different from real controller (example: ability instructs another player to targeting)
      */
     public TargetEvent(Card target, UUID sourceId, UUID sourceControllerId) {
-        super(GameEvent.EventType.TARGET, target.getId(), null, sourceControllerId);
-        this.setSourceId(sourceId);
+        this(target.getId(), sourceId, sourceControllerId);
     }
 
     public TargetEvent(Player target, UUID sourceId, UUID sourceControllerId) {
-        super(GameEvent.EventType.TARGET, target.getId(), null, sourceControllerId);
+        this(target.getId(), sourceId, sourceControllerId);
+    }
+
+    public TargetEvent(UUID targetId, UUID sourceId, UUID sourceControllerId) {
+        super(GameEvent.EventType.TARGET, targetId, null, sourceControllerId);
         this.setSourceId(sourceId);
     }
 
-    /**
-     * @param targetId
-     * @param source
-     */
     public TargetEvent(UUID targetId, Ability source) {
         super(GameEvent.EventType.TARGET, targetId, source, source.getControllerId());
     }

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -42,7 +42,11 @@ public class Spell extends StackObjectImpl implements Card {
 
     private final List<SpellAbility> spellAbilities = new ArrayList<>();
 
+    // this.card.getSpellAbility() - blueprint ability with zero selected targets
+    // this.ability - real casting ability with selected targets
+    // so if you need to check targets on cast then try to use "Ability source" param first (e.g. aura legality on etb)
     private final Card card;
+
     private ManaCosts<ManaCost> manaCost;
     private final ObjectColor color;
     private final ObjectColor frameColor;
@@ -1157,7 +1161,7 @@ public class Spell extends StackObjectImpl implements Card {
             applier.modifySpell(spellCopy, game);
         }
         spellCopy.setZone(Zone.STACK, game);  // required for targeting ex: Nivmagus Elemental
-        game.getStack().push(spellCopy);
+        game.getStack().push(game, spellCopy);
 
         // new targets
         if (newTargetFilterPredicate != null) {

--- a/Mage/src/main/java/mage/game/stack/SpellStack.java
+++ b/Mage/src/main/java/mage/game/stack/SpellStack.java
@@ -3,6 +3,7 @@ package mage.game.stack;
 
 import mage.MageObject;
 import mage.abilities.Ability;
+import mage.collectors.DataCollectorServices;
 import mage.constants.PutCards;
 import mage.constants.Zone;
 import mage.game.Game;
@@ -136,9 +137,16 @@ public class SpellStack extends ArrayDeque<StackObject> {
     }
 
     @Override
+    @Deprecated // must use only full version with game param
     public void push(StackObject e) {
         super.push(e);
         this.dateLastAdded = new Date();
+    }
+
+    public void push(Game game, StackObject e) {
+        super.push(e);
+        this.dateLastAdded = new Date();
+        DataCollectorServices.getInstance().onTestsStackPush(game);
     }
 
     public Date getDateLastAdded() {

--- a/Mage/src/main/java/mage/game/stack/StackAbility.java
+++ b/Mage/src/main/java/mage/game/stack/StackAbility.java
@@ -744,7 +744,7 @@ public class StackAbility extends StackObjectImpl implements Ability {
         newAbility.setControllerId(newControllerId);
 
         StackAbility newStackAbility = new StackAbility(newAbility, newControllerId);
-        game.getStack().push(newStackAbility);
+        game.getStack().push(game, newStackAbility);
 
         // new targets
         if (newTargetFilterPredicate != null) {

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -1231,10 +1231,6 @@ public interface Player extends MageItem, Copyable<Player> {
 
     /**
      * Only used for test player for pre-setting targets
-     *
-     * @param ability
-     * @param game
-     * @return
      */
     boolean addTargets(Ability ability, Game game);
 

--- a/Mage/src/main/java/mage/players/StubPlayer.java
+++ b/Mage/src/main/java/mage/players/StubPlayer.java
@@ -43,7 +43,7 @@ public class StubPlayer extends PlayerImpl {
         if (target instanceof TargetPlayer) {
             for (Player player : game.getPlayers().values()) {
                 if (player.getId().equals(getId())
-                        && target.canTarget(getId(), game)
+                        && target.canTarget(getId(), source, game)
                         && !target.contains(getId())) {
                     target.add(player.getId(), game);
                     return true;

--- a/Mage/src/main/java/mage/target/Target.java
+++ b/Mage/src/main/java/mage/target/Target.java
@@ -1,11 +1,13 @@
 package mage.target;
 
+import mage.MageObject;
 import mage.abilities.Ability;
 import mage.cards.Cards;
 import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.Filter;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.util.Copyable;
 
@@ -27,10 +29,24 @@ public interface Target extends Copyable<Target>, Serializable {
      * Warning, for "up to" targets it will return true all the time, so make sure your dialog
      * use do-while logic and call "choose" one time min or use isChoiceCompleted
      */
-    @Deprecated // TODO: replace with UUID abilityControllerId, Ability source, Game game
+    @Deprecated
+    // TODO: replace with UUID abilityControllerId, Ability source, Game game
     boolean isChosen(Game game);
 
-    boolean isChoiceCompleted(UUID abilityControllerId, Ability source, Game game);
+    /**
+     * Checking target complete and nothing to choose (X=0, all selected, all possible selected, etc)
+     *
+     * @param fromCards can be null for non cards selection
+     */
+    boolean isChoiceCompleted(UUID abilityControllerId, Ability source, Game game, Cards fromCards);
+
+    /**
+     * Temporary status to work with "up to" targets (mark target that it was skip on selection)
+     * TODO: remove after target.chooseXXX remove
+     */
+    boolean isSkipChoice();
+
+    void setSkipChoice(boolean isSkipChoice);
 
     void clearChosen();
 
@@ -51,16 +67,50 @@ public interface Target extends Copyable<Target>, Serializable {
      */
     Target withNotTarget(boolean notTarget);
 
-    // methods for targets
+    /**
+     * Checks if there are enough targets the player can choose from among them
+     * or if they are autochosen since there are fewer than the minimum number.
+     * <p>
+     * Implement as return canChooseFromPossibleTargets(sourceControllerId, source, game);
+     * TODO: remove after all canChoose replaced with default
+     *
+     * @param sourceControllerId - controller of the target event source
+     * @param source             - can be null
+     * @param game
+     * @return - true if enough valid choices exist
+     */
     boolean canChoose(UUID sourceControllerId, Ability source, Game game);
 
     /**
+     * Make sure target can be fully selected or already selected, e.g. by AI sims
+     * <p>
+     * Do not override
+     */
+    default boolean canChooseOrAlreadyChosen(UUID sourceControllerId, Ability source, Game game) {
+        return this.isChosen(game) || this.canChoose(sourceControllerId, source, game);
+    }
+
+    default boolean canChooseFromPossibleTargets(UUID sourceControllerId, Ability source, Game game) {
+        // TODO: replace all canChoose override methods by that code call
+        if (getMinNumberOfTargets() == 0) {
+            return true;
+        }
+
+        int selectedCount = getSize();
+        int moreSelectCount = possibleTargets(sourceControllerId, source, game).size();
+
+        if (selectedCount >= getMaxNumberOfTargets()) {
+            return false;
+        }
+
+        return moreSelectCount > 0 && selectedCount + moreSelectCount >= getMinNumberOfTargets();
+    }
+
+    /**
      * Returns a set of all possible targets that match the criteria of the implemented Target class.
+     * WARNING, it must filter already selected targets by keepValidPossibleTargets call at the end
      *
-     * @param sourceControllerId UUID of the ability's controller
-     * @param source             Ability which requires the targets
-     * @param game               Current game
-     * @return Set of the UUIDs of possible targets
+     * @param source - can be null
      */
     Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game);
 
@@ -68,6 +118,42 @@ public interface Target extends Copyable<Target>, Serializable {
         // do not override
         return possibleTargets(sourceControllerId, source, game).stream()
                 .filter(id -> cards == null || cards.contains(id))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Keep only valid and not selected targets - must be used inside any possibleTargets implementation
+     */
+    default Set<UUID> keepValidPossibleTargets(Set<UUID> possibleTargets, UUID sourceControllerId, Ability source, Game game) {
+        // TODO: check target amount in human dialogs - is it allow to select it again
+        // do not override
+        // keep only valid and not selected targets list
+        return possibleTargets.stream()
+                .filter(this::notContains)
+                .filter(targetId -> {
+                    // non-target allow any
+                    if (source == null || source.getSourceId() == null || isNotTarget()) {
+                        return true;
+                    }
+                    MageObject sourceObject = game.getObject(source);
+                    if (sourceObject == null) {
+                        return true;
+                    }
+
+                    // target allow non-protected
+                    Player targetPlayer = game.getPlayer(targetId);
+                    if (targetPlayer != null) {
+                        return !targetPlayer.hasLeft()
+                                && canTarget(sourceControllerId, targetId, source, game)
+                                && targetPlayer.canBeTargetedBy(sourceObject, sourceControllerId, source, game);
+                    }
+                    Permanent targetPermanent = game.getPermanent(targetId);
+                    if (targetPermanent != null) {
+                        return canTarget(sourceControllerId, targetId, source, game)
+                                && targetPermanent.canBeTargetedBy(sourceObject, sourceControllerId, source, game);
+                    }
+                    return true;
+                })
                 .collect(Collectors.toSet());
     }
 
@@ -86,8 +172,6 @@ public interface Target extends Copyable<Target>, Serializable {
     void addTarget(UUID id, Ability source, Game game, boolean skipEvent);
 
     void addTarget(UUID id, int amount, Ability source, Game game, boolean skipEvent);
-
-    boolean canTarget(UUID id, Game game);
 
     /**
      * @param id
@@ -108,11 +192,12 @@ public interface Target extends Copyable<Target>, Serializable {
      */
     List<? extends Target> getTargetOptions(Ability source, Game game);
 
-    boolean canChoose(UUID sourceControllerId, Game game);
+    default boolean canChoose(UUID sourceControllerId, Game game) {
+        return canChoose(sourceControllerId, null, game);
+    }
 
-    Set<UUID> possibleTargets(UUID sourceControllerId, Game game);
-
-    @Deprecated // TODO: need replace to source only version?
+    @Deprecated
+        // TODO: need replace to source only version?
     boolean choose(Outcome outcome, UUID playerId, UUID sourceId, Ability source, Game game);
 
     /**
@@ -235,6 +320,11 @@ public interface Target extends Copyable<Target>, Serializable {
     int getSize();
 
     boolean contains(UUID targetId);
+
+    default boolean notContains(UUID targetId) {
+        // for better usage in streams
+        return !contains(targetId);
+    }
 
     /**
      * This function tries to auto-choose the next target.

--- a/Mage/src/main/java/mage/target/TargetAmount.java
+++ b/Mage/src/main/java/mage/target/TargetAmount.java
@@ -5,6 +5,7 @@ import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.dynamicvalue.common.StaticValue;
 import mage.cards.Card;
+import mage.cards.Cards;
 import mage.constants.Outcome;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
@@ -68,7 +69,7 @@ public abstract class TargetAmount extends TargetImpl {
     }
 
     @Override
-    public boolean isChoiceCompleted(UUID abilityControllerId, Ability source, Game game) {
+    public boolean isChoiceCompleted(UUID abilityControllerId, Ability source, Game game, Cards fromCards) {
         // make sure target request called one time minimum (for "up to" targets)
         // choice is selected after any addTarget call (by test, AI or human players)
         if (!isChoiceSelected()) {
@@ -78,6 +79,11 @@ public abstract class TargetAmount extends TargetImpl {
         // make sure selected targets are valid
         if (!isChosen(game)) {
             return false;
+        }
+
+        // already selected
+        if (this.getSize() >= getMaxNumberOfTargets()) {
+            return true;
         }
 
         // TODO: need auto-choose here? See super
@@ -178,7 +184,7 @@ public abstract class TargetAmount extends TargetImpl {
             chosen = isChosen(game);
 
             // stop by full complete
-            if (isChoiceCompleted(targetController.getId(), source, game)) {
+            if (isChoiceCompleted(targetController.getId(), source, game, null)) {
                 break;
             }
 

--- a/Mage/src/main/java/mage/target/TargetCard.java
+++ b/Mage/src/main/java/mage/target/TargetCard.java
@@ -1,6 +1,5 @@
 package mage.target;
 
-import mage.MageItem;
 import mage.abilities.Ability;
 import mage.cards.Card;
 import mage.cards.Cards;
@@ -56,196 +55,9 @@ public class TargetCard extends TargetObject {
         return this;
     }
 
-    /**
-     * Checks if there are enough {@link Card} that can be selected.
-     *
-     * @param sourceControllerId - controller of the select event
-     * @param game
-     * @return - true if enough valid {@link Card} exist
-     */
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        return canChoose(sourceControllerId, null, game);
-    }
-
-    /**
-     * Checks if there are enough {@link Card cards} in the appropriate zone that the player can choose from among them
-     * or if they are autochosen since there are fewer than the minimum number.
-     *
-     * @param sourceControllerId - controller of the target event source
-     * @param source
-     * @param game
-     * @return - true if enough valid {@link Card} exist
-     */
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        int possibleTargets = 0;
-        if (getMinNumberOfTargets() == 0) { // if 0 target is valid, the canChoose is always true
-            return true;
-        }
-        for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            Player player = game.getPlayer(playerId);
-            if (player != null) {
-                if (this.minNumberOfTargets == 0) {
-                    return true;
-                }
-                switch (zone) {
-                    case HAND:
-                        possibleTargets += countPossibleTargetInHand(game, player, sourceControllerId, source,
-                                filter, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-                        break;
-                    case GRAVEYARD:
-                        possibleTargets += countPossibleTargetInGraveyard(game, player, sourceControllerId, source,
-                                filter, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-                        break;
-                    case LIBRARY:
-                        possibleTargets += countPossibleTargetInLibrary(game, player, sourceControllerId, source,
-                                filter, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-                        break;
-                    case EXILED:
-                        possibleTargets += countPossibleTargetInExile(game, player, sourceControllerId, source,
-                                filter, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-                        break;
-                    case COMMAND:
-                        possibleTargets += countPossibleTargetInCommandZone(game, player, sourceControllerId, source,
-                                filter, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-                        break;
-                    case ALL:
-                        possibleTargets += countPossibleTargetInAnyZone(game, player, sourceControllerId, source,
-                                filter, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-                        break;
-                    default:
-                        throw new IllegalArgumentException("Unsupported TargetCard zone: " + zone);
-                }
-                if (possibleTargets >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * count up to N possible target cards in a player's hand matching the filter
-     */
-    protected static int countPossibleTargetInHand(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget, int countUpTo) {
-        UUID sourceId = source != null ? source.getSourceId() : null;
-        int possibleTargets = 0;
-        for (Card card : player.getHand().getCards(filter, sourceControllerId, source, game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                possibleTargets++;
-                if (possibleTargets >= countUpTo) {
-                    return possibleTargets; // early return for faster computation.
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    /**
-     * count up to N possible target cards in a player's graveyard matching the filter
-     */
-    protected static int countPossibleTargetInGraveyard(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget, int countUpTo) {
-        UUID sourceId = source != null ? source.getSourceId() : null;
-        int possibleTargets = 0;
-        for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                possibleTargets++;
-                if (possibleTargets >= countUpTo) {
-                    return possibleTargets; // early return for faster computation.
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    /**
-     * count up to N possible target cards in a player's library matching the filter
-     */
-    protected static int countPossibleTargetInLibrary(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget, int countUpTo) {
-        UUID sourceId = source != null ? source.getSourceId() : null;
-        int possibleTargets = 0;
-        for (Card card : player.getLibrary().getUniqueCards(game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                if (filter.match(card, game)) {
-                    possibleTargets++;
-                    if (possibleTargets >= countUpTo) {
-                        return possibleTargets; // early return for faster computation.
-                    }
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    /**
-     * count up to N possible target cards in a player's exile matching the filter
-     */
-    protected static int countPossibleTargetInExile(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget, int countUpTo) {
-        UUID sourceId = source != null ? source.getSourceId() : null;
-        int possibleTargets = 0;
-        for (Card card : game.getExile().getPermanentExile().getCards(game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                if (filter.match(card, player.getId(), source, game)) {
-                    possibleTargets++;
-                    if (possibleTargets >= countUpTo) {
-                        return possibleTargets; // early return for faster computation.
-                    }
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    /**
-     * count up to N possible target cards in a player's command zone matching the filter
-     */
-    protected static int countPossibleTargetInCommandZone(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget, int countUpTo) {
-        UUID sourceId = source != null ? source.getSourceId() : null;
-        int possibleTargets = 0;
-        List<Card> possibleCards = game.getCommandersIds(player, CommanderCardType.ANY, false).stream()
-                .map(game::getCard)
-                .filter(Objects::nonNull)
-                .filter(card -> game.getState().getZone(card.getId()).equals(Zone.COMMAND))
-                .filter(card -> filter.match(card, sourceControllerId, source, game))
-                .collect(Collectors.toList());
-        for (Card card : possibleCards) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                possibleTargets++;
-                if (possibleTargets >= countUpTo) {
-                    return possibleTargets; // early return for faster computation.
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    /**
-     * count up to N possible target cards in ANY zone
-     */
-    protected static int countPossibleTargetInAnyZone(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget, int countUpTo) {
-        UUID sourceId = source != null ? source.getSourceId() : null;
-        int possibleTargets = 0;
-        for (Card card : game.getCards()) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                if (filter.match(card, game)) {
-                    possibleTargets++;
-                    if (possibleTargets >= countUpTo) {
-                        return possibleTargets; // early return for faster computation.
-                    }
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        return possibleTargets(sourceControllerId, null, game);
-    }
-
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Cards cards, Ability source, Game game) {
-        return cards.getCards(filter, sourceControllerId, source, game).stream().map(MageItem::getId).collect(Collectors.toSet());
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
@@ -278,7 +90,7 @@ public class TargetCard extends TargetObject {
                 }
             }
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     /**
@@ -286,12 +98,8 @@ public class TargetCard extends TargetObject {
      */
     protected static Set<UUID> getAllPossibleTargetInHand(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget) {
         Set<UUID> possibleTargets = new HashSet<>();
-        UUID sourceId = source != null ? source.getSourceId() : null;
         for (Card card : player.getHand().getCards(filter, sourceControllerId, source, game)) {
-            // TODO: Why for sourceId == null?
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                possibleTargets.add(card.getId());
-            }
+            possibleTargets.add(card.getId());
         }
         return possibleTargets;
     }
@@ -301,11 +109,8 @@ public class TargetCard extends TargetObject {
      */
     protected static Set<UUID> getAllPossibleTargetInGraveyard(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget) {
         Set<UUID> possibleTargets = new HashSet<>();
-        UUID sourceId = source != null ? source.getSourceId() : null;
         for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                possibleTargets.add(card.getId());
-            }
+            possibleTargets.add(card.getId());
         }
         return possibleTargets;
     }
@@ -315,12 +120,9 @@ public class TargetCard extends TargetObject {
      */
     protected static Set<UUID> getAllPossibleTargetInLibrary(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget) {
         Set<UUID> possibleTargets = new HashSet<>();
-        UUID sourceId = source != null ? source.getSourceId() : null;
         for (Card card : player.getLibrary().getUniqueCards(game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                if (filter.match(card, sourceControllerId, source, game)) {
-                    possibleTargets.add(card.getId());
-                }
+            if (filter.match(card, sourceControllerId, source, game)) {
+                possibleTargets.add(card.getId());
             }
         }
         return possibleTargets;
@@ -332,11 +134,9 @@ public class TargetCard extends TargetObject {
     protected static Set<UUID> getAllPossibleTargetInExile(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget) {
         Set<UUID> possibleTargets = new HashSet<>();
         UUID sourceId = source != null ? source.getSourceId() : null;
-        for (Card card : game.getExile().getPermanentExile().getCards(game)) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                if (filter.match(card, sourceControllerId, source, game)) {
-                    possibleTargets.add(card.getId());
-                }
+        for (Card card : game.getExile().getAllCardsByRange(game, sourceControllerId)) {
+            if (filter.match(card, sourceControllerId, source, game)) {
+                possibleTargets.add(card.getId());
             }
         }
         return possibleTargets;
@@ -367,31 +167,21 @@ public class TargetCard extends TargetObject {
      */
     protected static Set<UUID> getAllPossibleTargetInAnyZone(Game game, Player player, UUID sourceControllerId, Ability source, FilterCard filter, boolean isNotTarget) {
         Set<UUID> possibleTargets = new HashSet<>();
-        UUID sourceId = source != null ? source.getSourceId() : null;
         for (Card card : game.getCards()) {
-            if (sourceId == null || isNotTarget || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                if (filter.match(card, sourceControllerId, source, game)) {
-                    possibleTargets.add(card.getId());
-                }
+            if (filter.match(card, sourceControllerId, source, game)) {
+                possibleTargets.add(card.getId());
             }
         }
         return possibleTargets;
     }
 
-    // TODO: check all class targets, if it override canTarget then make sure it override ALL 3 METHODS with canTarget and possibleTargets (method with cards doesn't need)
-
     @Override
-    public boolean canTarget(UUID id, Game game) {
+    public boolean canTarget(UUID id, Ability source, Game game) {
         // copy-pasted from super but with card instead object
         Card card = game.getCard(id);
         return card != null
                 && zone != null && zone.match(game.getState().getZone(id))
                 && getFilter() != null && getFilter().match(card, game);
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        return canTarget(id, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/TargetObject.java
+++ b/Mage/src/main/java/mage/target/TargetObject.java
@@ -50,13 +50,9 @@ public abstract class TargetObject extends TargetImpl {
     /**
      * Warning, don't use with non card objects here like commanders/emblems/etc. If you want it then
      * override canTarget in your own target.
-     *
-     * @param id
-     * @param game
-     * @return
      */
     @Override
-    public boolean canTarget(UUID id, Game game) {
+    public boolean canTarget(UUID id, Ability source, Game game) {
         MageObject object = game.getObject(id);
         return object != null
                 && zone != null && zone.match(game.getState().getZone(id))
@@ -64,13 +60,7 @@ public abstract class TargetObject extends TargetImpl {
     }
 
     @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        return canTarget(id, game);
-    }
-
-    @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         return canTarget(id, source, game);
     }
-
 }

--- a/Mage/src/main/java/mage/target/TargetPlayer.java
+++ b/Mage/src/main/java/mage/target/TargetPlayer.java
@@ -51,82 +51,21 @@ public class TargetPlayer extends TargetImpl {
         return filter;
     }
 
-    /**
-     * Checks if there are enough {@link Player} that can be chosen. Should only
-     * be used for Ability targets since this checks for protection, shroud etc.
-     *
-     * @param sourceControllerId - controller of the target event source
-     * @param source
-     * @param game
-     * @return - true if enough valid {@link Player} exist
-     */
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        int count = 0;
-        MageObject targetSource = game.getObject(source);
-        for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            Player player = game.getPlayer(playerId);
-            if (player != null && !player.hasLeft() && filter.match(player, sourceControllerId, source, game)) {
-                if (player.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                    count++;
-                    if (count >= this.minNumberOfTargets) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Checks if there are enough {@link Player} that can be selected. Should
-     * not be used for Ability targets since this does not check for protection,
-     * shroud etc.
-     *
-     * @param sourceControllerId - controller of the select event
-     * @param game
-     * @return - true if enough valid {@link Player} exist
-     */
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        int count = 0;
-        for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            Player player = game.getPlayer(playerId);
-            if (player != null && !player.hasLeft() && filter.match(player, game)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
-        MageObject targetSource = game.getObject(source);
         for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
             Player player = game.getPlayer(playerId);
-            if (player != null && !player.hasLeft() && filter.match(player, sourceControllerId, source, game)) {
-                if (isNotTarget() || player.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                    possibleTargets.add(playerId);
-                }
-            }
-        }
-        return possibleTargets;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        Set<UUID> possibleTargets = new HashSet<>();
-        for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            Player player = game.getPlayer(playerId);
-            if (player != null && !player.hasLeft() && filter.match(player, game)) {
+            if (player != null && filter.match(player, sourceControllerId, source, game)) {
                 possibleTargets.add(playerId);
             }
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
@@ -136,12 +75,6 @@ public class TargetPlayer extends TargetImpl {
             return true; // 0 targets selected is valid
         }
         return targets.keySet().stream().anyMatch(playerId -> canTarget(playerId, source, game));
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Game game) {
-        Player player = game.getPlayer(id);
-        return filter.match(player, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/TargetSource.java
+++ b/Mage/src/main/java/mage/target/TargetSource.java
@@ -90,62 +90,8 @@ public class TargetSource extends TargetObject {
     }
 
     @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        return canChoose(sourceControllerId, (Ability) null, game);
-    }
-
-    @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        int count = 0;
-        for (StackObject stackObject : game.getStack()) {
-            if (game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
-                    && filter.match(stackObject, sourceControllerId, source, game)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(sourceControllerId, game)) {
-            if (filter.match(permanent, sourceControllerId, source, game)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        for (Player player : game.getPlayers().values()) {
-            for (Card card : player.getGraveyard().getCards(game)) {
-                if (filter.match(card, sourceControllerId, source, game)) {
-                    count++;
-                    if (count >= this.minNumberOfTargets) {
-                        return true;
-                    }
-                }
-            }
-        }
-        for (Card card : game.getExile().getAllCards(game)) {
-            if (filter.match(card, sourceControllerId, source, game)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        for (CommandObject commandObject : game.getState().getCommand()) {
-            if (filter.match(commandObject, sourceControllerId, source, game)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        return possibleTargets(sourceControllerId, (Ability) null, game);
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
@@ -179,7 +125,8 @@ public class TargetSource extends TargetObject {
                 possibleTargets.add(commandObject.getId());
             }
         }
-        return possibleTargets;
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/TargetStackObject.java
+++ b/Mage/src/main/java/mage/target/TargetStackObject.java
@@ -56,22 +56,7 @@ public class TargetStackObject extends TargetObject {
 
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        int count = 0;
-        for (StackObject stackObject : game.getStack()) {
-            if (game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
-                    && filter.match(stackObject, sourceControllerId, source, game)) {
-                count++;
-                if (count >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        return canChoose(sourceControllerId, null, game);
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
@@ -83,12 +68,7 @@ public class TargetStackObject extends TargetObject {
                 possibleTargets.add(stackObject.getId());
             }
         }
-        return possibleTargets;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        return this.possibleTargets(sourceControllerId, null, game);
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetActivatedAbility.java
+++ b/Mage/src/main/java/mage/target/common/TargetActivatedAbility.java
@@ -54,38 +54,21 @@ public class TargetActivatedAbility extends TargetObject {
 
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        return canChoose(sourceControllerId, game);
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        for (StackObject stackObject : game.getStack()) {
-            if (stackObject.getStackAbility() != null
-                    && stackObject.getStackAbility().isActivatedAbility()
-                    && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId())
-            ) {
-                return true;
-            }
-        }
-        return false;
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        return possibleTargets(sourceControllerId, game);
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
         for (StackObject stackObject : game.getStack()) {
             if (stackObject.getStackAbility().isActivatedAbility()
                     && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getStackAbility().getControllerId())
-                    && filter.match(stackObject, game)) {
+                    && filter.match(stackObject,sourceControllerId, source, game)
+                    && this.notContains(stackObject.getId())) {
                 possibleTargets.add(stackObject.getStackAbility().getId());
             }
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardAndOrCardInLibrary.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardAndOrCardInLibrary.java
@@ -14,7 +14,6 @@ import mage.filter.predicate.mageobject.NamePredicate;
 import mage.game.Game;
 import mage.util.CardUtil;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -72,47 +71,22 @@ public class TargetCardAndOrCardInLibrary extends TargetCardInLibrary {
     }
 
     @Override
-    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(playerId, id, source, game)) {
-            return false;
-        }
-        Card card = game.getCard(id);
-        if (card == null) {
-            return false;
-        }
-        if (this.getTargets().isEmpty()) {
-            return true;
-        }
-        Cards cards = new CardsImpl(this.getTargets());
-        cards.add(card);
-        return assignment.getRoleCount(cards, game) >= cards.size();
-    }
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game);
-        // assuming max targets = 2, need to expand this code if not
-        Card card = game.getCard(this.getFirstTarget());
-        if (card == null) {
-            return possibleTargets; // no further restriction if no target yet chosen
-        }
-        Cards cards = new CardsImpl(card);
-        if (assignment.getRoleCount(cards, game) == 2) {
-            // if the first chosen target is both types, no further restriction
-            return possibleTargets;
-        }
-        Set<UUID> leftPossibleTargets = new HashSet<>();
-        for (UUID possibleId : possibleTargets) {
-            Card possibleCard = game.getCard(possibleId);
-            Cards checkCards = cards.copy();
-            checkCards.add(possibleCard);
-            if (assignment.getRoleCount(checkCards, game) == 2) {
-                // if the possible target and the existing target have both types, it's legal
-                // but this prevents the case of both targets with the same type
-                leftPossibleTargets.add(possibleId);
+
+        // only valid roles
+        Cards existingTargets = new CardsImpl(this.getTargets());
+        possibleTargets.removeIf(id -> {
+            Card card = game.getCard(id);
+            if (card == null) {
+                return true;
             }
-        }
-        return leftPossibleTargets;
+            Cards newTargets = existingTargets.copy();
+            newTargets.add(card);
+            return assignment.getRoleCount(newTargets, game) < newTargets.size();
+        });
+
+        return possibleTargets;
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInASingleGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInASingleGraveyard.java
@@ -5,7 +5,6 @@ import mage.cards.Card;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.game.Game;
-import mage.game.events.TargetEvent;
 import mage.players.Player;
 import mage.target.TargetCard;
 
@@ -29,70 +28,34 @@ public class TargetCardInASingleGraveyard extends TargetCard {
     }
 
     @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        UUID firstTarget = this.getFirstTarget();
-
-        // If a card is already targeted, ensure that this new target has the same owner as currently chosen target
-        if (firstTarget != null) {
-            Card card = game.getCard(firstTarget);
-            Card targetCard = game.getCard(id);
-            if (card == null || targetCard == null || !card.isOwnedBy(targetCard.getOwnerId())) {
-                return false;
-            }
-        }
-
-        // If it has the same owner (or no target picked) check that it's a valid target with super
-        return super.canTarget(id, source, game);
-    }
-
-    /**
-     * Set of UUIDs of all possible targets
-     *
-     * @param sourceControllerId UUID of the ability's controller
-     * @param source             Ability which requires the targets
-     * @param game               Current game
-     * @return Set of the UUIDs of possible targets
-     */
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
-        UUID sourceId = source != null ? source.getSourceId() : null;
 
-        UUID controllerOfFirstTarget = null;
-
-        // If any targets have been chosen, get the UUID of the owner in order to limit the targets to that owner's graveyard
-        if (!targets.isEmpty()) {
-            for (UUID cardInGraveyardId : targets.keySet()) {
-                Card targetCard = game.getCard(cardInGraveyardId);
-                if (targetCard == null) {
-                    continue;
-                }
-
-                controllerOfFirstTarget = targetCard.getOwnerId();
-                break; // Only need the first UUID since they will all be the same
-            }
-        }
+        Card firstTarget = game.getCard(source.getFirstTarget());
 
         for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            // If the playerId of this iteration is not the same as that of any existing target, then continue
-            // All cards must be from the same player's graveyard.
-            if (controllerOfFirstTarget != null && !playerId.equals(controllerOfFirstTarget)) {
-                continue;
-            }
-
             Player player = game.getPlayer(playerId);
             if (player == null) {
                 continue;
             }
 
-            for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-                // TODO: Why for sourceId == null?
-                if (sourceId == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, sourceId, sourceControllerId))) {
-                    possibleTargets.add(card.getId());
+            if (firstTarget == null) {
+                // playable or not selected
+                // use any player
+            } else {
+                // already selected
+                // use from same player
+                if (!playerId.equals(firstTarget.getOwnerId())) {
+                    continue;
                 }
             }
+
+            for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
+                possibleTargets.add(card.getId());
+            }
         }
-        return possibleTargets;
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInCommandZone.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInCommandZone.java
@@ -46,7 +46,7 @@ public class TargetCardInCommandZone extends TargetCard {
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
-        return this.canTarget(source.getControllerId(), id, source, game);
+        return this.canTarget(source == null ? null : source.getControllerId(), id, source, game);
     }
 
     @Override
@@ -59,30 +59,13 @@ public class TargetCardInCommandZone extends TargetCard {
 
         Cards cards = new CardsImpl(game.getCommanderCardsFromCommandZone(player, CommanderCardType.ANY));
         for (Card card : cards.getCards(filter, sourceControllerId, source, game)) {
-            if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                possibleTargets.add(card.getId());
-            }
+            possibleTargets.add(card.getId());
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        Player player = game.getPlayer(sourceControllerId);
-        if (player == null) {
-            return false;
-        }
-
-        int possibletargets = 0;
-        Cards cards = new CardsImpl(game.getCommanderCardsFromCommandZone(player, CommanderCardType.ANY));
-        for (Card card : cards.getCards(filter, sourceControllerId, source, game)) {
-            if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                possibletargets++;
-                if (possibletargets >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 }

--- a/Mage/src/main/java/mage/target/common/TargetCardInExile.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInExile.java
@@ -12,34 +12,22 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-
 /**
  * @author BetaSteward_at_googlemail.com
  */
 public class TargetCardInExile extends TargetCard {
 
-    // If null, can target any card in exile matching [filter]
-    // If non-null, can only target
-    private final UUID zoneId;
+    private final UUID zoneId; // use null to target any exile zone or only specific
 
-    /**
-     * @param filter filter for the card to be a target
-     */
     public TargetCardInExile(FilterCard filter) {
         this(1, 1, filter);
     }
 
-    /**
-     * @param minNumTargets minimum number of targets
-     * @param maxNumTargets maximum number of targets
-     * @param filter        filter for the card to be a target
-     */
     public TargetCardInExile(int minNumTargets, int maxNumTargets, FilterCard filter) {
         this(minNumTargets, maxNumTargets, filter, null);
     }
 
     /**
-     * @param filter filter for the card to be a target
      * @param zoneId if non-null can only target cards in that exileZone. if null card can be in ever exile zone.
      */
     public TargetCardInExile(FilterCard filter, UUID zoneId) {
@@ -47,10 +35,7 @@ public class TargetCardInExile extends TargetCard {
     }
 
     /**
-     * @param minNumTargets minimum number of targets
-     * @param maxNumTargets maximum number of targets
-     * @param filter        filter for the card to be a target
-     * @param zoneId        if non-null can only target cards in that exileZone. if null card can be in ever exile zone.
+     * @param zoneId if non-null can only target cards in that exileZone. if null card can be in ever exile zone.
      */
     public TargetCardInExile(int minNumTargets, int maxNumTargets, FilterCard filter, UUID zoneId) {
         super(minNumTargets, maxNumTargets, Zone.EXILED, filter);
@@ -65,6 +50,7 @@ public class TargetCardInExile extends TargetCard {
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
+
         if (zoneId == null) { // no specific exile zone
             for (Card card : game.getExile().getAllCardsByRange(game, sourceControllerId)) {
                 if (filter.match(card, sourceControllerId, source, game)) {
@@ -81,40 +67,8 @@ public class TargetCardInExile extends TargetCard {
                 }
             }
         }
-        return possibleTargets;
-    }
 
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        if (zoneId == null) { // no specific exile zone
-            int numberTargets = 0;
-            for (ExileZone exileZone : game.getExile().getExileZones()) {
-                numberTargets += exileZone.count(filter, sourceControllerId, source, game);
-                if (numberTargets >= this.minNumberOfTargets) {
-                    return true;
-                }
-            }
-        } else {
-            ExileZone exileZone = game.getExile().getExileZone(zoneId);
-            return exileZone != null && exileZone.count(filter, sourceControllerId, source, game) >= this.minNumberOfTargets;
-
-        }
-        return false;
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Ability source, Game game) {
-        Card card = game.getCard(id);
-        if (card != null && game.getState().getZone(card.getId()) == Zone.EXILED) {
-            if (zoneId == null) { // no specific exile zone
-                return filter.match(card, source.getControllerId(), source, game);
-            }
-            ExileZone exile = game.getExile().getExileZone(zoneId);
-            if (exile != null && exile.contains(id)) {
-                return filter.match(card, source.getControllerId(), source, game);
-            }
-        }
-        return false;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInGraveyardBattlefieldOrStack.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInGraveyardBattlefieldOrStack.java
@@ -1,6 +1,5 @@
 package mage.target.common;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.constants.ComparisonType;
 import mage.constants.Zone;
@@ -18,7 +17,6 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- *
  * @author LevelX2
  */
 public class TargetCardInGraveyardBattlefieldOrStack extends TargetCard {
@@ -59,28 +57,12 @@ public class TargetCardInGraveyardBattlefieldOrStack extends TargetCard {
 
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        if (super.canChoose(sourceControllerId, source, game)) {
-            return true;
-        }
-        MageObject targetSource = game.getObject(source);
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(filterPermanent, sourceControllerId, source, game)) {
-            if (notTarget || permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                return true;
-            }
-        }
-        for (StackObject stackObject : game.getStack()) {
-            if (stackObject instanceof Spell
-                    && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
-                    && filterSpell.match(stackObject, sourceControllerId, source, game)) {
-                return true;
-            }
-        }
-        return false;
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
-        return this.canTarget(source.getControllerId(), id, source, game);
+        return this.canTarget(source == null ? null : source.getControllerId(), id, source, game);
     }
 
     @Override
@@ -90,31 +72,22 @@ public class TargetCardInGraveyardBattlefieldOrStack extends TargetCard {
         }
         Permanent permanent = game.getPermanent(id);
         if (permanent != null) {
-            return filterPermanent.match(permanent, playerId, source, game);
+            return playerId == null ? filterPermanent.match(permanent, game) : filterPermanent.match(permanent, playerId, source, game);
         }
         Spell spell = game.getSpell(id);
-        return spell != null && filterSpell.match(spell, playerId, source, game);
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Game game) {
-        return this.canTarget(null, id, null, game); // wtf
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        return this.possibleTargets(sourceControllerId, (Ability) null, game);
+        return spell != null && (playerId == null ? filter.match(spell, game) : filterSpell.match(spell, playerId, source, game));
     }
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = super.possibleTargets(sourceControllerId, source, game); // in graveyard first
-        MageObject targetSource = game.getObject(source);
+
+        // from battlefield
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filterPermanent, sourceControllerId, source, game)) {
-            if (notTarget || permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) {
-                possibleTargets.add(permanent.getId());
-            }
+            possibleTargets.add(permanent.getId());
         }
+
+        // from stack
         for (StackObject stackObject : game.getStack()) {
             if (stackObject instanceof Spell
                     && game.getState().getPlayersInRange(sourceControllerId, game).contains(stackObject.getControllerId())
@@ -122,7 +95,8 @@ public class TargetCardInGraveyardBattlefieldOrStack extends TargetCard {
                 possibleTargets.add(stackObject.getId());
             }
         }
-        return possibleTargets;
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInLibrary.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInLibrary.java
@@ -97,7 +97,7 @@ public class TargetCardInLibrary extends TargetCard {
             chosen = isChosen(game);
 
             // stop by full complete
-            if (isChoiceCompleted(abilityControllerId, source, game)) {
+            if (isChoiceCompleted(abilityControllerId, source, game, null)) {
                 break;
             }
 

--- a/Mage/src/main/java/mage/target/common/TargetCardInOpponentsGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInOpponentsGraveyard.java
@@ -71,50 +71,6 @@ public class TargetCardInOpponentsGraveyard extends TargetCard {
     }
 
     @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        return canChoose(sourceControllerId, null, game);
-    }
-
-    /**
-     * Checks if there are enough {@link Card} that can be chosen.
-     *
-     * @param sourceControllerId - controller of the target event source
-     * @param source
-     * @param game
-     * @return - true if enough valid {@link Card} exist
-     */
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        int possibleTargets = 0;
-        if (getMinNumberOfTargets() == 0) { // if 0 target is valid, the canChoose is always true
-            return true;
-        }
-        Player sourceController = game.getPlayer(sourceControllerId);
-        for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            if (!sourceController.hasOpponent(playerId, game)) {
-                continue;
-            }
-            if (this.allFromOneOpponent) {
-                possibleTargets = 0;
-            }
-            if (!playerId.equals(sourceControllerId)) {
-                Player player = game.getPlayer(playerId);
-                if (player != null) {
-                    for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-                        if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                            possibleTargets++;
-                            if (possibleTargets >= this.minNumberOfTargets) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
         Player sourceController = game.getPlayer(sourceControllerId);
@@ -126,9 +82,7 @@ public class TargetCardInOpponentsGraveyard extends TargetCard {
             if (player != null) {
                 Set<UUID> targetsInThisGraveyeard = new HashSet<>();
                 for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-                    if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                        targetsInThisGraveyeard.add(card.getId());
-                    }
+                    targetsInThisGraveyeard.add(card.getId());
                 }
                 // if there is not enough possible targets, the can't be any
                 if (this.allFromOneOpponent && targetsInThisGraveyeard.size() < this.minNumberOfTargets) {
@@ -137,7 +91,7 @@ public class TargetCardInOpponentsGraveyard extends TargetCard {
                 possibleTargets.addAll(targetsInThisGraveyeard);
             }
         }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyard.java
@@ -80,59 +80,9 @@ public class TargetCardInYourGraveyard extends TargetCard {
         Set<UUID> possibleTargets = new HashSet<>();
         Player player = game.getPlayer(sourceControllerId);
         for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-            if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                possibleTargets.add(card.getId());
-            }
+            possibleTargets.add(card.getId());
         }
-        return possibleTargets;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Cards cards, Ability source, Game game) {
-        Set<UUID> possibleTargets = new HashSet<>();
-        Player player = game.getPlayer(sourceControllerId);
-        if (player == null) {
-            return possibleTargets;
-        }
-
-        for (Card card : cards.getCards(filter, sourceControllerId, source, game)) {
-            if (player.getGraveyard().getCards(game).contains(card)) {
-                possibleTargets.add(card.getId());
-            }
-        }
-        return possibleTargets;
-    }
-
-    /**
-     * Checks if there are enough {@link Card} that can be selected.
-     *
-     * @param sourceControllerId - controller of the select event
-     * @param game
-     * @return - true if enough valid {@link Card} exist
-     */
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        return game.getPlayer(sourceControllerId).getGraveyard().count(filter, game) >= this.minNumberOfTargets;
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        Player player = game.getPlayer(sourceControllerId);
-        if (player != null) {
-            if (this.minNumberOfTargets == 0) {
-                return true;
-            }
-            int possibleTargets = 0;
-            for (Card card : player.getGraveyard().getCards(filter, sourceControllerId, source, game)) {
-                if (source == null || source.getSourceId() == null || isNotTarget() || !game.replaceEvent(new TargetEvent(card, source.getSourceId(), sourceControllerId))) {
-                    possibleTargets++;
-                    if (possibleTargets >= this.minNumberOfTargets) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyardOrExile.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyardOrExile.java
@@ -34,46 +34,25 @@ public class TargetCardInYourGraveyardOrExile extends TargetCard {
     }
 
     @Override
-    public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        Player player = game.getPlayer(sourceControllerId);
-        if (player == null) {
-            return false;
-        }
-        int possibleTargets = 0;
-        // in your graveyard:
-        possibleTargets += countPossibleTargetInGraveyard(game, player, sourceControllerId, source,
-                filterGraveyard, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-        if (possibleTargets >= this.minNumberOfTargets) {
-            return true;
-        }
-        // in exile:
-        possibleTargets += countPossibleTargetInExile(game, player, sourceControllerId, source,
-                filterExile, isNotTarget(), this.minNumberOfTargets - possibleTargets);
-        return possibleTargets >= this.minNumberOfTargets;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        return this.possibleTargets(sourceControllerId, (Ability) null, game);
-    }
-
-    @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
         Set<UUID> possibleTargets = new HashSet<>();
+
         Player player = game.getPlayer(sourceControllerId);
         if (player == null) {
             return possibleTargets;
         }
-        // in your graveyard:
+
+        // in your graveyard
         possibleTargets.addAll(getAllPossibleTargetInGraveyard(game, player, sourceControllerId, source, filterGraveyard, isNotTarget()));
-        // in exile:
+        // in exile
         possibleTargets.addAll(getAllPossibleTargetInExile(game, player, sourceControllerId, source, filterExile, isNotTarget()));
-        return possibleTargets;
+
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
-        return this.canTarget(source.getControllerId(), id, source, game);
+        return this.canTarget(source == null ? null : source.getControllerId(), id, source, game);
     }
 
     @Override
@@ -84,17 +63,12 @@ public class TargetCardInYourGraveyardOrExile extends TargetCard {
         }
         switch (game.getState().getZone(id)) {
             case GRAVEYARD:
-                return filterGraveyard.match(card, playerId, source, game);
+                return playerId == null ? filterGraveyard.match(card, game) : filterGraveyard.match(card, playerId, source, game);
             case EXILED:
-                return filterExile.match(card, playerId, source, game);
+                return playerId == null ? filterExile.match(card, game) : filterExile.match(card, playerId, source, game);
             default:
                 return false;
         }
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Game game) {
-        return this.canTarget(null, id, null, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCreaturesWithDifferentPowers.java
+++ b/Mage/src/main/java/mage/target/common/TargetCreaturesWithDifferentPowers.java
@@ -34,8 +34,8 @@ public class TargetCreaturesWithDifferentPowers extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         Permanent creature = game.getPermanent(id);

--- a/Mage/src/main/java/mage/target/common/TargetOpponentsChoicePermanent.java
+++ b/Mage/src/main/java/mage/target/common/TargetOpponentsChoicePermanent.java
@@ -12,6 +12,8 @@ import mage.target.TargetPermanent;
 import java.util.UUID;
 
 /**
+ * TODO: rework to support possible targets
+ *
  * @author Mael
  */
 public class TargetOpponentsChoicePermanent extends TargetPermanent {
@@ -28,20 +30,15 @@ public class TargetOpponentsChoicePermanent extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game, boolean flag) {
-        return opponentId != null && super.canTarget(opponentId, id, source, game, flag);
-    }
-
-    @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Permanent permanent = game.getPermanent(id);
         if (opponentId != null) {
             if (permanent != null) {
                 if (source != null) {
                     boolean canSourceControllerTarget = true;
                     if (!isNotTarget()) {
-                        if (!permanent.canBeTargetedBy(game.getObject(source.getId()), controllerId, source, game)
-                                || !permanent.canBeTargetedBy(game.getObject(source), controllerId, source, game)) {
+                        if (!permanent.canBeTargetedBy(game.getObject(source.getId()), playerId, source, game)
+                                || !permanent.canBeTargetedBy(game.getObject(source), playerId, source, game)) {
                             canSourceControllerTarget = false;
                         }
                     }

--- a/Mage/src/main/java/mage/target/common/TargetPermanentOrPlayer.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentOrPlayer.java
@@ -62,16 +62,6 @@ public class TargetPermanentOrPlayer extends TargetImpl {
     }
 
     @Override
-    public boolean canTarget(UUID id, Game game) {
-        Permanent permanent = game.getPermanent(id);
-        if (permanent != null) {
-            return filter.match(permanent, game);
-        }
-        Player player = game.getPlayer(id);
-        return filter.match(player, game);
-    }
-
-    @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         return canTarget(id, source, game);
     }
@@ -183,33 +173,16 @@ public class TargetPermanentOrPlayer extends TargetImpl {
         MageObject targetSource = game.getObject(source);
         for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
             Player player = game.getPlayer(playerId);
-            if (player != null && (notTarget || player.canBeTargetedBy(targetSource, sourceControllerId, source, game)) && filter.match(player, sourceControllerId, source, game)) {
+            if (player != null && filter.match(player, sourceControllerId, source, game)) {
                 possibleTargets.add(playerId);
             }
         }
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter.getPermanentFilter(), sourceControllerId, game)) {
-            if ((notTarget || permanent.canBeTargetedBy(targetSource, sourceControllerId, source, game)) && filter.match(permanent, sourceControllerId, source, game)) {
+            if (filter.match(permanent, sourceControllerId, source, game)) {
                 possibleTargets.add(permanent.getId());
             }
         }
-        return possibleTargets;
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        Set<UUID> possibleTargets = new HashSet<>();
-        for (UUID playerId : game.getState().getPlayersInRange(sourceControllerId, game)) {
-            Player player = game.getPlayer(playerId);
-            if (filter.match(player, game)) {
-                possibleTargets.add(playerId);
-            }
-        }
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(filter.getPermanentFilter(), sourceControllerId, game)) {
-            if (filter.match(permanent, sourceControllerId, null, game)) {
-                possibleTargets.add(permanent.getId());
-            }
-        }
-        return possibleTargets;
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetPermanentOrSuspendedCard.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentOrSuspendedCard.java
@@ -55,18 +55,7 @@ public class TargetPermanentOrSuspendedCard extends TargetImpl {
 
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        MageObject sourceObject = game.getObject(source);
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(filter.getPermanentFilter(), sourceControllerId, game)) {
-            if (permanent.canBeTargetedBy(sourceObject, sourceControllerId, source, game) && filter.match(permanent, sourceControllerId, source, game)) {
-                return true;
-            }
-        }
-        for (Card card : game.getExile().getAllCards(game)) {
-            if (filter.match(card, sourceControllerId, source, game)) {
-                return true;
-            }
-        }
-        return false;
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetPermanentOrSuspendedCard.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentOrSuspendedCard.java
@@ -71,10 +71,9 @@ public class TargetPermanentOrSuspendedCard extends TargetImpl {
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        Set<UUID> possibleTargets = new HashSet<>(20);
-        MageObject sourceObject = game.getObject(source);
+        Set<UUID> possibleTargets = new HashSet<>();
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter.getPermanentFilter(), sourceControllerId, game)) {
-            if (permanent.canBeTargetedBy(sourceObject, sourceControllerId, source, game) && filter.match(permanent, sourceControllerId, source, game)) {
+            if (filter.match(permanent, sourceControllerId, source, game)) {
                 possibleTargets.add(permanent.getId());
             }
         }
@@ -83,17 +82,7 @@ public class TargetPermanentOrSuspendedCard extends TargetImpl {
                 possibleTargets.add(card.getId());
             }
         }
-        return possibleTargets;
-    }
-
-    @Override
-    public boolean canTarget(UUID id, Game game) {
-        Permanent permanent = game.getPermanent(id);
-        if (permanent != null) {
-            return filter.match(permanent, game);
-        }
-        Card card = game.getExile().getCard(id, game);
-        return filter.match(card, game);
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
@@ -101,8 +90,7 @@ public class TargetPermanentOrSuspendedCard extends TargetImpl {
         Permanent permanent = game.getPermanent(id);
         if (permanent != null) {
             if (source != null) {
-                MageObject targetSource = game.getObject(source);
-                return permanent.canBeTargetedBy(targetSource, source.getControllerId(), source, game)
+                return (isNotTarget() || permanent.canBeTargetedBy(game.getObject(source), source.getControllerId(), source, game))
                         && filter.match(permanent, source.getControllerId(), source, game);
             } else {
                 return filter.match(permanent, game);
@@ -115,16 +103,6 @@ public class TargetPermanentOrSuspendedCard extends TargetImpl {
     @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         return this.canTarget(id, source, game);
-    }
-
-    @Override
-    public boolean canChoose(UUID sourceControllerId, Game game) {
-        return this.canChoose(sourceControllerId, null, game);
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
-        return this.possibleTargets(sourceControllerId, null, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetPermanentSameController.java
+++ b/Mage/src/main/java/mage/target/common/TargetPermanentSameController.java
@@ -28,8 +28,8 @@ public class TargetPermanentSameController extends TargetPermanent {
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (!super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
             return false;
         }
         if (this.getTargets().isEmpty()) {

--- a/Mage/src/main/java/mage/target/common/TargetTappedPermanentAsYouCast.java
+++ b/Mage/src/main/java/mage/target/common/TargetTappedPermanentAsYouCast.java
@@ -30,21 +30,21 @@ public class TargetTappedPermanentAsYouCast extends TargetPermanent {
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        return game.getBattlefield().getActivePermanents(getFilter(), source.getControllerId(), source, game).stream()
+        Set<UUID> possibleTargets = game.getBattlefield().getActivePermanents(getFilter(), sourceControllerId, source, game).stream()
                 .filter(Permanent::isTapped)
                 .map(Permanent::getId)
                 .collect(Collectors.toSet());
+        return keepValidPossibleTargets(possibleTargets, sourceControllerId, source, game);
     }
 
     @Override
     public boolean canChoose(UUID sourceControllerId, Ability source, Game game) {
-        return game.getBattlefield().getActivePermanents(getFilter(), source.getControllerId(), source, game).stream()
-                .anyMatch(Permanent::isTapped);
+        return canChooseFromPossibleTargets(sourceControllerId, source, game);
     }
 
     @Override
-    public boolean canTarget(UUID controllerId, UUID id, Ability source, Game game) {
-        if (super.canTarget(controllerId, id, source, game)) {
+    public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (super.canTarget(playerId, id, source, game)) {
             Permanent permanent = game.getPermanent(id);
             return permanent != null && permanent.isTapped();
         }
@@ -54,6 +54,14 @@ public class TargetTappedPermanentAsYouCast extends TargetPermanent {
     // See ruling: https://www.mtgsalvation.com/forums/magic-fundamentals/magic-rulings/magic-rulings-archives/253345-dream-leash
     @Override
     public boolean stillLegalTarget(UUID controllerId, UUID id, Ability source, Game game) {
+        // on resolve must ignore tapped status
+
+        // The middle ability of Enthralling Hold affects only the choice of target as the spell is cast.
+        // If the creature becomes untapped before the spell resolves, it still resolves. If a player is allowed
+        // to change the spell's target while it's on the stack, they may choose an untapped creature. If you put
+        // Enthralling Hold onto the battlefield without casting it, you may attach it to an untapped creature.
+        // (2020-06-23)
+
         Permanent permanent = game.getPermanent(id);
         return permanent != null 
                 && getFilter().match(permanent, game)

--- a/Mage/src/main/java/mage/target/common/TargetTriggeredAbility.java
+++ b/Mage/src/main/java/mage/target/common/TargetTriggeredAbility.java
@@ -65,14 +65,10 @@ public class TargetTriggeredAbility extends TargetObject {
 
     @Override
     public Set<UUID> possibleTargets(UUID sourceControllerId, Ability source, Game game) {
-        return possibleTargets(sourceControllerId, game);
-    }
-
-    @Override
-    public Set<UUID> possibleTargets(UUID sourceControllerId, Game game) {
         return game.getStack().stream()
                 .filter(TargetTriggeredAbility::isTriggeredAbility)
                 .map(stackObject -> stackObject.getStackAbility().getId())
+                .filter(this::notContains)
                 .collect(Collectors.toSet());
     }
 

--- a/Mage/src/main/java/mage/util/ConsoleUtil.java
+++ b/Mage/src/main/java/mage/util/ConsoleUtil.java
@@ -1,0 +1,19 @@
+package mage.util;
+
+/**
+ * Helper class to work with console logs
+ */
+public class ConsoleUtil {
+
+    public static String asRed(String text) {
+        return "\u001B[31m" + text + "\u001B[0m";
+    }
+
+    public static String asGreen(String text) {
+        return "\u001B[32m" + text + "\u001B[0m";
+    }
+
+    public static String asYellow(String text) {
+        return "\u001B[33m" + text + "\u001B[0m";
+    }
+}

--- a/Mage/src/main/java/mage/watchers/common/RevoltWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/RevoltWatcher.java
@@ -17,7 +17,7 @@ import java.util.UUID;
  */
 public class RevoltWatcher extends Watcher {
 
-    private final Set<UUID> revoltActivePlayerIds = new HashSet<>(0);
+    private final Set<UUID> revoltActivePlayerIds = new HashSet<>();
 
     public RevoltWatcher() {
         super(WatcherScope.GAME);


### PR DESCRIPTION
That's PR contains more targeting improvements for human, AI and test players (continue work from #13638, #13766).

**Most important changes**

1 - unit tests show additional game logs:
- all choices from test player are visible now (useful to find source of the choice or miss test command);
- all stack's push and resolve are visible now before any choices (useful to find current failed ability);
- <img width="1067" height="540" alt="shot_250726_185509" src="https://github.com/user-attachments/assets/0a249c4d-e8fd-40f1-831c-b0ea6159a4ef" />

2 - custom target implementation was simplified, so dev must override only `possibleTargets` (plus `canTarget` in some use cases). all other works are done by default (notTarget, filter selected targets, protection and other things). There are still exists a complex targets and old methods but it will be reworked in next refactors too.

3 - AI games are stable and fully workable now

**Detailed changes**

Test framework improves:
- now game logs will show stack ability on push and on resolve (before any choices);
- now game logs will show used choices made by cast/activate, setChoice, setMode and addTarget commands (not work for AI tests, part of #13832);
- improved choice logic for modes and yes/not dialogs (now it's use a more strictly checks, use TestPlayer.MODE_SKIP to stop mode selection);
- improved error logs and testable dialogs menu in cheat mode;

Reworked AI, targeting and targets logic:
- refactor: simplified target implementation from a dozen canTarget, canChoose and possibleTargets methods to canTarget/possibleTargets only (part of #13638, #13766);
- refactor: fixed wrong target implementations in many cards (example: TargetCardInHand for opponent's hand, close #6210);
- AI: now human, AI and test players -- all use possibleTargets logic in most use cases instead filters or custom validation;
- AI: improved AI sims support for multiple targets abilities;
- AI: improved AI stability, freezes and targets errors in some use cases;

Additional fixes:
- close #13840
- close #13865
- close #13857
- close #13650