### PR TITLE
Replace the "Done" button with context-aware prompts

### DIFF
--- a/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/FeedbackPanel.java
@@ -7,6 +7,7 @@ import mage.client.chat.ChatPanelBasic;
 import mage.client.dialog.MageDialog;
 import mage.client.util.audio.AudioManager;
 import mage.client.util.gui.ArrowBuilder;
+import mage.constants.PhaseStep;
 import mage.constants.PlayerAction;
 import mage.constants.TurnPhase;
 import mage.util.ThreadUtils;
@@ -21,9 +22,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static mage.constants.Constants.Option.*;
 
@@ -118,7 +121,13 @@ public class FeedbackPanel extends javax.swing.JPanel {
                 this.helper.setUndoEnabled(false);
                 break;
             case SELECT:
-                setButtonState("", "Done", mode);
+                if (options != null && options.containsKey(CUSTOM_SELECT_MESSAGE)) {
+                    String customMessage = (String) options.get(CUSTOM_SELECT_MESSAGE);
+                    setButtonState("", customMessage, mode);
+                }
+                else {
+                    setButtonState("", "Done", mode);
+                }
                 break;
             case END:
                 setButtonState("", "Close game", mode);
@@ -301,9 +310,18 @@ public class FeedbackPanel extends javax.swing.JPanel {
     }
 
     public void pressOKYesOrDone() {
-        if (btnLeft.getText().equals("OK") || btnLeft.getText().equals("Yes")) {
+        if (btnLeft.getText().equals("OK") || btnLeft.getText().equals("Yes") || btnLeft.getText().equals("No response")) {
             btnLeft.doClick();
-        } else if (btnRight.getText().equals("OK") || btnRight.getText().equals("Yes") || btnRight.getText().equals("Done")) {
+        } else if (btnRight.getText().equals("OK") || btnRight.getText().equals("Yes") || btnRight.getText().equals("Done") ||  btnRight.getText().equals("No response")) {
+            btnRight.doClick();
+        }
+
+        List<String> stepsNames = PhaseStep.userFacingSteps.stream().map(phaseStep -> phaseStep.toString()).collect(Collectors.toList());
+
+        if (stepsNames.contains(btnLeft.getText())) {
+            btnLeft.doClick();
+        }
+        else if (stepsNames.contains(btnRight.getText())) {
             btnRight.doClick();
         }
     }

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -2150,6 +2150,31 @@ public final class GamePanel extends javax.swing.JPanel {
             priorityPlayerText = " / priority " + gameView.getPriorityPlayerName();
         }
         String additionalMessage = activePlayerText + " / " + gameView.getStep().toString() + priorityPlayerText;
+
+        String customSelectMessage = null;
+
+        if (this.stackObjects.getNumberOfCards() == 0) {
+            // Empty stack, passing priority means going to the next phase
+            PhaseStep curStep = gameView.getStep();
+
+            int idx = PhaseStep.userFacingSteps.indexOf(curStep);
+            if (idx != -1) {
+                int nextStep = idx+1;
+                if (nextStep >= PhaseStep.userFacingSteps.size()) {
+                    nextStep = 0;
+                }
+
+                customSelectMessage = PhaseStep.userFacingSteps.get(nextStep).toString();
+            }
+        }
+        else {
+            customSelectMessage = "No response";
+        }
+
+        if (customSelectMessage != null) {
+            panelOptions.put(Constants.Option.CUSTOM_SELECT_MESSAGE, customSelectMessage);
+        }
+
         this.feedbackPanel.prepareFeedback(FeedbackMode.SELECT, message, additionalMessage, gameView.getSpecial(), panelOptions, true, gameView.getPhase());
     }
 

--- a/Mage.Common/src/main/java/mage/constants/Constants.java
+++ b/Mage.Common/src/main/java/mage/constants/Constants.java
@@ -60,5 +60,6 @@ public final class Constants {
         public static final String SECOND_MESSAGE = "secondMessage";
         public static final String HINT_TEXT = "hintText";
         public static final String AUTO_ANSWER_MESSAGE = "autoAnswerMessage";
+        public static final String CUSTOM_SELECT_MESSAGE = "customSelectMessage";
     }
 }

--- a/Mage/src/main/java/mage/constants/PhaseStep.java
+++ b/Mage/src/main/java/mage/constants/PhaseStep.java
@@ -1,6 +1,8 @@
 package mage.constants;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author North
@@ -19,6 +21,24 @@ public enum PhaseStep {
     POSTCOMBAT_MAIN("Postcombat Main", 10, "postcombat main step", "M2"),
     END_TURN("End Turn", 11, "end turn step", "ET"),
     CLEANUP("Cleanup", 12, "cleanup step", "CL");
+
+    /**
+     * List of phase steps where the player has agency
+     */
+    public static final List<PhaseStep> userFacingSteps = Arrays.asList(
+            PhaseStep.UNTAP,
+            PhaseStep.UPKEEP,
+            PhaseStep.DRAW,
+            PhaseStep.PRECOMBAT_MAIN,
+            PhaseStep.BEGIN_COMBAT,
+            PhaseStep.DECLARE_ATTACKERS,
+            PhaseStep.DECLARE_BLOCKERS,
+            PhaseStep.FIRST_COMBAT_DAMAGE,
+            PhaseStep.COMBAT_DAMAGE,
+            PhaseStep.END_COMBAT,
+            PhaseStep.POSTCOMBAT_MAIN,
+            PhaseStep.END_TURN
+    );
 
     private final String text;
     private final String stepText;


### PR DESCRIPTION
The goal of this PR is to change the "Done" button to be more context-aware (this should fix part of #1802 )

It adds a new `Option` for `FeedbackPanel.prepareFeedback()` called `CUSTOM_SELECT_MESSAGE`, which overrides the "Done" message if it is present.

Then, `GamePanel.select()` has some more logic to set a custom message:

- If the stack has things in it, we show "No response"
<img width="501" height="148" alt="image" src="https://github.com/user-attachments/assets/4af9f1e6-27a1-444d-9696-2e9590c6be1c" />

- Otherwise, we try to show the name of the next phase step (the order is hardcoded, I could not find a way to get the next step name programatically)
<img width="501" height="148" alt="image" src="https://github.com/user-attachments/assets/1b13ab50-ee69-4b6d-ae58-dfc2bc39b385" />

Cheers!

**EDIT:** I have also updated `pressYesOkOrDone()` to auto-press "No response" or any button which matches a phase transition. Because this required having the phase step order again, I moved this list to the `PhaseStep` class, as a static member (I hope that's OK).