### PR TITLE
[fix] Boromir, Warden of the Tower doesn't limit countering based on where it was cast from

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BoromirWardenOfTheTower.java
+++ b/Mage.Sets/src/mage/cards/b/BoromirWardenOfTheTower.java
@@ -36,8 +36,7 @@ public final class BoromirWardenOfTheTower extends CardImpl {
 
         // Whenever an opponent casts a spell, if no mana was spent to cast it, counter that spell.
         this.addAbility(new SpellCastOpponentTriggeredAbility(
-                Zone.BATTLEFIELD, new CounterTargetEffect(),
-                StaticFilters.FILTER_SPELL_NO_MANA_SPENT, false, true
+            new CounterTargetEffect(), StaticFilters.FILTER_SPELL_NO_MANA_SPENT, false
         ));
 
         // Sacrifice Boromir, Warden of the Tower: Creatures you control gain indestructible until end of turn. The Ring tempts you.


### PR DESCRIPTION
Fixes https://github.com/magefree/mage/issues/14346

This previously set `onlyFromNonHand` to `true` which is incorrect.  The card has no such limitation.

Setting that argument to `false` is equivalent to omitting it;

```
    public SpellCastOpponentTriggeredAbility(Zone zone, Effect effect, FilterSpell filter, boolean optional) {
        this(zone, effect, filter, optional, false);
    }

    public SpellCastOpponentTriggeredAbility(Zone zone, Effect effect, FilterSpell filter, boolean optional, boolean onlyFromNonHand) {
        this(zone, effect, filter, optional, SetTargetPointer.NONE, onlyFromNonHand);
    }
```

Looking further at constructors available, omitting the `Zone` is also equivalent;

```
    public SpellCastOpponentTriggeredAbility(Effect effect, FilterSpell filter, boolean optional) {
        this(effect, filter, optional, false);
    }

    public SpellCastOpponentTriggeredAbility(Effect effect, FilterSpell filter, boolean optional, boolean onlyFromNonHand) {
        this(Zone.BATTLEFIELD, effect, filter, optional, onlyFromNonHand);
    }

    public SpellCastOpponentTriggeredAbility(Zone zone, Effect effect, FilterSpell filter, boolean optional) {
        this(zone, effect, filter, optional, false);
    }

    public SpellCastOpponentTriggeredAbility(Zone zone, Effect effect, FilterSpell filter, boolean optional, boolean onlyFromNonHand) {
        this(zone, effect, filter, optional, SetTargetPointer.NONE, onlyFromNonHand);
    }
```