### PR TITLE
Attribute blight counter placement to player paying blight cost

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/enchantments/NestOfScarabsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/enchantments/NestOfScarabsTest.java
@@ -247,4 +247,27 @@ public class NestOfScarabsTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Insect Token", 0);
         assertPermanentCount(playerB, "Insect Token", 0);
     }
+
+    // https://github.com/magefree/mage/issues/14421
+    @Test
+    public void noTriggerOpponentBlight() {
+        // Whenever {this} or another Elf you control enters, each opponent blights 1.
+        // Tap three untapped Elves you control: Proliferate. Activate only as a sorcery.
+        addCard(Zone.HAND, playerA, "High Perfect Morcant");
+        addCard(Zone.BATTLEFIELD, playerA, nestScarabs);
+        addCard(Zone.BATTLEFIELD, playerB, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "High Perfect Morcant");
+        setChoice(playerB, "Memnite");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerB, "Memnite", 1);
+        assertPermanentCount(playerA, "Insect Token", 0);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/costs/common/BlightCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/BlightCost.java
@@ -72,7 +72,7 @@ public class BlightCost extends CostImpl {
         player.choose(Outcome.UnboostCreature, target, source, game);
         Permanent permanent = game.getPermanent(target.getFirstTarget());
         if (permanent != null) {
-            permanent.addCounters(CounterType.M1M1.createInstance(amount), source, game);
+            permanent.addCounters(CounterType.M1M1.createInstance(amount), player.getId(), source, game);
         }
         return permanent;
     }


### PR DESCRIPTION
It is the player paying the blight cost that puts the counters on their creatures.  Without specifying this explicitly it defaults to the controller of the ability triggering the blight, which is not necessarily the same as the player paying the blight cost.

Fixes https://github.com/magefree/mage/issues/14421