### PR TITLE
Explicitly set earthbend animate effect target

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EarthbendTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EarthbendTest.java
@@ -1,0 +1,30 @@
+package org.mage.test.cards.abilities.keywords;
+
+import mage.constants.CardType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class EarthbendTest extends CardTestPlayerBase {
+
+    @Test
+    public void testMultipleEarthbend() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 3);
+        addCard(Zone.HAND, playerA, "Dai Li Agents");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Dai Li Agents");
+        addTarget(playerA, "Swamp");
+        addTarget(playerA, "Forest");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertType("Swamp", CardType.CREATURE, true);
+        assertType("Forest", CardType.CREATURE, true);
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/effects/keyword/EarthbendTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/EarthbendTargetEffect.java
@@ -71,7 +71,7 @@ public class EarthbendTargetEffect extends OneShotEffect {
                 new CreatureToken(0, 0)
                         .withAbility(HasteAbility.getInstance()),
                 false, true, Duration.Custom
-        ), source);
+        ).setTargetPointer(new FixedTarget(permanent.getId())), source);
         // Make the land into a creature before putting counters on, for the purposes of counter doublers that only apply to creatures.
         game.processAction();
         permanent.addCounters(CounterType.P1P1.createInstance(value), source, game);


### PR DESCRIPTION
Without setting the target of the earthbend animate effect, it defaults to the first target of the ability, and thus on a multiple apply the animate effect applies twice to the first target.

Fixes https://github.com/magefree/mage/issues/14426