### PR TITLE
Refactor a pair of cards to use custom predicates and DestroyAllEffect

### DIFF
--- a/Mage.Sets/src/mage/cards/f/ForcedMarch.java
+++ b/Mage.Sets/src/mage/cards/f/ForcedMarch.java
@@ -1,16 +1,15 @@
 package mage.cards.f;
 
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
-
 import java.util.UUID;
 
 /**
@@ -18,11 +17,17 @@ import java.util.UUID;
  */
 public final class ForcedMarch extends CardImpl {
 
+    private static final FilterCreaturePermanent filter = new FilterCreaturePermanent("creatures with converted mana cost X or less");
+
+    static {
+        filter.add(ForcedMarchPredicate.instance);
+    }
+
     public ForcedMarch(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{B}{B}{B}");
 
         // Destroy all creatures with converted mana cost X or less
-        this.getSpellAbility().addEffect(new ForcedMarchEffect());
+        this.getSpellAbility().addEffect(new DestroyAllEffect(filter));
     }
 
     private ForcedMarch(final ForcedMarch card) {
@@ -35,33 +40,11 @@ public final class ForcedMarch extends CardImpl {
     }
 }
 
-class ForcedMarchEffect extends OneShotEffect {
-
-    ForcedMarchEffect() {
-        super(Outcome.DestroyPermanent);
-        staticText = "Destroy all creatures with mana value X or less";
-    }
-
-    private ForcedMarchEffect(final ForcedMarchEffect effect) {
-        super(effect);
-    }
+enum ForcedMarchPredicate implements ObjectSourcePlayerPredicate<Card> {
+    instance;
 
     @Override
-    public ForcedMarchEffect copy() {
-        return new ForcedMarchEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-
-        // for(Permanent permanent : game.getBattlefield().getAllActivePermanents(CardType.CREATURE)) {
-        for (Permanent permanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE,
-                source.getControllerId(),
-                source, game)) {
-            if (permanent.getManaValue() <= CardUtil.getSourceCostsTag(game, source, "X", 0)) {
-                permanent.destroy(source, game, false);
-            }
-        }
-        return true;
+    public boolean apply(ObjectSourcePlayer<Card> input, Game game) {
+        return input.getObject().getManaValue() <= GetXValue.instance.calculate(game, input.getSource(), null);
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HammerMage.java
+++ b/Mage.Sets/src/mage/cards/h/HammerMage.java
@@ -7,16 +7,16 @@ import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.DiscardCardCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.dynamicvalue.common.GetXValue;
+import mage.abilities.effects.common.DestroyAllEffect;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.common.FilterArtifactPermanent;
-import mage.filter.predicate.mageobject.ManaValuePredicate;
+import mage.filter.predicate.ObjectSourcePlayer;
+import mage.filter.predicate.ObjectSourcePlayerPredicate;
 import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
-
 import java.util.UUID;
 
 /**
@@ -24,6 +24,12 @@ import java.util.UUID;
  * @author LoneFox
  */
 public final class HammerMage extends CardImpl {
+
+    private static final FilterArtifactPermanent filter = new FilterArtifactPermanent("artifacts with converted mana cost X or less");
+
+    static {
+        filter.add(HammerMagePredicate.instance);
+    }
 
    public HammerMage(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{1}{R}");
@@ -33,7 +39,7 @@ public final class HammerMage extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {X}{R}, {tap}, Discard a card: Destroy all artifacts with converted mana cost X or less.
-        Ability ability = new SimpleActivatedAbility(new HammerMageEffect(), new ManaCostsImpl<>("{X}{R}"));
+        Ability ability = new SimpleActivatedAbility(new DestroyAllEffect(filter), new ManaCostsImpl<>("{X}{R}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new DiscardCardCost());
         this.addAbility(ability);
@@ -49,29 +55,11 @@ public final class HammerMage extends CardImpl {
     }
 }
 
-class HammerMageEffect extends  OneShotEffect {
-
-    public HammerMageEffect() {
-        super(Outcome.DestroyPermanent);
-        staticText = "Destroy all artifacts with mana value X or less";
-    }
-
-    private HammerMageEffect(final HammerMageEffect effect) {
-        super(effect);
-    }
+enum HammerMagePredicate implements ObjectSourcePlayerPredicate<Card> {
+    instance;
 
     @Override
-    public HammerMageEffect copy() {
-        return new HammerMageEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        FilterArtifactPermanent filter = new FilterArtifactPermanent();
-        filter.add(new ManaValuePredicate(ComparisonType.FEWER_THAN, CardUtil.getSourceCostsTag(game, source, "X", 0) + 1));
-        for(Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), source, game)) {
-            permanent.destroy(source, game, false);
-        }
-        return true;
+    public boolean apply(ObjectSourcePlayer<Card> input, Game game) {
+        return input.getObject().getManaValue() <= GetXValue.instance.calculate(game, input.getSource(), null);
     }
 }


### PR DESCRIPTION
Off the back of feedback in #14681 which was originally implemented based on these. If we're refactoring there, let's refactor here for consistency and to aid the next sucker to implement cards.