### PR TITLE
Fix Shay Cormac not removing hexproof, protection, or ward

### DIFF
--- a/Mage.Sets/src/mage/cards/s/ShayCormac.java
+++ b/Mage.Sets/src/mage/cards/s/ShayCormac.java
@@ -109,12 +109,11 @@ class ShayCormacEffect extends ContinuousEffectImpl {
             if (permanent == null) {
                 continue;
             }
-            // I know the removeIf is deprecated but I can't see any reason not to use it based on what the removeAbility method actually does
-            permanent.getAbilities(game).removeIf(HexproofBaseAbility.class::isInstance);
+            permanent.getAbilities(game).stream().filter(HexproofBaseAbility.class::isInstance).forEach(ability -> permanent.removeAbility(ability, source.getSourceId(), game));
             permanent.removeAbility(IndestructibleAbility.getInstance(), source.getSourceId(), game);
-            permanent.getAbilities(game).removeIf(ProtectionAbility.class::isInstance);
+            permanent.getAbilities(game).stream().filter(ProtectionAbility.class::isInstance).forEach(ability -> permanent.removeAbility(ability, source.getSourceId(), game));
             permanent.removeAbility(ShroudAbility.getInstance(), source.getSourceId(), game);
-            permanent.getAbilities(game).removeIf(WardAbility.class::isInstance);
+            permanent.getAbilities(game).stream().filter(WardAbility.class::isInstance).forEach(ability -> permanent.removeAbility(ability, source.getSourceId(), game));
         }
         return true;
     }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/acr/ShayCormacTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/acr/ShayCormacTest.java
@@ -1,0 +1,29 @@
+package org.mage.test.cards.single.acr;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ShayCormacTest extends CardTestPlayerBase {
+
+    @Test
+    public void testRemoveWard() {
+        addCard(Zone.BATTLEFIELD, playerA, "Shay Cormac");
+        addCard(Zone.BATTLEFIELD, playerB, "Tomakul Honor Guard");
+        addCard(Zone.HAND, playerA, "Fell");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}:");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fell", "Tomakul Honor Guard");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Tomakul Honor Guard", 0);
+        assertGraveyardCount(playerB, "Tomakul Honor Guard", 1);
+    }
+
+}


### PR DESCRIPTION
These three were not working since they were calling the deprecated `Abilities.removeIf`.  Replacing with equivalent
`Permanent.removeAbility` calls fixes the issue.