### PR TITLE
fix CarnageCrimsonChaos ability

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CarnageCrimsonChaos.java
+++ b/Mage.Sets/src/mage/cards/c/CarnageCrimsonChaos.java
@@ -35,6 +35,7 @@ public final class CarnageCrimsonChaos extends CardImpl {
     private static final FilterCard filter = new FilterCard("creature card with mana value 3 or less");
 
     static {
+        filter.add(CardType.CREATURE.getPredicate());
         filter.add(new ManaValuePredicate(ComparisonType.OR_LESS, 3));
     }
 


### PR DESCRIPTION
The ability say "return target creature card with mana value 3 or less". Before the fix you can choose any kind of card creating an error when adding the second part of the ability