### PR TITLE
[fix] Alpine Moon was not correctly removing existing abilities

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AlpineMoon.java
+++ b/Mage.Sets/src/mage/cards/a/AlpineMoon.java
@@ -93,6 +93,7 @@ class AlpineMoonEffect extends ContinuousEffectImpl {
                     land.removeAllSubTypes(game, SubTypeSet.NonBasicLandType);
                     break;
                 case AbilityAddingRemovingEffects_6:
+                    land.removeAbilities(land.getAbilities(), source.getSourceId(), game);
                     land.addAbility(new AnyColorManaAbility(), source.getSourceId(), game);
                     break;
             }


### PR DESCRIPTION
Fixes #14357 

Looks like while it removed the subtypes, it never actually removed the other abilities as it was supposed to. So remove them all first, and then add the new colorless mana ability.