### PR TITLE
[do not merge] On demand image download

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/PreferencesDialog.java
@@ -84,6 +84,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     public static final String KEY_CARD_IMAGES_PATH = "cardImagesPath";
     public static final String KEY_CARD_IMAGES_SAVE_TO_ZIP = "cardImagesSaveToZip";
     public static final String KEY_CARD_IMAGES_PREF_LANGUAGE = "cardImagesPreferredImageLaguage";
+    public static final String KEY_CARD_IMAGES_AUTO_DOWNLOAD = "cardImagesAutoDownload";
 
     public static final String KEY_CARD_RENDERING_IMAGE_MODE = "cardRenderingMode";
     public static final String KEY_CARD_RENDERING_ICONS_FOR_ABILITIES = "cardRenderingIconsForAbilities";
@@ -957,6 +958,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         txtImageFolderPath = new javax.swing.JTextField();
         btnBrowseImageLocation = new javax.swing.JButton();
         cbSaveToZipFiles = new javax.swing.JCheckBox();
+        cbAutoDownloadImages = new javax.swing.JCheckBox();
         cbPreferredImageLanguage = new javax.swing.JComboBox<>();
         labelPreferredImageLanguage = new javax.swing.JLabel();
         panelCardStyles = new javax.swing.JPanel();
@@ -2277,6 +2279,9 @@ public class PreferencesDialog extends javax.swing.JDialog {
             }
         });
 
+        cbAutoDownloadImages.setText("Download missing images automatically");
+        cbAutoDownloadImages.setToolTipText("Automatically download card images from Scryfall when they are first displayed");
+
         cbPreferredImageLanguage.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
 
         labelPreferredImageLanguage.setText("Default images language:");
