### PR TITLE
Fix Jegantha, the Wellspring mana payment calculations

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JeganthaTheWellspring.java
+++ b/Mage.Sets/src/mage/cards/j/JeganthaTheWellspring.java
@@ -6,6 +6,8 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.mana.ManaCosts;
 import mage.abilities.keyword.CompanionAbility;
 import mage.abilities.keyword.CompanionCondition;
 import mage.abilities.mana.ConditionalColoredManaAbility;
@@ -106,7 +108,14 @@ class JeganthaManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costsToPay) {
-        // TODO find a better method.  this one forces the user to pay off the generic mana before continuing.
-        return source.getManaCostsToPay().getUnpaid().getMana().getGeneric() == 0;
+        if (costsToPay instanceof ManaCosts) {
+            // allowed to contribute towards any overall costs which contain colored costs
+            return ((ManaCosts)costsToPay).getMana().countColored() > 0;
+        }
+        if (costsToPay instanceof ManaCost) {
+            // not allowed to pay for specific cost components consisting of generic mana
+            return ((ManaCost)costsToPay).getUnpaid().getMana().getGeneric() == 0;
+        }
+        return false;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/conditional/ConditionalManaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/conditional/ConditionalManaTest.java
@@ -458,4 +458,50 @@ public class ConditionalManaTest extends CardTestPlayerBase {
         Assert.assertEquals("Incorrect number of mana", 5, manaOptions.size());
     }
 
+    // https://github.com/magefree/mage/issues/9796
+    @Test
+    public void testJeganthaYes() {
+        addCard(Zone.BATTLEFIELD, playerA, "Jegantha, the Wellspring");
+        addCard(Zone.HAND, playerA, "Lost Auramancers");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lost Auramancers");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Lost Auramancers", 1);
+    }
+
+    @Test
+    public void testJeganthaYes2() {
+        addCard(Zone.BATTLEFIELD, playerA, "Jegantha, the Wellspring");
+        addCard(Zone.HAND, playerA, "Honden of Infinite Rage");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Honden of Infinite Rage");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Honden of Infinite Rage", 1);
+    }
+
+    @Test
+    public void testJeganthaNo() {
+        addCard(Zone.BATTLEFIELD, playerA, "Jegantha, the Wellspring");
+        addCard(Zone.HAND, playerA, "Lost Auramancers");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains");
+
+        checkPlayableAbility("nope", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Lost Auramancers", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Lost Auramancers", 0);
+    }
 }


### PR DESCRIPTION
The issue seems to be that `ManaCondition.apply()` is called at multiple points: first passing the entire `ManaCosts` of the overall cost, then passing each individual `ManaCost` sub-cost.  The first call is effectively just checking whether the conditional mana can contribute towards paying the cost at all.  So we can just allow it there, and then filter more granularly during the follow-up calls where each sub-cost is checked.

Fixes https://github.com/magefree/mage/commit/f0ca05e
Fixes https://github.com/magefree/mage/issues/9796