### PR TITLE
The Aesir Escape Valhalla shouldn't move itself to exile zone

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TheAesirEscapeValhalla.java
+++ b/Mage.Sets/src/mage/cards/t/TheAesirEscapeValhalla.java
@@ -19,6 +19,8 @@ import mage.target.common.TargetControlledCreaturePermanent;
 import mage.util.CardUtil;
 
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  *
@@ -158,13 +160,15 @@ class TheAesirEscapeValhallaThreeEffect extends OneShotEffect {
         ExileZone exileZone = game.getExile().getExileZone(exileId);
         Player controller = game.getPlayer(source.getControllerId());
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
-        if (controller == null || exileZone == null || exileZone.isEmpty()) {
+        if (controller == null) {
             return false;
         }
-        if (sourcePermanent != null) {
-            exileZone.add(sourcePermanent);
-        }
-        controller.moveCards(exileZone, Zone.HAND, source, game);
+        controller.moveCards(
+            Stream.concat(
+                (sourcePermanent != null) ? Stream.of(sourcePermanent) : Stream.of(),
+                exileZone.getCards(game).stream()
+            ).collect(Collectors.toSet()),
+        Zone.HAND, source, game);
         return true;
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/acr/TheAesirEscapeValhallaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/acr/TheAesirEscapeValhallaTest.java
@@ -46,5 +46,7 @@ public class TheAesirEscapeValhallaTest extends CardTestPlayerBase {
 
         assertHandCount(playerA, "Gigantosaurus", 1);
         assertHandCount(playerA, aesir, 1);
+        assertExileCount(playerA, "Gigantosaurus", 0);
+        assertExileCount(playerA, aesir, 0);
     }
 }


### PR DESCRIPTION
The Aesir Escape Valhalla was adding itself to the exile zone set to be bounced back to hand with its target permanent, which was leaving a reference to itself in that zone (not actually being moved there, it's just a reference to the original card which is now in hand, but it still shows up in the exile zone in the UI).  Just move it directly to hand.

Additionally, this should handle better if the target card gets removed from exile by another method, before Aesir has a chance to bounce it back to hand, with Aesir itself still going back to hand.

Fixes https://github.com/magefree/mage/issues/14408