### PR TITLE
Declare a zero-param token constructor where missing

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AinokStrikeLeader.java
+++ b/Mage.Sets/src/mage/cards/a/AinokStrikeLeader.java
@@ -40,7 +40,7 @@ public final class AinokStrikeLeader extends CardImpl {
 
     public AinokStrikeLeader(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}");
-        
+
         this.subtype.add(SubType.DOG);
         this.subtype.add(SubType.WARRIOR);
         this.power = new MageInt(2);
@@ -103,7 +103,7 @@ class AinokStrikeLeaderEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         for (UUID playerId : game.getOpponents(source.getControllerId())) {
-            new GoblinToken(false).putOntoBattlefield(1, game, source, source.getControllerId(), true, true, playerId);
+            new GoblinToken().putOntoBattlefield(1, game, source, source.getControllerId(), true, true, playerId);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/n/NerivCracklingVanguard.java
+++ b/Mage.Sets/src/mage/cards/n/NerivCracklingVanguard.java
@@ -54,7 +54,7 @@ public final class NerivCracklingVanguard extends CardImpl {
         this.addAbility(DeathtouchAbility.getInstance());
 
         // When Neriv enters, create two 1/1 red Goblin creature tokens.
-        this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new GoblinToken(false), 2)));
+        this.addAbility(new EntersBattlefieldTriggeredAbility(new CreateTokenEffect(new GoblinToken(), 2)));
 
         // Whenever Neriv attacks, exile a number of cards from the top of your library equal to the number of differently named tokens you control. During any turn you attacked with a commander, you may play those cards.
         this.addAbility(new AttacksTriggeredAbility(new NerivCracklingVanguardEffect()).addHint(NerivCracklingVanguardEffect.getHint()));

--- a/Mage/src/main/java/mage/game/permanent/token/NalaarAetherjetToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/NalaarAetherjetToken.java
@@ -8,6 +8,10 @@ import mage.constants.SubType;
 
 public class NalaarAetherjetToken extends TokenImpl{
 
+    public NalaarAetherjetToken() {
+        this(0);
+    }
+
     public NalaarAetherjetToken(int xValue) {
         super("Nalaar Aetherjet", "X/X colorless Vehicle artifact token named Nalaar Aetherjet with flying and crew 2");
         cardType.add(CardType.ARTIFACT);


### PR DESCRIPTION
Linked to #14316 

```
Error: token must have default constructor with zero params: mage.game.permanent.token.NalaarAetherjetToken
```

 * Adds the missing zero param constructor
 * Also did a quick check for instances of tokens that don't call their zero-param constructor and needlessly pass in args. Only instances were for Goblin tokens without haste, which is the default. 