### PR TITLE
Additional Promo Sets and Cards

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -546,9 +546,11 @@ public class ScryfallImageSupportCards {
             add("30A"); // 30th Anniversary Edition
             add("P30A"); // 30th Anniversary Play Promos
             add("P30M"); // 30th Anniversary Misc Promos
+            add("P30H"); // 30th Anniversary History Promos
             add("PEWK"); // Eternal Weekend
             add("LTR"); // The Lord of the Rings: Tales of Middle-Earth
             add("LTC"); // Tales of Middle-Earth Commander
+            add("PF23"); // MagicFest 2023
             add("CMM"); // Commander Masters
             add("WHO"); // Doctor Who
             add("WOE"); // Wilds of Eldraine

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -560,6 +560,7 @@ public class ScryfallImageSupportCards {
             add("SPG"); // Special Guests
             add("PW24"); // Wizards Play Network 2024
             add("RVR"); // Ravnica Remastered
+            add("PL24"); // Year of the Dragon 2024
             add("PIP"); // Fallout
             add("MKM"); // Murders at Karlov Manor
             add("MKC"); // Murders at Karlov Manor Commander
@@ -585,6 +586,7 @@ public class ScryfallImageSupportCards {
             add("PSPL"); // Spotlight Series
             add("INR"); // Innistrad Remastered
             add("PF25"); // MagicFest 2025
+            add("PL25"); // Year of the Snake 2025
             add("DFT"); // Aetherdrift
             add("DRC"); // Aetherdrift Commander
             add("PLG25"); // Love Your LGS 2025

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -465,6 +465,7 @@ public class ScryfallImageSupportCards {
             // add("MD1"); // Modern Event Deck
             // add("DD3"); // Duel Decks Anthology
             // add("PZ1"); // Legendary Cube
+            add("PLG20"); // Love Your LGS 2020
             add("IKO"); // Ikoria: Lair of Behemoths
             add("C20"); // Commander 2020
             add("M21"); // Core Set 2021

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -514,11 +514,13 @@ public class ScryfallImageSupportCards {
             add("NCC"); // New Capenna Commander
             add("SLX"); // Universes Within
             add("CLB"); // Commander Legends: Battle for Baldur's Gate
+            add("PLG22"); // Love Your LGS 2022
             add("2X2"); // Double Masters 2022
             add("SCH"); // Store Championships
             add("DMU"); // Dominaria United
             add("DMC"); // Dominaria United Commander
             add("YDMU"); // Alchemy: Dominaria
+            add("PRCQ"); // Regional Championship Qualifiers 2022
             add("40K"); // Warhammer 40,000 Commander
             add("UNF"); // Unfinity
             add("GN3"); // Game Night: Free-for-All

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -559,11 +559,13 @@ public class ScryfallImageSupportCards {
             add("REX"); // Jurassic World Collection
             add("SPG"); // Special Guests
             add("PW24"); // Wizards Play Network 2024
+            add("PF24"); // MagicFest 2024
             add("RVR"); // Ravnica Remastered
             add("PL24"); // Year of the Dragon 2024
             add("PIP"); // Fallout
             add("MKM"); // Murders at Karlov Manor
             add("MKC"); // Murders at Karlov Manor Commander
+            add("PSS4"); // MKM Standard Showdown
             add("CLU"); // Ravnica: Clue Edition
             add("OTJ"); // Outlaws of Thunder Junction
             add("OTC"); // Outlaws of Thunder Junction Commander
@@ -575,6 +577,7 @@ public class ScryfallImageSupportCards {
             add("ACR"); // Assassin's Creed
             add("BLB"); // Bloomburrow
             add("BLC"); // Bloomburrow Commander
+            add("PLG24"); // Love Your LGS 2024
             add("PCBB"); // Cowboy Bebop
             add("MB2"); // Mystery Booster 2
             add("DSK"); // Duskmourn: House of Horror

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2931,6 +2931,12 @@ public class ScryfallImageSupportTokens {
             // PL23
             put("PL23/Food", "https://api.scryfall.com/cards/pl23/2?format=image");
 
+            // PL24
+            put("PL24/Dragon", "https://api.scryfall.com/cards/pl24/3?format=image");
+
+            // PL25
+            put("PL25/Snake", "https://api.scryfall.com/cards/pl25/2?format=image");
+
             // generate supported sets
             supportedSets.clear();
             for (String cardName : this.keySet()) {

--- a/Mage.Sets/src/mage/sets/LoveYourLGS2020.java
+++ b/Mage.Sets/src/mage/sets/LoveYourLGS2020.java
@@ -1,0 +1,26 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/plg20
+ */
+public class LoveYourLGS2020 extends ExpansionSet {
+
+    private static final LoveYourLGS2020 instance = new LoveYourLGS2020();
+
+    public static LoveYourLGS2020 getInstance() {
+        return instance;
+    }
+
+    private LoveYourLGS2020() {
+        super("Love Your LGS 2020", "PLG20", ExpansionSet.buildDate(2020, 5, 18), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Hangarback Walker", 2, Rarity.RARE, mage.cards.h.HangarbackWalker.class));
+        cards.add(new SetCardInfo("Reliquary Tower", 1, Rarity.RARE, mage.cards.r.ReliquaryTower.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/LoveYourLGS2022.java
+++ b/Mage.Sets/src/mage/sets/LoveYourLGS2022.java
@@ -1,0 +1,26 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/plg22
+ */
+public class LoveYourLGS2022 extends ExpansionSet {
+
+    private static final LoveYourLGS2022 instance = new LoveYourLGS2022();
+
+    public static LoveYourLGS2022 getInstance() {
+        return instance;
+    }
+
+    private LoveYourLGS2022() {
+        super("Love Your LGS 2022", "PLG22", ExpansionSet.buildDate(2022, 7, 1), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Sol Ring", 1, Rarity.RARE, mage.cards.s.SolRing.class, RETRO_ART));
+        cards.add(new SetCardInfo("Thought Vessel", 2, Rarity.RARE, mage.cards.t.ThoughtVessel.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/LoveYourLGS2024.java
+++ b/Mage.Sets/src/mage/sets/LoveYourLGS2024.java
@@ -1,0 +1,29 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/plg24
+ */
+public class LoveYourLGS2024 extends ExpansionSet {
+
+    private static final LoveYourLGS2024 instance = new LoveYourLGS2024();
+
+    public static LoveYourLGS2024 getInstance() {
+        return instance;
+    }
+
+    private LoveYourLGS2024() {
+        super("Love Your LGS 2025", "PLG25", ExpansionSet.buildDate(2024, 8, 6), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Cut Down", "3J", Rarity.RARE, mage.cards.c.CutDown.class));
+        cards.add(new SetCardInfo("Lay Down Arms", "1J", Rarity.RARE, mage.cards.l.LayDownArms.class));
+        cards.add(new SetCardInfo("Sakura-Tribe Elder", 1, Rarity.RARE, mage.cards.s.SakuraTribeElder.class, FULL_ART));
+        cards.add(new SetCardInfo("Sheoldred's Edict", "4J", Rarity.RARE, mage.cards.s.SheoldredsEdict.class));
+        cards.add(new SetCardInfo("Sleight of Hand", "2J", Rarity.RARE, mage.cards.s.SleightOfHand.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/LoveYourLGS2024.java
+++ b/Mage.Sets/src/mage/sets/LoveYourLGS2024.java
@@ -16,7 +16,7 @@ public class LoveYourLGS2024 extends ExpansionSet {
     }
 
     private LoveYourLGS2024() {
-        super("Love Your LGS 2025", "PLG25", ExpansionSet.buildDate(2024, 8, 6), SetType.PROMOTIONAL);
+        super("Love Your LGS 2024", "PLG24", ExpansionSet.buildDate(2024, 8, 6), SetType.PROMOTIONAL);
         this.hasBoosters = false;
         this.hasBasicLands = false;
 

--- a/Mage.Sets/src/mage/sets/MKMStandardShowdown.java
+++ b/Mage.Sets/src/mage/sets/MKMStandardShowdown.java
@@ -1,0 +1,29 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/pss4
+ */
+public class MKMStandardShowdown extends ExpansionSet {
+
+    private static final MKMStandardShowdown instance = new MKMStandardShowdown();
+
+    public static MKMStandardShowdown getInstance() {
+        return instance;
+    }
+
+    private MKMStandardShowdown() {
+        super("MKM Standard Showdown", "PSS4", ExpansionSet.buildDate(2024, 2, 10), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = true;
+
+        cards.add(new SetCardInfo("Forest", 5, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Island", 2, Rarity.LAND, mage.cards.basiclands.Island.class));
+        cards.add(new SetCardInfo("Mountain", 4, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Plains", 1, Rarity.LAND, mage.cards.basiclands.Plains.class));
+        cards.add(new SetCardInfo("Swamp", 3, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/MKMStandardShowdown.java
+++ b/Mage.Sets/src/mage/sets/MKMStandardShowdown.java
@@ -20,10 +20,10 @@ public class MKMStandardShowdown extends ExpansionSet {
         this.hasBoosters = false;
         this.hasBasicLands = true;
 
-        cards.add(new SetCardInfo("Forest", 5, Rarity.LAND, mage.cards.basiclands.Forest.class));
-        cards.add(new SetCardInfo("Island", 2, Rarity.LAND, mage.cards.basiclands.Island.class));
-        cards.add(new SetCardInfo("Mountain", 4, Rarity.LAND, mage.cards.basiclands.Mountain.class));
-        cards.add(new SetCardInfo("Plains", 1, Rarity.LAND, mage.cards.basiclands.Plains.class));
-        cards.add(new SetCardInfo("Swamp", 3, Rarity.LAND, mage.cards.basiclands.Swamp.class));
+        cards.add(new SetCardInfo("Forest", 5, Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Island", 2, Rarity.LAND, mage.cards.basiclands.Island.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Mountain", 4, Rarity.LAND, mage.cards.basiclands.Mountain.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Plains", 1, Rarity.LAND, mage.cards.basiclands.Plains.class, FULL_ART_BFZ_VARIOUS));
+        cards.add(new SetCardInfo("Swamp", 3, Rarity.LAND, mage.cards.basiclands.Swamp.class, FULL_ART_BFZ_VARIOUS));
     }
 }

--- a/Mage.Sets/src/mage/sets/MagicFest2023.java
+++ b/Mage.Sets/src/mage/sets/MagicFest2023.java
@@ -1,0 +1,29 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/pf23
+ *
+ * @author resech
+ */
+public class MagicFest2023 extends ExpansionSet {
+
+    private static final MagicFest2023 instance = new MagicFest2023();
+
+    public static MagicFest2023 getInstance() {
+        return instance;
+    }
+
+    private MagicFest2023() {
+        super("MagicFest 2023", "PF23", ExpansionSet.buildDate(2023, 7, 1), SetType.PROMOTIONAL);
+        hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Gandalf, Friend of the Shire", 1, Rarity.RARE, mage.cards.g.GandalfFriendOfTheShire.class));
+        cards.add(new SetCardInfo("Reliquary Tower", 3, Rarity.RARE, mage.cards.r.ReliquaryTower.class, FULL_ART));
+        cards.add(new SetCardInfo("TARDIS", 4, Rarity.RARE, mage.cards.t.TARDIS.class));
+        cards.add(new SetCardInfo("Tranquil Thicket", 2, Rarity.RARE, mage.cards.t.TranquilThicket.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/MagicFest2024.java
+++ b/Mage.Sets/src/mage/sets/MagicFest2024.java
@@ -1,0 +1,26 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/pf24
+ *
+ * @author resech
+ */
+public class MagicFest2024 extends ExpansionSet {
+
+    private static final MagicFest2024 instance = new MagicFest2024();
+
+    public static MagicFest2024 getInstance() {
+        return instance;
+    }
+
+    private MagicFest2024() {
+        super("MagicFest 2024", "PF24", ExpansionSet.buildDate(2024, 1, 1), SetType.PROMOTIONAL);
+        hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Counterspell", 1, Rarity.RARE, mage.cards.c.Counterspell.class, FULL_ART));
+    }
+}

--- a/Mage.Sets/src/mage/sets/MagicFest2025.java
+++ b/Mage.Sets/src/mage/sets/MagicFest2025.java
@@ -21,16 +21,19 @@ public class MagicFest2025 extends ExpansionSet {
         super("MagicFest 2025", "PF25", ExpansionSet.buildDate(2025, 2, 3), SetType.PROMOTIONAL);
         hasBasicLands = false;
 
-        cards.add(new SetCardInfo("Avacyn's Pilgrim", "1F", Rarity.RARE, mage.cards.a.AvacynsPilgrim.class, FULL_ART));
-        cards.add(new SetCardInfo("Ponder", 2, Rarity.RARE, mage.cards.p.Ponder.class));
-        cards.add(new SetCardInfo("Serra the Benevolent", 1, Rarity.MYTHIC, mage.cards.s.SerraTheBenevolent.class, RETRO_ART));
-        cards.add(new SetCardInfo("The First Sliver", 3, Rarity.MYTHIC, mage.cards.t.TheFirstSliver.class));
-        cards.add(new SetCardInfo("Yoshimaru, Ever Faithful", 5, Rarity.MYTHIC, mage.cards.y.YoshimaruEverFaithful.class));
-        cards.add(new SetCardInfo("Ugin, the Spirit Dragon", 6, Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class, RETRO_ART));
-        cards.add(new SetCardInfo("Sliver Hive", 7, Rarity.RARE, mage.cards.s.SliverHive.class, RETRO_ART));
-        cards.add(new SetCardInfo("Tifa Lockhart", 9, Rarity.RARE, mage.cards.t.TifaLockhart.class));
         cards.add(new SetCardInfo("Arcane Signet", 10, Rarity.RARE, mage.cards.a.ArcaneSignet.class));
+        cards.add(new SetCardInfo("Avacyn's Pilgrim", "1F", Rarity.RARE, mage.cards.a.AvacynsPilgrim.class, FULL_ART));
+        cards.add(new SetCardInfo("Lightning Bolt", 13, Rarity.RARE, mage.cards.l.LightningBolt.class));
+        cards.add(new SetCardInfo("Ponder", 2, Rarity.RARE, mage.cards.p.Ponder.class));
         cards.add(new SetCardInfo("Rograkh, Son of Rohgahh", 11, Rarity.RARE, mage.cards.r.RograkhSonOfRohgahh.class));
-        cards.add(new SetCardInfo("Swords to Plowshares", 13, Rarity.RARE, mage.cards.s.SwordsToPlowshares.class));
+        cards.add(new SetCardInfo("Scourge of Valkas", 14, Rarity.RARE, mage.cards.s.ScourgeOfValkas.class, RETRO_ART));
+        cards.add(new SetCardInfo("Serra the Benevolent", 1, Rarity.MYTHIC, mage.cards.s.SerraTheBenevolent.class, RETRO_ART));
+        cards.add(new SetCardInfo("Sliver Hive", 7, Rarity.RARE, mage.cards.s.SliverHive.class, RETRO_ART));
+        cards.add(new SetCardInfo("Swords to Plowshares", 12, Rarity.RARE, mage.cards.s.SwordsToPlowshares.class));
+        cards.add(new SetCardInfo("The First Sliver", 3, Rarity.MYTHIC, mage.cards.t.TheFirstSliver.class));
+        cards.add(new SetCardInfo("The Ur-Dragon", 15, Rarity.MYTHIC, mage.cards.t.TheUrDragon.class));
+        cards.add(new SetCardInfo("Tifa Lockhart", 9, Rarity.RARE, mage.cards.t.TifaLockhart.class));
+        cards.add(new SetCardInfo("Ugin, the Spirit Dragon", 6, Rarity.MYTHIC, mage.cards.u.UginTheSpiritDragon.class, RETRO_ART));
+        cards.add(new SetCardInfo("Yoshimaru, Ever Faithful", 5, Rarity.MYTHIC, mage.cards.y.YoshimaruEverFaithful.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/RegionalChampionshipQualifiers2022.java
+++ b/Mage.Sets/src/mage/sets/RegionalChampionshipQualifiers2022.java
@@ -1,0 +1,27 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/prcq
+ */
+public class RegionalChampionshipQualifiers2022 extends ExpansionSet {
+
+    private static final RegionalChampionshipQualifiers2022 instance = new RegionalChampionshipQualifiers2022();
+
+    public static RegionalChampionshipQualifiers2022 getInstance() {
+        return instance;
+    }
+
+    private RegionalChampionshipQualifiers2022() {
+        super("Regional Championship Qualifiers 2022", "PRCQ", ExpansionSet.buildDate(2022, 10, 1), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Gideon, Ally of Zendikar", 1, Rarity.MYTHIC, mage.cards.g.GideonAllyOfZendikar.class));
+        cards.add(new SetCardInfo("Selfless Spirit", 2, Rarity.RARE, mage.cards.s.SelflessSpirit.class));
+        cards.add(new SetCardInfo("Thraben Inspector", 3, Rarity.RARE, mage.cards.t.ThrabenInspector.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/SecretLairDrop.java
+++ b/Mage.Sets/src/mage/sets/SecretLairDrop.java
@@ -1201,6 +1201,10 @@ public class SecretLairDrop extends ExpansionSet {
         cards.add(new SetCardInfo("Gaea's Blessing", 1303, Rarity.RARE, mage.cards.g.GaeasBlessing.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Twilight Prophet", 1304, Rarity.MYTHIC, mage.cards.t.TwilightProphet.class));
         cards.add(new SetCardInfo("Worldspine Wurm", 1305, Rarity.MYTHIC, mage.cards.w.WorldspineWurm.class));
+        cards.add(new SetCardInfo("Pack Rat", 1307, Rarity.RARE, mage.cards.p.PackRat.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Shared Summons", 1308, Rarity.RARE, mage.cards.s.SharedSummons.class));
+        cards.add(new SetCardInfo("Sylvan Offering", 1309, Rarity.RARE, mage.cards.s.SylvanOffering.class));
+        cards.add(new SetCardInfo("Sliver Legion", 1310, Rarity.MYTHIC, mage.cards.s.SliverLegion.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Goblin Lackey", 1311, Rarity.RARE, mage.cards.g.GoblinLackey.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Goblin Lackey", "1311*", Rarity.RARE, mage.cards.g.GoblinLackey.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Goblin Matron", 1312, Rarity.RARE, mage.cards.g.GoblinMatron.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/StoreChampionships.java
+++ b/Mage.Sets/src/mage/sets/StoreChampionships.java
@@ -55,6 +55,7 @@ public final class StoreChampionships extends ExpansionSet {
         cards.add(new SetCardInfo("Preacher of the Schism", 34, Rarity.RARE, mage.cards.p.PreacherOfTheSchism.class));
         cards.add(new SetCardInfo("Preordain", 39, Rarity.RARE, mage.cards.p.Preordain.class));
         cards.add(new SetCardInfo("Reality Smasher", 31, Rarity.RARE, mage.cards.r.RealitySmasher.class));
+        cards.add(new SetCardInfo("Reflection of Kiki-Jiki", 44, Rarity.RARE, mage.cards.r.ReflectionOfKikiJiki.class));
         cards.add(new SetCardInfo("Shark Typhoon", 28, Rarity.RARE, mage.cards.s.SharkTyphoon.class));
         cards.add(new SetCardInfo("Slickshot Show-Off", 43, Rarity.RARE, mage.cards.s.SlickshotShowOff.class));
         cards.add(new SetCardInfo("Spell Pierce", 4, Rarity.RARE, mage.cards.s.SpellPierce.class));

--- a/Mage.Sets/src/mage/sets/StoreChampionships.java
+++ b/Mage.Sets/src/mage/sets/StoreChampionships.java
@@ -26,6 +26,7 @@ public final class StoreChampionships extends ExpansionSet {
         cards.add(new SetCardInfo("Angel of Despair", 22, Rarity.RARE, mage.cards.a.AngelOfDespair.class));
         cards.add(new SetCardInfo("Annex Sentry", 7, Rarity.RARE, mage.cards.a.AnnexSentry.class));
         cards.add(new SetCardInfo("Archmage's Charm", 2, Rarity.RARE, mage.cards.a.ArchmagesCharm.class));
+        cards.add(new SetCardInfo("Bitter Triumph", 42, Rarity.RARE, mage.cards.b.BitterTriumph.class));
         cards.add(new SetCardInfo("Blazing Rootwalla", 24, Rarity.RARE, mage.cards.b.BlazingRootwalla.class));
         cards.add(new SetCardInfo("Cauldron Familiar", 18, Rarity.RARE, mage.cards.c.CauldronFamiliar.class));
         cards.add(new SetCardInfo("Charming Scoundrel", 37, Rarity.RARE, mage.cards.c.CharmingScoundrel.class));
@@ -37,6 +38,7 @@ public final class StoreChampionships extends ExpansionSet {
         cards.add(new SetCardInfo("Death's Shadow", 40, Rarity.RARE, mage.cards.d.DeathsShadow.class));
         cards.add(new SetCardInfo("Deep-Cavern Bat", 33, Rarity.RARE, mage.cards.d.DeepCavernBat.class));
         cards.add(new SetCardInfo("Eidolon of the Great Revel", 14, Rarity.RARE, mage.cards.e.EidolonOfTheGreatRevel.class));
+        cards.add(new SetCardInfo("Fable of the Mirror-Breaker", 44, Rarity.RARE, mage.cards.f.FableOfTheMirrorBreaker.class));
         cards.add(new SetCardInfo("Flame Slash", 1, Rarity.RARE, mage.cards.f.FlameSlash.class));
         cards.add(new SetCardInfo("Gifted Aetherborn", 13, Rarity.RARE, mage.cards.g.GiftedAetherborn.class));
         cards.add(new SetCardInfo("Gilded Goose", 5, Rarity.RARE, mage.cards.g.GildedGoose.class));
@@ -44,7 +46,7 @@ public final class StoreChampionships extends ExpansionSet {
         cards.add(new SetCardInfo("Goddric, Cloaked Reveler", 38, Rarity.RARE, mage.cards.g.GoddricCloakedReveler.class, FULL_ART));
         cards.add(new SetCardInfo("Hollow One", 25, Rarity.RARE, mage.cards.h.HollowOne.class));
         cards.add(new SetCardInfo("Koth, Fire of Resistance", 9, Rarity.RARE, mage.cards.k.KothFireOfResistance.class));
-        cards.add(new SetCardInfo("Lier, Disciple of the Drowned", 20, Rarity.RARE, mage.cards.l.LierDiscipleOfTheDrowned.class));
+        cards.add(new SetCardInfo("Lier, Disciple of the Drowned", 20, Rarity.RARE, mage.cards.l.LierDiscipleOfTheDrowned.class, FULL_ART));
         cards.add(new SetCardInfo("Memory Deluge", 8, Rarity.RARE, mage.cards.m.MemoryDeluge.class));
         cards.add(new SetCardInfo("Monastery Swiftspear", 27, Rarity.RARE, mage.cards.m.MonasterySwiftspear.class));
         cards.add(new SetCardInfo("Moonshaker Cavalry", 17, Rarity.MYTHIC, mage.cards.m.MoonshakerCavalry.class, FULL_ART));
@@ -54,6 +56,7 @@ public final class StoreChampionships extends ExpansionSet {
         cards.add(new SetCardInfo("Preordain", 39, Rarity.RARE, mage.cards.p.Preordain.class));
         cards.add(new SetCardInfo("Reality Smasher", 31, Rarity.RARE, mage.cards.r.RealitySmasher.class));
         cards.add(new SetCardInfo("Shark Typhoon", 28, Rarity.RARE, mage.cards.s.SharkTyphoon.class));
+        cards.add(new SetCardInfo("Slickshot Show-Off", 43, Rarity.RARE, mage.cards.s.SlickshotShowOff.class));
         cards.add(new SetCardInfo("Spell Pierce", 4, Rarity.RARE, mage.cards.s.SpellPierce.class));
         cards.add(new SetCardInfo("Strangle", 10, Rarity.RARE, mage.cards.s.Strangle.class));
         cards.add(new SetCardInfo("Tail Swipe", 15, Rarity.RARE, mage.cards.t.TailSwipe.class));

--- a/Mage.Sets/src/mage/sets/The30thAnniversaryHistoryPromos.java
+++ b/Mage.Sets/src/mage/sets/The30thAnniversaryHistoryPromos.java
@@ -1,0 +1,36 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/p30h
+ *
+ * @author resech
+ */
+public class The30thAnniversaryHistoryPromos extends ExpansionSet {
+
+    private static final The30thAnniversaryHistoryPromos instance = new The30thAnniversaryHistoryPromos();
+
+    public static The30thAnniversaryHistoryPromos getInstance() {
+        return instance;
+    }
+
+    private The30thAnniversaryHistoryPromos() {
+        super("30th Anniversary History Promos", "P30H", ExpansionSet.buildDate(2022, 9, 9), SetType.PROMOTIONAL);
+        hasBasicLands = false;
+
+
+        cards.add(new SetCardInfo("Llanowar Elves", "5*", Rarity.RARE, mage.cards.l.LlanowarElves.class, RETRO_ART_USE_VARIOUS));
+        cards.add(new SetCardInfo("Llanowar Elves", 5, Rarity.RARE, mage.cards.l.LlanowarElves.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lord of Atlantis", "2*", Rarity.RARE, mage.cards.l.LordOfAtlantis.class, RETRO_ART_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lord of Atlantis", 2, Rarity.RARE, mage.cards.l.LordOfAtlantis.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sengir Vampire", "3*", Rarity.RARE, mage.cards.s.SengirVampire.class, RETRO_ART_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sengir Vampire", 3, Rarity.RARE, mage.cards.s.SengirVampire.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Serra Angel", "1*", Rarity.RARE, mage.cards.s.SerraAngel.class, RETRO_ART_USE_VARIOUS));
+        cards.add(new SetCardInfo("Serra Angel", 1, Rarity.RARE, mage.cards.s.SerraAngel.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Shivan Dragon", "4*", Rarity.RARE, mage.cards.s.ShivanDragon.class, RETRO_ART_USE_VARIOUS));
+        cards.add(new SetCardInfo("Shivan Dragon", 4, Rarity.RARE, mage.cards.s.ShivanDragon.class, NON_FULL_USE_VARIOUS));
+    }
+}

--- a/Mage.Sets/src/mage/sets/URLConventionPromos.java
+++ b/Mage.Sets/src/mage/sets/URLConventionPromos.java
@@ -23,14 +23,13 @@ public class URLConventionPromos extends ExpansionSet {
         cards.add(new SetCardInfo("Aeronaut Tinkerer", 8, Rarity.COMMON, mage.cards.a.AeronautTinkerer.class));
         cards.add(new SetCardInfo("Bloodthrone Vampire", 3, Rarity.RARE, mage.cards.b.BloodthroneVampire.class));
         cards.add(new SetCardInfo("Chandra's Fury", 5, Rarity.RARE, mage.cards.c.ChandrasFury.class));
+        cards.add(new SetCardInfo("Counterspell", 2, Rarity.RARE, mage.cards.c.Counterspell.class));
+        cards.add(new SetCardInfo("Hylda of the Icy Crown", "2025-1", Rarity.MYTHIC, mage.cards.h.HyldaOfTheIcyCrown.class));
+        cards.add(new SetCardInfo("Katara, the Fearless", "2025-3", Rarity.RARE, mage.cards.k.KataraTheFearless.class));
         cards.add(new SetCardInfo("Kor Skyfisher", 23, Rarity.RARE, mage.cards.k.KorSkyfisher.class));
         cards.add(new SetCardInfo("Merfolk Mesmerist", 4, Rarity.RARE, mage.cards.m.MerfolkMesmerist.class));
-        // Italian-only printing
-        //cards.add(new SetCardInfo("Relentless Rats", 9, Rarity.RARE, mage.cards.r.RelentlessRats.class));
-        // Japanese-only printing
-        //cards.add(new SetCardInfo("Shepherd of the Lost", "34*", Rarity.UNCOMMON, mage.cards.s.ShepherdOfTheLost.class));
+        cards.add(new SetCardInfo("Shepherd of the Lost", "34*", Rarity.UNCOMMON, mage.cards.s.ShepherdOfTheLost.class));
         cards.add(new SetCardInfo("Stealer of Secrets", 7, Rarity.RARE, mage.cards.s.StealerOfSecrets.class));
         cards.add(new SetCardInfo("Steward of Valeron", 1, Rarity.RARE, mage.cards.s.StewardOfValeron.class));
-        cards.add(new SetCardInfo("Counterspell", 2, Rarity.RARE, mage.cards.c.Counterspell.class));
      }
 }

--- a/Mage.Sets/src/mage/sets/WizardsPlayNetwork2025.java
+++ b/Mage.Sets/src/mage/sets/WizardsPlayNetwork2025.java
@@ -24,9 +24,11 @@ public class WizardsPlayNetwork2025 extends ExpansionSet {
         cards.add(new SetCardInfo("Despark", 2, Rarity.UNCOMMON, mage.cards.d.Despark.class));
         cards.add(new SetCardInfo("Dragon's Hoard", "1p", Rarity.RARE, mage.cards.d.DragonsHoard.class, RETRO_ART));
         cards.add(new SetCardInfo("Dragonspeaker Shaman", 3, Rarity.RARE, mage.cards.d.DragonspeakerShaman.class));
+        cards.add(new SetCardInfo("Monstrous Rage", 9, Rarity.RARE, mage.cards.m.MonstrousRage.class, RETRO_ART));
         cards.add(new SetCardInfo("Palladium Myr", 6, Rarity.RARE, mage.cards.p.PalladiumMyr.class, RETRO_ART));
         cards.add(new SetCardInfo("Rishkar's Expertise", 1, Rarity.RARE, mage.cards.r.RishkarsExpertise.class, RETRO_ART));
         cards.add(new SetCardInfo("Spectacular Spider-Man", 7, Rarity.RARE, mage.cards.s.SpectacularSpiderMan.class));
+        cards.add(new SetCardInfo("Trinket Mage", 8, Rarity.RARE, mage.cards.t.TrinketMage.class, RETRO_ART));
         cards.add(new SetCardInfo("Zidane, Tantalus Thief", 5, Rarity.RARE, mage.cards.z.ZidaneTantalusThief.class));
     }
 }

--- a/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
@@ -5,7 +5,7 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 /**
- * https://scryfall.com/sets/pl23
+ * https://scryfall.com/sets/pl24
  */
 public class YearOfTheDragon2024 extends ExpansionSet {
 
@@ -23,7 +23,7 @@ public class YearOfTheDragon2024 extends ExpansionSet {
         cards.add(new SetCardInfo("Dragon Tempest", 7, Rarity.RARE, mage.cards.d.DragonTempest.class));
         cards.add(new SetCardInfo("Dragonlord's Servant", 1, Rarity.RARE, mage.cards.d.DragonlordsServant.class));
         cards.add(new SetCardInfo("Korvold, Fae-Cursed King", 6, Rarity.MYTHIC, mage.cards.k.KorvoldFaeCursedKing.class));
-        cards.add(new SetCardInfo("Mountain", 5, Rarity.RARE, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 5, Rarity.LAND, mage.cards.basiclands.Mountain.class));
         cards.add(new SetCardInfo("Sarkhan Unbroken", 2, Rarity.MYTHIC, mage.cards.s.SarkhanUnbroken.class));
         cards.add(new SetCardInfo("Steel Hellkite", 4, Rarity.RARE, mage.cards.s.SteelHellkite.class));
     }

--- a/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
@@ -23,7 +23,7 @@ public class YearOfTheDragon2024 extends ExpansionSet {
         cards.add(new SetCardInfo("Dragon Tempest", 7, Rarity.RARE, mage.cards.d.DragonTempest.class));
         cards.add(new SetCardInfo("Dragonlord's Servant", 1, Rarity.RARE, mage.cards.d.DragonlordsServant.class));
         cards.add(new SetCardInfo("Korvold, Fae-Cursed King", 6, Rarity.MYTHIC, mage.cards.k.KorvoldFaeCursedKing.class));
-        cards.add(new SetCardInfo("Mountain", 5, Rarity.LAND, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Mountain", 5, Rarity.LAND, mage.cards.basiclands.Mountain.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Sarkhan Unbroken", 2, Rarity.MYTHIC, mage.cards.s.SarkhanUnbroken.class));
         cards.add(new SetCardInfo("Steel Hellkite", 4, Rarity.RARE, mage.cards.s.SteelHellkite.class));
     }

--- a/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
@@ -18,7 +18,7 @@ public class YearOfTheDragon2024 extends ExpansionSet {
     private YearOfTheDragon2024() {
         super("Year of the Dragon 2024", "PL24", ExpansionSet.buildDate(2024, 2, 8), SetType.PROMOTIONAL);
         this.hasBoosters = false;
-        this.hasBasicLands = false;
+        this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Dragon Tempest", 7, Rarity.RARE, mage.cards.d.DragonTempest.class));
         cards.add(new SetCardInfo("Dragonlord's Servant", 1, Rarity.RARE, mage.cards.d.DragonlordsServant.class));

--- a/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheDragon2024.java
@@ -1,0 +1,30 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/pl23
+ */
+public class YearOfTheDragon2024 extends ExpansionSet {
+
+    private static final YearOfTheDragon2024 instance = new YearOfTheDragon2024();
+
+    public static YearOfTheDragon2024 getInstance() {
+        return instance;
+    }
+
+    private YearOfTheDragon2024() {
+        super("Year of the Dragon 2024", "PL24", ExpansionSet.buildDate(2024, 2, 8), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Dragon Tempest", 7, Rarity.RARE, mage.cards.d.DragonTempest.class));
+        cards.add(new SetCardInfo("Dragonlord's Servant", 1, Rarity.RARE, mage.cards.d.DragonlordsServant.class));
+        cards.add(new SetCardInfo("Korvold, Fae-Cursed King", 6, Rarity.MYTHIC, mage.cards.k.KorvoldFaeCursedKing.class));
+        cards.add(new SetCardInfo("Mountain", 5, Rarity.RARE, mage.cards.basiclands.Mountain.class));
+        cards.add(new SetCardInfo("Sarkhan Unbroken", 2, Rarity.MYTHIC, mage.cards.s.SarkhanUnbroken.class));
+        cards.add(new SetCardInfo("Steel Hellkite", 4, Rarity.RARE, mage.cards.s.SteelHellkite.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
@@ -18,7 +18,7 @@ public class YearOfTheSnake2025 extends ExpansionSet {
     private YearOfTheSnake2025() {
         super("Year of the Snake 2025", "PL25", ExpansionSet.buildDate(2025, 2, 14), SetType.PROMOTIONAL);
         this.hasBoosters = false;
-        this.hasBasicLands = false;
+        this.hasBasicLands = true;
 
         cards.add(new SetCardInfo("Forest", 6, Rarity.RARE, mage.cards.basiclands.Forest.class));
         cards.add(new SetCardInfo("Kaseto, Orochi Archmage", 5, Rarity.MYTHIC, mage.cards.k.KasetoOrochiArchmage.class));

--- a/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
@@ -20,7 +20,7 @@ public class YearOfTheSnake2025 extends ExpansionSet {
         this.hasBoosters = false;
         this.hasBasicLands = true;
 
-        cards.add(new SetCardInfo("Forest", 6, Rarity.LAND, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 6, Rarity.LAND, mage.cards.basiclands.Forest.class, FULL_ART_BFZ_VARIOUS));
         cards.add(new SetCardInfo("Kaseto, Orochi Archmage", 5, Rarity.MYTHIC, mage.cards.k.KasetoOrochiArchmage.class));
         cards.add(new SetCardInfo("Lotus Cobra", 3, Rarity.RARE, mage.cards.l.LotusCobra.class));
         cards.add(new SetCardInfo("Sakura-Tribe Elder", 4, Rarity.RARE, mage.cards.s.SakuraTribeElder.class));

--- a/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
@@ -1,0 +1,29 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * https://scryfall.com/sets/pl23
+ */
+public class YearOfTheSnake2025 extends ExpansionSet {
+
+    private static final YearOfTheSnake2025 instance = new YearOfTheSnake2025();
+
+    public static YearOfTheSnake2025 getInstance() {
+        return instance;
+    }
+
+    private YearOfTheSnake2025() {
+        super("Year of the Snake 2025", "PL25", ExpansionSet.buildDate(2025, 2, 14), SetType.PROMOTIONAL);
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Forest", 6, Rarity.RARE, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Kaseto, Orochi Archmage", 5, Rarity.MYTHIC, mage.cards.k.KasetoOrochiArchmage.class));
+        cards.add(new SetCardInfo("Lotus Cobra", 3, Rarity.RARE, mage.cards.l.LotusCobra.class));
+        cards.add(new SetCardInfo("Sakura-Tribe Elder", 4, Rarity.RARE, mage.cards.s.SakuraTribeElder.class));
+        cards.add(new SetCardInfo("Xyris, the Writhing Storm", 1, Rarity.MYTHIC, mage.cards.x.XyrisTheWrithingStorm.class));
+    }
+}

--- a/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
+++ b/Mage.Sets/src/mage/sets/YearOfTheSnake2025.java
@@ -5,7 +5,7 @@ import mage.constants.Rarity;
 import mage.constants.SetType;
 
 /**
- * https://scryfall.com/sets/pl23
+ * https://scryfall.com/sets/pl25
  */
 public class YearOfTheSnake2025 extends ExpansionSet {
 
@@ -20,7 +20,7 @@ public class YearOfTheSnake2025 extends ExpansionSet {
         this.hasBoosters = false;
         this.hasBasicLands = true;
 
-        cards.add(new SetCardInfo("Forest", 6, Rarity.RARE, mage.cards.basiclands.Forest.class));
+        cards.add(new SetCardInfo("Forest", 6, Rarity.LAND, mage.cards.basiclands.Forest.class));
         cards.add(new SetCardInfo("Kaseto, Orochi Archmage", 5, Rarity.MYTHIC, mage.cards.k.KasetoOrochiArchmage.class));
         cards.add(new SetCardInfo("Lotus Cobra", 3, Rarity.RARE, mage.cards.l.LotusCobra.class));
         cards.add(new SetCardInfo("Sakura-Tribe Elder", 4, Rarity.RARE, mage.cards.s.SakuraTribeElder.class));

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -2943,3 +2943,9 @@
 
 # PL23
 |Generate|TOK:PL23|Food|||FoodToken|
+
+# PL24
+|Generate|TOK:PL24|Dragon|||DragonToken|
+
+# PL25
+|Generate|TOK:PL25|Snake|||SnakeToken|


### PR DESCRIPTION
Added the following sets:

- Love Your LGS 2020
- Love Your LGS 2022
- Regional Championship Qualifiers 2022
- 30th Anniversary History Promos
- MagicFest 2023
- MagicFest 2024
- Year of the Dragon 2024
- MKM Standard Showdown
- Love Your LGS 2024
- Year of the Snake 2025

Added new cards to:

- Store Championships
- Wizards Play Network 2025
- URL/Convention Promos
- Secret Laid Drop
- Magicfest 2025