### PR TITLE
Ensure Water Crystal only triggers when the mill amount is 1 or more

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TheWaterCrystal.java
+++ b/Mage.Sets/src/mage/cards/t/TheWaterCrystal.java
@@ -86,7 +86,7 @@ class TheWaterCrystalEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        return game.getOpponents(source.getControllerId()).contains(event.getPlayerId());
+        return game.getOpponents(source.getControllerId()).contains(event.getPlayerId()) && event.getAmount() >= 1;
     }
 
     @Override


### PR DESCRIPTION
Reported on Discord;

[[Hope Estheim]] + [[The Water Crystal]] were on board. No life gain was had that turn.

Looking at the code, it looks like Hope triggered the Mill effect with a `0` value, and Water Crystal just adds four to that.

This guards on the Water Crystal effect if it sees a mill effect that does not meet its Oracle text of `one or more`

Semantically, one could argue that a guard goes in place for Hope, but as it is written, this ability triggers always, but X is just 0. A player can still respond to it, even if it would be a no-op in most cases per rule section 603.

> 603.2. Whenever a game event or game state matches a triggered ability’s trigger event, that ability automatically triggers. The ability doesn’t do anything at this point.
