### PR TITLE
[SOS] Implement Silverquill, the Disputant

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SilverquillTheDisputant.java
+++ b/Mage.Sets/src/mage/cards/s/SilverquillTheDisputant.java
@@ -1,0 +1,62 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.common.FilterNonlandCard;
+import mage.filter.predicate.Predicates;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.effects.common.continuous.GainAbilityControlledSpellsEffect;
+import mage.abilities.keyword.CasualtyAbility;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.VigilanceAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author muz
+ */
+public final class SilverquillTheDisputant extends CardImpl {
+
+    private static final FilterNonlandCard filter = new FilterNonlandCard("instant and sorcery spells");
+
+    static {
+        filter.add(Predicates.or(
+            CardType.INSTANT.getPredicate(),
+            CardType.SORCERY.getPredicate()
+        ));
+    }
+
+    public SilverquillTheDisputant(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{W}{B}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ELDER);
+        this.subtype.add(SubType.DRAGON);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(4);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Vigilance
+        this.addAbility(VigilanceAbility.getInstance());
+
+        // Each instant and sorcery spell you cast has casualty 1.
+        this.addAbility(
+        new SimpleStaticAbility(new GainAbilityControlledSpellsEffect(new CasualtyAbility (1), filter)
+                .setText("Each instant and sorcery spell you cast has casualty 1.")));
+    }
+
+    private SilverquillTheDisputant(final SilverquillTheDisputant card) {
+        super(card);
+    }
+
+    @Override
+    public SilverquillTheDisputant copy() {
+        return new SilverquillTheDisputant(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
+++ b/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
@@ -274,6 +274,8 @@ public final class SecretsOfStrixhaven extends ExpansionSet {
         cards.add(new SetCardInfo("Shopkeeper's Bane", 159, Rarity.COMMON, mage.cards.s.ShopkeepersBane.class));
         cards.add(new SetCardInfo("Silverquill Charm", 225, Rarity.UNCOMMON, mage.cards.s.SilverquillCharm.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Silverquill Charm", 366, Rarity.UNCOMMON, mage.cards.s.SilverquillCharm.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Silverquill, the Disputant", 226, Rarity.MYTHIC, mage.cards.s.SilverquillTheDisputant.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Silverquill, the Disputant", 287, Rarity.MYTHIC, mage.cards.s.SilverquillTheDisputant.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skycoach Conductor", 322, Rarity.RARE, mage.cards.s.SkycoachConductor.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skycoach Conductor", 67, Rarity.RARE, mage.cards.s.SkycoachConductor.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Skycoach Waypoint", 261, Rarity.UNCOMMON, mage.cards.s.SkycoachWaypoint.class));


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/issues/14329

Unlike notorious cards like Zinnia, or ECC Ashling, this only cares about cast-time for the granted Casualty effect to kick in, so maybe it's okay? I tested it locally in an admittedly rudimentary test scenario and it seemed OK 🤷 I was able to sac bears to copy, and optionally change targets of the Bolts

```
[silverquill]
battlefield:Human:Silverquill, the Disputant:1
battlefield:Human:Grizzly Bears:2
hand:Human:Lightning Bolt:2
```