### PR TITLE
Audit Subtypes enum

### DIFF
--- a/Mage/src/main/java/mage/constants/SubType.java
+++ b/Mage/src/main/java/mage/constants/SubType.java
@@ -30,13 +30,13 @@ public enum SubType {
     GATE("Gate", SubTypeSet.NonBasicLandType),
     LAIR("Lair", SubTypeSet.NonBasicLandType),
     LOCUS("Locus", SubTypeSet.NonBasicLandType),
-    PLANET("Planet", SubTypeSet.NonBasicLandType),
-    SPHERE("Sphere", SubTypeSet.NonBasicLandType),
-    URZAS("Urza's", SubTypeSet.NonBasicLandType),
     MINE("Mine", SubTypeSet.NonBasicLandType),
+    PLANET("Planet", SubTypeSet.NonBasicLandType),
     POWER_PLANT("Power-Plant", SubTypeSet.NonBasicLandType),
+    SPHERE("Sphere", SubTypeSet.NonBasicLandType),
     TOWER("Tower", SubTypeSet.NonBasicLandType),
     TOWN("Town", SubTypeSet.NonBasicLandType),
+    URZAS("Urza's", SubTypeSet.NonBasicLandType),
 
     // 205.3h Enchantments have their own unique set of subtypes; these subtypes are called enchantment types.
     AURA("Aura", SubTypeSet.EnchantmentType),
@@ -134,8 +134,8 @@ public enum SubType {
     CAT("Cat", SubTypeSet.CreatureType),
     CENTAUR("Centaur", SubTypeSet.CreatureType),
     CEREAN("Cerean", SubTypeSet.CreatureType, true), // Star Wars
-    CHIMERA("Chimera", SubTypeSet.CreatureType),
     CHILD("Child", SubTypeSet.CreatureType),
+    CHIMERA("Chimera", SubTypeSet.CreatureType),
     CHISS("Chiss", SubTypeSet.CreatureType, true),
     CITIZEN("Citizen", SubTypeSet.CreatureType),
     CLAMFOLK("Clamfolk", SubTypeSet.CreatureType, true), // Unglued
@@ -349,8 +349,8 @@ public enum SubType {
     PROCESSOR("Processor", SubTypeSet.CreatureType),
     PUREBLOOD("Pureblood", SubTypeSet.CreatureType, true),
     // Q
-    QUARREN("Quarren", SubTypeSet.CreatureType, true), // Star Wars
     QU("Qu", SubTypeSet.CreatureType),
+    QUARREN("Quarren", SubTypeSet.CreatureType, true), // Star Wars
     // R
     RABBIT("Rabbit", SubTypeSet.CreatureType),
     RACCOON("Raccoon", SubTypeSet.CreatureType),
@@ -377,9 +377,9 @@ public enum SubType {
     SCORPION("Scorpion", SubTypeSet.CreatureType),
     SCOUT("Scout", SubTypeSet.CreatureType),
     SCULPTURE("Sculpture", SubTypeSet.CreatureType),
+    SEAL("Seal", SubTypeSet.CreatureType),
     SERF("Serf", SubTypeSet.CreatureType),
     SERPENT("Serpent", SubTypeSet.CreatureType),
-    SEAL("Seal", SubTypeSet.CreatureType),
     SERVO("Servo", SubTypeSet.CreatureType),
     SHADE("Shade", SubTypeSet.CreatureType),
     SHAMAN("Shaman", SubTypeSet.CreatureType),


### PR DESCRIPTION
Did some quick auditting of subtypes per the Comprehensive Rules and noticed a few missing items per the [latest published CR](https://media.wizards.com/2025/downloads/MagicCompRules%2020251114.txt?_gl=1*80iyxt*FPAU*MTM0MTkyMDU3NC4xNzY2ODQ2NjYw).

 * Attractions are a valid Artifact type, even if they're not implemented (yet! 😉)
 * Child is a valid Creature type. Outside of joke sets, it does feature on [a single tournament legal card](https://scryfall.com/card/unf/127/wee-champion)
 * A couple of Artifact subtypes were mixed in with the Creature subtypes. Functionally it was fine, but from a maintainer POV this was a minor inconvenience for checking if things were missing
 * Cite the CR references inline for future maintainers and provide some minor whitespace consistency 

For reference, I was able to cross check the CR with the Class definition via some rudimentary bash...

e.g. for planeswalkers copying the CR definition and running something like the below;
```
muz@m1 mage % for type in $(ruby -e '"Ajani, Aminatou, Angrath, Arlinn, Ashiok, Bahamut, Basri, Bolas, Calix, Chandra, Comet, Dack, Dakkon, Daretti, Davriel, Dihada, Domri, Dovin, Ellywick, Elminster, Elspeth, Estrid, Freyalise, Garruk, Gideon, Grist, Guff, Huatli, Jace, Jared, Jaya, Jeska, Kaito, Karn, Kasmina, Kaya, Kiora, Koth, Liliana, Lolth, Lukka, Minsc, Mordenkainen, Nahiri, Narset, Niko, Nissa, Nixilis, Oko, Quintorius, Ral, Rowan, Saheeli, Samut, Sarkhan, Serra, Sivitri, Sorin, Szat, Tamiyo, Tasha, Teferi, Teyo, Tezzeret, Tibalt, Tyvar, Ugin, Urza, Venser, Vivien, Vraska, Vronos, Will, Windgrace, Wrenn, Xenagos, Yanggu, Yanling, Zariel".split(", ").map {|x| puts x}'); do if grep -q $type /Users/muz/mage/Mage/src/main/java/mage/constants/SubType.java; then echo "$type FOUND"; else echo "$type MISSING"; fi; done | grep MISSING
```