### PR TITLE
[minor] Fixes for gen-list-unimplemented-cards-for-set.pl

### DIFF
--- a/Utils/gen-list-unimplemented-cards-for-set.pl
+++ b/Utils/gen-list-unimplemented-cards-for-set.pl
@@ -117,6 +117,7 @@ foreach my $card (sort cardSort @setCards) {
     my $currentFileName = "../Mage.Sets/src/mage/cards/" . lc(substr($className, 0, 1)) . "/" . $className . ".java";
     my $cardNameForUrl = $cardName;
     $cardNameForUrl =~ s/ //g;
+    $cardNameForUrl =~ s/\&/%26/g; # URL encode ampersands
     my $cardEntry = "- [ ] In progress -- [$cardName](https://scryfall.com/search?q=!\"$cardNameForUrl\"&nbsp;e:$setAbbr)";
 
     if(-e $currentFileName) {
@@ -139,6 +140,7 @@ foreach my $cardName (sort keys %cardNames) {
         my $urlCardName = $cardName;
         $urlCardName =~ s/ //g;
         $urlCardName =~ s/"/\\"/g;  # Escape quotes
+        $urlCardName =~ s/\&/%26/g; # URL encode ampersands
         push(@unimplementedNames, "!\"$urlCardName\"");
     }
 }


### PR DESCRIPTION
Noticed this while running it locally to see what's still missing from TMT;

 * Scryfall links for cards where ampersands (`&`) feature in the name need URL encoding to be usable, both on the individual card line items, but also the summary unimplemented card view link
 * When locating if a card is implemented or not, strip Colons and Ampersand, like how `gen-card.pl` does, so that it can correctly find files that were created via that script and avoid falsely claiming things aren't implemented, when they are.

Tested this locally by re-running the Perl script on a number of sets and confirming the output is good