### PR TITLE
Fatal Fissure needs manual targeting to earthbend

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FatalFissure.java
+++ b/Mage.Sets/src/mage/cards/f/FatalFissure.java
@@ -1,5 +1,6 @@
 package mage.cards.f;
 
+import mage.abilities.Ability;
 import mage.abilities.DelayedTriggeredAbility;
 import mage.abilities.common.delayed.WhenTargetDiesDelayedTriggeredAbility;
 import mage.abilities.effects.common.CreateDelayedTriggeredAbilityEffect;
@@ -8,8 +9,12 @@ import mage.abilities.effects.keyword.EarthbendTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.game.Game;
+import mage.players.Player;
+import mage.target.Target;
 import mage.target.common.TargetControlledLandPermanent;
 import mage.target.common.TargetCreaturePermanent;
+import mage.target.targetpointer.FixedTarget;
 
 import java.util.UUID;
 
@@ -22,10 +27,8 @@ public final class FatalFissure extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{B}");
 
         // Choose target creature. When that creature dies this turn, you earthbend 4.
-        DelayedTriggeredAbility ability = new WhenTargetDiesDelayedTriggeredAbility(new EarthbendTargetEffect(4).setText("you earthbend 4"));
-        ability.addTarget(new TargetControlledLandPermanent());
         this.getSpellAbility().addEffect(new InfoEffect("choose target creature"));
-        this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(ability, false));
+        this.getSpellAbility().addEffect(new CreateDelayedTriggeredAbilityEffect(new WhenTargetDiesDelayedTriggeredAbility(new FatalFissureEffect())));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
     }
 
@@ -36,5 +39,36 @@ public final class FatalFissure extends CardImpl {
     @Override
     public FatalFissure copy() {
         return new FatalFissure(this);
+    }
+}
+
+class FatalFissureEffect extends EarthbendTargetEffect {
+
+    FatalFissureEffect() {
+        super(4);
+    }
+
+    private FatalFissureEffect(final FatalFissureEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public FatalFissureEffect copy() {
+        return new FatalFissureEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        final Player controller = game.getPlayer(source.getControllerId());
+        if (controller == null) {
+            return false;
+        }
+	final Target target = new TargetControlledLandPermanent();
+        if (target.canChoose(controller.getId(), source, game)
+                && controller.chooseTarget(this.outcome, target, source, game)) {
+	    this.setTargetPointer(new FixedTarget(target.getFirstTarget()));
+	    return super.apply(game, source);
+        }
+        return false;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EarthbendTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EarthbendTest.java
@@ -27,4 +27,26 @@ public class EarthbendTest extends CardTestPlayerBase {
         assertType("Forest", CardType.CREATURE, true);
     }
 
+    @Test
+    public void testEarthbendDifferentTarget() {
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears");
+        addCard(Zone.HAND, playerA, "Fatal Fissure");
+        addCard(Zone.HAND, playerA, "Fell");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fatal Fissure");
+        addTarget(playerA, "Balduvian Bears");
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Fell");
+        addTarget(playerA, "Balduvian Bears");
+        addTarget(playerA, "Wastes");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertType("Wastes", CardType.CREATURE, true);
+        assertPowerToughness(playerA, "Wastes", 4, 4);
+    }
+
 }

--- a/Mage/src/main/java/mage/abilities/effects/keyword/EarthbendTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/EarthbendTargetEffect.java
@@ -44,7 +44,7 @@ public class EarthbendTargetEffect extends OneShotEffect {
         this.withReminderText = withReminderText;
     }
 
-    private EarthbendTargetEffect(final EarthbendTargetEffect effect) {
+    protected EarthbendTargetEffect(final EarthbendTargetEffect effect) {
         super(effect);
         this.amount = effect.amount;
         this.withReminderText = effect.withReminderText;


### PR DESCRIPTION
Unfortunately, `WhenTargetDiesDelayedTriggeredAbility` does not support any effects which require a separate target independent of the triggering target.  So in order to choose a separate target at trigger time, we have to do it manually in a custom effect.

The only other card I could find with a similar effect is [[Reincarnation]], so this is mostly copied from it.

Fixes https://github.com/magefree/mage/issues/14765