### PR TITLE
Creature type choice to string must use `getChoiceKey()`

### DIFF
--- a/Mage.Sets/src/mage/cards/b/BloodlineBidding.java
+++ b/Mage.Sets/src/mage/cards/b/BloodlineBidding.java
@@ -69,7 +69,7 @@ class BloodlineBiddingEffect extends OneShotEffect {
         }
         Choice choice = new ChoiceCreatureType(game, source);
         player.choose(outcome, choice, game);
-        SubType subType = SubType.byDescription(choice.getChoice());
+        SubType subType = SubType.byDescription(choice.getChoiceKey());
         if (subType == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/c/CelestialReunion.java
+++ b/Mage.Sets/src/mage/cards/c/CelestialReunion.java
@@ -170,7 +170,7 @@ class CelestialReunionCost extends CostImpl {
         }
         ChoiceCreatureType choice = new ChoiceCreatureType(game, source);
         player.choose(Outcome.Benefit, choice, game);
-        SubType subType = SubType.byDescription(choice.getChoice());
+        SubType subType = SubType.byDescription(choice.getChoiceKey());
         if (subType == null) {
             paid = false;
             return paid;

--- a/Mage.Sets/src/mage/cards/h/HarmonizedCrescendo.java
+++ b/Mage.Sets/src/mage/cards/h/HarmonizedCrescendo.java
@@ -66,7 +66,7 @@ class HarmonizedCrescendoEffect extends OneShotEffect {
         }
         Choice choice = new ChoiceCreatureType(game, source);
         player.choose(outcome, choice, game);
-        SubType subType = SubType.byDescription(choice.getChoice());
+        SubType subType = SubType.byDescription(choice.getChoiceKey());
         if (subType == null) {
             return false;
         }

--- a/Mage.Sets/src/mage/cards/o/OkoLorwynLiege.java
+++ b/Mage.Sets/src/mage/cards/o/OkoLorwynLiege.java
@@ -112,7 +112,7 @@ class OkoShadowmoorScionEffect extends OneShotEffect {
         }
         Choice choice = new ChoiceCreatureType(game, source);
         player.choose(outcome, choice, game);
-        SubType subType = SubType.byDescription(choice.getChoice());
+        SubType subType = SubType.byDescription(choice.getChoiceKey());
         if (subType == null) {
             return false;
         }


### PR DESCRIPTION
Not `getChoice()`, this can't be tested since it breaks for human players only where the hint text (e.g. "(me)") is appended.

Fixes https://github.com/magefree/mage/commit/1056e4c