### PR TITLE
Update dependency versions

### DIFF
--- a/Mage.Client/pom.xml
+++ b/Mage.Client/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-transcoder</artifactId>
-            <version>1.17</version>
+            <version>1.19</version>
         </dependency>
         <!-- svg support END -->
 

--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.27.1</version>
+            <version>1.28.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
                 <!-- json support -->
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.11.0</version>
+                <version>2.13.1</version>
             </dependency>
             <dependency>
                 <!-- extended lib from google (collections, io, etc) -->
@@ -367,13 +367,13 @@
                 <!-- lib with useful code and utils -->
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>3.18.0</version>
             </dependency>
             <dependency>
                 <!-- scraping lib to download and parse html/symbols/images/svg -->
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.21.1</version>
+                <version>1.21.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
                 <!-- json support -->
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
-                <version>2.13.1</version>
+                <version>2.13.2</version>
             </dependency>
             <dependency>
                 <!-- extended lib from google (collections, io, etc) -->


### PR DESCRIPTION
Closes out a few additional vulnerabilities with dependencies and dependencies of dependencies.

Updates:

* batik-transcoder to 1.19
* commons-compress to 1.28.0
* gson to 2.13.2
* commons-lang3 to 3.18.0
* jsoup to 1.21.2