### PR TITLE
[fix] Fix unimplemented card leaking into Set info

### DIFF
--- a/Mage.Sets/src/mage/sets/TeenageMutantNinjaTurtles.java
+++ b/Mage.Sets/src/mage/sets/TeenageMutantNinjaTurtles.java
@@ -206,7 +206,6 @@ public final class TeenageMutantNinjaTurtles extends ExpansionSet {
         cards.add(new SetCardInfo("Primordial Pachyderm", 129, Rarity.COMMON, mage.cards.p.PrimordialPachyderm.class));
         cards.add(new SetCardInfo("Punk Frogs", 164, Rarity.COMMON, mage.cards.p.PunkFrogs.class));
         cards.add(new SetCardInfo("Purple Dragon Punks", 100, Rarity.COMMON, mage.cards.p.PurpleDragonPunks.class));
-        cards.add(new SetCardInfo("Putrid Pals", 165, Rarity.COMMON, mage.cards.p.PutridPals.class));
         cards.add(new SetCardInfo("Ragamuffin Raptor", 130, Rarity.COMMON, mage.cards.r.RagamuffinRaptor.class));
         cards.add(new SetCardInfo("Raph & Leo, Sibling Rivals", 166, Rarity.RARE, mage.cards.r.RaphAndLeoSiblingRivals.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Raph & Leo, Sibling Rivals", 249, Rarity.RARE, mage.cards.r.RaphAndLeoSiblingRivals.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
This should not have made it into `master` yet and is probably my bad from it being included accidentally in an unrelated PR.

Let's remove it for now to get `master` building correctly and re-add it once the card is actually implemented. Which will likely be soon.