### PR TITLE
Cover style for background images

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/theme/ThemePluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/theme/ThemePluginImpl.java
@@ -82,7 +82,7 @@ public class ThemePluginImpl implements ThemePlugin {
             }
 
             if (ui.containsKey("gamePanel") && ui.containsKey("jLayeredPane")) {
-                ImagePanel bgPanel = new ImagePanel(backgroundImage, ImagePanelStyle.TILED);
+                ImagePanel bgPanel = new ImagePanel(backgroundImage, ImagePanelStyle.COVER);
 
                 // TODO: research - is all components used? And why it make transparent?
                 unsetOpaque(ui.get("splitChatAndLogs"));

--- a/Mage.Common/src/main/java/mage/components/ImagePanel.java
+++ b/Mage.Common/src/main/java/mage/components/ImagePanel.java
@@ -78,6 +78,9 @@ public class ImagePanel extends JPanel {
             case ACTUAL:
                 drawActual(g);
                 break;
+            case COVER:
+                drawCover(g);
+                break;
         }
     }
 
@@ -98,5 +101,26 @@ public class ImagePanel extends JPanel {
         float x = (d.width - image.getWidth(null)) * alignmentX;
         float y = (d.height - image.getHeight(null)) * alignmentY;
         g.drawImage(image, (int) x, (int) y, this);
+    }
+
+    private void drawCover(Graphics g) {
+        Dimension d = getSize();
+        int imageWidth = image.getWidth(null);
+        int imageHeight = image.getHeight(null);
+
+        // Calculate scale to cover the entire panel while maintaining aspect ratio
+        double scaleX = (double) d.width / imageWidth;
+        double scaleY = (double) d.height / imageHeight;
+        double scale = Math.max(scaleX, scaleY);
+
+        // Calculate the scaled dimensions
+        int scaledWidth = (int) (imageWidth * scale);
+        int scaledHeight = (int) (imageHeight * scale);
+
+        // Center the image
+        int x = (d.width - scaledWidth) / 2;
+        int y = (d.height - scaledHeight) / 2;
+
+        g.drawImage(image, x, y, scaledWidth, scaledHeight, null);
     }
 }

--- a/Mage.Common/src/main/java/mage/components/ImagePanelStyle.java
+++ b/Mage.Common/src/main/java/mage/components/ImagePanelStyle.java
@@ -4,5 +4,5 @@ package mage.components;
  * Created by IGOUDT on 7-3-2017.
  */
 public enum ImagePanelStyle {
-    TILED, SCALED, ACTUAL
+    TILED, SCALED, ACTUAL, COVER
 }


### PR DESCRIPTION
Adds a new COVER style for background images that scales them to fill the entire panel while maintaining aspect ratio, similar to CSS background-size: cover. This provides better visual presentation for battlefield backgrounds by ensuring they cover  the full play area without distortion or tiling artifacts.

  Changes:
  - Added COVER enum value to ImagePanelStyle
  - Implemented drawCover() method in ImagePanel that scales and centers the image
  - Updated battlefield background to use COVER instead of TILED for better appearance


Before 
<img width="2560" height="1440" alt="before" src="https://github.com/user-attachments/assets/a2c6f47d-c175-4eed-80ab-bd1656608dcc" />

After

<img width="2560" height="1440" alt="after" src="https://github.com/user-attachments/assets/2535e29d-c8fe-4446-ac58-33d366727a30" />
