### PR TITLE
Allow Azami to tap non creature wizards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AzamiLadyOfScrolls.java
+++ b/Mage.Sets/src/mage/cards/a/AzamiLadyOfScrolls.java
@@ -12,8 +12,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.constants.Zone;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.permanent.TappedPredicate;
 import mage.target.common.TargetControlledPermanent;
 
@@ -22,7 +21,7 @@ import mage.target.common.TargetControlledPermanent;
  */
 public final class AzamiLadyOfScrolls extends CardImpl {
 
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("untapped Wizard you control");
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("untapped Wizard you control");
 
     static {
         filter.add(TappedPredicate.UNTAPPED);


### PR DESCRIPTION
Azami Lady of Scrolls should allow you to tap any untapped wizard, not just creatures.

For example Firdoch Core is a wizard, but not a creature
<img width="672" height="936" alt="image" src="https://github.com/user-attachments/assets/c3ffe6c7-a677-44f7-9ea6-ef2f73f548a9" />
