### PR TITLE
Refactor Enchantment flip cards to not use private token classes

### DIFF
--- a/Mage.Sets/src/mage/cards/e/ErayoSoratamiAscendant.java
+++ b/Mage.Sets/src/mage/cards/e/ErayoSoratamiAscendant.java
@@ -16,8 +16,7 @@ import mage.constants.SuperType;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.EnchantmentToken;
 import mage.target.targetpointer.FixedTarget;
 import mage.watchers.common.CastSpellLastTurnWatcher;
 
@@ -42,7 +41,6 @@ public final class ErayoSoratamiAscendant extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Whenever the fourth spell of a turn is cast, flip Erayo, Soratami Ascendant.
         this.addAbility(new ErayoSoratamiAscendantTriggeredAbility());
-
     }
 
     private ErayoSoratamiAscendant(final ErayoSoratamiAscendant card) {
@@ -63,7 +61,12 @@ class ErayoSoratamiAscendantTriggeredAbility extends TriggeredAbilityImpl {
     }
 
     private static Effect getFlipEffect() {
-        Effect effect = new FlipSourceEffect(new ErayosEssenceToken());
+        Effect tokenEffect = new CounterTargetEffect().setText("counter that spell");
+        EnchantmentToken flipToken = new EnchantmentToken("Erayo's Essence", true)
+            .withColor("U")
+            .withAbility(new ErayosEssenceTriggeredAbility(tokenEffect));
+
+        Effect effect = new FlipSourceEffect(flipToken);
         effect.setText("flip {this}");
         return effect;
     }
@@ -86,29 +89,6 @@ class ErayoSoratamiAscendantTriggeredAbility extends TriggeredAbilityImpl {
     @Override
     public ErayoSoratamiAscendantTriggeredAbility copy() {
         return new ErayoSoratamiAscendantTriggeredAbility(this);
-    }
-}
-
-class ErayosEssenceToken extends TokenImpl {
-
-    ErayosEssenceToken() {
-        super("Erayo's Essence", "");
-        this.supertype.add(SuperType.LEGENDARY);
-        cardType.add(CardType.ENCHANTMENT);
-
-        color.setBlue(true);
-
-        // Whenever an opponent casts a spell for the first time in a turn, counter that spell.
-        Effect effect = new CounterTargetEffect();
-        effect.setText("counter that spell");
-        this.addAbility(new ErayosEssenceTriggeredAbility(effect));
-    }
-    private ErayosEssenceToken(final ErayosEssenceToken token) {
-        super(token);
-    }
-
-    public ErayosEssenceToken copy() {
-        return new ErayosEssenceToken(this);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/h/HomuraHumanAscendant.java
+++ b/Mage.Sets/src/mage/cards/h/HomuraHumanAscendant.java
@@ -23,10 +23,10 @@ import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.EnchantmentToken;
 import mage.game.permanent.token.Token;
 import mage.players.Player;
 
@@ -47,10 +47,25 @@ public final class HomuraHumanAscendant extends CardImpl {
         this.flipCard = true;
         this.flipCardName = "Homura's Essence";
 
+        Ability ability = new SimpleStaticAbility(new BoostControlledEffect(2, 2, Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURE, false));
+        Effect effect = new GainAbilityControlledEffect(
+            FlyingAbility.getInstance(), Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURE
+        ).setText("and have flying");
+        ability.addEffect(effect);
+        Ability gainedAbility = new SimpleActivatedAbility(new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{R}"));
+        effect = new GainAbilityControlledEffect(
+            gainedAbility, Duration.WhileOnBattlefield, StaticFilters.FILTER_PERMANENT_CREATURE
+        ).setText("and \"{R}: This creature gets +1/+0 until end of turn.\"");
+        ability.addEffect(effect);
+
+        EnchantmentToken flipToken = new EnchantmentToken("Homura's Essence", true)
+            .withColor("R")
+            .withAbility(ability);
+
         // Homura, Human Ascendant can't block.
         this.addAbility(new CantBlockAbility());
         // When Homura dies, return it to the battlefield flipped.
-        this.addAbility(new DiesSourceTriggeredAbility(new HomuraReturnFlippedSourceEffect(new HomurasEssence2())));
+        this.addAbility(new DiesSourceTriggeredAbility(new HomuraReturnFlippedSourceEffect(flipToken)));
     }
 
     private HomuraHumanAscendant(final HomuraHumanAscendant card) {
@@ -100,32 +115,4 @@ class HomuraReturnFlippedSourceEffect extends OneShotEffect {
         return new HomuraReturnFlippedSourceEffect(this);
     }
 
-}
-
-class HomurasEssence2 extends TokenImpl {
-
-    HomurasEssence2() {
-        super("Homura's Essence", "");
-        this.supertype.add(SuperType.LEGENDARY);
-        cardType.add(CardType.ENCHANTMENT);
-        color.setRed(true);
-        // Creatures you control get +2/+2 and have flying and "{R}: This creature gets +1/+0 until end of turn."
-        FilterCreaturePermanent filter = new FilterCreaturePermanent();
-        Ability ability = new SimpleStaticAbility(new BoostControlledEffect(2, 2, Duration.WhileOnBattlefield, filter, false));
-        Effect effect = new GainAbilityControlledEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield, filter);
-        effect.setText("and have flying");
-        ability.addEffect(effect);
-        Ability gainedAbility = new SimpleActivatedAbility(new BoostSourceEffect(1, 0, Duration.EndOfTurn), new ManaCostsImpl<>("{R}"));
-        effect = new GainAbilityControlledEffect(gainedAbility, Duration.WhileOnBattlefield, filter);
-        effect.setText("and \"{R}: This creature gets +1/+0 until end of turn.\"");
-        ability.addEffect(effect);
-        this.addAbility(ability);
-    }
-    private HomurasEssence2(final HomurasEssence2 token) {
-        super(token);
-    }
-
-    public HomurasEssence2 copy() {
-        return new HomurasEssence2(this);
-    }
 }

--- a/Mage.Sets/src/mage/cards/k/KuonOgreAscendant.java
+++ b/Mage.Sets/src/mage/cards/k/KuonOgreAscendant.java
@@ -17,7 +17,7 @@ import mage.constants.SuperType;
 import mage.constants.TargetController;
 import mage.filter.StaticFilters;
 import mage.game.Game;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.EnchantmentToken;
 import mage.watchers.common.CreaturesDiedWatcher;
 
 /**
@@ -38,9 +38,17 @@ public final class KuonOgreAscendant extends CardImpl {
         this.flipCard = true;
         this.flipCardName = "Kuon's Essence";
 
+        EnchantmentToken flipToken = new EnchantmentToken("Kuon's Essence", true)
+            .withColor("B")
+            .withAbility(new BeginningOfUpkeepTriggeredAbility(
+                TargetController.ANY,
+                new SacrificeEffect(StaticFilters.FILTER_PERMANENT_CREATURE, 1, "that player"),
+                false
+            ));
+
         // At the beginning of the end step, if three or more creatures died this turn, flip Kuon, Ogre Ascendant.
         this.addAbility(new BeginningOfEndStepTriggeredAbility(
-                TargetController.NEXT, new FlipSourceEffect(new KuonsEssenceToken()),
+                TargetController.NEXT, new FlipSourceEffect(flipToken),
                 false, KuonOgreAscendantCondition.instance));
     }
 
@@ -51,29 +59,6 @@ public final class KuonOgreAscendant extends CardImpl {
     @Override
     public KuonOgreAscendant copy() {
         return new KuonOgreAscendant(this);
-    }
-}
-
-class KuonsEssenceToken extends TokenImpl {
-
-    KuonsEssenceToken() {
-        super("Kuon's Essence", "");
-        this.supertype.add(SuperType.LEGENDARY);
-        cardType.add(CardType.ENCHANTMENT);
-
-        color.setBlack(true);
-
-        // At the beginning of each player's upkeep, that player sacrifices a creature..
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                TargetController.ANY, new SacrificeEffect(StaticFilters.FILTER_PERMANENT_CREATURE, 1, "that player"),
-                false));
-    }
-    private KuonsEssenceToken(final KuonsEssenceToken token) {
-        super(token);
-    }
-
-    public KuonsEssenceToken copy() {
-        return new KuonsEssenceToken(this);
     }
 }
 

--- a/Mage.Sets/src/mage/cards/s/SasayaOrochiAscendant.java
+++ b/Mage.Sets/src/mage/cards/s/SasayaOrochiAscendant.java
@@ -22,7 +22,7 @@ import mage.filter.predicate.mageobject.NamePredicate;
 import mage.filter.predicate.permanent.PermanentIdPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.token.TokenImpl;
+import mage.game.permanent.token.custom.EnchantmentToken;
 import mage.players.Player;
 
 import java.util.List;
@@ -83,38 +83,18 @@ class SasayaOrochiAscendantFlipEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            if (controller.getHand().count(new FilterLandCard(), game) > 6) {
-                new FlipSourceEffect(new SasayasEssence()).apply(game, source);
-            }
+        if (controller != null && controller.getHand().count(new FilterLandCard(), game) >= 7) {
+            EnchantmentToken flipToken = new EnchantmentToken("Sasaya's Essence", true)
+                .withColor("G")
+                .withAbility(new TapForManaAllTriggeredManaAbility(
+                    new SasayasEssenceManaEffect(), new FilterControlledLandPermanent(), SetTargetPointer.PERMANENT
+                ));
+
+            new FlipSourceEffect(flipToken).apply(game, source);
             return true;
         }
+
         return false;
-    }
-}
-
-class SasayasEssence extends TokenImpl {
-
-    SasayasEssence() {
-        super("Sasaya's Essence", "");
-        this.supertype.add(SuperType.LEGENDARY);
-        cardType.add(CardType.ENCHANTMENT);
-
-        color.setGreen(true);
-
-        // Whenever a land you control is tapped for mana, for each other land you control with the same name, add one mana of any type that land produced.
-        this.addAbility(new TapForManaAllTriggeredManaAbility(
-                new SasayasEssenceManaEffect(),
-                new FilterControlledLandPermanent(), SetTargetPointer.PERMANENT));
-    }
-
-    private SasayasEssence(final SasayasEssence token) {
-        super(token);
-    }
-
-    @Override
-    public SasayasEssence copy() {
-        return new SasayasEssence(this);
     }
 }
 
@@ -163,7 +143,7 @@ class SasayasEssenceManaEffect extends ManaEffect {
                 }
                 if (producedMana.getColorless() > 0) {
                     netMana.add(Mana.ColorlessMana(count));
-                }                
+                }
             }
         }
         return netMana;

--- a/Mage/src/main/java/mage/game/permanent/token/custom/EnchantmentToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/custom/EnchantmentToken.java
@@ -1,0 +1,42 @@
+package mage.game.permanent.token.custom;
+
+import mage.ObjectColor;
+import mage.abilities.Ability;
+import mage.constants.CardType;
+import mage.constants.SuperType;
+import mage.game.permanent.token.TokenImpl;
+
+/**
+ * Builder for blueprints to pass into flip effects etc.
+ *
+ * @author muz
+ */
+public final class EnchantmentToken extends TokenImpl {
+
+    public EnchantmentToken(String name, boolean isLegendary) {
+        super(name, "");
+        this.cardType.add(CardType.ENCHANTMENT);
+        if (isLegendary) {
+            this.supertype.add(SuperType.LEGENDARY);
+        }
+    }
+
+    public EnchantmentToken withAbility(Ability ability) {
+        this.addAbility(ability);
+        return this;
+    }
+
+    public EnchantmentToken withColor(String extraColors) {
+        ObjectColor extraColorsList = new ObjectColor(extraColors);
+        this.getColor(null).addColor(extraColorsList);
+        return this;
+    }
+
+    private EnchantmentToken(final EnchantmentToken token) {
+        super(token);
+    }
+
+    public EnchantmentToken copy() {
+        return new EnchantmentToken(this);
+   }
+}


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/pull/14315

Follow up to #14569

Again, there's one implementation that would throw `Flexible Constructor Bodies` warnings, so it's beyond a quick refactor like the rest; `RuneTailEssence from mage.cards.r.RuneTailEssence` which can be tackled in a follow up PR