### PR TITLE
[tests] Enable play boosters for TMT

### DIFF
--- a/Mage.Sets/src/mage/sets/TarkirDragonstorm.java
+++ b/Mage.Sets/src/mage/sets/TarkirDragonstorm.java
@@ -1,8 +1,5 @@
 package mage.sets;
 
-import java.util.Arrays;
-import java.util.List;
-
 import mage.cards.ExpansionSet;
 import mage.constants.Rarity;
 import mage.constants.SetType;

--- a/Mage.Sets/src/mage/sets/TeenageMutantNinjaTurtles.java
+++ b/Mage.Sets/src/mage/sets/TeenageMutantNinjaTurtles.java
@@ -20,6 +20,8 @@ public final class TeenageMutantNinjaTurtles extends ExpansionSet {
         this.blockName = "Teenage Mutant Ninja Turtles"; // for sorting in GUI
         this.hasBasicLands = true;
 
+        this.enablePlayBooster(257);
+
         cards.add(new SetCardInfo("Action News Crew", 1, Rarity.COMMON, mage.cards.a.ActionNewsCrew.class));
         cards.add(new SetCardInfo("Agent Bishop, Man in Black", 2, Rarity.RARE, mage.cards.a.AgentBishopManInBlack.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Agent Bishop, Man in Black", 258, Rarity.RARE, mage.cards.a.AgentBishopManInBlack.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
```
Error: wrong booster settings (set MUST HAVE booster, but haven't) - 2026 - TMT - Teenage Mutant Ninja Turtles - boosters: [play]
```

Enable Play boosters and set the max collector number to where the pizza lands end, and before we hit Collector booster exclusive items

Also remove a pair of unused imports in another set file that I stumbled across and were flagged by my IDE whilst fixing this. 