### PR TITLE
[dev] Change gen-card.pl to bail after checking set print info

### DIFF
--- a/Utils/gen-card.pl
+++ b/Utils/gen-card.pl
@@ -123,9 +123,7 @@ if (index($cardName, $splitDelimiter) != -1) {
 
 # Check if card is already implemented
 my $fileName = "../Mage.Sets/src/mage/cards/" . lc(substr($cardName, 0, 1)) . "/" . toCamelCase($cardName) . ".java";
-if (-e $fileName) {
-    die "$cardName is already implemented.\n$fileName\n";
-}
+my $cardAlreadyImplemented = -e $fileName;
 
 # Generate lines to corresponding sets
 my %vars;
@@ -182,6 +180,10 @@ foreach my $setName (keys %{$cards{$originalName}}) {
         unlink $setFileName . ".bak";
         print "$setFileName\n";
     }
+}
+
+if ($cardAlreadyImplemented) {
+    die "$cardName is already implemented.\n$fileName\n";
 }
 
 # Generate the card


### PR DESCRIPTION
Previously if the card was already implemented, it would die on line 127.

Now, we set a flag that is checked after the set printing info stuff is done. 

This enables cards that are implemented to just have `gen-card.pl` ran against them and the set info auto update from the script. Useful for when WotC produces later reprints of existing cards OR when things are under rapid development during spoiler and preview season and not all card printings are known during initial implementation. 