### PR TITLE
Use CreatureToken instead of custom private tokens. Cards V-Z

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TurnBurn.java
+++ b/Mage.Sets/src/mage/cards/t/TurnBurn.java
@@ -1,7 +1,6 @@
 
 package mage.cards.t;
 
-import mage.MageInt;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.continuous.BecomesCreatureTargetEffect;
@@ -11,7 +10,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SpellAbilityType;
 import mage.constants.SubType;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.common.TargetAnyTarget;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -28,8 +27,12 @@ public final class TurnBurn extends SplitCard {
 
         // Turn
         // Until end of turn, target creature loses all abilities and becomes a red Weird with base power and toughness 0/1.
-        Effect effect = new BecomesCreatureTargetEffect(new WeirdToken(), true, false, Duration.EndOfTurn)
-                .withDurationRuleAtStart(true);
+        Effect effect = new BecomesCreatureTargetEffect(
+            new CreatureToken(0, 1, "red Weird with base power and toughness 0/1", SubType.WEIRD).withColor("R"),
+            true,
+            false,
+            Duration.EndOfTurn
+        ).withDurationRuleAtStart(true);
         getLeftHalfCard().getSpellAbility().addEffect(effect);
         getLeftHalfCard().getSpellAbility().addTarget(new TargetCreaturePermanent().withChooseHint("becomes a Weird"));
 
@@ -48,25 +51,4 @@ public final class TurnBurn extends SplitCard {
     public TurnBurn copy() {
         return new TurnBurn(this);
     }
-
-    private static class WeirdToken extends TokenImpl {
-
-        private WeirdToken() {
-            super("Weird", "red Weird with base power and toughness 0/1");
-            cardType.add(CardType.CREATURE);
-            color.setRed(true);
-            subtype.add(SubType.WEIRD);
-            power = new MageInt(0);
-            toughness = new MageInt(1);
-        }
-        private WeirdToken(final WeirdToken token) {
-            super(token);
-        }
-
-        public WeirdToken copy() {
-            return new WeirdToken(this);
-        }
-
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/v/VastwoodAnimist.java
+++ b/Mage.Sets/src/mage/cards/v/VastwoodAnimist.java
@@ -12,11 +12,14 @@ import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.BecomesCreatureTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.common.TargetControlledPermanent;
 
 /**
@@ -34,7 +37,7 @@ public final class VastwoodAnimist extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
-        // {tap}: Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.
+        // {T}: Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.
         Ability ability = new SimpleActivatedAbility(new VastwoodAnimistEffect(), new TapSourceCost());
         ability.addTarget(new TargetControlledPermanent(new FilterControlledLandPermanent()));
         this.addAbility(ability);
@@ -52,14 +55,10 @@ public final class VastwoodAnimist extends CardImpl {
 
 class VastwoodAnimistEffect extends OneShotEffect {
 
-    static final FilterControlledPermanent filterAllies = new FilterControlledPermanent("allies you control");
-
-    static {
-        filterAllies.add(SubType.ALLY.getPredicate());
-    }
+    static final FilterControlledPermanent filterAllies = new FilterControlledPermanent(SubType.ALLY);
 
     public VastwoodAnimistEffect() {
-        super(Outcome.Benefit);
+        super(Outcome.BecomeCreature);
         this.staticText = "Target land you control becomes an X/X Elemental creature until end of turn, where X is the number of Allies you control. It's still a land.";
     }
 
@@ -75,27 +74,14 @@ class VastwoodAnimistEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         int amount = new PermanentsOnBattlefieldCount(filterAllies).calculate(game, source, this);
-        ContinuousEffect effect = new BecomesCreatureTargetEffect(new VastwoodAnimistElementalToken(amount), false, true, Duration.EndOfTurn);
+        ContinuousEffect effect = new BecomesCreatureTargetEffect(
+            new CreatureToken(amount, amount, "X/X Elemental creature, where X is the number of Allies you control", SubType.ELEMENTAL),
+            false,
+            true,
+            Duration.EndOfTurn
+        );
         effect.setTargetPointer(this.getTargetPointer().copy());
         game.addEffect(effect, source);
         return false;
-    }
-}
-
-class VastwoodAnimistElementalToken extends TokenImpl {
-
-    VastwoodAnimistElementalToken(int amount) {
-        super("", "X/X Elemental creature, where X is the number of Allies you control");
-        cardType.add(CardType.CREATURE);
-        subtype.add(SubType.ELEMENTAL);
-        power = new MageInt(amount);
-        toughness = new MageInt(amount);
-    }
-    private VastwoodAnimistElementalToken(final VastwoodAnimistElementalToken token) {
-        super(token);
-    }
-
-    public VastwoodAnimistElementalToken copy() {
-        return new VastwoodAnimistElementalToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WakerootElemental.java
+++ b/Mage.Sets/src/mage/cards/w/WakerootElemental.java
@@ -14,7 +14,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledLandPermanent;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -38,7 +38,11 @@ public final class WakerootElemental extends CardImpl {
                 new UntapTargetEffect(), new ManaCostsImpl<>("{G}{G}{G}{G}{G}")
         );
         ability.addEffect(new BecomesCreatureTargetEffect(
-                new WakerootElementalToken(), false, true, Duration.Custom
+            new CreatureToken(5, 5, "Elemental creature with haste", SubType.ELEMENTAL)
+                .withAbility(HasteAbility.getInstance()),
+            false,
+            true,
+            Duration.Custom
         ).setText("It becomes a 5/5 Elemental creature with haste. It's still a land."));
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
@@ -51,27 +55,5 @@ public final class WakerootElemental extends CardImpl {
     @Override
     public WakerootElemental copy() {
         return new WakerootElemental(this);
-    }
-}
-
-class WakerootElementalToken extends TokenImpl {
-
-    WakerootElementalToken() {
-        super("", "5/5 Elemental creature with haste");
-        this.cardType.add(CardType.CREATURE);
-        this.subtype.add(SubType.ELEMENTAL);
-
-        this.power = new MageInt(5);
-        this.toughness = new MageInt(5);
-
-        this.addAbility(HasteAbility.getInstance());
-    }
-
-    private WakerootElementalToken(final WakerootElementalToken token) {
-        super(token);
-    }
-
-    public WakerootElementalToken copy() {
-        return new WakerootElementalToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WindZendikon.java
+++ b/Mage.Sets/src/mage/cards/w/WindZendikon.java
@@ -1,8 +1,6 @@
 package mage.cards.w;
 
 import java.util.UUID;
-import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.DiesAttachedTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.AttachEffect;
@@ -12,9 +10,11 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
-import mage.game.permanent.token.TokenImpl;
-import mage.target.TargetPermanent;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.common.TargetLandPermanent;
 
 /**
@@ -27,24 +27,25 @@ public final class WindZendikon extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ENCHANTMENT},"{U}");
         this.subtype.add(SubType.AURA);
 
-
         // Enchant land
         // Enchanted land is a 2/2 blue Elemental creature with flying. It's still a land.
         // When enchanted land dies, return that card to its owner's hand.
-        
-        TargetPermanent auraTarget = new TargetLandPermanent();
+
+        TargetLandPermanent auraTarget = new TargetLandPermanent();
         this.getSpellAbility().addTarget(auraTarget);
-        this.getSpellAbility().addEffect(new AttachEffect(Outcome.PutCreatureInPlay));
-        Ability ability = new EnchantAbility(auraTarget);
-        this.addAbility(ability);
-        
-        Ability ability2 = new SimpleStaticAbility(new BecomesCreatureAttachedEffect(
-                new WindZendikonElementalToken(), "Enchanted land is a 2/2 blue Elemental creature with flying. It's still a land",
-                Duration.WhileOnBattlefield, BecomesCreatureAttachedEffect.LoseType.COLOR));
-        this.addAbility(ability2);
-        
-        Ability ability3 = new DiesAttachedTriggeredAbility(new ReturnToHandAttachedEffect(), "enchanted land", false);
-        this.addAbility(ability3);
+        this.getSpellAbility().addEffect(new AttachEffect(Outcome.BecomeCreature));
+        this.addAbility(new EnchantAbility(auraTarget));
+
+        this.addAbility(new SimpleStaticAbility(new BecomesCreatureAttachedEffect(
+            new CreatureToken(
+                2, 2, "2/2 blue Elemental creature with flying", SubType.ELEMENTAL
+            ).withColor("U").withAbility(FlyingAbility.getInstance()),
+            "Enchanted land is a 2/2 blue Elemental creature with flying. It's still a land",
+            Duration.WhileOnBattlefield,
+            BecomesCreatureAttachedEffect.LoseType.COLOR
+        )));
+
+        this.addAbility(new DiesAttachedTriggeredAbility(new ReturnToHandAttachedEffect(), "enchanted land"));
     }
 
     private WindZendikon(final WindZendikon card) {
@@ -54,26 +55,5 @@ public final class WindZendikon extends CardImpl {
     @Override
     public WindZendikon copy() {
         return new WindZendikon(this);
-    }
-
-}
-
-class WindZendikonElementalToken extends TokenImpl {
-
-    WindZendikonElementalToken() {
-        super("", "2/2 blue Elemental creature with flying");
-        cardType.add(CardType.CREATURE);
-        color.setBlue(true);
-        subtype.add(SubType.ELEMENTAL);
-        power = new MageInt(2);
-        toughness = new MageInt(2);
-        addAbility(FlyingAbility.getInstance());
-    }
-    private WindZendikonElementalToken(final WindZendikonElementalToken token) {
-        super(token);
-    }
-
-    public WindZendikonElementalToken copy() {
-        return new WindZendikonElementalToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/w/WoodwraithCorrupter.java
+++ b/Mage.Sets/src/mage/cards/w/WoodwraithCorrupter.java
@@ -14,7 +14,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.filter.common.FilterLandPermanent;
 import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;

--- a/Mage.Sets/src/mage/cards/w/WoodwraithCorrupter.java
+++ b/Mage.Sets/src/mage/cards/w/WoodwraithCorrupter.java
@@ -16,7 +16,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.filter.common.FilterLandPermanent;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 
 /**
@@ -40,7 +40,13 @@ public final class WoodwraithCorrupter extends CardImpl {
         this.toughness = new MageInt(6);
 
         // {1}{B}{G}, {T}: Target Forest becomes a 4/4 black and green Elemental Horror creature. It's still a land.
-        Effect effect = new BecomesCreatureTargetEffect(new WoodwraithCorrupterToken(), false, true, Duration.Custom);
+        Effect effect = new BecomesCreatureTargetEffect(
+            new CreatureToken(4, 4, "4/4 black and green Elemental Horror creature", SubType.ELEMENTAL, SubType.HORROR)
+                .withColor("BG"),
+            false,
+            true,
+            Duration.Custom
+        );
         Ability ability = new SimpleActivatedAbility(effect, new ManaCostsImpl<>("{1}{B}{G}"));
         ability.addTarget(new TargetPermanent(filter));
         ability.addCost(new TapSourceCost());
@@ -54,28 +60,5 @@ public final class WoodwraithCorrupter extends CardImpl {
     @Override
     public WoodwraithCorrupter copy() {
         return new WoodwraithCorrupter(this);
-    }
-}
-
-class WoodwraithCorrupterToken extends TokenImpl {
-
-    public WoodwraithCorrupterToken() {
-        super("", "4/4 black and green Elemental Horror creature");
-        cardType.add(CardType.CREATURE);
-
-        color.setBlack(true);
-        color.setGreen(true);
-        subtype.add(SubType.ELEMENTAL);
-        subtype.add(SubType.HORROR);
-
-        power = new MageInt(4);
-        toughness = new MageInt(4);
-    }
-    private WoodwraithCorrupterToken(final WoodwraithCorrupterToken token) {
-        super(token);
-    }
-
-    public WoodwraithCorrupterToken copy() {
-        return new WoodwraithCorrupterToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/x/XanthicStatue.java
+++ b/Mage.Sets/src/mage/cards/x/XanthicStatue.java
@@ -2,7 +2,6 @@
 package mage.cards.x;
 
 import java.util.UUID;
-import mage.MageInt;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.continuous.BecomesCreatureSourceEffect;
@@ -11,8 +10,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Zone;
-import mage.game.permanent.token.TokenImpl;
+import mage.constants.SubType;
+import mage.game.permanent.token.custom.CreatureToken;
 
 /**
  *
@@ -24,9 +23,15 @@ public final class XanthicStatue extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{8}");
 
         // {5}: Until end of turn, Xanthic Statue becomes an 8/8 Golem artifact creature with trample.
-        this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(new XanthicStatueCreature(), CardType.ARTIFACT, Duration.EndOfTurn)
-                .setText("until end of turn, {this} becomes an 8/8 Golem artifact creature with trample")
-                , new ManaCostsImpl<>("{5}")));
+        this.addAbility(new SimpleActivatedAbility(
+            new BecomesCreatureSourceEffect(
+                new CreatureToken(8, 8, "8/8 Golem artifact creature with trample", SubType.GOLEM)
+                    .withAbility(TrampleAbility.getInstance()),
+                CardType.ARTIFACT,
+                Duration.EndOfTurn
+            ).setText("until end of turn, {this} becomes an 8/8 Golem artifact creature with trample"),
+            new ManaCostsImpl<>("{5}")
+        ));
     }
 
     private XanthicStatue(final XanthicStatue card) {
@@ -36,25 +41,5 @@ public final class XanthicStatue extends CardImpl {
     @Override
     public XanthicStatue copy() {
         return new XanthicStatue(this);
-    }
-}
-
-class XanthicStatueCreature extends TokenImpl {
-
-    public XanthicStatueCreature() {
-        super("Xanthic Statue", "8/8 Golem artifact creature with trample");
-        cardType.add(CardType.ARTIFACT);
-        cardType.add(CardType.CREATURE);
-        power = new MageInt(8);
-        toughness = new MageInt(8);
-
-        this.addAbility(TrampleAbility.getInstance());
-    }
-    private XanthicStatueCreature(final XanthicStatueCreature token) {
-        super(token);
-    }
-
-    public XanthicStatueCreature copy() {
-        return new XanthicStatueCreature(this);
     }
 }


### PR DESCRIPTION
Related to #14315 

Confirmed that none of these have equivalent public tokens and Tokens were never printed by WotC. 

Minor cleanup done in associated classes, given I was under the hood anyway...

This is scoped to tokens that were beginning with V through to Z inclusive.