### PR TITLE
Extend card image filename handling to exclude other Windows-unsafe characters

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
@@ -790,7 +790,7 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
                 // gen temp file (download to images folder)
                 String tempPath = getImagesDir() + File.separator + "downloading" + File.separator;
                 if (useSpecifiedPaths) {
-                    fileTempImage = new TFile(tempPath + actualFilename + "-" + card.hashCode() + ".jpg");
+                    fileTempImage = new TFile(tempPath + CardImageUtils.prepareCardNameForFile(actualFilename) + "-" + card.hashCode() + ".jpg");
                 } else {
                     fileTempImage = new TFile(tempPath + CardImageUtils.prepareCardNameForFile(card.getName()) + "-" + card.hashCode() + ".jpg");
                 }
@@ -804,9 +804,9 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
                 // gen dest file name
                 if (useSpecifiedPaths) {
                     if (card.isToken()) {
-                        destFile = new TFile(CardImageUtils.buildImagePathToSet(card) + actualFilename + ".jpg");
+                        destFile = new TFile(CardImageUtils.buildImagePathToSet(card) + CardImageUtils.prepareCardNameForFile(actualFilename) + ".jpg");
                     } else {
-                        destFile = new TFile(CardImageUtils.buildImagePathToTokens() + actualFilename + ".jpg");
+                        destFile = new TFile(CardImageUtils.buildImagePathToTokens() + CardImageUtils.prepareCardNameForFile(actualFilename) + ".jpg");
                     }
                 } else {
                     destFile = new TFile(CardImageUtils.buildImagePathToCardOrToken(card));

--- a/Mage.Client/src/main/java/org/mage/plugins/card/utils/CardImageUtils.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/utils/CardImageUtils.java
@@ -25,10 +25,19 @@ public final class CardImageUtils {
     private static final Logger LOGGER = Logger.getLogger(CardImageUtils.class);
 
     public static String prepareCardNameForFile(String cardName) {
+        // remove characters that are invalid in Windows file names: \ / : * ? " < > |
+        // note: // is used in split card names like "Fire // Ice" and replaced with -
         return cardName
+                .replace("//", "-")
+                .replace("\\", "")
+                .replace("/", "")
                 .replace(":", "")
+                .replace("*", "")
+                .replace("?", "")
                 .replace("\"", "")
-                .replace("//", "-");
+                .replace("<", "")
+                .replace(">", "")
+                .replace("|", "");
     }
 
     public static String getImagesDir() {


### PR DESCRIPTION
Fixes #14602 

 * Extends the characters to strip from card image filenames
 * Ensures that temp files uses the same sanitisation 