### PR TITLE
Fix optional waterbending not being considered mana costs

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/WaterbendTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/WaterbendTest.java
@@ -109,4 +109,28 @@ public class WaterbendTest extends CardTestPlayerBase {
         assertTapped(relic, true);
         assertTapped(spirit, false);
     }
+
+    @Test
+    public void testCostReduction() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Arcane Melee");
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears");
+        addCard(Zone.HAND, playerA, "Spirit Water Revival");
+        addCard(Zone.HAND, playerA, "Grizzly Bears", 7);
+
+        // cost should be reduced from {1}{U}{U}{waterbend(6)} -> {U}{U}{waterbend(5)} with bears paying for 1
+        // so 6 free mana needed
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 6);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Spirit Water Revival");
+        setChoice(playerA, true);
+        setChoice(playerA, "Balduvian Bears");
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        // we drew 7 cards
+        assertHandCount(playerA, 14);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/costs/common/WaterbendCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/WaterbendCost.java
@@ -24,7 +24,7 @@ public class WaterbendCost extends GenericManaCost {
     public WaterbendCost(int amount) {
         super(amount);
         for (int i = 0; i < amount; i++) {
-            options.add(Mana.ColorlessMana(i));
+            options.add(Mana.GenericMana(i));
         }
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/WaterbendAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/WaterbendAbility.java
@@ -82,7 +82,7 @@ public class WaterbendAbility extends StaticAbility implements OptionalAdditiona
 
         additionalCost.activate();
         for (Cost cost : ((Costs<Cost>) additionalCost)) {
-            ability.getCosts().add(cost.copy());
+            ability.addCost(cost.copy());
         }
         ability.setCostsTag(WATERBEND_ACTIVATION_VALUE_KEY, null);
     }


### PR DESCRIPTION
Optional waterbending costs should also be considered mana costs and thus eligible for cost reduction and anything else that affects mana costs.