### PR TITLE
Fix Commander Liara Portyr cost reduction

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CommanderLiaraPortyr.java
+++ b/Mage.Sets/src/mage/cards/c/CommanderLiaraPortyr.java
@@ -65,7 +65,7 @@ class CommanderLiaraPortyrCostEffect extends CostModificationEffectImpl {
     @Override
     public boolean apply(Game game, Ability source, Ability abilityToModify) {
         Optional.ofNullable((Integer) getValue(AttacksWithCreaturesTriggeredAbility.VALUEKEY_NUMBER_DEFENDING_PLAYERS))
-                .ifPresent(i -> CardUtil.reduceCost(abilityToModify, 1));
+                .ifPresent(i -> CardUtil.reduceCost(abilityToModify, i));
         return true;
     }
 


### PR DESCRIPTION
Fixes https://github.com/magefree/mage/issues/14353

It was hardcoded to 1 instead of passing in the int value retrieved of number of attacked players.