### PR TITLE
[fix] Correct a pair of "when you discard one or more X cards" triggered abilities

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MishraExcavationProdigy.java
+++ b/Mage.Sets/src/mage/cards/m/MishraExcavationProdigy.java
@@ -7,7 +7,7 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.common.DiscardCardControllerTriggeredAbility;
+import mage.abilities.effects.common.DiscardOneOrMoreCardsTriggeredAbility;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.mana.BasicManaEffect;
 import mage.abilities.keyword.HasteAbility;
@@ -16,17 +16,14 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterCard;
-import mage.filter.common.FilterArtifactCard;
-
+import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import java.util.UUID;
 
 /**
  * @author TheElk801
  */
 public final class MishraExcavationProdigy extends CardImpl {
-
-    private static final FilterCard filter = new FilterArtifactCard("one or more artifact cards");
 
     public MishraExcavationProdigy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{R}");
@@ -47,8 +44,11 @@ public final class MishraExcavationProdigy extends CardImpl {
         this.addAbility(ability);
 
         // Whenever you discard one or more artifact cards, add {R}{R}. This ability triggers only once each turn.
-        this.addAbility(new DiscardCardControllerTriggeredAbility(
-                new BasicManaEffect(Mana.RedMana(2)), false, filter
+        this.addAbility(new DiscardOneOrMoreCardsTriggeredAbility(
+                Zone.BATTLEFIELD,
+                new BasicManaEffect(Mana.RedMana(2)),
+                false,
+                StaticFilters.FILTER_CARD_ARTIFACTS
         ).setTriggersLimitEachTurn(1));
     }
 

--- a/Mage.Sets/src/mage/cards/u/UrzaPowerstoneProdigy.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaPowerstoneProdigy.java
@@ -6,7 +6,7 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.CreateTokenEffect;
-import mage.abilities.effects.common.DiscardCardControllerTriggeredAbility;
+import mage.abilities.effects.common.DiscardOneOrMoreCardsTriggeredAbility;
 import mage.abilities.effects.common.DrawDiscardControllerEffect;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.cards.CardImpl;
@@ -14,8 +14,8 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
-import mage.filter.FilterCard;
-import mage.filter.common.FilterArtifactCard;
+import mage.constants.Zone;
+import mage.filter.StaticFilters;
 import mage.game.permanent.token.PowerstoneToken;
 
 import java.util.UUID;
@@ -24,8 +24,6 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class UrzaPowerstoneProdigy extends CardImpl {
-
-    private static final FilterCard filter = new FilterArtifactCard("one or more artifact cards");
 
     public UrzaPowerstoneProdigy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
@@ -47,8 +45,11 @@ public final class UrzaPowerstoneProdigy extends CardImpl {
         this.addAbility(ability);
 
         // Whenever you discard one or more artifact cards, create a tapped Powerstone token. This ability triggers only once each turn.
-        this.addAbility(new DiscardCardControllerTriggeredAbility(
-                new CreateTokenEffect(new PowerstoneToken(), 1, true), false, filter
+        this.addAbility(new DiscardOneOrMoreCardsTriggeredAbility(
+                Zone.BATTLEFIELD,
+                new CreateTokenEffect(new PowerstoneToken(), 1, true),
+                false,
+                StaticFilters.FILTER_CARD_ARTIFACTS
         ).setTriggersLimitEachTurn(1));
     }
 


### PR DESCRIPTION
This should not be merged until after #14335 is complete.

 * #14335 was reviewed and identified mis-use of `DiscardCardControllerTriggeredAbility` where `DiscardOneOrMoreCardsTriggeredAbility` should be used
 * Doctor Doom has a requirement to filter on the cards being discarded so `DiscardOneOrMoreCardsTriggeredAbility` was updated to support this in a backwards compatible manner
 * I did a quick audit to see elsewhere WotC has had "whenever you discard one or more <something> cards" and found these two card implementations
 * Both cards are using the wrong TriggerAbility, and can use the updated one that takes a filter arg