### PR TITLE
Arm with Aether should apply to noncombat damage also

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArmWithAether.java
+++ b/Mage.Sets/src/mage/cards/a/ArmWithAether.java
@@ -2,7 +2,7 @@
 package mage.cards.a;
 
 import mage.abilities.Ability;
-import mage.abilities.common.DealsCombatDamageToAPlayerTriggeredAbility;
+import mage.abilities.common.DealsDamageToAPlayerTriggeredAbility;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.ReturnToHandTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
@@ -28,7 +28,7 @@ public final class ArmWithAether extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{2}{U}");
 
         // Until end of turn, creatures you control gain "Whenever this creature deals damage to an opponent, you may return target creature that player controls to its owner's hand."
-        Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(new ReturnToHandTargetEffect(), false, true);
+        Ability ability = new DealsDamageToAPlayerTriggeredAbility(new ReturnToHandTargetEffect(), false, true);
         ability.addTarget(new TargetPermanent(filter));
         ability.setTargetAdjuster(new ThatPlayerControlsTargetAdjuster());
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/nph/ArmWithAetherTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/nph/ArmWithAetherTest.java
@@ -1,0 +1,30 @@
+package org.mage.test.cards.single.nph;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ArmWithAetherTest extends CardTestPlayerBase {
+
+    // Until end of turn, creatures you control gain "Whenever this creature deals damage to an opponent, you may return target creature that player controls to its owner's hand."
+    @Test
+    public void testNoncombatDamage() {
+        addCard(Zone.BATTLEFIELD, playerA, "Chandra's Magmutt");
+        addCard(Zone.HAND, playerA, "Arm with Aether");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Arm with Aether");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}:");
+        addTarget(playerA, playerB);
+        addTarget(playerA, "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerB, "Balduvian Bears", 1);
+    }
+}


### PR DESCRIPTION
There is an explicit ruling on this:
> The granted ability triggers on all damage dealt by the creature to one of your opponents, not just combat damage.
> (2011-06-01)