### PR TITLE
Fix Soldevi Golem missing target selection filter

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SoldeviGolem.java
+++ b/Mage.Sets/src/mage/cards/s/SoldeviGolem.java
@@ -17,7 +17,7 @@ import mage.constants.TargetController;
 import mage.constants.Zone;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.permanent.TappedPredicate;
-import mage.target.common.TargetCreaturePermanent;
+import mage.target.TargetPermanent;
 
 /**
  *
@@ -45,7 +45,7 @@ public final class SoldeviGolem extends CardImpl {
         // At the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap Soldevi Golem.
         Ability ability = new BeginningOfUpkeepTriggeredAbility(new UntapTargetEffect().setText("untap target tapped creature an opponent controls"), true);
         ability.addEffect(new UntapSourceEffect().setText("If you do, untap {this}"));
-        ability.addTarget(new TargetCreaturePermanent());
+        ability.addTarget(new TargetPermanent(filter));
         this.addAbility(ability);
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ice/SoldeviGolemTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ice/SoldeviGolemTest.java
@@ -1,0 +1,29 @@
+package org.mage.test.cards.single.ice;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author matoro
+ */
+public class SoldeviGolemTest extends CardTestPlayerBase {
+
+    /*
+     * This creature doesn't untap during your untap step.
+     * At the beginning of your upkeep, you may untap target tapped creature an opponent controls. If you do, untap this creature.
+     */
+
+    @Test
+    public void testCantTargetSelf() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Soldevi Golem", 1, true);
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertTapped("Soldevi Golem", true);
+    }
+}


### PR DESCRIPTION
The filter was already written but unused.

Fixes https://github.com/magefree/mage/issues/14403