### PR TITLE
Enable test_checkMissingTokenData

### DIFF
--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1384,7 +1384,6 @@ public class VerifyCardDataTest {
     }
 
     @Test
-    @Ignore  // TODO: enable test after massive token fixes
     public void test_checkMissingTokenData() {
 
         Collection<String> errorsList = new ArrayList<>();
@@ -1465,30 +1464,30 @@ public class VerifyCardDataTest {
         }
 
         // CHECK: private class for inner tokens (no needs at all -- all private tokens must be replaced by CreatureToken)
-        for (Class<? extends TokenImpl> tokenClass : privateTokens) {
-            String className = extractShortClass(tokenClass);
-            errorsList.add("Warning: no needs in private tokens, replace it with CreatureToken: " + className + " from " + tokenClass.getName());
-        }
+        // for (Class<? extends TokenImpl> tokenClass : privateTokens) {
+        //     String className = extractShortClass(tokenClass);
+        //     errorsList.add("Warning: no needs in private tokens, replace it with CreatureToken: " + className + " from " + tokenClass.getName());
+        // }
 
         // CHECK: all public tokens must have tok-data (private tokens uses for innner abilities -- no need images for it)
-        for (Class<? extends TokenImpl> tokenClass : publicTokens) {
-            Token token = (Token) createNewObject(tokenClass);
-            if (token == null) {
-                // how-to fix:
-                // - create empty param
-                // - fix error in token's constructor
-                errorsList.add("Error: token must have default constructor with zero params: " + tokenClass.getName());
-            } else if (tokDataNamesIndex.getOrDefault(token.getName().replace(" Token", ""), "").isEmpty()) {
-                if (token instanceof CreatureToken || token instanceof XmageToken) {
-                    // ignore custom token builders
-                    continue;
-                }
-                // how-to fix:
-                // - public token must be downloadable, so tok-data must contain miss set
-                //   (also don't forget to add new set to scryfall download)
-                errorsList.add("Error: can't find data in tokens-database.txt for token: " + tokenClass.getName() + " -> " + token.getName());
-            }
-        }
+        // for (Class<? extends TokenImpl> tokenClass : publicTokens) {
+        //     Token token = (Token) createNewObject(tokenClass);
+        //     if (token == null) {
+        //         // how-to fix:
+        //         // - create empty param
+        //         // - fix error in token's constructor
+        //         errorsList.add("Error: token must have default constructor with zero params: " + tokenClass.getName());
+        //     } else if (tokDataNamesIndex.getOrDefault(token.getName().replace(" Token", ""), "").isEmpty()) {
+        //         if (token instanceof CreatureToken || token instanceof XmageToken) {
+        //             // ignore custom token builders
+        //             continue;
+        //         }
+        //         // how-to fix:
+        //         // - public token must be downloadable, so tok-data must contain miss set
+        //         //   (also don't forget to add new set to scryfall download)
+        //         errorsList.add("Error: can't find data in tokens-database.txt for token: " + tokenClass.getName() + " -> " + token.getName());
+        //     }
+        // }
 
         // 111.4. A spell or ability that creates a token sets both its name and its subtype(s).
         // If the spell or ability doesn’t specify the name of the token, its name is the same
@@ -1502,20 +1501,20 @@ public class VerifyCardDataTest {
             }
 
             // CHECK: tokens must have Token word in the name
-            if (token.getDescription().startsWith(token.getName() + ", ")
-                    || token.getDescription().contains("named " + token.getName())
-                    || (token instanceof CreatureToken)
-                    || (token instanceof XmageToken)) {
-                // ignore some names:
-                // - Boo, a legendary 1/1 red Hamster creature token with trample and haste
-                // - 1/1 green Insect creature token with flying named Butterfly
-                // - custom token builders
-            } else {
-                if (!token.getName().endsWith("Token")) {
-                    errorsList.add("Error: token's name must ends with Token: "
-                            + tokenClass.getName() + " - " + token.getName());
-                }
-            }
+            // if (token.getDescription().startsWith(token.getName() + ", ")
+            //         || token.getDescription().contains("named " + token.getName())
+            //         || (token instanceof CreatureToken)
+            //         || (token instanceof XmageToken)) {
+            //     // ignore some names:
+            //     // - Boo, a legendary 1/1 red Hamster creature token with trample and haste
+            //     // - 1/1 green Insect creature token with flying named Butterfly
+            //     // - custom token builders
+            // } else {
+            //     if (!token.getName().endsWith("Token")) {
+            //         errorsList.add("Error: token's name must ends with Token: "
+            //                 + tokenClass.getName() + " - " + token.getName());
+            //     }
+            // }
 
             // CHECK: named tokens must not have Token in the name
             if (token.getDescription().contains("named") && token.getName().contains("Token")) {
@@ -1939,7 +1938,7 @@ public class VerifyCardDataTest {
 
     // "copy" fails means that the copy constructor are not correct inside a card.
     // To fix those, try to find the class that did trigger the copy failure, and check
-    // that copy() exists, a copy constructor exists, and the copy constructor is right. 
+    // that copy() exists, a copy constructor exists, and the copy constructor is right.
     private void checkCardCanBeCopied(Card card1) {
         Card card2;
         try {


### PR DESCRIPTION
I'm eager to actually have this test run and deliver value given various other bits of tinkering I've done, and plan to do around tokens.

I think there's some value to this test as is, especially around stating what desired state is even if the codebase isn't there today.

So;

 * Unmark the test as `@Ignore`d
 * Comment out selectively the parts which actively throw errors today, due to implementation details
 * Allow this to run to catch either the introduction of new errors, or regressions
 
 Running this locally, it passes on the tip of `master`, albeit it does produce a number of `info` and `warning` messages that are visible in the surefire reports. I think this is fine, and do not think it's worth addressing them all quite yet as some of these are tied up in the more fundamental and far reaching aim to move things that should be using `CreatureToken` to doing that.