### PR TITLE
Add in Tokens from Lorwyn Eclipsed Commander

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -2857,6 +2857,18 @@ public class ScryfallImageSupportTokens {
             put("TLE/Marit Lage", "https://api.scryfall.com/cards/ttle/1/?format=image");
             put("TLE/Soldier", "https://api.scryfall.com/cards/ttle/2?format=image");
 
+            // ECC
+            put("ECC/Elemental/1", "https://api.scryfall.com/cards/tecc/2?format=image");
+            put("ECC/Elemental/2", "https://api.scryfall.com/cards/tecc/9?format=image");
+            put("ECC/Elemental/3", "https://api.scryfall.com/cards/tecc/10?format=image");
+            put("ECC/Elf Warrior", "https://api.scryfall.com/cards/tecc/4?format=image");
+            put("ECC/Plant", "https://api.scryfall.com/cards/tecc/5?format=image");
+            put("ECC/Rhino Warrior", "https://api.scryfall.com/cards/tecc/6?format=image");
+            put("ECC/Saproling", "https://api.scryfall.com/cards/tecc/7?format=image");
+            put("ECC/Scarecrow", "https://api.scryfall.com/cards/tecc/11?format=image");
+            put("ECC/Snake", "https://api.scryfall.com/cards/tecc/8?format=image");
+            put("ECC/Zombie", "https://api.scryfall.com/cards/tecc/3?format=image");
+
             // TMT
             put("TMT/Mutagen", "https://api.scryfall.com/cards/ttmt/9?format=image");
 

--- a/Mage/src/main/java/mage/cards/repository/TokenRepository.java
+++ b/Mage/src/main/java/mage/cards/repository/TokenRepository.java
@@ -274,6 +274,8 @@ public enum TokenRepository {
         res.add(createXmageToken(XMAGE_IMAGE_NAME_COPY, 14, "https://api.scryfall.com/cards/tspm/1/en?format=image"));
         res.add(createXmageToken(XMAGE_IMAGE_NAME_COPY, 15, "https://api.scryfall.com/cards/ttla/1/en?format=image"));
         res.add(createXmageToken(XMAGE_IMAGE_NAME_COPY, 16, "https://api.scryfall.com/cards/ttla/2/en?format=image"));
+        res.add(createXmageToken(XMAGE_IMAGE_NAME_COPY, 17, "https://api.scryfall.com/cards/tecc/1/en?format=image"));
+
 
         // City's Blessing
         // https://scryfall.com/search?q=type%3Atoken+include%3Aextras+unique%3Aprints+City%27s+Blessing+&unique=cards&as=grid&order=name
@@ -320,6 +322,7 @@ public enum TokenRepository {
         res.add(createXmageToken(XMAGE_IMAGE_NAME_THE_MONARCH, 2, "https://api.scryfall.com/cards/tcn2/1/en?format=image"));
         res.add(createXmageToken(XMAGE_IMAGE_NAME_THE_MONARCH, 3, "https://api.scryfall.com/cards/tltc/15/en?format=image"));
         res.add(createXmageToken(XMAGE_IMAGE_NAME_THE_MONARCH, 4, "https://api.scryfall.com/cards/tfic/11/en?format=image"));
+        res.add(createXmageToken(XMAGE_IMAGE_NAME_THE_MONARCH, 5, "https://api.scryfall.com/cards/tecc/12/en?format=image"));
 
         // Radiation (for trigger)
         res.add(createXmageToken(XMAGE_IMAGE_NAME_RADIATION, 1, "https://api.scryfall.com/cards/tpip/22/en?format=image"));

--- a/Mage/src/main/java/mage/game/permanent/token/ScarecrowToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/ScarecrowToken.java
@@ -1,0 +1,28 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.constants.CardType;
+import mage.constants.SubType;
+
+/**
+ * @author muz
+ */
+public final class ScarecrowToken extends TokenImpl {
+
+    public ScarecrowToken() {
+        super("Scarecrow", "2/2 colorless Scarecrow artifact creature token named Scarecrow");
+        cardType.add(CardType.ARTIFACT);
+        cardType.add(CardType.CREATURE);
+        this.subtype.add(SubType.SCARECROW);
+        power = new MageInt(2);
+        toughness = new MageInt(2);
+    }
+
+    private ScarecrowToken(final ScarecrowToken token) {
+        super(token);
+    }
+
+    public ScarecrowToken copy() {
+        return new ScarecrowToken(this);
+    }
+}

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -2913,6 +2913,18 @@
 # ECL
 |Generate|TOK:ECL|Goblin|||BlackAndRedGoblinToken|
 
+# ECC
+|Generate|TOK:ECC|Elemental|1||WhiteElementalToken|
+|Generate|TOK:ECC|Elemental|2||OmnathElementalToken|
+|Generate|TOK:ECC|Elemental|3||VoiceOfResurgenceToken|
+|Generate|TOK:ECC|Elf Warrior|||ElfWarriorToken|
+|Generate|TOK:ECC|Plant|||PlantToken|
+|Generate|TOK:ECC|Rhino Warrior|||RhinoWarriorToken|
+|Generate|TOK:ECC|Saproling|||SaprolingToken|
+|Generate|TOK:ECC|Scarecrow|||ScarecrowToken|
+|Generate|TOK:ECC|Snake|||DeathtouchSnakeToken|
+|Generate|TOK:ECC|Zombie|||ZombieToken|
+
 #TMT
 |Generate|TOK:TMT|Mutagen|||MutagenToken|
 


### PR DESCRIPTION
Token data has been published with card art and collector numbers. 

https://magic.wizards.com/en/news/announcements/lorwyn-eclipsed-commander-decklists

Once Scryfall updates, given their stable URL structure, this should be where the art is accessible from