### PR TITLE
Refactor private tokens to CreatureToken; B

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BalduvianFrostwaker.java
+++ b/Mage.Sets/src/mage/cards/b/BalduvianFrostwaker.java
@@ -11,9 +11,12 @@ import mage.abilities.effects.common.continuous.BecomesCreatureTargetEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.filter.common.FilterLandPermanent;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 
 /**
@@ -36,7 +39,16 @@ public final class BalduvianFrostwaker extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {U}, {T}: Target snow land becomes a 2/2 blue Elemental creature with flying. It's still a land.
-        Ability ability = new SimpleActivatedAbility(new BecomesCreatureTargetEffect(new BalduvianFrostwakerToken(), false, true, Duration.Custom), new ManaCostsImpl<>("{U}"));
+        Ability ability = new SimpleActivatedAbility(
+            new BecomesCreatureTargetEffect(
+                new CreatureToken(2, 2, "2/2 blue Elemental creature with flying", SubType.ELEMENTAL)
+                    .withColor("U").withAbility(FlyingAbility.getInstance()),
+                false,
+                true,
+                Duration.Custom
+            ),
+            new ManaCostsImpl<>("{U}")
+        );
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
@@ -49,25 +61,5 @@ public final class BalduvianFrostwaker extends CardImpl {
     @Override
     public BalduvianFrostwaker copy() {
         return new BalduvianFrostwaker(this);
-    }
-}
-
-class BalduvianFrostwakerToken extends TokenImpl {
-
-    public BalduvianFrostwakerToken() {
-        super("Elemental", "2/2 blue Elemental creature with flying");
-        this.cardType.add(CardType.CREATURE);
-        color.setBlue(true);
-        subtype.add(SubType.ELEMENTAL);
-        this.power = new MageInt(2);
-        this.toughness = new MageInt(2);
-        this.addAbility(FlyingAbility.getInstance());
-    }
-    private BalduvianFrostwakerToken(final BalduvianFrostwakerToken token) {
-        super(token);
-    }
-
-    public BalduvianFrostwakerToken copy() {
-        return new BalduvianFrostwakerToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
+++ b/Mage.Sets/src/mage/cards/b/BogardanDragonheart.java
@@ -12,8 +12,7 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
-import mage.game.permanent.token.TokenImpl;
-import mage.target.common.TargetControlledPermanent;
+import mage.game.permanent.token.custom.CreatureToken;
 
 import java.util.UUID;
 
@@ -32,7 +31,10 @@ public final class BogardanDragonheart extends CardImpl {
 
         // Sacrifice another creature: Until end of turn, Bogardan Dragonheart becomes a Dragon with base power and toughness 4/4, flying, and haste.
         this.addAbility(new SimpleActivatedAbility(new BecomesCreatureSourceEffect(
-                new BogardanDragonheartToken(), CardType.CREATURE, Duration.EndOfTurn
+            new CreatureToken(4, 4, "Dragon with base power and toughness 4/4, flying, and haste", SubType.DRAGON)
+                .withAbility(FlyingAbility.getInstance()).withAbility(HasteAbility.getInstance()),
+            CardType.CREATURE,
+            Duration.EndOfTurn
         ), new SacrificeTargetCost(StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE)));
     }
 
@@ -43,27 +45,5 @@ public final class BogardanDragonheart extends CardImpl {
     @Override
     public BogardanDragonheart copy() {
         return new BogardanDragonheart(this);
-    }
-}
-
-class BogardanDragonheartToken extends TokenImpl {
-
-    BogardanDragonheartToken() {
-        super("", "Dragon with base power and toughness 4/4, flying, and haste");
-        cardType.add(CardType.CREATURE);
-        subtype.add(SubType.DRAGON);
-        power = new MageInt(4);
-        toughness = new MageInt(4);
-
-        addAbility(FlyingAbility.getInstance());
-        addAbility(HasteAbility.getInstance());
-    }
-
-    private BogardanDragonheartToken(final BogardanDragonheartToken token) {
-        super(token);
-    }
-
-    public BogardanDragonheartToken copy() {
-        return new BogardanDragonheartToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/s/Skinshifter.java
+++ b/Mage.Sets/src/mage/cards/s/Skinshifter.java
@@ -30,8 +30,6 @@ public final class Skinshifter extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
-        // TODO: Either confirm it's not safe and delete this comment, or replace
-        // rhinoToken with public RhinoToken. See #14315
         CreatureToken rhinoToken = new CreatureToken(
             4, 4,
             "Rhino with base power and toughness 4/4 and gains trample",

--- a/Mage.Sets/src/mage/cards/s/Skinshifter.java
+++ b/Mage.Sets/src/mage/cards/s/Skinshifter.java
@@ -13,7 +13,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.SubType;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 
 import java.util.UUID;
 
@@ -30,15 +30,35 @@ public final class Skinshifter extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(1);
 
+        // TODO: Either confirm it's not safe and delete this comment, or replace
+        // rhinoToken with public RhinoToken. See #14315
+        CreatureToken rhinoToken = new CreatureToken(
+            4, 4,
+            "Rhino with base power and toughness 4/4 and gains trample",
+            SubType.RHINO
+        ).withAbility(TrampleAbility.getInstance());
+
+        CreatureToken birdToken = new CreatureToken(
+            2, 2,
+            "Bird with base power and toughness 2/2 and gains flying",
+            SubType.BIRD
+        ).withAbility(FlyingAbility.getInstance());
+
+        CreatureToken plantToken = new CreatureToken(
+            0, 8,
+            "Plant with base power and toughness 0/8",
+            SubType.PLANT
+        );
+
         Ability ability = new SimpleActivatedAbility(
-                new BecomesCreatureSourceEffect(new RhinoToken(), CardType.CREATURE, Duration.EndOfTurn),
+                new BecomesCreatureSourceEffect(rhinoToken, CardType.CREATURE, Duration.EndOfTurn),
                 new ManaCostsImpl<>("{G}"));
         ability.getModes().setChooseText("Choose one. Activate only once each turn.");
 
-        Mode mode = new Mode(new BecomesCreatureSourceEffect(new BirdToken(), CardType.CREATURE, Duration.EndOfTurn));
+        Mode mode = new Mode(new BecomesCreatureSourceEffect(birdToken, CardType.CREATURE, Duration.EndOfTurn));
         ability.addMode(mode);
 
-        mode = new Mode(new BecomesCreatureSourceEffect(new PlantToken(), CardType.CREATURE, Duration.EndOfTurn));
+        mode = new Mode(new BecomesCreatureSourceEffect(plantToken, CardType.CREATURE, Duration.EndOfTurn));
         ability.addMode(mode);
 
         this.addAbility(ability);
@@ -51,70 +71,5 @@ public final class Skinshifter extends CardImpl {
     @Override
     public Skinshifter copy() {
         return new Skinshifter(this);
-    }
-
-    private static final class RhinoToken extends TokenImpl {
-
-        public RhinoToken() {
-            super("Rhino", "Rhino with base power and toughness 4/4 and gains trample");
-            this.cardType.add(CardType.CREATURE);
-            this.subtype.add(SubType.RHINO);
-
-            this.color.setGreen(true);
-            this.power = new MageInt(4);
-            this.toughness = new MageInt(4);
-            this.addAbility(TrampleAbility.getInstance());
-        }
-
-        private RhinoToken(final RhinoToken token) {
-            super(token);
-        }
-
-        public RhinoToken copy() {
-            return new RhinoToken(this);
-        }
-    }
-
-    private static final class BirdToken extends TokenImpl {
-
-        public BirdToken() {
-            super("Bird", "Bird with base power and toughness 2/2 and gains flying");
-            this.cardType.add(CardType.CREATURE);
-            this.subtype.add(SubType.BIRD);
-
-            this.color.setGreen(true);
-            this.power = new MageInt(2);
-            this.toughness = new MageInt(2);
-            this.addAbility(FlyingAbility.getInstance());
-        }
-
-        private BirdToken(final BirdToken token) {
-            super(token);
-        }
-
-        public BirdToken copy() {
-            return new BirdToken(this);
-        }
-    }
-
-    private static final class PlantToken extends TokenImpl {
-
-        public PlantToken() {
-            super("Plant", "Plant with base power and toughness 0/8");
-            this.cardType.add(CardType.CREATURE);
-            this.subtype.add(SubType.PLANT);
-
-            this.color.setGreen(true);
-            this.power = new MageInt(0);
-            this.toughness = new MageInt(8);
-        }
-
-        private PlantToken(final PlantToken token) {
-            super(token);
-        }
-
-        public PlantToken copy() {
-            return new PlantToken(this);
-        }
     }
 }


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/pull/14315

~~Addresses private tokens starting with B; but with a potential TODO depending on how decision making in the aforementioned issue goes around reusing established Public tokens vs always using a custom CreatureToken instance.~~

~~I figure that introducing a TODO that I (or anyone) can easily either just delete or action to unblock progressing enabling the test is the lesser of two evils here.~~ see https://github.com/magefree/mage/pull/14315#discussion_r2750441215