### PR TITLE
Mana abilities should be controlled by their activator

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/NonTappingManaAbilitiesTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/NonTappingManaAbilitiesTest.java
@@ -1,6 +1,7 @@
 package org.mage.test.cards.mana;
 
 import mage.abilities.mana.ManaOptions;
+import mage.constants.ManaType;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.counters.CounterType;
@@ -308,6 +309,25 @@ public class NonTappingManaAbilitiesTest extends CardTestPlayerBase {
         Assert.assertEquals("mana variations don't fit", 1, manaOptions.size());
         assertManaOptions("{C}{C}", manaOptions);
     }    
+
+    @Test
+    public void Test_ManaCacheActivate() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Upwelling");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+
+        // At the beginning of each player's end step, put a charge counter on Mana Cache for each untapped land that player controls.
+        // Remove a charge counter from Mana Cache: Add {C}. Any player may activate this ability but only during their turn before the end step.
+        addCard(Zone.BATTLEFIELD, playerA, "Mana Cache", 1);
+
+        activateManaAbility(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Remove a charge counter");
+
+        setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertManaPool(playerB, ManaType.COLORLESS, 1);
+    }
     
     @Test
     public void testAvailableManaWithSpiritGuides() {

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1517,6 +1517,10 @@ public abstract class PlayerImpl implements Player, Serializable {
 
     protected boolean playManaAbility(ActivatedManaAbilityImpl ability, Game game) {
         int bookmark = game.bookmarkState();
+        //20260116 - 109.4a
+        //The controller of a mana ability is determined as though it were on the stack.
+        ability.newId();
+        ability.setControllerId(playerId);
         if (ability.activate(game, false) && ability.resolve(game)) {
             if (ability.isUndoPossible()) {
                 if (storedBookmark == -1 || storedBookmark > bookmark) { // e.g. useful for undo Nykthos, Shrine to Nyx


### PR DESCRIPTION
Per rule 113.8, the controller of an activated ability on the stack is the player who activated it.  This matters for cards with activated abilities which specify they can be activated by players other than the controller of the permanent, e.g. [[Mana Cache]] which will add mana to its controller's mana pool on activation.