### PR TITLE
Refactor a couple of cards to use CreatureToken over custom private Tokens

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AnsweredPrayers.java
+++ b/Mage.Sets/src/mage/cards/a/AnsweredPrayers.java
@@ -1,6 +1,5 @@
 package mage.cards.a;
 
-import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldControlledTriggeredAbility;
 import mage.abilities.effects.OneShotEffect;
@@ -16,8 +15,7 @@ import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.token.Angel33Token;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 
 import java.util.UUID;
 
@@ -73,7 +71,10 @@ class AnsweredPrayersEffect extends OneShotEffect {
             return true;
         }
         game.addEffect(new BecomesCreatureSourceEffect(
-                new Angel33Token(), CardType.ENCHANTMENT, Duration.EndOfTurn
+            new CreatureToken(3, 3, "3/3 Angel creature with flying", SubType.ANGEL)
+                .withAbility(FlyingAbility.getInstance()),
+                CardType.ENCHANTMENT,
+                Duration.EndOfTurn
         ), source);
         return true;
     }


### PR DESCRIPTION
Testing the waters a bit...

In other efforts to address some TODOs around Token implementations I saw there's a comment encouraging that we move towards using CreatureToken;
https://github.com/magefree/mage/blob/57ad5749a49a94c39cb82970120b403497b904c8/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java#L1467

That coupled with @theelk801 (rightly!) calling me out on PR comments to align with this, suggests to be that there's a long-standing desire to just get away from custom Private Tokens and it's just a matter of time/effort to do that...

So, I've had a stab at adjusting two instances below to remove their dependency on custom classes. If this PR is approved, or more guidance can be given, I can align with that and have a go at cleaning up other instances retroactively that exist in the codebase 🙏 Happy to break the PRs out into a handful at a time to make reviewing easier to digest too 😄 