### PR TITLE
Shadow Puppeteers modify base P/T only at sublayer 7b

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShadowPuppeteers.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowPuppeteers.java
@@ -109,8 +109,10 @@ class ShadowPuppeteersContinousEffect extends ContinuousEffectImpl {
                 permanent.getColor(game).setRed(true);
                 break;
             case PTChangingEffects_7:
-                permanent.getToughness().setModifiedBaseValue(4);
-                permanent.getPower().setModifiedBaseValue(4);
+                if (sublayer.equals(SubLayer.SetPT_7b)) {
+                    permanent.getToughness().setModifiedBaseValue(4);
+                    permanent.getPower().setModifiedBaseValue(4);
+                }
         }
         return true;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/woc/ShadowPuppeteersTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/woc/ShadowPuppeteersTest.java
@@ -1,0 +1,28 @@
+package org.mage.test.cards.single.woc;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ShadowPuppeteersTest extends CardTestPlayerBase {
+
+    // https://github.com/magefree/mage/issues/14326
+    @Test
+    public void testSublayer() {
+        addCard(Zone.BATTLEFIELD, playerA, "Glen Elendra Liege");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 7);
+        addCard(Zone.HAND, playerA, "Shadow Puppeteers");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Shadow Puppeteers");
+        attack(3, playerA, "Faerie Rogue Token");
+        setChoice(playerA, true);
+
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertLife(playerB, 15);
+    }
+
+}


### PR DESCRIPTION
Effects that set the base power/toughness of a creature, like the one on Shadow Puppeteers, should apply only during sublayer 7b, otherwise they will blow away other power/toughness modifications made at other sublayers.

Fixes https://github.com/magefree/mage/issues/14326