### PR TITLE
Fix removal of Avatar Kyoshi, Earthbender

### DIFF
--- a/Mage.Sets/src/mage/sets/AvatarTheLastAirbenderEternal.java
+++ b/Mage.Sets/src/mage/sets/AvatarTheLastAirbenderEternal.java
@@ -39,7 +39,8 @@ public final class AvatarTheLastAirbenderEternal extends ExpansionSet {
         cards.add(new SetCardInfo("Appa, Aang's Companion", 268, Rarity.UNCOMMON, mage.cards.a.AppaAangsCompanion.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Appa, the Vigilant", 62, Rarity.RARE, mage.cards.a.AppaTheVigilant.class));
         cards.add(new SetCardInfo("Arcane Signet", 315, Rarity.RARE, mage.cards.a.ArcaneSignet.class));
-        cards.add(new SetCardInfo("Avatar Kyoshi, Earthbender", 130, Rarity.MYTHIC, mage.cards.a.AvatarKyoshiEarthbender.class));
+        cards.add(new SetCardInfo("Avatar Kyoshi, Earthbender", 130, Rarity.MYTHIC, mage.cards.a.AvatarKyoshiEarthbender.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Avatar Kyoshi, Earthbender", 201, Rarity.MYTHIC, mage.cards.a.AvatarKyoshiEarthbender.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Azula, Ruthless Firebender", 101, Rarity.MYTHIC, mage.cards.a.AzulaRuthlessFirebender.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Azula, Ruthless Firebender", 184, Rarity.MYTHIC, mage.cards.a.AzulaRuthlessFirebender.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Baboon Spirit", 177, Rarity.RARE, mage.cards.b.BaboonSpirit.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
The set entry for [[Avatar Kyoshi, Earthbender]] was removed in this commit:

https://github.com/magefree/mage/commit/5b2629f0dc9e939aa7c53881c3f34623d7522d1d

It seems like they meant to remove Avatar Kyoshi, the back face of [[The Legend of Kyoshi]], but this got removed instead. It seems like there was not a set entry for Avatar Kyoshi to begin with, and there is not one now.

I didn't check to see if other cards got erroneously nuked.

