### PR TITLE
fix TestPlayer not supporting complex filters during graveyard cards targetting

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/sos/MoseoVeinsNewDeanTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/sos/MoseoVeinsNewDeanTest.java
@@ -3,7 +3,6 @@ package org.mage.test.cards.single.sos;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -55,7 +54,6 @@ public class MoseoVeinsNewDeanTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Craw Wurm", 0);
     }
 
-    @Ignore
     @Test
     public void test_Gain5_NoValidTarget_Attempt() {
         addCard(Zone.BATTLEFIELD, playerA, moseo, 1);

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -53,14 +53,13 @@ import mage.util.RandomUtil;
 import mage.watchers.common.AttackedOrBlockedThisCombatWatcher;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
+import static org.mage.test.serverside.base.impl.CardTestPlayerAPIImpl.*;
 
 import java.io.Serializable;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static org.mage.test.serverside.base.impl.CardTestPlayerAPIImpl.*;
 
 /**
  * Basic implementation of testable player
@@ -2553,7 +2552,7 @@ public class TestPlayer implements Player {
                         IterateGraveyards:
                         for (UUID playerId : needPlayers) {
                             Player player = game.getPlayer(playerId);
-                            for (Card card : player.getGraveyard().getCards(targetFull.getFilter(), game)) {
+                            for (Card card : player.getGraveyard().getCards(targetFull.getFilter(), playerId, source, game)) {
                                 if (hasObjectTargetNameOrAlias(card, targetName) || (card.getName() + '-' + card.getExpansionSetCode()).equals(targetName)) { // TODO: remove set code search?
                                     if (target.canTarget(abilityControllerId, card.getId(), source, game) && !target.contains(card.getId())) {
                                         target.addTarget(card.getId(), source, game);

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2437,7 +2437,7 @@ public class TestPlayer implements Player {
                     String[] targetList = targetDefinition.split("\\^");
                     boolean targetFound = false;
                     for (String targetName : targetList) {
-                        for (Card card : computerPlayer.getHand().getCards(((TargetCard) target.getOriginalTarget()).getFilter(), game)) {
+                        for (Card card : computerPlayer.getHand().getCards(((TargetCard) target.getOriginalTarget()).getFilter(), abilityControllerId, source, game)) {
                             if (hasObjectTargetNameOrAlias(card, targetName) || (card.getName() + '-' + card.getExpansionSetCode()).equals(targetName)) { // TODO: remove set code search?
                                 if (target.canTarget(abilityControllerId, card.getId(), source, game) && !target.contains(card.getId())) {
                                     target.addTarget(card.getId(), source, game);
@@ -2475,7 +2475,7 @@ public class TestPlayer implements Player {
                     String[] targetList = targetDefinition.split("\\^");
                     boolean targetFound = false;
                     for (String targetName : targetList) {
-                        for (Card card : game.getExile().getCards(filter, game)) {
+                        for (Card card : game.getExile().getCardsInRange(filter, abilityControllerId, source, game)) {
                             if (hasObjectTargetNameOrAlias(card, targetName) || (card.getName() + '-' + card.getExpansionSetCode()).equals(targetName)) { // TODO: remove set code search?
                                 if (target.canTarget(abilityControllerId, card.getId(), source, game) && !target.contains(card.getId())) {
                                     target.addTarget(card.getId(), source, game);

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2552,7 +2552,7 @@ public class TestPlayer implements Player {
                         IterateGraveyards:
                         for (UUID playerId : needPlayers) {
                             Player player = game.getPlayer(playerId);
-                            for (Card card : player.getGraveyard().getCards(targetFull.getFilter(), playerId, source, game)) {
+                            for (Card card : player.getGraveyard().getCards(targetFull.getFilter(), abilityControllerId, source, game)) {
                                 if (hasObjectTargetNameOrAlias(card, targetName) || (card.getName() + '-' + card.getExpansionSetCode()).equals(targetName)) { // TODO: remove set code search?
                                     if (target.canTarget(abilityControllerId, card.getId(), source, game) && !target.contains(card.getId())) {
                                         target.addTarget(card.getId(), source, game);

--- a/Mage/src/main/java/mage/cards/Cards.java
+++ b/Mage/src/main/java/mage/cards/Cards.java
@@ -24,15 +24,15 @@ public interface Cards extends Set<UUID>, Serializable, Copyable<Cards> {
      *
      * @param cardId UUID of the card to get
      * @param game   the current game
-     * @return       The Card corresponding to the UUID, or null if that UUID is not in the set
+     * @return The Card corresponding to the UUID, or null if that UUID is not in the set
      */
     Card get(UUID cardId, Game game);
 
     /**
      * Remove a specific card from the set in a safe manner.
      *
-     * @param card  the card to remove from this set
-     * @return      boolean indicating if removing the card was done successfully
+     * @param card the card to remove from this set
+     * @return boolean indicating if removing the card was done successfully
      */
     boolean remove(Card card);
 
@@ -42,7 +42,9 @@ public interface Cards extends Set<UUID>, Serializable, Copyable<Cards> {
 
     /**
      * Warning: this method ignores ObjectSourcePlayer predicates in the filter
+     * Use the 4-argument one when in doubt.
      */
+    @Deprecated
     Set<Card> getCards(FilterCard filter, Game game);
 
     Set<Card> getCards(FilterCard filter, UUID playerId, Ability source, Game game);
@@ -52,8 +54,8 @@ public interface Cards extends Set<UUID>, Serializable, Copyable<Cards> {
     /**
      * Get a collection view of the unique non-null cards in this set.
      *
-     * @param game  The current game
-     * @return      Collection of unique non-null cards.
+     * @param game The current game
+     * @return Collection of unique non-null cards.
      */
     Collection<Card> getUniqueCards(Game game);
 

--- a/Mage/src/main/java/mage/cards/CardsImpl.java
+++ b/Mage/src/main/java/mage/cards/CardsImpl.java
@@ -121,6 +121,8 @@ public class CardsImpl extends LinkedHashSet<UUID> implements Cards, Serializabl
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    // In most situation, you should provide source and playerId when filterings CardsImpl. Else complex filters will not work.
+    @Deprecated
     @Override
     public Set<Card> getCards(FilterCard filter, Game game) {
         return stream()


### PR DESCRIPTION
I stumbled on an unit test not working properly as a predicate in Moseo Vein's New Dean requires the source to be provided to the filter.

There might be a need for others fixes in the test suite for `chooseTarget`, for other kinds of filters.