### PR TITLE
Fandaniel, Telophoroi Ascian players w/o creatures subject to life loss

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FandanielTelophoroiAscian.java
+++ b/Mage.Sets/src/mage/cards/f/FandanielTelophoroiAscian.java
@@ -77,7 +77,11 @@ class FandanielTelophoroiAscianEffect extends OneShotEffect {
         List<Permanent> permanents = new ArrayList<>();
         for (UUID playerId : game.getOpponents(source.getControllerId())) {
             Player player = game.getPlayer(playerId);
-            if (player == null || !game.getBattlefield().contains(
+            if (player == null) {
+                continue;
+            }
+            players.add(playerId);
+            if (!game.getBattlefield().contains(
                     StaticFilters.FILTER_CONTROLLED_CREATURE_NON_TOKEN,
                     playerId, source, game, 1
             )) {
@@ -88,7 +92,6 @@ class FandanielTelophoroiAscianEffect extends OneShotEffect {
             );
             player.choose(Outcome.Sacrifice, target, source, game);
             permanents.add(game.getPermanent(target.getFirstTarget()));
-            players.add(playerId);
         }
         permanents.removeIf(Objects::isNull);
         for (Permanent permanent : permanents) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/fic/FandanielTelophoroiAscianTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/fic/FandanielTelophoroiAscianTest.java
@@ -1,0 +1,30 @@
+package org.mage.test.cards.single.fic;
+ 
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+ 
+/**
+ * @author matoro
+ */
+public class FandanielTelophoroiAscianTest extends CardTestPlayerBase {
+    /*
+     * Whenever you cast an instant or sorcery spell, surveil 1.
+     * At the beginning of your end step, each opponent may sacrifice a nontoken creature of their choice. Each opponent who doesn't loses 2 life for each instant and sorcery card in your graveyard.
+     */
+
+    // https://github.com/magefree/mage/issues/13965
+    @Test
+    public void testNoSacrifice() {
+        addCard(Zone.BATTLEFIELD, playerA, "Fandaniel, Telophoroi Ascian");
+        addCard(Zone.GRAVEYARD, playerA, "Counterspell");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerB, 18);
+    }
+
+}


### PR DESCRIPTION
Per the wording on the card, opponents who are unable to sacrifice creatures because they have none are still subject to the life loss.

Fixes https://github.com/magefree/mage/issues/13965