### PR TITLE
Madame Null, Power Broker add counters directly to entering permanent

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MadameNullPowerBroker.java
+++ b/Mage.Sets/src/mage/cards/m/MadameNullPowerBroker.java
@@ -18,7 +18,6 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.util.CardUtil;
 
-import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -81,9 +80,7 @@ class MadameNullPowerBrokerEffect extends OneShotEffect {
         if (power < 1 || !CardUtil.tryPayLife(power, player, source, game)) {
             return false;
         }
-        Optional.ofNullable(getTargetPointer().getFirst(game, source))
-                .map(game::getPermanent)
-                .ifPresent(p -> p.addCounters(CounterType.P1P1.createInstance(power), source, game));
+        permanent.addCounters(CounterType.P1P1.createInstance(power), source, game);
         return true;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/tmt/MadameNullPowerBrokerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/tmt/MadameNullPowerBrokerTest.java
@@ -1,0 +1,26 @@
+package org.mage.test.cards.single.tmt;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class MadameNullPowerBrokerTest extends CardTestPlayerBase {
+
+    @Test
+    public void testBasic() {
+        addCard(Zone.BATTLEFIELD, playerA, "Madame Null, Power Broker");
+        addCard(Zone.HAND, playerA, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Balduvian Bears");
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Balduvian Bears", 4, 4);
+        assertLife(playerA, 18);
+    }
+}


### PR DESCRIPTION
Not working since this was trying to add counters to ability target, when we already have a reference to the entering permanent and can just add counters directly to it.

Fixes https://github.com/magefree/mage/issues/14764