### PR TITLE
FullArt and Retro Frame Test

### DIFF
--- a/Mage.Verify/src/main/java/mage/verify/mtgjson/MtgJsonCard.java
+++ b/Mage.Verify/src/main/java/mage/verify/mtgjson/MtgJsonCard.java
@@ -43,6 +43,8 @@ public final class MtgJsonCard {
     public String frameVersion;
     public List<String> printings; // set codes with that card
     public boolean isFunny;
+    public List<String> promoTypes;
+    public boolean isTextless;
 
     @Override
     public String toString() {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -790,6 +790,13 @@ public class VerifyCardDataTest {
                             + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
                 }
 
+               // CHECK: full art lands must use full art setting
+               boolean isLand = card.getRarity().equals(Rarity.LAND);
+               if (jsonCard.isFullArt && isLand && !card.isFullArt()) {
+                   errorsList.add("Error: card must use full art setting: "
+                           + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+               }
+
                 // CHECK: must use retro frame setting
                 if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {
                     errorsList.add("Error: card must use retro art setting: "

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -772,12 +772,6 @@ public class VerifyCardDataTest {
         Collection<String> errorsList = new ArrayList<>();
         Collection<ExpansionSet> xmageSets = Sets.getInstance().values();
 
-        // fast check instead card's db search (only main side card)
-        Set<String> implementedIndex = new HashSet<>();
-        CardRepository.instance.findCards(new CardCriteria()).forEach(card -> {
-            implementedIndex.add(card.getName());
-        });
-
         // CHECK: wrong card numbers
         for (ExpansionSet set : xmageSets) {
             if (skipListHaveName(SKIP_LIST_WRONG_CARD_NUMBERS, set.getCode())) {
@@ -790,14 +784,8 @@ public class VerifyCardDataTest {
                     continue;
                 }
 
-                // CHECK: poster promoType must use full art setting
-                if ((jsonCard.promoTypes != null && jsonCard.promoTypes.contains("poster")) && !card.isFullArt()) {
-                    errorsList.add("Error: card must use full art setting: "
-                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-                }
-
-                // CHECK: textless must use full art setting
-                if (jsonCard.isTextless && !card.isFullArt()) {
+                // CHECK: poster promoType and/or textless must use full art setting
+                if (((jsonCard.promoTypes != null && jsonCard.promoTypes.contains("poster")) || jsonCard.isTextless) && !card.isFullArt()) {
                     errorsList.add("Error: card must use full art setting: "
                             + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
                 }

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -719,7 +719,7 @@ public class VerifyCardDataTest {
 //                }
 
                 // CHECK: poster promoType must use full art setting
-                if (jsonCard.promoTypes.contains("poster") && !card.isFullArt()) {
+                if ((jsonCard.promoTypes != null && jsonCard.promoTypes.contains("poster")) && !card.isFullArt()) {
                     errorsList.add("Error: card must use full art setting: "
                             + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
                 }

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -718,6 +718,18 @@ public class VerifyCardDataTest {
 //                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
 //                }
 
+                // CHECK: poster promoType must use full art setting
+                if (jsonCard.promoTypes.contains("poster") && !card.isFullArt()) {
+                   errorsList.add("Error: card must use full art setting: "
+                           + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+               }
+
+                // CHECK: textless must use full art setting
+                if (jsonCard.isTextless && !card.isFullArt()) {
+                   errorsList.add("Error: card must use full art setting: "
+                           + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+               }
+
                 // CHECK: must use retro frame setting
                 if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {
                     errorsList.add("Error: card must use retro art setting: "

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -718,18 +718,6 @@ public class VerifyCardDataTest {
 //                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
 //                }
 
-                // CHECK: poster promoType must use full art setting
-                if ((jsonCard.promoTypes != null && jsonCard.promoTypes.contains("poster")) && !card.isFullArt()) {
-                    errorsList.add("Error: card must use full art setting: "
-                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-                }
-
-                // CHECK: textless must use full art setting
-                if (jsonCard.isTextless && !card.isFullArt()) {
-                    errorsList.add("Error: card must use full art setting: "
-                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-                }
-
                 // CHECK: must use retro frame setting
                 if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {
                     errorsList.add("Error: card must use retro art setting: "
@@ -772,6 +760,56 @@ public class VerifyCardDataTest {
         }
 
         printMessages(warningsList);
+        printMessages(errorsList);
+        if (errorsList.size() > 0) {
+            Assert.fail("Found wrong cards data in sets, errors: " + errorsList.size());
+        }
+    }
+
+    @Test
+    @Ignore
+    public void test_checkWrongFullArtAndRetro() {
+        Collection<String> errorsList = new ArrayList<>();
+        Collection<ExpansionSet> xmageSets = Sets.getInstance().values();
+
+        // fast check instead card's db search (only main side card)
+        Set<String> implementedIndex = new HashSet<>();
+        CardRepository.instance.findCards(new CardCriteria()).forEach(card -> {
+            implementedIndex.add(card.getName());
+        });
+
+        // CHECK: wrong card numbers
+        for (ExpansionSet set : xmageSets) {
+            if (skipListHaveName(SKIP_LIST_WRONG_CARD_NUMBERS, set.getCode())) {
+                continue;
+            }
+
+            for (ExpansionSet.SetCardInfo card : set.getSetCardInfo()) {
+                MtgJsonCard jsonCard = MtgJsonService.cardFromSet(set.getCode(), card.getName(), card.getCardNumber());
+                if (jsonCard == null) {
+                    continue;
+                }
+
+                // CHECK: poster promoType must use full art setting
+                if ((jsonCard.promoTypes != null && jsonCard.promoTypes.contains("poster")) && !card.isFullArt()) {
+                    errorsList.add("Error: card must use full art setting: "
+                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+                }
+
+                // CHECK: textless must use full art setting
+                if (jsonCard.isTextless && !card.isFullArt()) {
+                    errorsList.add("Error: card must use full art setting: "
+                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+                }
+
+                // CHECK: must use retro frame setting
+                if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {
+                    errorsList.add("Error: card must use retro art setting: "
+                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+                }
+            }
+        }
+
         printMessages(errorsList);
         if (errorsList.size() > 0) {
             Assert.fail("Found wrong cards data in sets, errors: " + errorsList.size());

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -697,32 +697,6 @@ public class VerifyCardDataTest {
 //                String code = MtgJsonService.xMageToMtgJsonCodes.getOrDefault(set.getCode(), set.getCode()) + " - " + jsonCard.getNameAsFull() + " - " + jsonCard.number;
 //                foundedJsonCards.add(code);
 //
-//                // CHECK: only lands can use full art in current version;
-//                // Another cards must be in text render mode as normal, example: https://scryfall.com/card/sld/76/athreos-god-of-passage
-//                // TODO: add support textless cards like https://scryfall.com/card/sch/12/thalia-and-the-gitrog-monster
-//                boolean isLand = card.getRarity().equals(Rarity.LAND);
-//                if (card.isFullArt() && !isLand) {
-//                    errorsList.add("Error: only lands can use full art setting: "
-//                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-//                }
-//
-//                // CHECK: must use full art setting
-//                if (jsonCard.isFullArt && isLand && !card.isFullArt()) {
-//                    errorsList.add("Error: card must use full art setting: "
-//                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-//                }
-//
-//                // CHECK: must not use full art setting
-//                if (!jsonCard.isFullArt && card.isFullArt()) {
-//                    errorsList.add("Error: card must NOT use full art setting: "
-//                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-//                }
-
-                // CHECK: must use retro frame setting
-                if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {
-                    errorsList.add("Error: card must use retro art setting: "
-                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-                }
             }
         }
 
@@ -792,14 +766,26 @@ public class VerifyCardDataTest {
 
                // CHECK: full art lands must use full art setting
                boolean isLand = card.getRarity().equals(Rarity.LAND);
-               if (jsonCard.isFullArt && isLand && !card.isFullArt()) {
-                   errorsList.add("Error: card must use full art setting: "
+               if (isLand && jsonCard.isFullArt && !card.isFullArt()) {
+                   errorsList.add("Error: card must use full art lands setting: "
+                           + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+               }
+
+               // CHECK: non-full art lands must not use full art setting
+               if (isLand && !jsonCard.isFullArt && card.isFullArt()) {
+                   errorsList.add("Error: card must NOT use full art lands setting: "
                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
                }
 
                 // CHECK: must use retro frame setting
                 if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {
                     errorsList.add("Error: card must use retro art setting: "
+                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+                }
+                
+                // CHECK: must not use retro frame setting
+                if ((!(jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997"))) && card.isRetroFrame()) {
+                    errorsList.add("Error: card must NOT use retro art setting: "
                             + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
                 }
             }

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -720,15 +720,15 @@ public class VerifyCardDataTest {
 
                 // CHECK: poster promoType must use full art setting
                 if (jsonCard.promoTypes.contains("poster") && !card.isFullArt()) {
-                   errorsList.add("Error: card must use full art setting: "
-                           + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-               }
+                    errorsList.add("Error: card must use full art setting: "
+                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+                }
 
                 // CHECK: textless must use full art setting
                 if (jsonCard.isTextless && !card.isFullArt()) {
-                   errorsList.add("Error: card must use full art setting: "
-                           + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
-               }
+                    errorsList.add("Error: card must use full art setting: "
+                            + set.getCode() + " - " + set.getName() + " - " + card.getName() + " - " + card.getCardNumber());
+                }
 
                 // CHECK: must use retro frame setting
                 if ((jsonCard.frameVersion.equals("1993") || jsonCard.frameVersion.equals("1997")) && !card.isRetroFrame()) {


### PR DESCRIPTION
I split out a few checks from `test_checkWrongCardsDataInSets` into their own test which greatly reduced the number of errors. `test_checkWrongFullArtAndRetro` will:

- check if cards are textless or a poster and not configured for FullArt
- check if cards should have a Retro frame and aren't configured with one
- check if land cards are fullart but not configured as fullart

I've kept it as Ignored but it looks good in my testing. Would greatly appreciate some extra reviews though and feedback on removing the Ignore.