### PR TITLE
Make DoubleFacedCard default getHalf functions abstract

### DIFF
--- a/Mage/src/main/java/mage/cards/DoubleFacedCard.java
+++ b/Mage/src/main/java/mage/cards/DoubleFacedCard.java
@@ -39,13 +39,9 @@ public abstract class DoubleFacedCard extends CardImpl implements CardWithHalves
         rightHalfCard.setParentCard(this);
     }
 
-    public DoubleFacedCardHalf getLeftHalfCard() {
-        return leftHalfCard;
-    }
+    public abstract DoubleFacedCardHalf getLeftHalfCard();
 
-    public DoubleFacedCardHalf getRightHalfCard() {
-        return leftHalfCard;
-    }
+    public abstract DoubleFacedCardHalf getRightHalfCard();
 
     public void setParts(DoubleFacedCardHalf leftHalfCard, DoubleFacedCardHalf rightHalfCard) {
         // for card copy only - set new parts


### PR DESCRIPTION
Just to clarify and prevent people from thinking we are doing the wrong thing here, make both of these functions abstract with no default implementation rather than having a default implementation that no longer makes sense after the split to `ModalDoubleFacedCard` & `TransformingDoubleFacedCard`.

Fixes https://github.com/magefree/mage/issues/14540