### PR TITLE
[dev] Update GHA to use versions on Node 24

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
There's a deprecation notice on our current Github Action runs;

```
[build](https://github.com/magefree/mage/actions/runs/24543686171/job/71754652894#step:9:2)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-java@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

e.g seen[ here ](https://github.com/magefree/mage/actions/runs/24543686171)

So let's bump these steps to use Node 24 based ones. I've done a PR against my fork and for the steps in question, they appear to be passing; https://github.com/muz/mage/actions/runs/24543991401/job/71755580782?pr=3