### PR TITLE
[don’t merge] Consider tokens copied from non-stack zone cards also copies

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/TokenCopyFlickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/TokenCopyFlickerTest.java
@@ -1,0 +1,107 @@
+package org.mage.test.cards.abilities.flicker;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author PurpleCrowbar
+ */
+public class TokenCopyFlickerTest extends CardTestPlayerBase {
+
+    // {1} Instant: Exile target creature you control, then return that card to the battlefield under your control.
+    private static final String flicker = "Cloudshift";
+    // {1}{W/U} Instant: Exile target creature. Return that card to the battlefield under its owner's control at the beginning of the next end step.
+    private static final String slowFlicker = "Turn to Mist";
+
+    /**
+     * Tests that a token (which isn't a copy of any other permanent) is correctly removed from the game when flickered.
+     * This test passing is proof of tokens not returning to the battlefield when flickered.
+     */
+    @Test
+    public void testNonCopyTokenFlicker() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Champion of the Perished");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+        addCard(Zone.HAND, playerA, "Reap the Seagraf"); // {2}{B} Sorcery: Create a 2/2 black Zombie creature token.
+        addCard(Zone.HAND, playerA, flicker);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Reap the Seagraf");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flicker, "Zombie Token");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Zombie Token", 0);
+        assertCounterCount("Champion of the Perished", CounterType.P1P1, 1); // only one +1/+1 counter added
+    }
+
+    /**
+     * Creates a token copy of a permanent and flickers the copy. Expected behavior: token is removed from game, nothing else happens.
+     * Current, bugged behavior: token is removed from game, then the original, copied creature is returned to the battlefield from wherever (GY in this case)
+     */
+    @Ignore
+    @Test
+    public void testCopyTokenFlicker() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Gilded Goose"); // Creature: When ~ enters, create a Food token.
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+
+        addCard(Zone.HAND, playerA, "Cackling Counterpart"); // {1}{U}{U} Instant: Create a token that's a copy of target creature you control.
+        addCard(Zone.HAND, playerA, "Incandescent Aria"); // {R}{G}{W} Sorcery: Deal 3 damage to each nontoken creature.
+        addCard(Zone.HAND, playerA, flicker);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cackling Counterpart", "Gilded Goose", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Incandescent Aria", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, flicker, "Gilded Goose");
+
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Gilded Goose", 0); // 0; original in GY, token removed from game
+        assertGraveyardCount(playerA, "Gilded Goose", 1); // original Goose in GY
+        assertPermanentCount(playerA, "Food Token", 1); // 1 from the Cackling Counterpart. 2 if a flickered Goose erroneously returned to the battlefield
+    }
+
+    /**
+     * As above, but uses a slow flicker (exiles, then returns to battlefield at end of turn).
+     */
+    @Ignore
+    @Test
+    public void testCopyTokenSlowFlicker() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Gilded Goose"); // Creature: When ~ enters, create a Food token.
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+
+        addCard(Zone.HAND, playerA, "Cackling Counterpart"); // {1}{U}{U} Instant: Create a token that's a copy of target creature you control.
+        addCard(Zone.HAND, playerA, "Incandescent Aria"); // {R}{G}{W} Sorcery: Deal 3 damage to each nontoken creature.
+        addCard(Zone.HAND, playerA, slowFlicker);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cackling Counterpart", "Gilded Goose", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Incandescent Aria", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, slowFlicker, "Gilded Goose");
+
+        setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Gilded Goose", 0); // 0; original in GY, token removed from game
+        assertGraveyardCount(playerA, "Gilded Goose", 1); // original Goose in GY
+        assertPermanentCount(playerA, "Food Token", 1); // 1 from the Cackling Counterpart. 2 if a flickered Goose erroneously returned to the battlefield
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/TokenCopyFlickerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/flicker/TokenCopyFlickerTest.java
@@ -46,7 +46,6 @@ public class TokenCopyFlickerTest extends CardTestPlayerBase {
      * Creates a token copy of a permanent and flickers the copy. Expected behavior: token is removed from game, nothing else happens.
      * Current, bugged behavior: token is removed from game, then the original, copied creature is returned to the battlefield from wherever (GY in this case)
      */
-    @Ignore
     @Test
     public void testCopyTokenFlicker() {
         setStrictChooseMode(true);
@@ -77,7 +76,6 @@ public class TokenCopyFlickerTest extends CardTestPlayerBase {
     /**
      * As above, but uses a slow flicker (exiles, then returns to battlefield at end of turn).
      */
-    @Ignore
     @Test
     public void testCopyTokenSlowFlicker() {
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/enchantments/SagaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/enchantments/SagaTest.java
@@ -250,4 +250,25 @@ public class SagaTest extends CardTestPlayerBase {
 
     }
 
+    // https://github.com/magefree/mage/issues/14409
+    @Test
+    public void testSagaToken() {
+       addCard(Zone.GRAVEYARD, playerA, "Michiko's Reign of Truth");
+       addCard(Zone.HAND, playerA, "Anikthea, Hand of Erebos");
+       addCard(Zone.BATTLEFIELD, playerA, "Plains");
+       addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+       addCard(Zone.BATTLEFIELD, playerA, "Forest");
+       addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+       castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Anikthea, Hand of Erebos");
+       addTarget(playerA, "Michiko's Reign of Truth");
+       addTarget(playerA, "Anikthea, Hand of Erebos");
+       addTarget(playerA, "Anikthea, Hand of Erebos");
+
+       setStrictChooseMode(true);
+       setStopAt(5, PhaseStep.PRECOMBAT_MAIN);
+       execute();
+
+       assertPermanentCount(playerA, "Portrait of Michiko", 0);
+    }
 }

--- a/Mage/src/main/java/mage/cards/RoomCard.java
+++ b/Mage/src/main/java/mage/cards/RoomCard.java
@@ -146,7 +146,7 @@ class RoomEnterUnlockEffect extends OneShotEffect {
         RoomCard roomCard = null;
         // Get the parent card to access the lastCastHalf variable
         if (permanent instanceof PermanentToken) {
-            Card mainCard = permanent.getMainCard();
+            Card mainCard = game.getCard((permanent.isCopy() ? permanent.getCopyFrom() : permanent).getId());
             if (mainCard instanceof RoomCard) {
                 roomCard = (RoomCard) mainCard;
             }

--- a/Mage/src/main/java/mage/game/permanent/PermanentToken.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentToken.java
@@ -145,15 +145,13 @@ public class PermanentToken extends PermanentImpl {
     }
 
     @Override
-    public Card getMainCard() {
-        // Check if we have a copy source card (for tokens created from copied spells)
-        Card copySourceCard = token.getCopySourceCard();
-        if (copySourceCard != null) {
-            return copySourceCard;
-        }
+    public boolean isCopy() {
+        return this.token.getCopySourceCard() != null;
+    }
 
-        // Fallback to current behavior
-        return this;
+    @Override
+    public MageObject getCopyFrom() {
+        return this.token.getCopySourceCard();
     }
 
     @Override


### PR DESCRIPTION
The problem here is kind of hard to follow, but currently a `PermanentToken` that is a copy of a card in a zone other than the stack returns `false` for `isCopy()`. However, it will point to the thing it was copied from in `getMainCard()`, and the result of `getMainCard()` is used when deciding what object to move between zones. So when blinking that token, after the first move if the copy source still existed, it would move even after the token stopped existing.

I believe `getMainCard()` is really meant to refer to the overall card for split, double-faced, etc cards, which a token still has. Instead, any behavior that specifically needs to refer to the source that the token was copied from, e.g. to get information about it, should go through `token.getCopySourceCard()`. I've exposed that via `getCopyFrom()`, so that callers don't need to explicitly check if a permanent is a token. So far Room cards do that, to get information about what room were unlocked when copying.

Fixes https://github.com/magefree/mage/issues/14409