### PR TITLE
[minor] Local build process updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ Utils/*implemented.txt
 # build tools
 mage-bundle.zip
 .env
+
+# build targets
+/deploy
+/temp

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ build:
 .PHONY: package
 package:
 	# Packaging Mage.Client to zip
-	cd Mage.Client && mvn assembly:single
+	cd Mage.Client && mvn package assembly:single
 	# Packaging Mage.Server to zip
-	cd Mage.Server && mvn assembly:single
+	cd Mage.Server && mvn package assembly:single
 	# Copying the files to the target directory
 	mkdir -p $(TARGET_DIR)
 	cp ./Mage.Server/target/mage-server.zip $(TARGET_DIR)


### PR DESCRIPTION
A handful of minor changes from trying to build things locally;

 * The `Makefile` needs to pass in `package` otherwise the expected JAR files for the Client and Server are not correctly built, and are then unable to be included in the generated ZIP file
 * The `Utils/build-and-package.pl` script  generates and tries to clean up after itself a `temp` directory. To safeguard the cleanup not working or local dev leaving it around, explicitly ignore it to prevent adding it to the git tree
 * The `Makefile` uses a `deploy` directory as a target, in the same vein as the second point, exclude it from git