### PR TITLE
Fix Turtle Van text

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TurtleVan.java
+++ b/Mage.Sets/src/mage/cards/t/TurtleVan.java
@@ -45,7 +45,6 @@ public final class TurtleVan extends CardImpl {
         ability.addEffect(new ConditionalOneShotEffect(
             new DoubleCountersTargetEffect(CounterType.P1P1),
             new TargetHasSubtypeCondition(SubType.MUTANT, SubType.NINJA, SubType.TURTLE),
-            "whenever this Vehicle attacks, put a +1/+1 counter on target creature that crewed it this turn. " +
             "Then if that creature is a Mutant, Ninja, or Turtle, double the number of +1/+1 counters on it"
         ));
         this.addAbility(ability, new CrewedVehicleWatcher());


### PR DESCRIPTION
Addressing this CI error:
```
Error: (abilities) target count text discrepancy: 1 in reference but 2 in card. for TMT - Turtle Van - 181
```

Before, it mentioned the first sentence twice due to how the effect text was passed in.

Corrected:

<img width="700" height="373" alt="Screenshot 2026-01-24 at 12 55 55 PM" src="https://github.com/user-attachments/assets/82f8b747-8500-4be0-88a2-9395df46e5f4" />
