### PR TITLE
[don't merge] Human player should not reject subset target selection

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -820,14 +820,10 @@ public class HumanPlayer extends PlayerImpl {
                 }
             } else {
                 // done or cancel button pressed
-                if (target.isChosen(game)) {
-                    // try to finish
-                    return false;
+                if (required) {
+                    return target.isChosen(game);
                 } else {
-                    if (!required) {
-                        // can stop at any moment
-                        return false;
-                    }
+                    return true;
                 }
             }
         }
@@ -915,14 +911,10 @@ public class HumanPlayer extends PlayerImpl {
                     }
                 } else {
                     // done or cancel button pressed
-                    if (target.isChosen(game)) {
-                        // try to finish
-                        return false;
+                    if (required) {
+                        return target.isChosen(game);
                     } else {
-                        if (!required) {
-                            // can stop at any moment
-                            return false;
-                        }
+                        return true;
                     }
                 }
                 // continue to next target


### PR DESCRIPTION
Based on my understanding of this, the human player plugin is rejecting target and target card selections of less than the maximum number of available targets/target cards, by returning `false` from `choose()` when the "Done" button is pressed early.  AI and unit test players seem to have no such problems.

I might require some testing guidance on what to look for w.r.t. impact from this change, since there don't seem to be any automatic tests set up here.  All I've been able to confirm so far is that it fixes the reporter's issue via a manual GUI test.

Fixes https://github.com/magefree/mage/commit/133e4fe4256
Fixes https://github.com/magefree/mage/issues/14413