### PR TITLE
Fix NullPointerException for null TrayIcon

### DIFF
--- a/Mage.Client/src/main/java/mage/client/components/tray/MageTray.java
+++ b/Mage.Client/src/main/java/mage/client/components/tray/MageTray.java
@@ -79,13 +79,15 @@ public enum MageTray {
             } catch (AWTException e) {
                 log.error("TrayIcon could not be added: ", e);
             }
-
         } catch (Exception e) {
             log.error(e);
         }
     }
 
     public synchronized void blink() {
+        if (trayIcon == null)
+            return;
+
         if (state == 0) {
             synchronized (MageTray.class) {
                 if (state == 0) {


### PR DESCRIPTION
On various systems there is no `TrayIcon` support (e.g. Gnome).
Currently events like joining/leaving tables causes error dialogs on those systems.

This PR adds a check if the `tray` object is non-null instead of running into an exception.