### PR TITLE
Bump sqlite-jdbc from 3.32.3.2 to 3.39.2.0

### DIFF
--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -239,7 +239,7 @@
             <!-- database support - sqlite db engine (additional db for game records and stats) -->
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.32.3.2</version>
+            <version>3.39.2.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is the first version to add support for ppc64le:  https://github.com/xerial/sqlite-jdbc/commit/6ee09e1c959dd97a9f1099246c2dcfe59604dd89

I have been running the server on this platform with success.