### PR TITLE
Abuelo's Awakening effect should fizzle after permanent disappears

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbuelosAwakening.java
+++ b/Mage.Sets/src/mage/cards/a/AbuelosAwakening.java
@@ -122,7 +122,7 @@ class AbuelosAwakeningContinuousEffect extends ContinuousEffectImpl {
             }
         }
         if (creature == null) {
-            this.used = true;
+            this.discard();
             return false;
         }
         switch (layer) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/lci/AbuelosAwakeningTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/lci/AbuelosAwakeningTest.java
@@ -75,4 +75,28 @@ public class AbuelosAwakeningTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, talisman, 0);
         assertGraveyardCount(playerA, talisman, 1);
     }
+
+    @Test
+    public void testAbuelosAwakeningFlicker() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.GRAVEYARD, playerA, "Shorikai, Genesis Engine");
+        addCard(Zone.HAND, playerA, abuelosAwakening);
+        addCard(Zone.HAND, playerA, "Flicker");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 6);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, abuelosAwakening, "Shorikai, Genesis Engine");
+        setChoiceAmount(playerA, 0);
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Flicker", "Shorikai, Genesis Engine");
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertType("Shorikai, Genesis Engine", CardType.ARTIFACT, true); // should still be artifact
+
+        // after being blinked, should no longer be a creature and should revert to base power/toughness
+        assertType("Shorikai, Genesis Engine", CardType.CREATURE, false);
+        assertBasePowerToughness(playerA, "Shorikai, Genesis Engine", 8, 8);
+    }
 }


### PR DESCRIPTION
[[Abuelo's Awakening]] should not persist across zone changes, and thus should be a oneshot effect, not a continuous one.