### PR TITLE
Ability source zone for forced discard triggers should always be valid

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DiscardTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/DiscardTest.java
@@ -36,6 +36,27 @@ public class DiscardTest extends CardTestPlayerBase {
         assertHandCount(playerA, 1); // the card drawn by Cycling
     }
 
+    // https://github.com/magefree/mage/issues/14419
+    @Test
+    public void testRestInPeaceAndDiscard() {
+        addCard(Zone.BATTLEFIELD, playerA, "Rest in Peace");
+        addCard(Zone.HAND, playerA, "Mind Sludge");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 4);
+        addCard(Zone.HAND, playerB, "Orvar, the All-Form");
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Mind Sludge");
+        addTarget(playerA, playerB);
+        addTarget(playerB, "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
+    }
+
     @Test
     public void AmnesiaTest() {
         addCard(Zone.BATTLEFIELD, playerA, "Island", 20);

--- a/Mage/src/main/java/mage/abilities/common/DiscardedByOpponentTriggeredAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/DiscardedByOpponentTriggeredAbility.java
@@ -13,7 +13,7 @@ import mage.game.stack.StackObject;
 public class DiscardedByOpponentTriggeredAbility extends TriggeredAbilityImpl {
 
     public DiscardedByOpponentTriggeredAbility(Effect effect) {
-        super(Zone.GRAVEYARD, effect, false);
+        super(Zone.ALL, effect, false); // support zone replacement effects like Rest in Peace
         setTriggerPhrase("When a spell or ability an opponent controls causes you to discard this card, ");
     }
 


### PR DESCRIPTION
When an ability triggers due to being forced to discard by an opponent, that ability should always go off even when the source of the ability goes to a zone other than the graveyard.

Fixes https://github.com/magefree/mage/issues/14419