### PR TITLE
Fix fetching double faced dual land art from ECL

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -763,6 +763,13 @@ public class ScryfallImageSupportCards {
             put("TDM/Scavenger Regent/379b", "https://api.scryfall.com/cards/tdm/379/en?format=image&face=back");
             put("TDM/Ugin, Eye of the Storms/382b", "https://api.scryfall.com/cards/tdm/382/en?format=image&face=back");
 
+            // ECL - double faced lands
+            put("ECL/Blood Crypt/349b", "https://api.scryfall.com/cards/ecl/349/en?format=image&face=back");
+            put("ECL/Hallowed Fountain/347b", "https://api.scryfall.com/cards/ecl/347/en?format=image&face=back");
+            put("ECL/Overgrown Tomb/350b", "https://api.scryfall.com/cards/ecl/350/en?format=image&face=back");
+            put("ECL/Steam Vents/348b", "https://api.scryfall.com/cards/ecl/348/en?format=image&face=back");
+            put("ECL/Temple Garden/351b", "https://api.scryfall.com/cards/ecl/351/en?format=image&face=back");
+
         }
     };
 


### PR DESCRIPTION
Current builds from `master` would throw these LOG lines and fail to fetch ECL's dual land art;

```
WARN  2025-12-30 11:17:44,565 Image download failed for ECL - Steam Vents, http code: 404, url: https://api.scryfall.com/cards/ecl/348b/en?format=image =>[XMAGE images downloader - 4] DownloadPicturesService$DownloadTask.run
WARN  2025-12-30 11:17:44,565 Image download failed for ECL - Steam Vents, http code: 404, url: https://api.scryfall.com/cards/ecl/348b?format=image&include_variations=true =>[XMAGE images downloader - 4] DownloadPicturesService$DownloadTask.run
INFO  2025-12-30 11:17:44,887 http request 404 Not Found https://api.scryfall.com/cards/ecl/351b?format=image&include_variations=true =>[XMAGE images downloader - 2] XmageURLConnection.printHttpResult
WARN  2025-12-30 11:17:44,889 Image download failed for ECL - Temple Garden, http code: 404, url: https://api.scryfall.com/cards/ecl/351b/en?format=image =>[XMAGE images downloader - 2] DownloadPicturesService$DownloadTask.run
WARN  2025-12-30 11:17:44,889 Image download failed for ECL - Temple Garden, http code: 404, url: https://api.scryfall.com/cards/ecl/351b?format=image&include_variations=true =>[XMAGE images downloader - 2] DownloadPicturesService$DownloadTask.run
```

Looks like this is another instance of needing the same treatment as prior sets with double-faced but not true flip cards.