### PR TITLE
GreatestPowerControlledPredicate controller filter and timing

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/dies/KravenTheHunterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/dies/KravenTheHunterTest.java
@@ -1,0 +1,26 @@
+package org.mage.test.cards.triggers.dies;
+ 
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class KravenTheHunterTest extends CardTestPlayerBase {
+
+    @Test
+    public void testKraven() {
+        addCard(Zone.BATTLEFIELD, playerA, "Kraven the Hunter");
+        addCard(Zone.HAND, playerA, "Fell");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fell", "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Kraven the Hunter", 5, 4);
+    }
+
+}

--- a/Mage/src/main/java/mage/filter/predicate/permanent/GreatestPowerControlledPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/GreatestPowerControlledPredicate.java
@@ -15,9 +15,9 @@ public enum GreatestPowerControlledPredicate implements ObjectSourcePlayerPredic
     @Override
     public boolean apply(ObjectSourcePlayer<Permanent> input, Game game) {
         int greatestPower = Integer.MIN_VALUE;
-        for (Permanent p : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_CONTROLLED_CREATURE, input.getPlayerId(), input.getSource(), game)) {
+        for (Permanent p : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_CONTROLLED_CREATURE, input.getObject().getControllerId(), input.getSource(), game)) {
             greatestPower = Math.max(greatestPower, p.getPower().getValue());
         }
-        return input.getObject().getPower().getValue() == greatestPower;
+        return input.getObject().getPower().getValue() >= greatestPower;
     }
 }


### PR DESCRIPTION
This seems to be two bugs in one.  First, `getPlayerId()` refers to the controller of the ability source in `ObjectSourcePlayerPredicate`, so we should refer to `getObject().getControllerId()` instead.

Secondly, it seems that by the time this predicate is evaluated, the dying creature has left the battlefield already, so the greatest power would be calculated from among remaining creatures controlled by that player (or `Integer.MIN_VALUE` otherwise).  That's fine, we still know to match if our power is greather than or equal to it.

Fixes: https://github.com/magefree/mage/commit/867fa64156ff47736bf7fcd904b6a25a8d417b46
Fixes: https://github.com/magefree/mage/issues/14395