### PR TITLE
Fix broken Scryfall image references

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportCards.java
@@ -742,11 +742,7 @@ public class ScryfallImageSupportCards {
             put("MB1/Prophetic Bolt", "https://api.scryfall.com/cards/plst/C15-231/");
 
             // LTR - 0 number for tokens only
-            // Scryfall has a bug, for some reason this link doesn't work with ?format=image even though it works with ?format=json
-            // and ?format=text. Base url fails because language is qya and not en and alternate url fails because of this bug
-            // TODO: This should be reverted when Scryfall fixes the bug 
-            // put("LTR/The One Ring/001", "https://api.scryfall.com/cards/ltr/0/");
-            put("LTR/The One Ring/001", "https://api.scryfall.com/cards/ltr/0/qya?format=image");
+            put("LTR/The One Ring/001", "https://api.scryfall.com/cards/ltr/0/");
 
             // REX - double faced lands (xmage uses two diff lands for it)
             put("REX/Command Tower/26b", "https://api.scryfall.com/cards/rex/26/en?format=image&face=back");
@@ -763,6 +759,11 @@ public class ScryfallImageSupportCards {
             put("TDM/Marang River Regent/378b", "https://api.scryfall.com/cards/tdm/378/en?format=image&face=back");
             put("TDM/Scavenger Regent/379b", "https://api.scryfall.com/cards/tdm/379/en?format=image&face=back");
             put("TDM/Ugin, Eye of the Storms/382b", "https://api.scryfall.com/cards/tdm/382/en?format=image&face=back");
+
+            // EMN - double faced cards
+            put("EMN/Bruna, The Fading Light/15a", "https://api.scryfall.com/cards/emn/15/");
+            put("EMN/Hanweir Garrison/130a", "https://api.scryfall.com/cards/emn/130/");
+            put("EMN/Midnight Scavengers/96a", "https://api.scryfall.com/cards/emn/96/");
 
         }
     };

--- a/Mage.Sets/src/mage/sets/MediaAndCollaborationPromos.java
+++ b/Mage.Sets/src/mage/sets/MediaAndCollaborationPromos.java
@@ -91,7 +91,7 @@ public class MediaAndCollaborationPromos extends ExpansionSet {
         cards.add(new SetCardInfo("Ultimecia, Temporal Threat", "2025-11", Rarity.RARE, mage.cards.u.UltimeciaTemporalThreat.class));
         cards.add(new SetCardInfo("Usher of the Fallen", "2022-3", Rarity.RARE, mage.cards.u.UsherOfTheFallen.class));
         cards.add(new SetCardInfo("Voltaic Key", "2020-1", Rarity.RARE, mage.cards.v.VoltaicKey.class, NON_FULL_USE_VARIOUS));
-        cards.add(new SetCardInfo("Voltaic Key", "2024-6", Rarity.RARE, mage.cards.v.VoltaicKey.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Voltaic Key", "2025-4", Rarity.RARE, mage.cards.v.VoltaicKey.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Warmonger", "1999-2", Rarity.UNCOMMON, mage.cards.w.Warmonger.class, RETRO_ART));
         cards.add(new SetCardInfo("Wild Growth", "2022-2", Rarity.RARE, mage.cards.w.WildGrowth.class));
         cards.add(new SetCardInfo("Winged Boots", "2023-7", Rarity.RARE, mage.cards.w.WingedBoots.class));


### PR DESCRIPTION
* EMN cards - We have them with `a` prefixes on the Collector Number, but Scryfall has since decided to expose the front side of these on the basic integer card number.
* PMEI - Looks like the collector number referenced has changed for some reason or another (a correction?) Regardless, this is the collector number [actually used by Scryfall](https://scryfall.com/search?q=set%3Apmei+%21VoltaicKey+unique%3Aprints&unique=cards&as=grid&order=set) and image downloads from that generated set number works as expected.
* LTR - Looks like Scryfall have fixed this, so the TODO can be addressed.
 ```
muz@m1 mage % curl -I "https://api.scryfall.com/cards/ltr/0/qya?format=image" | grep location       
 location: https://cards.scryfall.io/large/front/9/3/93de9042-cc62-4ade-8d8d-68fdbc84bfae.jpg?1740417602
muz@m1 mage % curl -I "https://api.scryfall.com/cards/ltr/0/?format=image" | grep location 
 location: https://cards.scryfall.io/large/front/9/3/93de9042-cc62-4ade-8d8d-68fdbc84bfae.jpg?1740417602
```