### PR TITLE
Correct image URLs for Unglued tokens

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2889,12 +2889,12 @@ public class ScryfallImageSupportTokens {
             put("REX/Treasure", "https://api.scryfall.com/cards/trex/2?format=image");
 
             // UGL
-            put("UGL/Goblin", "https://api.scryfall.com/cards/tugl/4?format=image");
-            put("UGL/Pegasus", "https://api.scryfall.com/cards/tugl/1?format=image");
-            put("UGL/Rabid Sheep", "https://api.scryfall.com/cards/tugl/5?format=image");
-            put("UGL/Soldier", "https://api.scryfall.com/cards/tugl/2?format=image");
-            put("UGL/Squirrel", "https://api.scryfall.com/cards/tugl/6?format=image");
-            put("UGL/Zombie", "https://api.scryfall.com/cards/tugl/3?format=image");
+            put("UGL/Goblin", "https://api.scryfall.com/cards/tugl/92?format=image");
+            put("UGL/Pegasus", "https://api.scryfall.com/cards/tugl/89?format=image");
+            put("UGL/Rabid Sheep", "https://api.scryfall.com/cards/tugl/93?format=image");
+            put("UGL/Soldier", "https://api.scryfall.com/cards/tugl/90?format=image");
+            put("UGL/Squirrel", "https://api.scryfall.com/cards/tugl/94?format=image");
+            put("UGL/Zombie", "https://api.scryfall.com/cards/tugl/91?format=image");
 
             // UST
             put("UST/Angel", "https://api.scryfall.com/cards/tust/1?format=image");


### PR DESCRIPTION
Previously trying to download images would incur things like:

```
INFO  2025-12-26 11:23:38,459 http request 404 Not Found https://api.scryfall.com/cards/tugl/4?format=image              =>[XMAGE images downloader - 1] XmageURLConnection.printHttpResult 
WARN  2025-12-26 11:23:38,460 Image download failed for UGL - Goblin, http code: 404, url: https://api.scryfall.com/cards/tugl/4?format=image =>[XMAGE images downloader - 1] DownloadPicturesService$DownloadTask.run 
INFO  2025-12-26 11:23:38,751 http request 404 Not Found https://api.scryfall.com/cards/tugl/1?format=image              =>[XMAGE images downloader - 8] XmageURLConnection.printHttpResult 
WARN  2025-12-26 11:23:38,752 Image download failed for UGL - Pegasus, http code: 404, url: https://api.scryfall.com/cards/tugl/1?format=image =>[XMAGE images downloader - 8] DownloadPicturesService$DownloadTask.run 
INFO  2025-12-26 11:23:39,052 http request 404 Not Found https://api.scryfall.com/cards/tugl/5?format=image              =>[XMAGE images downloader - 6] XmageURLConnection.printHttpResult 
```

Checking the URLs being hit, those collector numbers don't map to what Scryfall uses.

<img width="252" height="440" alt="Screenshot 2025-12-26 at 11 50 12 AM" src="https://github.com/user-attachments/assets/99ee47d2-58bb-4c7c-8036-1d78fa77be2e" />

Correcting the image URLs accordingly and re-trying to download images from a locally built client succeeds. 