### PR TITLE
Set fromZone for copied spells to stack

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AnheloThePainter.java
+++ b/Mage.Sets/src/mage/cards/a/AnheloThePainter.java
@@ -80,7 +80,7 @@ class AnheloThePainterGainCausalityEffect extends ContinuousEffectImpl {
         boolean applied = false;
         for (StackObject stackObject : game.getStack()) {
             if (!(stackObject instanceof Spell)
-                    || stackObject.isCopy()
+                    || !((Spell)stackObject).wasCast()
                     || !stackObject.isControlledBy(source.getControllerId())
                     || !AnheloThePainterWatcher.checkSpell(stackObject, game) ) {
                 continue;
@@ -128,7 +128,7 @@ class AnheloThePainterWatcher extends Watcher {
     }
 
     static boolean checkSpell(StackObject stackObject, Game game) {
-        if (stackObject.isCopy() || !(stackObject instanceof Spell)) {
+        if (!(stackObject instanceof Spell) || !((Spell)stackObject).wasCast()) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/a/ApproachOfTheSecondSun.java
+++ b/Mage.Sets/src/mage/cards/a/ApproachOfTheSecondSun.java
@@ -72,8 +72,7 @@ class ApproachOfTheSecondSunEffect extends OneShotEffect {
         }
         //If this spell was cast from your hand and you've cast another spell named {this} this game
         //A copy of a spell isn’t cast, so it won’t count as the first nor as the second Approach of the Second Sun. (2017-04-18)
-        if (!spell.isCopy() //TODO: copied spells should not be "from" hand
-                && spell.getFromZone() == Zone.HAND
+        if (spell.wasCastFrom(Zone.HAND)
                 && watcher.getApproachesCast(controller.getId()) > 1) {
             // Win the game
             controller.won(game);

--- a/Mage.Sets/src/mage/cards/e/ErrantStreetArtist.java
+++ b/Mage.Sets/src/mage/cards/e/ErrantStreetArtist.java
@@ -18,6 +18,7 @@ import mage.constants.TargetController;
 import mage.filter.FilterSpell;
 import mage.filter.predicate.Predicate;
 import mage.game.Game;
+import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
 import mage.target.TargetSpell;
 
@@ -75,6 +76,6 @@ enum ErrantStreetArtistPredicate implements Predicate<StackObject> {
 
     @Override
     public boolean apply(StackObject input, Game game) {
-        return input.isCopy();
+        return input instanceof Spell && !((Spell)input).wasCast();
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EyeOfTheStorm.java
+++ b/Mage.Sets/src/mage/cards/e/EyeOfTheStorm.java
@@ -68,7 +68,7 @@ class EyeOfTheStormAbility extends TriggeredAbilityImpl {
     public boolean checkTrigger(GameEvent event, Game game) {
         Spell spell = game.getStack().getSpell(event.getTargetId());
         if (spell != null
-                && !spell.isCopy()
+                && spell.wasCast()
                 && spell.getCard() != null
                 && !spell.getCard().isCopy()
                 && spell.isInstantOrSorcery(game)) {

--- a/Mage.Sets/src/mage/cards/f/FeatherTheRedeemed.java
+++ b/Mage.Sets/src/mage/cards/f/FeatherTheRedeemed.java
@@ -144,7 +144,7 @@ class FeatherTheRedeemedEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Spell sourceSpell = morSpell.getSpell(game);
-        if (sourceSpell == null || sourceSpell.isCopy()) {
+        if (sourceSpell == null || !sourceSpell.wasCast()) {
             return false;
         }
         Player player = game.getPlayer(sourceSpell.getOwnerId());

--- a/Mage.Sets/src/mage/cards/f/ForgersFoundry.java
+++ b/Mage.Sets/src/mage/cards/f/ForgersFoundry.java
@@ -127,7 +127,7 @@ class ForgersFoundryExileEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Spell sourceSpell = game.getStack().getSpell(morSpell.getSourceId());
-        if (sourceSpell == null || sourceSpell.isCopy()) {
+        if (sourceSpell == null || !sourceSpell.wasCast()) {
             return false;
         }
         Player player = game.getPlayer(sourceSpell.getOwnerId());
@@ -150,7 +150,7 @@ class ForgersFoundryExileEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         Spell sourceSpell = morSpell.getSpell(game);
-        if (sourceSpell == null || sourceSpell.isCopy()) {
+        if (sourceSpell == null || !sourceSpell.wasCast()) {
             return false;
         }
         Player player = game.getPlayer(sourceSpell.getOwnerId());

--- a/Mage.Sets/src/mage/cards/g/GandalfOfTheSecretFire.java
+++ b/Mage.Sets/src/mage/cards/g/GandalfOfTheSecretFire.java
@@ -112,7 +112,7 @@ class GandalfOfTheSecretFireEffect extends ReplacementEffectImpl {
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Player controller = game.getPlayer(source.getControllerId());
         Spell sourceSpell = morSpell.getSpell(game);
-        if (controller == null || sourceSpell == null || sourceSpell.isCopy()) {
+        if (controller == null || sourceSpell == null || !sourceSpell.wasCast()) {
             return false;
         }
         controller.moveCards(sourceSpell, Zone.EXILED, source, game);

--- a/Mage.Sets/src/mage/cards/g/GoliathDaydreamer.java
+++ b/Mage.Sets/src/mage/cards/g/GoliathDaydreamer.java
@@ -76,7 +76,7 @@ class GoliathDaydreamerExileEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Spell sourceSpell = game.getSpell(getTargetPointer().getFirst(game, source));
-        if (sourceSpell == null || sourceSpell.isCopy()) {
+        if (sourceSpell == null || !sourceSpell.wasCast()) {
             return false;
         }
         Player player = game.getPlayer(sourceSpell.getOwnerId());

--- a/Mage.Sets/src/mage/cards/m/MaelstromNexus.java
+++ b/Mage.Sets/src/mage/cards/m/MaelstromNexus.java
@@ -66,12 +66,13 @@ class MaelstromNexusGainCascadeFirstSpellEffect extends ContinuousEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             for (StackObject stackObject : game.getStack()) {
-                // only spells cast, so no copies of spells
-                if ((stackObject instanceof Spell) && !stackObject.isCopy() && stackObject.isControlledBy(source.getControllerId())) {
+                if ((stackObject instanceof Spell) && stackObject.isControlledBy(source.getControllerId())) {
                     Spell spell = (Spell) stackObject;
-                    FirstSpellCastThisTurnWatcher watcher = game.getState().getWatcher(FirstSpellCastThisTurnWatcher.class);
-                    if (watcher != null && spell.getId().equals(watcher.getIdOfFirstCastSpell(source.getControllerId()))) {
-                        game.getState().addOtherAbility(spell.getCard(), cascadeAbility);
+                    if (spell.wasCast()) {
+                        FirstSpellCastThisTurnWatcher watcher = game.getState().getWatcher(FirstSpellCastThisTurnWatcher.class);
+                        if (watcher != null && spell.getId().equals(watcher.getIdOfFirstCastSpell(source.getControllerId()))) {
+                            game.getState().addOtherAbility(spell.getCard(), cascadeAbility);
+                        }
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/r/RaidingSchemes.java
+++ b/Mage.Sets/src/mage/cards/r/RaidingSchemes.java
@@ -65,7 +65,7 @@ class GainConspireEffect extends ContinuousEffectImpl {
     public boolean apply(Game game, Ability source) {
         for (StackObject stackObject : game.getStack()) {
             // only spells cast, so no copies of spells
-            if (!(stackObject instanceof Spell) || stackObject.isCopy()
+            if (!(stackObject instanceof Spell) || !((Spell)stackObject).wasCast()
                     || !stackObject.isControlledBy(source.getControllerId())) {
                 continue;
             }

--- a/Mage.Sets/src/mage/cards/r/RainOfRiches.java
+++ b/Mage.Sets/src/mage/cards/r/RainOfRiches.java
@@ -114,8 +114,7 @@ class RainOfRichesWatcher extends Watcher {
     }
 
     boolean checkSpell(StackObject stackObject, Game game) {
-        if (stackObject.isCopy()
-                || !(stackObject instanceof Spell)) {
+        if (!(stackObject instanceof Spell) || !((Spell)stackObject).wasCast()) {
             return false;
         }
         if (playerMap.containsKey(stackObject.getControllerId())) {

--- a/Mage.Sets/src/mage/cards/r/ReturnToDust.java
+++ b/Mage.Sets/src/mage/cards/r/ReturnToDust.java
@@ -128,6 +128,6 @@ enum ReturnToDustCondition implements Condition {
         return (game.isActivePlayer(source.getControllerId())
                 && game.getTurnPhaseType().isMain())
                 && spell != null
-                && !spell.isCopy();
+                && spell.wasCast();
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RodOfAbsorption.java
+++ b/Mage.Sets/src/mage/cards/r/RodOfAbsorption.java
@@ -112,7 +112,7 @@ class RodOfAbsorptionExileEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         Spell sourceSpell = morSpell.getSpell(game);
-        if (sourceSpell == null || sourceSpell.isCopy()) {
+        if (sourceSpell == null || !sourceSpell.wasCast()) {
             return false;
         }
         Player player = game.getPlayer(sourceSpell.getOwnerId());

--- a/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
+++ b/Mage.Sets/src/mage/cards/s/SoulfireGrandMaster.java
@@ -98,7 +98,7 @@ class SoulfireGrandMasterCastFromHandReplacementEffect extends ReplacementEffect
         StackObject stackObject = game.getStack().getFirstOrNull();
         if (stackObject instanceof Spell) {
             Spell spell = (Spell) stackObject;
-            if (!spell.isCopy() && !spell.isCountered()) {
+            if (spell.wasCast() && !spell.isCountered()) {
                 Card sourceCard = game.getCard(spellId);
                 if (sourceCard != null && Zone.STACK.equals(game.getState().getZone(spellId))) {
                     Player player = game.getPlayer(sourceCard.getOwnerId());

--- a/Mage.Sets/src/mage/cards/t/TheTwelfthDoctor.java
+++ b/Mage.Sets/src/mage/cards/t/TheTwelfthDoctor.java
@@ -81,11 +81,12 @@ class TheTwelfthDoctorGainDemonstrateEffect extends ContinuousEffectImpl {
 
         for (StackObject stackObject : game.getStack()) {
             if ((stackObject instanceof Spell)
-                    && !stackObject.isCopy()
                     && stackObject.isControlledBy(source.getControllerId())) {
                 Spell spell = (Spell) stackObject;
-                if (FirstSpellCastFromNotHandEachTurnCondition.instance.apply(game, source)) {
-                    game.getState().addOtherAbility(spell.getCard(), new DemonstrateAbility());
+                if (spell.wasCast()) {
+                    if (FirstSpellCastFromNotHandEachTurnCondition.instance.apply(game, source)) {
+                        game.getState().addOtherAbility(spell.getCard(), new DemonstrateAbility());
+                    }
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/w/WildMagicSorcerer.java
+++ b/Mage.Sets/src/mage/cards/w/WildMagicSorcerer.java
@@ -78,14 +78,12 @@ class WildMagicSorcererGainCascadeFirstSpellCastFromExileEffect extends Continuo
         }
 
         for (StackObject stackObject : game.getStack()) {
-            // only spells cast, so no copies of spells
-            if ((stackObject instanceof Spell)
-                    && !stackObject.isCopy()
-                    && stackObject.isControlledBy(source.getControllerId())) {
+            if ((stackObject instanceof Spell) && stackObject.isControlledBy(source.getControllerId())) {
                 Spell spell = (Spell) stackObject;
-
-                if (FirstSpellCastFromExileEachTurnCondition.instance.apply(game, source)) {
-                    game.getState().addOtherAbility(spell.getCard(), cascadeAbility);
+                if (spell.wasCast()) {
+                    if (FirstSpellCastFromExileEachTurnCondition.instance.apply(game, source)) {
+                        game.getState().addOtherAbility(spell.getCard(), cascadeAbility);
+                    }
                 }
             }
         }
@@ -134,8 +132,7 @@ class WildMagicSorcererWatcher extends Watcher {
     }
 
     static boolean checkSpell(StackObject stackObject, Game game) {
-        if (stackObject.isCopy()
-                || !(stackObject instanceof Spell)) {
+        if (!(stackObject instanceof Spell) || !((Spell)stackObject).wasCast()) {
             return false;
         }
         WildMagicSorcererWatcher watcher = game.getState().getWatcher(WildMagicSorcererWatcher.class);

--- a/Mage.Sets/src/mage/cards/w/WortTheRaidmother.java
+++ b/Mage.Sets/src/mage/cards/w/WortTheRaidmother.java
@@ -82,12 +82,13 @@ class WortGainConspireEffect extends ContinuousEffectImpl {
     @Override
     public boolean apply(Game game, Ability source) {
         for (StackObject stackObject : game.getStack()) {
-            // only spells cast, so no copies of spells
-            if (!(stackObject instanceof Spell) || stackObject.isCopy()
-                    || !stackObject.isControlledBy(source.getControllerId())) {
+            if (!(stackObject instanceof Spell) || !stackObject.isControlledBy(source.getControllerId())) {
                 continue;
             }
             Spell spell = (Spell) stackObject;
+            if (!spell.wasCast()) {
+                continue;
+            }
             if (filter.match(stackObject, game)) {
                 game.getState().addOtherAbility(spell.getCard(), conspireAbility.setAddedById(source.getSourceId()));
             }

--- a/Mage.Sets/src/mage/cards/y/YidrisMaelstromWielder.java
+++ b/Mage.Sets/src/mage/cards/y/YidrisMaelstromWielder.java
@@ -70,10 +70,9 @@ class YidrisMaelstromWielderGainCascadeEffect extends ContinuousEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         if (controller != null) {
             for (StackObject stackObject : game.getStack()) {
-                // only spells cast, so no copies of spells
-                if ((stackObject instanceof Spell) && !stackObject.isCopy() && stackObject.isControlledBy(source.getControllerId())) {
+                if ((stackObject instanceof Spell) && stackObject.isControlledBy(source.getControllerId())) {
                     Spell spell = (Spell) stackObject;
-                    if (spell.getFromZone() == Zone.HAND) {
+                    if (spell.wasCastFrom(Zone.HAND)) {
                         game.getState().addOtherAbility(spell.getCard(), cascadeAbility);
                     }
                 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/CopySpellTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/CopySpellTest.java
@@ -979,4 +979,22 @@ public class CopySpellTest extends CardTestPlayerBase {
         assertTapped(engine, true);
         assertLife(playerA, 20 + 1);
     }
+
+    @Test
+    public void testCopyOnStack() {
+        addCard(Zone.BATTLEFIELD, playerA, "Silverquill, the Disputant");
+        addCard(Zone.HAND, playerA, "Transpose");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Transpose");
+        setChoice(playerA, true);
+        setChoice(playerA, "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Wizard Token", 1);
+    }
 }

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -848,7 +848,7 @@ public class Spell extends StackObjectImpl implements Card {
         Card copiedPart = (Card) mapOldToNew.get(this.card.getId());
 
         // copy spell
-        Spell spellCopy = new Spell(copiedPart, this.ability.copySpell(this.card, copiedPart), this.controllerId, this.fromZone, game, true);
+        Spell spellCopy = new Spell(copiedPart, this.ability.copySpell(this.card, copiedPart), this.controllerId, Zone.STACK, game, true);
         UUID copiedSourceId = spellCopy.ability.getSourceId();
 
         // non-fused spell:

--- a/Mage/src/main/java/mage/game/stack/Spell.java
+++ b/Mage/src/main/java/mage/game/stack/Spell.java
@@ -1008,6 +1008,14 @@ public class Spell extends StackObjectImpl implements Card {
         return this.fromZone;
     }
 
+    public boolean wasCast() {
+        return !this.fromZone.match(Zone.STACK);
+    }
+
+    public boolean wasCastFrom(Zone zone) {
+        return this.wasCast() && this.fromZone.match(zone);
+    }
+
     @Override
     public void setCopy(boolean isCopy, MageObject copyFrom) {
         this.copy = isCopy;


### PR DESCRIPTION
Spells on the stack seem to use a separate `fromZone` member variable to track where they were cast from, independent of the zone of the card or the object.  This should be unconditionally set to the stack for copied spells rather than inheriting the zone of the parent spell.

This sets it in the constructor rather than `Spell.setZone()` to keep the field `final`.