### PR TITLE
Mark copied tokens as copies of their copied object

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/snc/UndercoverOperativeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/snc/UndercoverOperativeTest.java
@@ -1,0 +1,36 @@
+package org.mage.test.cards.single.snc;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class UndercoverOperativeTest extends CardTestPlayerBase {
+
+    @Test
+    public void testWithAstralDragon() {
+        addCard(Zone.BATTLEFIELD, playerA, "Princess Yue");
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears");
+        addCard(Zone.HAND, playerA, "Undercover Operative");
+        addCard(Zone.HAND, playerA, "Astral Dragon");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 12);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Undercover Operative");
+        setChoice(playerA, true);
+        setChoice(playerA, "Princess Yue");
+        setChoice(playerA, "Princess Yue[no copy]");
+        setChoice(playerA, true);
+        setChoice(playerA, "Balduvian Bears");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Astral Dragon");
+        addTarget(playerA, "Moon");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Balduvian Bears", 3);
+    }
+
+}

--- a/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
+++ b/Mage/src/main/java/mage/util/functions/CopyTokenFunction.java
@@ -200,6 +200,8 @@ public class CopyTokenFunction {
         target.setToughness(sourceObj.getToughness().getBaseValue());
         target.setStartingLoyalty(sourceObj.getStartingLoyalty());
         target.setStartingDefense(sourceObj.getStartingDefense());
+
+        target.setCopy(true, sourceObj);
     }
 
     private Token from(Card source, Game game, Spell spell) {


### PR DESCRIPTION
I observed this crash when trying to perform the combo in this test (the real combo casts Astral Dragon first, then Undercover Operative, but reversing them still reproduces the issue and isn't infinite).

Applying this change seems to fix the issue, and makes Undercover Operative behave identically to other clone cards that did not exhibit the issue.  The infinite combo still seems to function.

```
java.lang.ClassCastException: class mage.game.permanent.token.EmptyToken cannot be cast to class mage.game.permanent.Permanent (mage.game.permanent.token.EmptyToken and mage.game.permanent.Permanent are in unnamed module of loader java.net.URLClassLoader @3c98781a)
        at mage.cards.u.UndercoverOperativeApplier.apply(UndercoverOperative.java:59)
        at mage.abilities.effects.common.CreateTokenCopyTargetEffect.apply(CreateTokenCopyTargetEffect.java:218)
        at mage.abilities.AbilityImpl.resolveMode(AbilityImpl.java:232)
        at mage.abilities.AbilityImpl.resolve(AbilityImpl.java:216)
        at mage.abilities.TriggeredAbilityImpl.resolve(TriggeredAbilityImpl.java:279)
        at mage.game.stack.StackAbility.resolve(StackAbility.java:85)
        at mage.game.GameImpl.resolve(GameImpl.java:1842)
        at mage.game.GameImpl.playPriority(GameImpl.java:1763)
        at mage.game.turn.Step.priority(Step.java:73)
        at mage.game.turn.Phase.playStep(Phase.java:205)
        at mage.game.turn.Phase.play(Phase.java:91)
        at mage.game.turn.Turn.play(Turn.java:132)
        at mage.game.GameImpl.playTurn(GameImpl.java:1180)
        at mage.game.GameImpl.play(GameImpl.java:1087)
        at mage.game.GameImpl.start(GameImpl.java:1063)
        at mage.server.game.GameWorker.call(GameWorker.java:35)
        at mage.server.game.GameWorker.call(GameWorker.java:16)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```