### PR TITLE
Remove cast from hand restriction on Demon of Fate's Design

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DemonOfFatesDesign.java
+++ b/Mage.Sets/src/mage/cards/d/DemonOfFatesDesign.java
@@ -5,7 +5,6 @@ import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.condition.CompoundCondition;
 import mage.abilities.condition.Condition;
 import mage.abilities.condition.common.SourceIsSpellCondition;
 import mage.abilities.costs.AlternativeCostSourceAbility;
@@ -140,7 +139,7 @@ class DemonOfFatesDesignAlternativeCostSourceAbility extends AlternativeCostSour
 
     DemonOfFatesDesignAlternativeCostSourceAbility() {
         super(
-                new CompoundCondition(SourceIsSpellCondition.instance, IsBeingCastFromHandCondition.instance),
+                SourceIsSpellCondition.instance,
                 null, StaticFilters.FILTER_CARD_ENCHANTMENT,
                 true, DemonOfFatesDesignCost.instance
         );

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/cmm/DemonOfFatesDesignTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/cmm/DemonOfFatesDesignTest.java
@@ -251,4 +251,53 @@ public class DemonOfFatesDesignTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Absolute Law", 1);
         assertLife(playerA, 20 - 3 - 2);
     }
+
+    // https://github.com/magefree/mage/issues/14571
+    @Test
+    public void testNoCastFromGraveyard() {
+        addCard(Zone.BATTLEFIELD, playerA, demon);
+        addCard(Zone.GRAVEYARD, playerA, "Glorious Anthem");
+
+        checkPlayableAbility("playable", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Glorious Anthem", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+    }
+
+    @Test
+    public void testYesCastFromGraveyard() {
+        addCard(Zone.BATTLEFIELD, playerA, demon);
+        addCard(Zone.GRAVEYARD, playerA, "Glorious Anthem");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.HAND, playerA, "Yawgmoth's Will");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Yawgmoth's Will", true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Glorious Anthem");
+        setChoice(playerA, "Cast with alternative cost: Pay 3 life");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Glorious Anthem", 1);
+        assertLife(playerA, 17);
+    }
+
+    // https://github.com/magefree/mage/issues/14572
+    @Test
+    public void testCanCastTransforming() {
+        addCard(Zone.BATTLEFIELD, playerA, demon);
+        addCard(Zone.HAND, playerA, "The Legend of Kyoshi");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "The Legend of Kyoshi");
+        setChoice(playerA, "Cast with alternative cost: Pay 6 life");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "The Legend of Kyoshi", 1);
+        assertLife(playerA, 14);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/CastCommanderTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/CastCommanderTest.java
@@ -6,6 +6,7 @@ import mage.constants.Zone;
 import mage.game.permanent.Permanent;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestCommanderDuelBase;
 
 /**
@@ -126,4 +127,22 @@ public class CastCommanderTest extends CardTestCommanderDuelBase {
         assertLife(playerA, 40);
         assertLife(playerB, 40);        
     }        
+
+    // https://github.com/magefree/mage/issues/14571
+    @Test
+    public void testCastWithDemonOfFatesDesign() {
+        addCard(Zone.BATTLEFIELD, playerA, "Demon of Fate's Design");
+        addCard(Zone.COMMAND, playerA, "Anikthea, Hand of Erebos");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Anikthea, Hand of Erebos");
+        setChoice(playerA, "Cast with alternative cost: Pay 5 life");
+        addTarget(playerA, TestPlayer.TARGET_SKIP);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Anikthea, Hand of Erebos", 1);
+        assertLife(playerA, 35);
+    }
 }


### PR DESCRIPTION
Nowhere in the card text does it say that the target of the cast must be in the hand. Should other effects make it possible to cast from other zones, they should be eligible for the cost reduction. And in EDH you implicitly have the ability to cast from command zone, so that should be included as well.

Fixes https://github.com/magefree/mage/issues/14571
Fixes https://github.com/magefree/mage/issues/14572