### PR TITLE
Refactor private tokens to CreatureToken; C

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CacophonyUnleashed.java
+++ b/Mage.Sets/src/mage/cards/c/CacophonyUnleashed.java
@@ -1,6 +1,5 @@
 package mage.cards.c;
 
-import mage.MageInt;
 import mage.abilities.common.EntersBattlefieldThisOrAnotherTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.condition.common.CastFromEverywhereSourceCondition;
@@ -18,7 +17,7 @@ import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.Predicates;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 
 import java.util.UUID;
 
@@ -42,9 +41,16 @@ public final class CacophonyUnleashed extends CardImpl {
 
         // Whenever Cacophony Unleashed or another enchantment you control enters, until end of turn, Cacophony Unleashed becomes a legendary 6/6 Nightmare God creature with menace and deathtouch. It's still an enchantment.
         this.addAbility(new EntersBattlefieldThisOrAnotherTriggeredAbility(
-                new BecomesCreatureSourceEffect(new CacophonyUnleashedToken(), CardType.ENCHANTMENT, Duration.EndOfTurn)
-                        .setText("until end of turn, {this} becomes a legendary 6/6 Nightmare God "
-                                + "creature with menace and deathtouch. It's still an enchantment."),
+                new BecomesCreatureSourceEffect(
+                    new CreatureToken(
+                        6, 6,
+                        "legendary 6/6 Nightmare God creature with menace and deathtouch",
+                        SubType.NIGHTMARE, SubType.GOD
+                    ).withSuperType(SuperType.LEGENDARY).withAbility(new MenaceAbility()).withAbility(DeathtouchAbility.getInstance()),
+                    CardType.ENCHANTMENT,
+                    Duration.EndOfTurn
+                ).setText("until end of turn, {this} becomes a legendary 6/6 Nightmare God "
+                    + "creature with menace and deathtouch. It's still an enchantment."),
                 StaticFilters.FILTER_PERMANENT_ENCHANTMENT,
                 false, true
         ));
@@ -57,28 +63,5 @@ public final class CacophonyUnleashed extends CardImpl {
     @Override
     public CacophonyUnleashed copy() {
         return new CacophonyUnleashed(this);
-    }
-}
-
-class CacophonyUnleashedToken extends TokenImpl {
-
-    CacophonyUnleashedToken() {
-        super("", "legendary 6/6 Nightmare God creature with menace and deathtouch");
-        supertype.add(SuperType.LEGENDARY);
-        cardType.add(CardType.CREATURE);
-        subtype.add(SubType.NIGHTMARE);
-        subtype.add(SubType.GOD);
-        power = new MageInt(6);
-        toughness = new MageInt(6);
-        addAbility(new MenaceAbility(false));
-        addAbility(DeathtouchAbility.getInstance());
-    }
-
-    private CacophonyUnleashedToken(final CacophonyUnleashedToken token) {
-        super(token);
-    }
-
-    public CacophonyUnleashedToken copy() {
-        return new CacophonyUnleashedToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CaseOfTheFilchedFalcon.java
+++ b/Mage.Sets/src/mage/cards/c/CaseOfTheFilchedFalcon.java
@@ -2,7 +2,6 @@ package mage.cards.c;
 
 import java.util.UUID;
 
-import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.CaseAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
@@ -28,7 +27,7 @@ import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterArtifactPermanent;
 import mage.game.Game;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 
 /**
@@ -53,9 +52,10 @@ public final class CaseOfTheFilchedFalcon extends CardImpl {
         Ability solvedAbility = new ActivateIfConditionActivatedAbility(
                 new AddCountersTargetEffect(CounterType.P1P1.createInstance(4)),
                 new ManaCostsImpl<>("{2}{U}"), SolvedSourceCondition.SOLVED);
-        solvedAbility.addEffect(new BecomesCreatureTargetEffect(new CaseOfTheFilchedFalconToken(),
-                false, false, Duration.WhileOnBattlefield)
-                .setText("It becomes a 0/0 Bird creature with flying in addition to its other types"));
+        solvedAbility.addEffect(new BecomesCreatureTargetEffect(
+            new CreatureToken(0, 0, "0/0 Bird creature with flying", SubType.BIRD).withAbility(FlyingAbility.getInstance()),
+            false, false, Duration.WhileOnBattlefield
+        ).setText("It becomes a 0/0 Bird creature with flying in addition to its other types"));
         solvedAbility.addCost(new SacrificeSourceCost().setText("sacrifice this Case"));
         solvedAbility.addTarget(new TargetPermanent(StaticFilters.FILTER_ARTIFACT_NON_CREATURE));
 
@@ -94,27 +94,5 @@ class CaseOfTheFilchedFalconHint extends CaseSolvedHint {
                 .count(StaticFilters.FILTER_CONTROLLED_PERMANENT_ARTIFACT, ability.getControllerId(),
                         ability, game);
         return "Artifacts: " + artifacts + " (need 3).";
-    }
-}
-
-class CaseOfTheFilchedFalconToken extends TokenImpl {
-
-    public CaseOfTheFilchedFalconToken() {
-        super("", "0/0 Bird creature with flying");
-        this.cardType.add(CardType.CREATURE);
-
-        this.subtype.add(SubType.BIRD);
-        this.power = new MageInt(0);
-        this.toughness = new MageInt(0);
-        this.addAbility(FlyingAbility.getInstance());
-    }
-
-    private CaseOfTheFilchedFalconToken(final CaseOfTheFilchedFalconToken token) {
-        super(token);
-    }
-
-    @Override
-    public CaseOfTheFilchedFalconToken copy() {
-        return new CaseOfTheFilchedFalconToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CaseOfTheGorgonsKiss.java
+++ b/Mage.Sets/src/mage/cards/c/CaseOfTheGorgonsKiss.java
@@ -1,6 +1,5 @@
 package mage.cards.c;
 
-import mage.MageInt;
 import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.CaseAbility;
@@ -21,7 +20,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 import mage.watchers.common.CardsPutIntoGraveyardWatcher;
 
@@ -51,10 +50,14 @@ public final class CaseOfTheGorgonsKiss extends CardImpl {
         Condition toSolveCondition = new CaseOfTheGorgonsKissCondition();
         // Solved -- This Case is a 4/4 Gorgon creature with deathtouch and lifelink in addition to its other types.
         Ability solvedAbility = new SimpleStaticAbility(new ConditionalContinuousEffect(
-                new BecomesCreatureSourceEffect(new CaseOfTheGorgonsKissToken(),
-                        CardType.ENCHANTMENT, Duration.WhileOnBattlefield),
-                SolvedSourceCondition.SOLVED, "")
-                .setText("This Case is a 4/4 Gorgon creature with deathtouch and lifelink in addition to its other types."));
+            new BecomesCreatureSourceEffect(
+                new CreatureToken(4, 4, "4/4 Gorgon creature with deathtouch and lifelink", SubType.GORGON)
+                    .withAbility(DeathtouchAbility.getInstance()).withAbility(LifelinkAbility.getInstance()),
+                CardType.ENCHANTMENT,
+                Duration.WhileOnBattlefield
+            ),
+            SolvedSourceCondition.SOLVED, ""
+        ).setText("This Case is a 4/4 Gorgon creature with deathtouch and lifelink in addition to its other types."));
 
         this.addAbility(new CaseAbility(initialAbility, toSolveCondition, solvedAbility)
                         .addHint(new CaseOfTheGorgonsKissHint(toSolveCondition)),
@@ -113,28 +116,5 @@ class CaseOfTheGorgonsKissHint extends CaseSolvedHint {
                 .filter(MageObject::isCreature)
                 .count();
         return "Creatures put into graveyards: " + creatures + " (need 3).";
-    }
-}
-
-class CaseOfTheGorgonsKissToken extends TokenImpl {
-
-    CaseOfTheGorgonsKissToken() {
-        super("", "4/4 Gorgon creature with deathtouch and lifelink");
-        this.cardType.add(CardType.CREATURE);
-
-        this.subtype.add(SubType.GORGON);
-        this.power = new MageInt(4);
-        this.toughness = new MageInt(4);
-        this.addAbility(DeathtouchAbility.getInstance());
-        this.addAbility(LifelinkAbility.getInstance());
-    }
-
-    private CaseOfTheGorgonsKissToken(final CaseOfTheGorgonsKissToken token) {
-        super(token);
-    }
-
-    @Override
-    public CaseOfTheGorgonsKissToken copy() {
-        return new CaseOfTheGorgonsKissToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
+++ b/Mage.Sets/src/mage/cards/c/ChromiumTheMutable.java
@@ -17,7 +17,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 
 /**
  *
@@ -46,7 +46,13 @@ public final class ChromiumTheMutable extends CardImpl {
         // Discard a card: Until end of turn, Chromium, the Mutable becomes a Human with base power and toughness 1/1, loses all abilities, and gains hexproof. It can't be blocked this turn.
         Ability ability = new SimpleActivatedAbility(
                 new BecomesCreatureSourceEffect(
-                        new ChromiumTheMutableToken(), CardType.CREATURE, Duration.EndOfTurn
+                    new CreatureToken(
+                        1, 1,
+                        "Human with base power and toughness 1/1, loses all abilities, and gains hexproof",
+                        SubType.HUMAN
+                    ).withAbility(HexproofAbility.getInstance()),
+                    CardType.CREATURE,
+                    Duration.EndOfTurn
                 ).andLoseAbilities(true),
                 new DiscardCardCost()
         );
@@ -64,26 +70,5 @@ public final class ChromiumTheMutable extends CardImpl {
     @Override
     public ChromiumTheMutable copy() {
         return new ChromiumTheMutable(this);
-    }
-}
-
-class ChromiumTheMutableToken extends TokenImpl {
-
-    public ChromiumTheMutableToken() {
-        super("", "Human with base power and toughness 1/1, loses all abilities, and gains hexproof");
-        cardType.add(CardType.CREATURE);
-        subtype.add(SubType.HUMAN);
-        power = new MageInt(1);
-        toughness = new MageInt(1);
-
-        addAbility(HexproofAbility.getInstance());
-    }
-
-    private ChromiumTheMutableToken(final ChromiumTheMutableToken token) {
-        super(token);
-    }
-
-    public ChromiumTheMutableToken copy() {
-        return new ChromiumTheMutableToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/ClanGuildmage.java
+++ b/Mage.Sets/src/mage/cards/c/ClanGuildmage.java
@@ -15,7 +15,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledLandPermanent;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
@@ -46,7 +46,10 @@ public final class ClanGuildmage extends CardImpl {
 
         // {2}{G}, {T}: Target land you control becomes a 4/4 Elemental creature with haste until end of turn. It's still a land.
         ability = new SimpleActivatedAbility(new BecomesCreatureTargetEffect(
-                new ClanGuildmageToken(), false, true, Duration.EndOfTurn
+            new CreatureToken(4, 4, "4/4 Elemental creature with haste", SubType.ELEMENTAL)
+                .withAbility(HasteAbility.getInstance()),
+            false, true,
+            Duration.EndOfTurn
         ), new ManaCostsImpl<>("{2}{G}"));
         ability.addCost(new TapSourceCost());
         ability.addTarget(new TargetPermanent(filter));
@@ -60,26 +63,5 @@ public final class ClanGuildmage extends CardImpl {
     @Override
     public ClanGuildmage copy() {
         return new ClanGuildmage(this);
-    }
-}
-
-class ClanGuildmageToken extends TokenImpl {
-
-    public ClanGuildmageToken() {
-        super("", "4/4 Elemental creature with haste");
-        this.cardType.add(CardType.CREATURE);
-        this.subtype.add(SubType.ELEMENTAL);
-        this.power = new MageInt(4);
-        this.toughness = new MageInt(4);
-
-        this.addAbility(HasteAbility.getInstance());
-    }
-
-    private ClanGuildmageToken(final ClanGuildmageToken token) {
-        super(token);
-    }
-
-    public ClanGuildmageToken copy() {
-        return new ClanGuildmageToken(this);
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CorruptedZendikon.java
+++ b/Mage.Sets/src/mage/cards/c/CorruptedZendikon.java
@@ -2,7 +2,6 @@
 package mage.cards.c;
 
 import java.util.UUID;
-import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DiesAttachedTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -16,8 +15,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetLandPermanent;
 
@@ -39,9 +37,12 @@ public final class CorruptedZendikon extends CardImpl {
         this.addAbility(ability);
 
         // Enchanted land is a 3/3 black Ooze creature. It's still a land.
-        Ability ability2 = new SimpleStaticAbility(
-                new BecomesCreatureAttachedEffect(new CorruptedZendikonOozeToken(),
-                        "Enchanted land is a 3/3 black Ooze creature. It's still a land.", Duration.WhileOnBattlefield, BecomesCreatureAttachedEffect.LoseType.COLOR));
+        Ability ability2 = new SimpleStaticAbility(new BecomesCreatureAttachedEffect(
+            new CreatureToken(3, 3, "3/3 black Ooze creature", SubType.OOZE).withColor("B"),
+            "Enchanted land is a 3/3 black Ooze creature. It's still a land.",
+            Duration.WhileOnBattlefield,
+            BecomesCreatureAttachedEffect.LoseType.COLOR
+        ));
         this.addAbility(ability2);
 
         // When enchanted land dies, return that card to its owner's hand.
@@ -57,24 +58,4 @@ public final class CorruptedZendikon extends CardImpl {
     public CorruptedZendikon copy() {
         return new CorruptedZendikon(this);
     }
-}
-
-class CorruptedZendikonOozeToken extends TokenImpl {
-
-    public CorruptedZendikonOozeToken() {
-        super("Ooze", "3/3 black Ooze creature");
-        cardType.add(CardType.CREATURE);
-        color.setBlack(true);
-        subtype.add(SubType.OOZE);
-        this.power = new MageInt(3);
-        this.toughness = new MageInt(3);
-    }
-    private CorruptedZendikonOozeToken(final CorruptedZendikonOozeToken token) {
-        super(token);
-    }
-
-    public CorruptedZendikonOozeToken copy() {
-        return new CorruptedZendikonOozeToken(this);
-    }
-
 }

--- a/Mage.Sets/src/mage/cards/c/CrusherZendikon.java
+++ b/Mage.Sets/src/mage/cards/c/CrusherZendikon.java
@@ -2,7 +2,6 @@
 package mage.cards.c;
 
 import java.util.UUID;
-import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.DiesAttachedTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -17,8 +16,7 @@ import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.CreatureToken;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetLandPermanent;
 
@@ -41,7 +39,12 @@ public final class CrusherZendikon extends CardImpl {
         this.addAbility(ability);
         // Enchanted land is a 4/2 red Beast creature with trample. It's still a land.
         Ability ability2 = new SimpleStaticAbility(new BecomesCreatureAttachedEffect(
-                new CrusherZendikonToken(), "Enchanted land is a 4/2 red Beast creature with trample. It's still a land.", Duration.WhileOnBattlefield, BecomesCreatureAttachedEffect.LoseType.COLOR));
+            new CreatureToken(4, 2, "4/2 red Beast creature with trample", SubType.BEAST)
+                .withColor("R").withAbility(TrampleAbility.getInstance()),
+            "Enchanted land is a 4/2 red Beast creature with trample. It's still a land.",
+            Duration.WhileOnBattlefield,
+            BecomesCreatureAttachedEffect.LoseType.COLOR
+        ));
         this.addAbility(ability2);
         // When enchanted land dies, return that card to its owner's hand.
         Ability ability3 = new DiesAttachedTriggeredAbility(new ReturnToHandAttachedEffect(), "enchanted land", false);
@@ -55,25 +58,5 @@ public final class CrusherZendikon extends CardImpl {
     @Override
     public CrusherZendikon copy() {
         return new CrusherZendikon(this);
-    }
-}
-
-class CrusherZendikonToken extends TokenImpl {
-
-    CrusherZendikonToken() {
-        super("", "4/2 red Beast creature with trample");
-        cardType.add(CardType.CREATURE);
-        color.setRed(true);
-        subtype.add(SubType.BEAST);
-        power = new MageInt(4);
-        toughness = new MageInt(2);
-        this.addAbility(TrampleAbility.getInstance());
-    }
-    private CrusherZendikonToken(final CrusherZendikonToken token) {
-        super(token);
-    }
-
-    public CrusherZendikonToken copy() {
-        return new CrusherZendikonToken(this);
     }
 }

--- a/Mage/src/main/java/mage/game/permanent/token/custom/CreatureToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/custom/CreatureToken.java
@@ -5,6 +5,7 @@ import mage.ObjectColor;
 import mage.abilities.Ability;
 import mage.constants.CardType;
 import mage.constants.SubType;
+import mage.constants.SuperType;
 import mage.game.permanent.token.Token;
 import mage.game.permanent.token.TokenImpl;
 
@@ -69,6 +70,13 @@ public final class CreatureToken extends TokenImpl {
     public CreatureToken withSubType(SubType extraSubType) {
         if (!this.subtype.contains(extraSubType)) {
             this.subtype.add(extraSubType);
+        }
+        return this;
+    }
+
+    public CreatureToken withSuperType(SuperType extraSuperType) {
+        if (!this.supertype.contains(extraSuperType)) {
+            this.supertype.add(extraSuperType);
         }
         return this;
     }


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/pull/14315

Addresses private tokens starting with C.

Confirmed that no printing of equivalent tokens was ever made for these items by Wizards via Scryfall