### PR TITLE
gui: Make color identity violation messaging clearer

### DIFF
--- a/Mage.Client/src/main/java/mage/client/components/LegalityLabel.java
+++ b/Mage.Client/src/main/java/mage/client/components/LegalityLabel.java
@@ -3,6 +3,7 @@ package mage.client.components;
 import mage.cards.decks.Deck;
 import mage.cards.decks.DeckValidator;
 import mage.cards.decks.DeckValidatorError;
+import org.mage.card.arcane.ManaSymbols;
 import org.unbescape.html.HtmlEscape;
 import org.unbescape.html.HtmlEscapeLevel;
 import org.unbescape.html.HtmlEscapeType;
@@ -100,6 +101,10 @@ public class LegalityLabel extends JLabel {
         return HtmlEscape.escapeHtml(string, HtmlEscapeType.HTML4_NAMED_REFERENCES_DEFAULT_TO_HEXA, HtmlEscapeLevel.LEVEL_0_ONLY_MARKUP_SIGNIFICANT_EXCEPT_APOS);
     }
 
+    protected String formatTooltipText(String string) {
+        return ManaSymbols.replaceSymbolsWithHTML(escapeHtml(string), ManaSymbols.Type.TOOLTIP);
+    }
+
     protected String formatInvalidTooltip(java.util.List<DeckValidatorError> sortedErrorsList) {
         return sortedErrorsList.stream()
                 .reduce("<html><body>"
@@ -107,7 +112,7 @@ public class LegalityLabel extends JLabel {
                                 + "<u>The following problems have been found (click to select problem cards):</u>"
                                 + "<br>"
                                 + "<table style=\"table-layout: fixed; width: " + TOOLTIP_TABLE_WIDTH + "px\">",
-                        (str, error) -> String.format("%s<tr><td style=\"word-wrap: break-word\"><b>%s</b></td><td style=\"word-wrap: break-word\">%s</td></tr>", str, escapeHtml(error.getGroup()), escapeHtml(error.getMessage())), String::concat)
+                (str, error) -> String.format("%s<tr><td style=\"word-wrap: break-word\"><b>%s</b></td><td style=\"word-wrap: break-word\">%s</td></tr>", str, formatTooltipText(error.getGroup()), formatTooltipText(error.getMessage())), String::concat)
                 + "</table>"
                 + "</body></html>";
     }
@@ -119,7 +124,7 @@ public class LegalityLabel extends JLabel {
                                 + "<u>The following problems have been found (click to select problem cards):</u>"
                                 + "<br>"
                                 + "<table style=\"table-layout: fixed; width: " + TOOLTIP_TABLE_WIDTH + "px\">",
-                        (str, error) -> String.format("%s<tr><td style=\"word-wrap: break-word\"><b>%s</b></td><td style=\"word-wrap: break-word\">%s</td></tr>", str, escapeHtml(error.getGroup()), escapeHtml(error.getMessage())), String::concat)
+                (str, error) -> String.format("%s<tr><td style=\"word-wrap: break-word\"><b>%s</b></td><td style=\"word-wrap: break-word\">%s</td></tr>", str, formatTooltipText(error.getGroup()), formatTooltipText(error.getMessage())), String::concat)
                 + "</table>"
                 + "</body></html>";
     }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AbstractCommander.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AbstractCommander.java
@@ -101,13 +101,13 @@ public abstract class AbstractCommander extends Constructed {
             boolean valid = true;
             for (Card card : deck.getCards()) {
                 if (!ManaUtil.isColorIdentityCompatible(colorIdentity, card.getColorIdentity())) {
-                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color (need " + colorIdentity + ", but get " + card.getColorIdentity() + ")", true);
+                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color identity (contains " + card.getColorIdentity() + ", but commander allows only " + colorIdentity + ")", true);
                     valid = false;
                 }
             }
             for (Card card : deck.getSideboard()) {
                 if (!ManaUtil.isColorIdentityCompatible(colorIdentity, card.getColorIdentity())) {
-                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color (need " + colorIdentity + ", but get " + card.getColorIdentity() + ")", true);
+                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color identity (contains " + card.getColorIdentity() + ", but commander allows only " + colorIdentity + ")", true);
                     valid = false;
                 }
             }

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AbstractCommander.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/AbstractCommander.java
@@ -101,13 +101,17 @@ public abstract class AbstractCommander extends Constructed {
             boolean valid = true;
             for (Card card : deck.getCards()) {
                 if (!ManaUtil.isColorIdentityCompatible(colorIdentity, card.getColorIdentity())) {
-                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color identity (contains " + card.getColorIdentity() + ", but commander allows only " + colorIdentity + ")", true);
+                    FilterMana restrictedColor = card.getColorIdentity().copy();
+                    restrictedColor.removeAll(colorIdentity);
+                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color identity (includes " + restrictedColor + ", but your commander(s) allow only " + colorIdentity + ")", true);
                     valid = false;
                 }
             }
             for (Card card : deck.getSideboard()) {
                 if (!ManaUtil.isColorIdentityCompatible(colorIdentity, card.getColorIdentity())) {
-                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color identity (contains " + card.getColorIdentity() + ", but commander allows only " + colorIdentity + ")", true);
+                    FilterMana restrictedColor = card.getColorIdentity().copy();
+                    restrictedColor.removeAll(colorIdentity);
+                    addError(DeckValidatorErrorType.OTHER, card.getName(), "Invalid color identity (includes " + restrictedColor + ", but your commander(s) allow only " + colorIdentity + ")", true);
                     valid = false;
                 }
             }


### PR DESCRIPTION
Via a question on Discord. The current message is definitely grammatically incorrect, so let's fix that at the very least and try to make the messaging a bit clearer

<img width="734" height="700" alt="Screenshot 2026-02-18 at 7 33 02 AM" src="https://github.com/user-attachments/assets/10a8f88d-93ac-43c2-a4f6-8c66838f0b1d" />