@@ -2297,6 +2302,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
                     .add(panelCardImagesLayout.createSequentialGroup()
                         .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                             .add(cbSaveToZipFiles)
+                            .add(cbAutoDownloadImages)
                             .add(panelCardImagesLayout.createSequentialGroup()
                                 .add(6, 6, 6)
                                 .add(labelPreferredImageLanguage)
@@ -2314,6 +2320,8 @@ public class PreferencesDialog extends javax.swing.JDialog {
                     .add(btnBrowseImageLocation))
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.UNRELATED)
                 .add(cbSaveToZipFiles)
+                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(cbAutoDownloadImages)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(panelCardImagesLayout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                     .add(labelPreferredImageLanguage)
@@ -3058,6 +3066,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
         save(prefs, dialog.cbUseDefaultImageFolder, KEY_CARD_IMAGES_USE_DEFAULT, "true", "false");
         saveImagesPath(prefs);
         save(prefs, dialog.cbSaveToZipFiles, KEY_CARD_IMAGES_SAVE_TO_ZIP, "true", "false");
+        save(prefs, dialog.cbAutoDownloadImages, KEY_CARD_IMAGES_AUTO_DOWNLOAD, "true", "false");
         save(prefs, dialog.cbPreferredImageLanguage, KEY_CARD_IMAGES_PREF_LANGUAGE);
 
         save(prefs, dialog.cbUseDefaultBackground, KEY_BACKGROUND_IMAGE_DEFAULT, "true", "false");
@@ -3513,6 +3522,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
             updateCache(KEY_CARD_IMAGES_PATH, path);
         }
         load(prefs, dialog.cbSaveToZipFiles, KEY_CARD_IMAGES_SAVE_TO_ZIP, "true", "false");
+        load(prefs, dialog.cbAutoDownloadImages, KEY_CARD_IMAGES_AUTO_DOWNLOAD, "true", "false");
         dialog.cbPreferredImageLanguage.setSelectedItem(MageFrame.getPreferences().get(KEY_CARD_IMAGES_PREF_LANGUAGE, CardLanguage.ENGLISH.getCode()));
 
         // rendering settings
@@ -3703,6 +3713,10 @@ public class PreferencesDialog extends javax.swing.JDialog {
 
     public static boolean isSaveImagesToZip() {
         return PreferencesDialog.getCachedValue(PreferencesDialog.KEY_CARD_IMAGES_SAVE_TO_ZIP, "false").equals("true");
+    }
+
+    public static boolean isAutoDownloadEnabled() {
+        return PreferencesDialog.getCachedValue(PreferencesDialog.KEY_CARD_IMAGES_AUTO_DOWNLOAD, "false").equals("true");
     }
 
     private static void load(Preferences prefs, JCheckBox checkBox, String propName, String yesValue) {
@@ -4066,6 +4080,7 @@ public class PreferencesDialog extends javax.swing.JDialog {
     private javax.swing.JButton buttonSizeDefault6;
     private javax.swing.JCheckBox cbAllowRequestToShowHandCards;
     private javax.swing.JCheckBox cbAskMoveToGraveOrder;
+    private javax.swing.JCheckBox cbAutoDownloadImages;
     private javax.swing.JCheckBox cbAutoOrderTrigger;
     private javax.swing.JCheckBox cbCardRenderHideSetSymbol;
     private javax.swing.JCheckBox cbCardRenderIconsForAbilities;

--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/ImageCache.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/ImageCache.java
@@ -88,12 +88,19 @@ public final class ImageCache {
 
                 // try unknown token image
                 if (tokenFile == null || !tokenFile.exists()) {
+                    // Queue token for on-demand download
+                    OnDemandImageDownloader.getInstance().queueDownload(info);
                     // TODO: replace empty token by other default card, not cardback
                     path = CardImageUtils.buildImagePathToDefault(DirectLinksForDownload.cardbackFilename);
                 }
             } else {
                 // CARD
                 path = CardImageUtils.buildImagePathToCardOrToken(info);
+                TFile cardFile = getTFile(path);
+                if (cardFile == null || !cardFile.exists()) {
+                    // Queue card for on-demand download
+                    OnDemandImageDownloader.getInstance().queueDownload(info);
+                }
             }
 
             TFile file = getTFile(path);

--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/ImageCache.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/ImageCache.java
@@ -378,4 +378,33 @@ public final class ImageCache {
         }
         return null;
     }
+
+    /**
+     * Invalidate all cache entries for a card so it will be reloaded from disk on next access.
+     * Used after on-demand image download completes.
+     *
+     * @param name card name
+     * @param setCode set code
+     * @param collectorId collector number
+     */
+    public static void invalidateCard(String name, String setCode, String collectorId) {
+        // Key format: imageFileName#setCode#imageNumber#cardNumber#imageSize#usesVariousArt
+        // We need to find and invalidate all keys matching this card
+        String keyPattern = "#" + setCode + "#";
+        String cardNumberPattern = "#" + collectorId + "#";
+
+        int cacheSize = SHARED_CARD_IMAGES_CACHE.asMap().size();
+        LOGGER.debug("ImageCache invalidateCard: " + name + " [" + setCode + "/" + collectorId + "] cache size before: " + cacheSize);
+
+        // Iterate through cache and invalidate matching entries
+        int removed = 0;
+        for (String key : SHARED_CARD_IMAGES_CACHE.asMap().keySet()) {
+            if (key.startsWith(name + "#") && key.contains(keyPattern) && key.contains(cardNumberPattern)) {
+                LOGGER.debug("ImageCache removing key: " + key);
+                SHARED_CARD_IMAGES_CACHE.invalidate(key);
+                removed++;
+            }
+        }
+        LOGGER.debug("ImageCache invalidateCard: removed " + removed + " entries");
+    }
 }

--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/OnDemandImageDownloader.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/OnDemandImageDownloader.java
@@ -1,0 +1,232 @@
+package org.mage.plugins.card.images;
+
+import mage.client.dialog.PreferencesDialog;
+import mage.client.remote.XmageURLConnection;
+import mage.util.XmageThreadFactory;
+import net.java.truevfs.access.TFile;
+import net.java.truevfs.access.TFileOutputStream;
+import org.apache.log4j.Logger;
+import org.mage.plugins.card.dl.sources.CardImageSource;
+import org.mage.plugins.card.dl.sources.CardImageUrls;
+import org.mage.plugins.card.dl.sources.ScryfallImageSourceNormal;
+import org.mage.plugins.card.utils.CardImageUtils;
+
+import java.io.*;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+
+import static org.mage.plugins.card.utils.CardImageUtils.getImagesDir;
+
+/**
+ * On-demand image downloader service.
+ * Downloads missing card images automatically when they are first displayed.
+ * Uses Scryfall as the image source with normal quality.
+ *
+ * @author Claude
+ */
+public class OnDemandImageDownloader {
+
+    private static final Logger logger = Logger.getLogger(OnDemandImageDownloader.class);
+
+    private static final OnDemandImageDownloader instance = new OnDemandImageDownloader();
+
+    // Track cards that have been queued or downloaded to avoid duplicates
+    private final Set<String> queuedOrDownloaded = ConcurrentHashMap.newKeySet();
+
+    // Download queue
+    private final BlockingQueue<CardDownloadData> downloadQueue = new LinkedBlockingQueue<>();
+
+    // Single-threaded executor for downloads (to respect rate limits)
+    private final ExecutorService executor;
+
+    // Image source - use normal quality Scryfall
+    private final CardImageSource imageSource = ScryfallImageSourceNormal.getInstance();
+
+    // Minimum file size to consider download successful
+    private static final int MIN_FILE_SIZE_OF_GOOD_IMAGE = 1024 * 6;
+
+    private OnDemandImageDownloader() {
+        executor = Executors.newSingleThreadExecutor(
+                new XmageThreadFactory("OnDemandImageDownloader", true)
+        );
+        executor.submit(this::downloadWorker);
+    }
+
+    public static OnDemandImageDownloader getInstance() {
+        return instance;
+    }
+
+    /**
+     * Queue a card for download if not already queued/downloaded.
+     * Only queues if auto-download is enabled in preferences.
+     *
+     * @param card The card to download
+     */
+    public void queueDownload(CardDownloadData card) {
+        // Check if feature is enabled
+        if (!PreferencesDialog.isAutoDownloadEnabled()) {
+            return;
+        }
+
+        if (card == null) {
+            return;
+        }
+
+        // Create unique key for this card
+        String key = createKey(card);
+
+        // Only queue if not already queued/downloaded
+        if (queuedOrDownloaded.add(key)) {
+            downloadQueue.offer(card);
+            logger.debug("Queued for on-demand download: " + card.getName() + " (" + card.getSet() + ")");
+        }
+    }
+
+    private String createKey(CardDownloadData card) {
+        return card.getName() + "#" + card.getSet() + "#" + card.getCollectorId() + "#" + card.isToken();
+    }
+
+    /**
+     * Background worker that processes the download queue
+     */
+    private void downloadWorker() {
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                CardDownloadData card = downloadQueue.take();
+                downloadCard(card);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                logger.error("Error in download worker: " + e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * Download a single card image
+     *
+     * @param card The card to download
+     * @return true if download was successful
+     */
+    private boolean downloadCard(CardDownloadData card) {
+        TFile fileTempImage = null;
+        TFile destFile = null;
+
+        try {
+            // Generate download URLs
+            CardImageUrls urls;
+            if (card.isToken()) {
+                urls = imageSource.generateTokenUrl(card);
+            } else {
+                urls = imageSource.generateCardUrl(card);
+            }
+
+            if (urls == null) {
+                logger.debug("No download URL available for: " + card.getName() + " (" + card.getSet() + ")");
+                return false;
+            }
+
+            // Create temp file
+            String tempPath = getImagesDir() + File.separator + "downloading" + File.separator;
+            fileTempImage = new TFile(tempPath + CardImageUtils.prepareCardNameForFile(card.getName()) + "-" + card.hashCode() + ".jpg");
+            TFile parentFile = fileTempImage.getParentFile();
+            if (parentFile != null && !parentFile.exists()) {
+                parentFile.mkdirs();
+            }
+
+            // Destination file
+            destFile = new TFile(CardImageUtils.buildImagePathToCardOrToken(card));
+
+            // Skip if file already exists (might have been downloaded by another means)
+            if (destFile.exists() && destFile.length() >= MIN_FILE_SIZE_OF_GOOD_IMAGE) {
+                logger.debug("Image already exists: " + card.getName() + " (" + card.getSet() + ")");
+                return true;
+            }
+
+            // Try to download from available URLs
+            List<String> downloadUrls = urls.getDownloadList();
+            XmageURLConnection connection = null;
+            boolean isDownloadOK = false;
+
+            for (String currentUrl : downloadUrls) {
+                // Rate limiting
+                imageSource.doPause(currentUrl);
+
+                connection = new XmageURLConnection(currentUrl);
+                connection.startConnection();
+                if (connection.isConnected()) {
+                    connection.setRequestHeaders(imageSource.getHttpRequestHeaders(currentUrl));
+
+                    try {
+                        connection.connect();
+                    } catch (SocketException | UnknownHostException e) {
+                        logger.debug("Network error downloading " + card.getName() + ": " + e.getMessage());
+                        continue;
+                    }
+
+                    int responseCode = connection.getResponseCode();
+                    if (responseCode == 200) {
+                        isDownloadOK = true;
+                        break;
+                    } else {
+                        logger.debug("HTTP " + responseCode + " for " + card.getName() + " from " + currentUrl);
+                    }
+                }
+            }
+
+            // Save the downloaded file
+            if (isDownloadOK && connection != null && connection.isConnected()) {
+                try (InputStream in = new BufferedInputStream(connection.getGoodResponseAsStream());
+                     OutputStream tempFileStream = new TFileOutputStream(fileTempImage);
+                     OutputStream out = new BufferedOutputStream(tempFileStream)) {
+
+                    byte[] buf = new byte[1024];
+                    int len;
+                    while ((len = in.read(buf)) != -1) {
+                        out.write(buf, 0, len);
+                    }
+                }
+
+                // Validate and move to final destination
+                if (fileTempImage.exists() && fileTempImage.length() >= MIN_FILE_SIZE_OF_GOOD_IMAGE) {
+                    if (!destFile.getParentFile().exists()) {
+                        destFile.getParentFile().mkdirs();
+                    }
+                    fileTempImage.cp_rp(destFile);
+                    logger.info("Downloaded: " + card.getName() + " (" + card.getSet() + ")");
+                    return true;
+                } else {
+                    logger.debug("Downloaded file too small for: " + card.getName());
+                }
+            }
+
+        } catch (AccessDeniedException e) {
+            logger.error("Access denied downloading " + card.getName() + ": " + e.getMessage());
+        } catch (Exception e) {
+            logger.error("Error downloading " + card.getName() + ": " + e.getMessage(), e);
+        } finally {
+            // Cleanup temp file
+            if (fileTempImage != null && fileTempImage.exists()) {
+                try {
+                    TFile.rm(fileTempImage);
+                } catch (Exception e) {
+                    logger.debug("Could not delete temp file: " + e.getMessage());
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Clear the tracking set (useful for testing or reset)
+     */
+    public void clearTracking() {
+        queuedOrDownloaded.clear();
+    }
+}


### PR DESCRIPTION
**Summary**
  - Download card images automatically once they are needed
  - Significantly improve user experience.
  - Significantly reduce bandwidth and disk usage. Most of the cards are never used in Magic. 

**Features**

  - Adds automatic downloading of missing card images when they are first displayed. 
  - Eliminate the need for users to manually download all images upfront via the bulk download dialog.
  - Card panels automatically refresh to show newly downloaded images without requiring user interaction.
  - Rate limiting (300ms between API calls) to respect Scryfall API limits.
  - Duplicate prevention - cards are only downloaded once.
  - New preference checkbox "Download missing images automatically" in the Images tab (disabled by default, opt-in)
  - Card panels register listeners to auto-refresh when their image becomes available

**Test plan**

  - Enable "Download missing images automatically" in Preferences → Images
  - Open a deck or game with cards that don't have local images
  - Image should be downloaded
  - Card should be updated with the new card
  - Disable the preference and verify no more downloads occur
  
**Video in action**

https://github.com/user-attachments/assets/fe886504-fa50-4c10-a015-f3d9392ba4aa



