### PR TITLE
Use spell mana value instead of card mana value for cascade

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CascadeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CascadeTest.java
@@ -264,4 +264,29 @@ public class CascadeTest extends CardTestPlayerBase {
         assertGraveyardCount(playerA, "Fireball", 1);
         assertLife(playerB, 16);
     }
+
+    @Test
+    public void testRemovedFromStack() {
+        skipInitShuffling();
+        playerA.getLibrary().clear();
+        addCard(Zone.LIBRARY, playerA, "Dwarven Trader");
+        addCard(Zone.HAND, playerA, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        addCard(Zone.HAND, playerB, "Unsubstantiate");
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Maelstrom Nexus");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears");
+        setChoice(playerA, true);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Unsubstantiate");
+        addTarget(playerB, "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Dwarven Trader", 1);
+        assertPermanentCount(playerA, "Balduvian Bears", 0);
+        assertHandCount(playerA, "Balduvian Bears", 1);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CascadeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/CascadeTest.java
@@ -4,6 +4,7 @@ import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -235,5 +236,32 @@ public class CascadeTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Ardent Plea", 1);
         assertGraveyardCount(playerA, "Breaking // Entering", 0);
         assertLibraryCount(playerA, "Breaking // Entering", 1);
+    }
+
+    // https://github.com/magefree/mage/issues/14687
+    @Test
+    public void testWithXCost() {
+        skipInitShuffling();
+        playerA.getLibrary().clear();
+        addCard(Zone.LIBRARY, playerA, "Lotus Petal");
+        addCard(Zone.LIBRARY, playerA, "Dwarven Trader");
+        addCard(Zone.HAND, playerA, "Fireball");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Maelstrom Nexus");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fireball");
+        setChoice(playerA, "X=4");
+        addTarget(playerA, playerB);
+        addTarget(playerA, TestPlayer.TARGET_SKIP);
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Dwarven Trader", 1);
+        assertPermanentCount(playerA, "Lotus Petal", 0);
+        assertGraveyardCount(playerA, "Fireball", 1);
+        assertLife(playerB, 16);
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/CascadeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CascadeAbility.java
@@ -113,7 +113,7 @@ class CascadeEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-        Spell sourceSpell = game.getStack().getSpell(this.getTargetPointer().getFirst(game, source));
+        Spell sourceSpell = game.getSpellOrLKIStack(this.getTargetPointer().getFirst(game, source));
         if (sourceSpell == null) {
             return false;
         }

--- a/Mage/src/main/java/mage/abilities/keyword/CascadeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CascadeAbility.java
@@ -17,6 +17,7 @@ import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
 import mage.players.Player;
 import mage.target.common.TargetCardInExile;
+import mage.target.targetpointer.FixedTarget;
 import mage.util.CardUtil;
 
 /**
@@ -79,6 +80,7 @@ public class CascadeAbility extends TriggeredAbilityImpl {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         Spell spell = game.getStack().getSpell(event.getTargetId());
+        this.getEffects().setTargetPointer(new FixedTarget(event.getTargetId()));
         return spell != null
                 && spell.getSourceId().equals(this.getSourceId());
     }
@@ -111,14 +113,14 @@ class CascadeEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-        Card sourceCard = game.getCard(source.getSourceId());
-        if (sourceCard == null) {
+        Spell sourceSpell = game.getStack().getSpell(this.getTargetPointer().getFirst(game, source));
+        if (sourceSpell == null) {
             return false;
         }
 
         // exile cards from the top of your library until you exile a nonland card whose converted mana cost is less than this spell's converted mana cost
         Cards cardsToExile = new CardsImpl();
-        int sourceCost = sourceCard.getManaValue();
+        int sourceCost = sourceSpell.getManaValue();
         Card cardToCast = null;
         for (Card card : controller.getLibrary().getCards(game)) {
             cardsToExile.add(card);


### PR DESCRIPTION
Cascade should use the mana value of the spell rather than the mana value of the card.  (Only?) relevant for X-cost spells.

No need to document rule 202.3e in `CascadeAbility` since it is already documented in `Spell.getManaValue()`.

Fixes https://github.com/magefree/mage/issues/14687