### PR TITLE
Use SwingWorker for Safe Async UI Modification

### DIFF
--- a/Mage.Client/src/main/java/mage/client/components/MageUI.java
+++ b/Mage.Client/src/main/java/mage/client/components/MageUI.java
@@ -142,7 +142,6 @@ public class MageUI {
         while (!j.isEnabled()) {
             TimeUnit.MILLISECONDS.sleep(10);
         }
-        Thread t = new Thread(() -> j.doClick());
-        t.start();
+        SwingUtilities.invokeLater(j::doClick);
     }
 }

--- a/Mage.Client/src/main/java/mage/client/game/BattlefieldPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/BattlefieldPanel.java
@@ -313,12 +313,15 @@ public class BattlefieldPanel extends javax.swing.JLayeredPane {
                 if (mageCard.getMainPanel() instanceof MagePermanent) {
                     MagePermanent magePermanent = (MagePermanent) mageCard.getMainPanel();
                     if (magePermanent.getOriginal().getId().equals(permanentId)) {
-                        Thread t = new Thread(() -> {
+                        SwingUtilities.invokeLater(() -> {
                             Plugins.instance.onRemoveCard(mageCard, count);
                             mageCard.setVisible(false);
-                            this.jPanel.remove(mageCard);
+                            if (mageCard.getParent() == jPanel) {
+                                jPanel.remove(mageCard);
+                                jPanel.revalidate();
+                                jPanel.repaint();
+                            }
                         });
-                        t.start();
                     }
                     if (magePermanent.getOriginal().isCreature()) {
                         removedCreature = true;

--- a/Mage.Client/src/main/java/mage/client/plugins/impl/Plugins.java
+++ b/Mage.Client/src/main/java/mage/client/plugins/impl/Plugins.java
@@ -12,6 +12,7 @@ import mage.interfaces.PluginException;
 import mage.interfaces.plugin.CardPlugin;
 import mage.interfaces.plugin.CounterPlugin;
 import mage.interfaces.plugin.ThemePlugin;
+import mage.util.ThreadUtils;
 import mage.view.CardView;
 import mage.view.PermanentView;
 import net.xeoh.plugins.base.PluginManager;
@@ -77,6 +78,7 @@ public enum Plugins implements MagePlugins {
 
     @Override
     public void updateGamePanel(Map<String, JComponent> ui) {
+        ThreadUtils.ensureRunInGUISwingThread();
         if (MageFrame.isLite() || MageFrame.isGray() || themePlugin == null) {
             return;
         }
@@ -85,6 +87,7 @@ public enum Plugins implements MagePlugins {
 
     @Override
     public JComponent updateTablePanel(Map<String, JComponent> ui) {
+        ThreadUtils.ensureRunInGUISwingThread();
         if (MageFrame.isLite() || MageFrame.isGray() || themePlugin == null) {
             return null;
         }
@@ -133,6 +136,7 @@ public enum Plugins implements MagePlugins {
 
     @Override
     public int sortPermanents(Map<String, JComponent> ui, Map<UUID, MageCard> cards, boolean topRow) {
+        ThreadUtils.ensureRunInGUISwingThread();
         if (this.cardPlugin != null) {
             return this.cardPlugin.sortPermanents(ui, cards, PreferencesDialog.getCachedValue("nonLandPermanentsInOnePile", "false").equals("true"), topRow);
         }
@@ -187,6 +191,7 @@ public enum Plugins implements MagePlugins {
 
     @Override
     public void onAddCard(MageCard card, int count) {
+        ThreadUtils.ensureRunInGUISwingThread();
         if (this.cardPlugin != null) {
             this.cardPlugin.onAddCard(card, count);
         }
@@ -194,6 +199,7 @@ public enum Plugins implements MagePlugins {
 
     @Override
     public void onRemoveCard(MageCard card, int count) {
+        ThreadUtils.ensureRunInGUISwingThread();
         if (this.cardPlugin != null) {
             this.cardPlugin.onRemoveCard(card, count);
         }


### PR DESCRIPTION
It is not allowed to modify UI in a raw `Thread`, so we must use `SwingWorker` for async operations that modify the UI on completion (https://docs.oracle.com/javase/8/docs/api/javax/swing/SwingWorker.html).

This could potentially fix some of the UI bugs/crashes.

(Second fix in `doClick` seems only used by tests but should also not use `Thread`.)