### PR TITLE
Unbound Flourishing: use null-safe CardUtil methods for accessing tagsMap

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
+++ b/Mage.Sets/src/mage/cards/u/UnboundFlourishing.java
@@ -115,9 +115,8 @@ class UnboundFlourishingDoubleXEffect extends OneShotEffect {
         if (player != null && controller != null) {
             Spell needObject = game.getSpell(getTargetPointer().getFirst(game, source));
             if (needObject != null) {
-                Map<String, Object> tagsMap = CardUtil.getSourceCostsTagsMap(game, needObject.getSpellAbility());
-                if (tagsMap.containsKey("X")) {
-                    tagsMap.put("X", ((int) tagsMap.get("X")) * 2);
+                if (CardUtil.checkSourceCostsTagExists(game, needObject.getSpellAbility(), "X")) {
+                    CardUtil.getSourceCostsTagsMap(game, needObject.getSpellAbility()).put("X", CardUtil.overflowMultiply(CardUtil.getSourceCostsTagX(game, needObject.getSpellAbility(), 0), 2));
                 }
             }
         }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mh1/UnboundFlourishingTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mh1/UnboundFlourishingTest.java
@@ -1,0 +1,48 @@
+package org.mage.test.cards.single.mh1;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class UnboundFlourishingTest extends CardTestPlayerBase {
+    @Test
+    public void testCastWanShiTong() {
+        skipInitShuffling();
+
+        addCard(Zone.HAND, playerA, "Wan Shi Tong, Librarian");
+        addCard(Zone.BATTLEFIELD, playerA, "Unbound Flourishing");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Wan Shi Tong, Librarian");
+        setChoice(playerA, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Wan Shi Tong, Librarian", 1);
+        assertPowerToughness(playerA, "Wan Shi Tong, Librarian", 5, 5);
+    }
+
+    @Test
+    public void testDiscoverWanShiTong() {
+        skipInitShuffling();
+
+        addCard(Zone.LIBRARY, playerA, "Wan Shi Tong, Librarian");
+        addCard(Zone.BATTLEFIELD, playerA, "Unbound Flourishing");
+        addCard(Zone.HAND, playerA, "Geological Appraiser");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Geological Appraiser");
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Geological Appraiser", 1);
+        assertPermanentCount(playerA, "Wan Shi Tong, Librarian", 1);
+        assertPowerToughness(playerA, "Wan Shi Tong, Librarian", 1, 1);
+    }
+}


### PR DESCRIPTION
This was doing a direct access to the tagsMap data structure, which is null when no tags have been applied to the object.

Fixes https://github.com/magefree/mage/issues/14414