### PR TITLE
Fix card gen for Ixalan Commander

### DIFF
--- a/Mage.Sets/src/mage/sets/TheLostCavernsOfIxalanCommander.java
+++ b/Mage.Sets/src/mage/sets/TheLostCavernsOfIxalanCommander.java
@@ -282,6 +282,7 @@ public final class TheLostCavernsOfIxalanCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Terramorphic Expanse", 360, Rarity.COMMON, mage.cards.t.TerramorphicExpanse.class));
         cards.add(new SetCardInfo("Tetzin, Gnome Champion", 13, Rarity.RARE, mage.cards.t.TetzinGnomeChampion.class));
         cards.add(new SetCardInfo("Thassa, God of the Sea", 176, Rarity.MYTHIC, mage.cards.t.ThassaGodOfTheSea.class));
+        cards.add(new SetCardInfo("The Grim Captain's Locker", 50, Rarity.RARE, mage.cards.t.TheGrimCaptainsLocker.class));
         cards.add(new SetCardInfo("The Indomitable", 43, Rarity.RARE, mage.cards.t.TheIndomitable.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("The Indomitable", 75, Rarity.RARE, mage.cards.t.TheIndomitable.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Thieving Skydiver", 177, Rarity.RARE, mage.cards.t.ThievingSkydiver.class));

--- a/Utils/known-sets.txt
+++ b/Utils/known-sets.txt
@@ -167,7 +167,7 @@ Tales of Middle-earth Commander|TalesOfMiddleEarthCommander|
 Lorwyn|Lorwyn|
 Lorwyn Eclipsed|LorwynEclipsed|
 The Lost Caverns of Ixalan|TheLostCavernsOfIxalan|
-The Lost Caverns of Ixalan Commander|LostCavernsOfIxalanCommander|
+The Lost Caverns of Ixalan Commander|TheLostCavernsOfIxalanCommander|
 Magic 2010|Magic2010|
 Magic 2011|Magic2011|
 Magic 2012|Magic2012|


### PR DESCRIPTION
I was looking to try a card from this set, and noticed it had been implemented, but was unusable. 

The reason seems to have been that `known-sets.txt` name for the set does not match, so the Util script did not create the set entry.