### PR TITLE
[DSK] Implement Walk-In Closet // Forgotten Cellar

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WalkInClosetForgottenCellar.java
+++ b/Mage.Sets/src/mage/cards/w/WalkInClosetForgottenCellar.java
@@ -1,0 +1,49 @@
+package mage.cards.w;
+
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.common.UnlockThisDoorTriggeredAbility;
+import mage.abilities.effects.common.replacement.GraveyardFromAnywhereExileReplacementEffect;
+import mage.abilities.effects.common.ruleModifying.PlayFromGraveyardControllerEffect;
+import mage.cards.CardSetInfo;
+import mage.cards.RoomCard;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SpellAbilityType;
+import mage.constants.SubType;
+import mage.filter.StaticFilters;
+
+import java.util.UUID;
+
+/**
+ * @author PurpleCrowbar
+ */
+public final class WalkInClosetForgottenCellar extends RoomCard {
+
+    public WalkInClosetForgottenCellar(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{G}", "{3}{G}{G}", SpellAbilityType.SPLIT);
+        this.subtype.add(SubType.ROOM);
+
+        // Walk-In Closet: You may play lands from your graveyard.
+        SimpleStaticAbility left = new SimpleStaticAbility(PlayFromGraveyardControllerEffect.playLands());
+
+        // Forgotten Cellar: When you unlock this door, you may cast spells from your graveyard this turn, and if a card would be put into your graveyard from anywhere this turn, exile it instead.
+        UnlockThisDoorTriggeredAbility right = new UnlockThisDoorTriggeredAbility(
+                new PlayFromGraveyardControllerEffect(StaticFilters.FILTER_CARD_NON_LAND, Duration.EndOfTurn)
+                        .setText("you may cast spells from your graveyard this turn"), false, false
+        );
+        right.addEffect(new GraveyardFromAnywhereExileReplacementEffect(Duration.EndOfTurn).concatBy(", and")
+                .setText("if a card would be put into your graveyard from anywhere this turn, exile it instead")
+        );
+
+        this.addRoomAbilities(left, right);
+    }
+
+    private WalkInClosetForgottenCellar(final WalkInClosetForgottenCellar card) {
+        super(card);
+    }
+
+    @Override
+    public WalkInClosetForgottenCellar copy() {
+        return new WalkInClosetForgottenCellar(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/DuskmournHouseOfHorror.java
+++ b/Mage.Sets/src/mage/sets/DuskmournHouseOfHorror.java
@@ -387,6 +387,8 @@ public final class DuskmournHouseOfHorror extends ExpansionSet {
         cards.add(new SetCardInfo("Victor, Valgavoth's Seneschal", 364, Rarity.RARE, mage.cards.v.VictorValgavothsSeneschal.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Vile Mutilator", 122, Rarity.UNCOMMON, mage.cards.v.VileMutilator.class));
         cards.add(new SetCardInfo("Violent Urge", 164, Rarity.UNCOMMON, mage.cards.v.ViolentUrge.class));
+        cards.add(new SetCardInfo("Walk-In Closet // Forgotten Cellar", 205, Rarity.MYTHIC, mage.cards.w.WalkInClosetForgottenCellar.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Walk-In Closet // Forgotten Cellar", 341, Rarity.MYTHIC, mage.cards.w.WalkInClosetForgottenCellar.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Waltz of Rage", 165, Rarity.RARE, mage.cards.w.WaltzOfRage.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Waltz of Rage", 318, Rarity.RARE, mage.cards.w.WaltzOfRage.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Wary Watchdog", 206, Rarity.COMMON, mage.cards.w.WaryWatchdog.class));


### PR DESCRIPTION
Tested and this works completely fine from a gameplay standpoint, but am making this a PR to highlight a weird quirk of the Rooms implementation. Playing a land from the graveyard using [Walk-In Closet](https://scryfall.com/card/dsk/205/walk-in-closet-forgotten-cellar)'s static ability opened up a window of four copies of the same ability, with two unique IDs among them (presumably the ID of the "door" and the ID of the entire room?).

With just Walk-In Closet unlocked:
<img width="765" height="529" alt="image" src="https://github.com/user-attachments/assets/c1d9d9c1-613b-4aad-a9ad-9e20ff0d1fce" />

With both halves unlocked:
<img width="772" height="501" alt="image" src="https://github.com/user-attachments/assets/a55933e6-1314-4691-9fe1-26d027340f26" />
