### PR TITLE
[SOS] Implement Wildgrowth Archaic

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WildgrowthArchaic.java
+++ b/Mage.Sets/src/mage/cards/w/WildgrowthArchaic.java
@@ -1,0 +1,135 @@
+package mage.cards.w;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.Mana;
+import mage.constants.SubType;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.events.EntersTheBattlefieldEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.Spell;
+import mage.abilities.keyword.TrampleAbility;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldAbility;
+import mage.abilities.common.SpellCastControllerTriggeredAbility;
+import mage.abilities.dynamicvalue.common.ColorsOfManaSpentToCastCount;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.keyword.ReachAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.AbilityWord;
+import mage.constants.CardType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.SetTargetPointer;
+
+/**
+ *
+ * @author muz
+ */
+public final class WildgrowthArchaic extends CardImpl {
+
+    public WildgrowthArchaic(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2/G}{2/G}");
+
+        this.subtype.add(SubType.AVATAR);
+        this.power = new MageInt(0);
+        this.toughness = new MageInt(0);
+
+        // Trample
+        this.addAbility(TrampleAbility.getInstance());
+
+        // Reach
+        this.addAbility(ReachAbility.getInstance());
+
+        // Converge -- This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.
+        this.addAbility(new EntersBattlefieldAbility(
+            new AddCountersSourceEffect(
+                CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()
+            ), null, AbilityWord.CONVERGE.formatWord() + "{this} enters with a +1/+1 counter " +
+            "on it for each color of mana spent to cast it.", null
+        ));
+
+        // Whenever you cast a creature spell, that creature enters with X additional +1/+1
+        // counters on it, where X is the number of colors of mana spent to cast it.
+        this.addAbility(new SpellCastControllerTriggeredAbility(
+            new WildgrowthArchaicEffect(),
+            StaticFilters.FILTER_SPELL_A_CREATURE,
+            false, SetTargetPointer.SPELL
+        ));
+
+    }
+
+    private WildgrowthArchaic(final WildgrowthArchaic card) {
+        super(card);
+    }
+
+    @Override
+    public WildgrowthArchaic copy() {
+        return new WildgrowthArchaic(this);
+    }
+}
+
+class WildgrowthArchaicEffect extends ReplacementEffectImpl {
+
+    WildgrowthArchaicEffect() {
+        super(Duration.EndOfTurn, Outcome.BoostCreature);
+        this.staticText = "that creature enters with X additional +1/+1 counters on it, where X is the number of colors of mana spent to cast it";
+    }
+
+    private WildgrowthArchaicEffect(final WildgrowthArchaicEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public WildgrowthArchaicEffect copy() {
+        return new WildgrowthArchaicEffect(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Spell spell = game.getSpellOrLKIStack(getTargetPointer().getFirst(game, source));
+        return spell != null && event.getTargetId().equals(spell.getSourceId());
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
+        if (creature == null) {
+            return false;
+        }
+        Spell spell = game.getSpellOrLKIStack(getTargetPointer().getFirst(game, source));
+        if (spell == null) {
+            return false;
+        }
+        Mana mana = spell.getSpellAbility().getManaCostsToPay().getUsedManaToPay();
+        int colorCount = 0;
+        if (mana.getBlack() > 0) {
+            colorCount++;
+        }
+        if (mana.getBlue() > 0) {
+            colorCount++;
+        }
+        if (mana.getGreen() > 0) {
+            colorCount++;
+        }
+        if (mana.getRed() > 0) {
+            colorCount++;
+        }
+        if (mana.getWhite() > 0) {
+            colorCount++;
+        }
+        creature.addCounters(CounterType.P1P1.createInstance(colorCount),
+            source.getControllerId(), source, game, event.getAppliedEffects());
+        return false; // Must return false, otherwise creature doesn't enter battlefield
+    }
+}

--- a/Mage.Sets/src/mage/cards/w/WildgrowthArchaic.java
+++ b/Mage.Sets/src/mage/cards/w/WildgrowthArchaic.java
@@ -2,7 +2,6 @@ package mage.cards.w;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.Mana;
 import mage.constants.SubType;
 import mage.counters.CounterType;
 import mage.filter.StaticFilters;
@@ -111,23 +110,9 @@ class WildgrowthArchaicEffect extends ReplacementEffectImpl {
         if (spell == null) {
             return false;
         }
-        Mana mana = spell.getSpellAbility().getManaCostsToPay().getUsedManaToPay();
-        int colorCount = 0;
-        if (mana.getBlack() > 0) {
-            colorCount++;
-        }
-        if (mana.getBlue() > 0) {
-            colorCount++;
-        }
-        if (mana.getGreen() > 0) {
-            colorCount++;
-        }
-        if (mana.getRed() > 0) {
-            colorCount++;
-        }
-        if (mana.getWhite() > 0) {
-            colorCount++;
-        }
+        int colorCount = ColorsOfManaSpentToCastCount.countColors(
+            spell.getSpellAbility().getManaCostsToPay().getUsedManaToPay()
+        );
         creature.addCounters(CounterType.P1P1.createInstance(colorCount),
             source.getControllerId(), source, game, event.getAppliedEffects());
         return false; // Must return false, otherwise creature doesn't enter battlefield

--- a/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
+++ b/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
@@ -345,6 +345,8 @@ public final class SecretsOfStrixhaven extends ExpansionSet {
         cards.add(new SetCardInfo("Visionary's Dance", 242, Rarity.COMMON, mage.cards.v.VisionarysDance.class));
         cards.add(new SetCardInfo("Wander Off", 104, Rarity.COMMON, mage.cards.w.WanderOff.class));
         cards.add(new SetCardInfo("Wild Hypothesis", 167, Rarity.COMMON, mage.cards.w.WildHypothesis.class));
+        cards.add(new SetCardInfo("Wildgrowth Archaic", 168, Rarity.RARE, mage.cards.w.WildgrowthArchaic.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Wildgrowth Archaic", 297, Rarity.RARE, mage.cards.w.WildgrowthArchaic.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Wilt in the Heat", 243, Rarity.COMMON, mage.cards.w.WiltInTheHeat.class));
         cards.add(new SetCardInfo("Wisdom of Ages", 323, Rarity.RARE, mage.cards.w.WisdomOfAges.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Wisdom of Ages", 368, Rarity.RARE, mage.cards.w.WisdomOfAges.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/ColorsOfManaSpentToCastCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/ColorsOfManaSpentToCastCount.java
@@ -38,22 +38,27 @@ public class ColorsOfManaSpentToCastCount implements DynamicValue {
         }
         if (spell != null) {
             // NOT the cmc of the spell on the stack
-            Mana mana = spell.getSpellAbility().getManaCostsToPay().getUsedManaToPay();
-            if (mana.getBlack() > 0) {
-                count++;
-            }
-            if (mana.getBlue() > 0) {
-                count++;
-            }
-            if (mana.getGreen() > 0) {
-                count++;
-            }
-            if (mana.getRed() > 0) {
-                count++;
-            }
-            if (mana.getWhite() > 0) {
-                count++;
-            }
+            count = countColors(spell.getSpellAbility().getManaCostsToPay().getUsedManaToPay());
+        }
+        return count;
+    }
+
+    public static int countColors(Mana mana) {
+        int count = 0;
+        if (mana.getBlack() > 0) {
+            count++;
+        }
+        if (mana.getBlue() > 0) {
+            count++;
+        }
+        if (mana.getGreen() > 0) {
+            count++;
+        }
+        if (mana.getRed() > 0) {
+            count++;
+        }
+        if (mana.getWhite() > 0) {
+            count++;
         }
         return count;
     }


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/issues/14329 

Seems a bit messy to re-implement what's essentially `ColorsOfManaSpentToCastCount` but passing it into the replacement effect would look at the triggering source, which is Wildgrowth Archaic. We want to look at the actual spell on the stack for the creature coming in.

Tested this locally and it seems to work as expected, and stack appropriately.

<img width="606" height="172" alt="Screenshot 2026-04-19 at 10 33 40 AM" src="https://github.com/user-attachments/assets/ea451b0e-a196-43b6-871d-cb6e145151f2" />
 