### PR TITLE
[minor] Address TODO in PZA set max collector number

### DIFF
--- a/Mage.Sets/src/mage/sets/TeenageMutantNinjaTurtlesSourceMaterial.java
+++ b/Mage.Sets/src/mage/sets/TeenageMutantNinjaTurtlesSourceMaterial.java
@@ -19,7 +19,7 @@ public final class TeenageMutantNinjaTurtlesSourceMaterial extends ExpansionSet 
         super("Teenage Mutant Ninja Turtles Source Material", "PZA", ExpansionSet.buildDate(2026, 3, 6), SetType.SUPPLEMENTAL);
         this.hasBoosters = false;
         this.hasBasicLands = false;
-        this.maxCardNumberInBooster = 64; // TODO: Update once more info is available
+        this.maxCardNumberInBooster = 20;
 
         cards.add(new SetCardInfo("All Will Be One", 8, Rarity.MYTHIC, mage.cards.a.AllWillBeOne.class));
         cards.add(new SetCardInfo("Arcbound Ravager", 14, Rarity.MYTHIC, mage.cards.a.ArcboundRavager.class));


### PR DESCRIPTION
> There are 20 different source material cards in Magic: The Gathering | Teenage Mutant Ninja Turtles. Non-foil source material cards appear in Play Boosters and Collector Boosters. Traditional foil source material cards appear only in Collector Boosters.

 - [Source](https://magic.wizards.com/en/news/feature/collecting-teenage-mutant-ninja-turtles)
 
 Take out that `TODO` and consider it addressed.