### PR TITLE
Support simple card list when loading a deck in deck editor 

### DIFF
--- a/Mage/src/main/java/mage/cards/decks/importer/DeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/DeckImporter.java
@@ -83,7 +83,16 @@ public abstract class DeckImporter {
     public static DeckCardLists importDeckFromFile(String file, StringBuilder errorMessages, boolean saveAutoFixedFile) {
         DeckImporter deckImporter = getDeckImporter(file);
         if (deckImporter != null) {
-            return deckImporter.importDeck(file, errorMessages, saveAutoFixedFile);
+            DeckCardLists deckCardLists = deckImporter.importDeck(file, errorMessages, saveAutoFixedFile);
+            // Fallback: if a .dck file produced no cards, retry as plain text
+            if (deckCardLists.getCards().isEmpty()
+                    && deckCardLists.getSideboard().isEmpty()
+                    && deckImporter instanceof DckDeckImporter) {
+                errorMessages.setLength(0);
+                TxtDeckImporter txtImporter = new TxtDeckImporter(haveSideboardSection(file));
+                deckCardLists = txtImporter.importDeck(file, errorMessages, saveAutoFixedFile);
+            }
+            return deckCardLists;
         } else {
             return new DeckCardLists();
         }


### PR DESCRIPTION
# Summary
Now you need to use the import function to load a deck and then save it in xmage format. If you have collection of decks, it require a lot of manual work to make them work in xmage.  This PR adds support for load decklists with simple text format.


### Testing

1. Open deck editor
2. Click Load 
3. Select a .dck file which has the deck below
4. Should not produce an error

```
1 Ancestral Recall
1 Black Lotus
1 Brainstorm
1 Demonic Tutor
1 Dig Through Time
1 Dress Down
4 Fatal Push
1 Flooded Strand
4 Force of Negation
4 Force of Will
1 Gitaxian Probe
1 Island
2 Lorien Revealed
1 Mana Drain
1 Mental Misstep
1 Mindbreak Trap
1 Momentum Breaker
1 Mox Jet
1 Mox Pearl
1 Mox Sapphire
1 Nihil Spellbomb
4 Orcish Bowmasters
4 Polluted Delta
4 Psychic Frog
2 Spell Pierce
1 Strip Mine
1 Swamp
1 Tamiyo, Inquisitive Student
1 Time Walk
1 Treasure Cruise
1 Undercity Sewers
4 Underground Sea
1 Urza's Saga
4 Wasteland

2 Consign to Memory
1 Dismember
1 Flusterstorm
2 Grafdigger's Cage
2 Long Goodbye
1 Lurrus of the Dream-Den
2 Null Rod
1 Pithing Needle
1 Soul-Guide Lantern
1 The Tabernacle at Pendrell Vale
1 Tormod's Crypt

```
