### PR TITLE
Fix card numbers for failing downloads

### DIFF
--- a/Mage.Sets/src/mage/sets/EldritchMoonPromos.java
+++ b/Mage.Sets/src/mage/sets/EldritchMoonPromos.java
@@ -26,7 +26,7 @@ public class EldritchMoonPromos extends ExpansionSet {
         cards.add(new SetCardInfo("Bedlam Reveler", "118s", Rarity.RARE, mage.cards.b.BedlamReveler.class));
         cards.add(new SetCardInfo("Bloodhall Priest", "181s", Rarity.RARE, mage.cards.b.BloodhallPriest.class));
         cards.add(new SetCardInfo("Brisela, Voice of Nightmares", "15bs", Rarity.MYTHIC, mage.cards.b.BriselaVoiceOfNightmares.class));
-        cards.add(new SetCardInfo("Bruna, the Fading Light", "15as", Rarity.RARE, mage.cards.b.BrunaTheFadingLight.class));
+        cards.add(new SetCardInfo("Bruna, the Fading Light", "15s", Rarity.RARE, mage.cards.b.BrunaTheFadingLight.class));
         cards.add(new SetCardInfo("Coax from the Blind Eternities", "51s", Rarity.RARE, mage.cards.c.CoaxFromTheBlindEternities.class));
         cards.add(new SetCardInfo("Collective Brutality", "85s", Rarity.RARE, mage.cards.c.CollectiveBrutality.class));
         cards.add(new SetCardInfo("Collective Defiance", "123s", Rarity.RARE, mage.cards.c.CollectiveDefiance.class));
@@ -48,7 +48,7 @@ public class EldritchMoonPromos extends ExpansionSet {
         cards.add(new SetCardInfo("Gisela, the Broken Blade", "28s", Rarity.MYTHIC, mage.cards.g.GiselaTheBrokenBlade.class));
         cards.add(new SetCardInfo("Grim Flayer", "184s", Rarity.MYTHIC, mage.cards.g.GrimFlayer.class));
         cards.add(new SetCardInfo("Hanweir Battlements", "204s", Rarity.RARE, mage.cards.h.HanweirBattlements.class));
-        cards.add(new SetCardInfo("Hanweir Garrison", "130as", Rarity.RARE, mage.cards.h.HanweirGarrison.class));
+        cards.add(new SetCardInfo("Hanweir Garrison", "130s", Rarity.RARE, mage.cards.h.HanweirGarrison.class));
         cards.add(new SetCardInfo("Hanweir, the Writhing Township", "130bs", Rarity.RARE, mage.cards.h.HanweirTheWrithingTownship.class));
         cards.add(new SetCardInfo("Harmless Offering", "131s", Rarity.RARE, mage.cards.h.HarmlessOffering.class));
         cards.add(new SetCardInfo("Heron's Grace Champion", 185, Rarity.RARE, mage.cards.h.HeronsGraceChampion.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/FromTheVaultTransform.java
+++ b/Mage.Sets/src/mage/sets/FromTheVaultTransform.java
@@ -28,7 +28,7 @@ public final class FromTheVaultTransform extends ExpansionSet {
         cards.add(new SetCardInfo("Arlinn, Embraced by the Moon", 3, Rarity.MYTHIC, mage.cards.a.ArlinnEmbracedByTheMoon.class));
         cards.add(new SetCardInfo("Bloodline Keeper", 4, Rarity.MYTHIC, mage.cards.b.BloodlineKeeper.class));
         cards.add(new SetCardInfo("Lord of Lineage", 4, Rarity.MYTHIC, mage.cards.l.LordOfLineage.class));
-        cards.add(new SetCardInfo("Bruna, the Fading Light", "5a", Rarity.MYTHIC, mage.cards.b.BrunaTheFadingLight.class));
+        cards.add(new SetCardInfo("Bruna, the Fading Light", 5, Rarity.MYTHIC, mage.cards.b.BrunaTheFadingLight.class));
         cards.add(new SetCardInfo("Brisela, Voice of Nightmares", "5b", Rarity.MYTHIC, mage.cards.b.BriselaVoiceOfNightmares.class));
         cards.add(new SetCardInfo("Chandra, Fire of Kaladesh", 6, Rarity.MYTHIC, mage.cards.c.ChandraFireOfKaladesh.class));
         cards.add(new SetCardInfo("Chandra, Roaring Flame", 6, Rarity.MYTHIC, mage.cards.c.ChandraRoaringFlame.class));

--- a/Mage.Sets/src/mage/sets/InnistradRemastered.java
+++ b/Mage.Sets/src/mage/sets/InnistradRemastered.java
@@ -107,7 +107,7 @@ public class InnistradRemastered extends ExpansionSet {
         cards.add(new SetCardInfo("Bramble Wurm", 187, Rarity.COMMON, mage.cards.b.BrambleWurm.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Bramble Wurm", 407, Rarity.COMMON, mage.cards.b.BrambleWurm.class, RETRO_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Brisela, Voice of Nightmares", "14b", Rarity.MYTHIC, mage.cards.b.BriselaVoiceOfNightmares.class));
-        cards.add(new SetCardInfo("Bruna, the Fading Light", "14a", Rarity.RARE, mage.cards.b.BrunaTheFadingLight.class));
+        cards.add(new SetCardInfo("Bruna, the Fading Light", 14, Rarity.RARE, mage.cards.b.BrunaTheFadingLight.class));
         cards.add(new SetCardInfo("Burning Vengeance", 147, Rarity.UNCOMMON, mage.cards.b.BurningVengeance.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Burning Vengeance", 397, Rarity.UNCOMMON, mage.cards.b.BurningVengeance.class,RETRO_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Butcher Ghoul", 373, Rarity.COMMON, mage.cards.b.ButcherGhoul.class, RETRO_ART_USE_VARIOUS));
@@ -272,7 +272,7 @@ public class InnistradRemastered extends ExpansionSet {
         cards.add(new SetCardInfo("Hamlet Captain", 201, Rarity.UNCOMMON, mage.cards.h.HamletCaptain.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Hamlet Captain", 413, Rarity.UNCOMMON, mage.cards.h.HamletCaptain.class, RETRO_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Hanweir Battlements", 279, Rarity.RARE, mage.cards.h.HanweirBattlements.class));
-        cards.add(new SetCardInfo("Hanweir Garrison", "157a", Rarity.RARE, mage.cards.h.HanweirGarrison.class));
+        cards.add(new SetCardInfo("Hanweir Garrison", 157, Rarity.RARE, mage.cards.h.HanweirGarrison.class));
         cards.add(new SetCardInfo("Hanweir Watchkeep", 158, Rarity.COMMON, mage.cards.h.HanweirWatchkeep.class));
         cards.add(new SetCardInfo("Hanweir, the Writhing Township", "157b", Rarity.RARE, mage.cards.h.HanweirTheWrithingTownship.class));
         cards.add(new SetCardInfo("Harvest Hand", 265, Rarity.COMMON, mage.cards.h.HarvestHand.class));

--- a/Mage.Sets/src/mage/sets/ShadowsOverInnistradRemastered.java
+++ b/Mage.Sets/src/mage/sets/ShadowsOverInnistradRemastered.java
@@ -61,7 +61,7 @@ public class ShadowsOverInnistradRemastered extends ExpansionSet {
         cards.add(new SetCardInfo("Brain in a Jar", 247, Rarity.UNCOMMON, mage.cards.b.BrainInAJar.class));
         cards.add(new SetCardInfo("Briarbridge Patrol", 187, Rarity.COMMON, mage.cards.b.BriarbridgePatrol.class));
         cards.add(new SetCardInfo("Brisela, Voice of Nightmares", "17b", Rarity.MYTHIC, mage.cards.b.BriselaVoiceOfNightmares.class));
-        cards.add(new SetCardInfo("Bruna, the Fading Light", "17a", Rarity.RARE, mage.cards.b.BrunaTheFadingLight.class));
+        cards.add(new SetCardInfo("Bruna, the Fading Light", 17, Rarity.RARE, mage.cards.b.BrunaTheFadingLight.class));
         cards.add(new SetCardInfo("Burn from Within", 147, Rarity.RARE, mage.cards.b.BurnFromWithin.class));
         cards.add(new SetCardInfo("Bygone Bishop", 18, Rarity.RARE, mage.cards.b.BygoneBishop.class));
         cards.add(new SetCardInfo("Byway Courier", 188, Rarity.COMMON, mage.cards.b.BywayCourier.class));
@@ -158,7 +158,7 @@ public class ShadowsOverInnistradRemastered extends ExpansionSet {
         cards.add(new SetCardInfo("Goldnight Castigator", 160, Rarity.MYTHIC, mage.cards.g.GoldnightCastigator.class));
         cards.add(new SetCardInfo("Graf Harvest", 114, Rarity.UNCOMMON, mage.cards.g.GrafHarvest.class));
         cards.add(new SetCardInfo("Graf Mole", 197, Rarity.UNCOMMON, mage.cards.g.GrafMole.class));
-        cards.add(new SetCardInfo("Graf Rats", "115a", Rarity.COMMON, mage.cards.g.GrafRats.class));
+        cards.add(new SetCardInfo("Graf Rats", 115, Rarity.COMMON, mage.cards.g.GrafRats.class));
         cards.add(new SetCardInfo("Grapple with the Past", 198, Rarity.COMMON, mage.cards.g.GrappleWithThePast.class));
         cards.add(new SetCardInfo("Grim Flayer", 234, Rarity.RARE, mage.cards.g.GrimFlayer.class));
         cards.add(new SetCardInfo("Grotesque Mutation", 116, Rarity.COMMON, mage.cards.g.GrotesqueMutation.class));
@@ -167,7 +167,7 @@ public class ShadowsOverInnistradRemastered extends ExpansionSet {
         cards.add(new SetCardInfo("Guardian of Pilgrims", 32, Rarity.COMMON, mage.cards.g.GuardianOfPilgrims.class));
         cards.add(new SetCardInfo("Hamlet Captain", 200, Rarity.UNCOMMON, mage.cards.h.HamletCaptain.class));
         cards.add(new SetCardInfo("Hanweir Battlements", 271, Rarity.RARE, mage.cards.h.HanweirBattlements.class));
-        cards.add(new SetCardInfo("Hanweir Garrison", "161a", Rarity.RARE, mage.cards.h.HanweirGarrison.class));
+        cards.add(new SetCardInfo("Hanweir Garrison", 161, Rarity.RARE, mage.cards.h.HanweirGarrison.class));
         cards.add(new SetCardInfo("Hanweir, the Writhing Township", "161b", Rarity.RARE, mage.cards.h.HanweirTheWrithingTownship.class));
         cards.add(new SetCardInfo("Harvest Hand", 252, Rarity.UNCOMMON, mage.cards.h.HarvestHand.class));
         cards.add(new SetCardInfo("Haunted Dead", 117, Rarity.UNCOMMON, mage.cards.h.HauntedDead.class));

--- a/Mage.Sets/src/mage/sets/TheBrothersWar.java
+++ b/Mage.Sets/src/mage/sets/TheBrothersWar.java
@@ -47,7 +47,7 @@ public final class TheBrothersWar extends ExpansionSet {
         cards.add(new SetCardInfo("Arcane Proxy", 319, Rarity.MYTHIC, mage.cards.a.ArcaneProxy.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Arcane Proxy", 75, Rarity.MYTHIC, mage.cards.a.ArcaneProxy.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Argivian Avenger", 232, Rarity.UNCOMMON, mage.cards.a.ArgivianAvenger.class));
-        cards.add(new SetCardInfo("Argoth, Sanctum of Nature", "256a", Rarity.RARE, mage.cards.a.ArgothSanctumOfNature.class));
+        cards.add(new SetCardInfo("Argoth, Sanctum of Nature", 256, Rarity.RARE, mage.cards.a.ArgothSanctumOfNature.class));
         cards.add(new SetCardInfo("Argothian Opportunist", 167, Rarity.COMMON, mage.cards.a.ArgothianOpportunist.class));
         cards.add(new SetCardInfo("Argothian Sprite", 168, Rarity.COMMON, mage.cards.a.ArgothianSprite.class));
         cards.add(new SetCardInfo("Arms Race", 126, Rarity.UNCOMMON, mage.cards.a.ArmsRace.class));
@@ -268,7 +268,7 @@ public final class TheBrothersWar extends ExpansionSet {
         cards.add(new SetCardInfo("Perennial Behemoth", 350, Rarity.RARE, mage.cards.p.PerennialBehemoth.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Perimeter Patrol", 188, Rarity.COMMON, mage.cards.p.PerimeterPatrol.class));
         cards.add(new SetCardInfo("Phalanx Vanguard", 19, Rarity.COMMON, mage.cards.p.PhalanxVanguard.class));
-        cards.add(new SetCardInfo("Phyrexian Dragon Engine", "163a", Rarity.RARE, mage.cards.p.PhyrexianDragonEngine.class));
+        cards.add(new SetCardInfo("Phyrexian Dragon Engine", 163, Rarity.RARE, mage.cards.p.PhyrexianDragonEngine.class));
         cards.add(new SetCardInfo("Phyrexian Fleshgorger", 121, Rarity.MYTHIC, mage.cards.p.PhyrexianFleshgorger.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Phyrexian Fleshgorger", 332, Rarity.MYTHIC, mage.cards.p.PhyrexianFleshgorger.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Plains", 268, Rarity.LAND, mage.cards.basiclands.Plains.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
Looks like a few card numbers have changed, causing download errors. Updated to match current scryfall numbering.

```
INFO  2025-09-09 08:17:28,526 Scryfall: bulk image not found (outdated cards data in xmage?): Bruna, the Fading Light/inr/14a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,528 Scryfall: bulk image not found (outdated cards data in xmage?): Bruna, the Fading Light/sir/17a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,581 Scryfall: bulk image not found (outdated cards data in xmage?): Bruna, the Fading Light/pemn/15as/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,591 Scryfall: bulk image not found (outdated cards data in xmage?): Hanweir Garrison/pemn/130as/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,597 Scryfall: bulk image not found (outdated cards data in xmage?): Bruna, the Fading Light/v17/5a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,607 Scryfall: bulk image not found (outdated cards data in xmage?): Hanweir Garrison/inr/157a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,613 Scryfall: bulk image not found (outdated cards data in xmage?): Phyrexian Dragon Engine/bro/163a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,624 Scryfall: bulk image not found (outdated cards data in xmage?): Argoth, Sanctum of Nature/bro/256a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,626 Scryfall: bulk image not found (outdated cards data in xmage?): Graf Rats/sir/115a/        =>[Thread-19] ScryfallImageSource.analyseBulkData 
INFO  2025-09-09 08:17:28,627 Scryfall: bulk image not found (outdated cards data in xmage?): Hanweir Garrison/sir/161a/  =>[Thread-19] ScryfallImageSource.analyseBulkData 
```