### PR TITLE
[minor] SOS release errata for card text

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChoreographedSparks.java
+++ b/Mage.Sets/src/mage/cards/c/ChoreographedSparks.java
@@ -54,7 +54,7 @@ public final class ChoreographedSparks extends CardImpl {
         this.getSpellAbility().addEffect(new CopyTargetStackObjectEffect());
         this.getSpellAbility().addTarget(new TargetSpell(filter));
 
-        // * Copy target creature spell you control. The copy gains haste and "At the beginning of the next end step, sacrifice this token."
+        // * Copy target creature spell you control. The copy gains haste and "At the beginning of the end step, sacrifice this token."
         Mode mode = new Mode(
             new CopyTargetStackObjectEffect(false, false, false, 1, ChoreographedSparksApplier.instance)
                 .setText("Copy target creature spell you control. "

--- a/Mage.Sets/src/mage/cards/s/SpryAndMighty.java
+++ b/Mage.Sets/src/mage/cards/s/SpryAndMighty.java
@@ -31,7 +31,7 @@ public final class SpryAndMighty extends CardImpl {
     public SpryAndMighty(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{4}{G}");
 
-        // Choose two creatures you control. You draw X cards and the chosen creatures get +X/+X and gain trample until end of turn, where X is the difference between the chosen creatures' powers.
+        // Choose exactly two creatures you control. You draw X cards and the chosen creatures get +X/+X and gain trample until end of turn, where X is the difference between the chosen creatures' powers.
         this.getSpellAbility().addEffect(new SpryAndMightyEffect());
     }
 
@@ -49,7 +49,7 @@ class SpryAndMightyEffect extends OneShotEffect {
 
     SpryAndMightyEffect() {
         super(Outcome.Benefit);
-        staticText = "choose two creatures you control. You draw X cards and the chosen creatures get +X/+X " +
+        staticText = "choose exactly two creatures you control. You draw X cards and the chosen creatures get +X/+X " +
                 "and gain trample until end of turn, where X is the difference between the chosen creatures' powers";
     }
 


### PR DESCRIPTION
https://magic.wizards.com/en/news/announcements/secrets-of-strixhaven-update-bulletin#:~:text=Volo%2C%20Itinerant%20Scholar-,School%20Dances

3 cards got erratas from their printed values. 

Slumbering Trudge is already up to date. 
Choreographed Sparks was producing the correct card text all along, but this brings the comment in line.
Spry and Mighty's text got updated, but functionally was doing as it should have all along from what I can see reviewing the code.