### PR TITLE
Process blink in `ExileAndReturnSourcEffect` & Estrid's Invocation

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EstridsInvocation.java
+++ b/Mage.Sets/src/mage/cards/e/EstridsInvocation.java
@@ -6,11 +6,13 @@ import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CopyPermanentEffect;
+import mage.abilities.effects.common.ExileAndReturnSourceEffect;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
+import mage.constants.PutCards;
 import mage.constants.Zone;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledEnchantmentPermanent;
@@ -58,38 +60,8 @@ class EstridsInvocationCopyApplier extends CopyApplier {
     public boolean apply(Game game, MageObject blueprint, Ability source, UUID copyToObjectId) {
         // At the beginning of your upkeep, you may exile this enchantment. If you do, return it to the battlefield under its owner's control.
         blueprint.getAbilities().add(new BeginningOfUpkeepTriggeredAbility(
-                new EstridsInvocationEffect(), true
+                new ExileAndReturnSourceEffect(PutCards.BATTLEFIELD), true
         ));
-        return true;
-    }
-}
-
-class EstridsInvocationEffect extends OneShotEffect {
-
-    EstridsInvocationEffect() {
-        super(Outcome.Neutral);
-        this.staticText = "exile this enchantment. If you do, return it to the battlefield under its owner's control";
-    }
-
-    private EstridsInvocationEffect(final EstridsInvocationEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public EstridsInvocationEffect copy() {
-        return new EstridsInvocationEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player player = game.getPlayer(source.getControllerId());
-        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
-        if (permanent == null || player == null) {
-            return false;
-        }
-        Card card = permanent.getMainCard();
-        player.moveCards(permanent, Zone.EXILED, source, game);
-        player.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, true, null);
         return true;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/EstridsInvocationTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/EstridsInvocationTest.java
@@ -1,0 +1,42 @@
+package org.mage.test.cards.copy;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class EstridsInvocationTest extends CardTestPlayerBase {
+
+    @Test
+    public void testCopyAura() {
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Bear Cub");
+        addCard(Zone.HAND, playerA, "Estrid's Invocation");
+        addCard(Zone.HAND, playerA, "Feather of Flight");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Impact Tremors");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Feather of Flight");
+        addTarget(playerA, "Balduvian Bears");
+
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Estrid's Invocation");
+        setChoice(playerA, true);
+        setChoice(playerA, "Feather of Flight");
+        setChoice(playerA, "Bear Cub");
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+        setChoice(playerA, "Feather of Flight");
+        setChoice(playerA, "Grizzly Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(5, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Balduvian Bears", 3, 2);
+        assertPowerToughness(playerA, "Grizzly Bears", 3, 2);
+        assertPowerToughness(playerA, "Bear Cub", 2, 2);
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileAndReturnSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileAndReturnSourceEffect.java
@@ -70,6 +70,7 @@ public class ExileAndReturnSourceEffect extends OneShotEffect {
             return true;
         }
         controller.moveCards(permanent, Zone.EXILED, source, game);
+        game.processAction();
         putCards.moveCard(
                 returnUnderYourControl ? controller : game.getPlayer(permanent.getOwnerId()),
                 permanent.getMainCard(), source, game, "card"


### PR DESCRIPTION
`ExileAndReturnSourcEffect` was not processing zone change triggers due to not calling `game.processAction()`, which
`ExileThenReturnTargetEffect` does.  Update it to do so, and convert Estrid's Invocation to use the common code, because it had the same bug.

Fixes https://github.com/magefree/mage/issues/14626