### PR TITLE
[SOS] Enable boosters and fix Mage.Verify failure

### DIFF
--- a/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
+++ b/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
@@ -24,6 +24,8 @@ public final class SecretsOfStrixhaven extends ExpansionSet {
         this.blockName = "Secrets of Strixhaven"; // for sorting in GUI
         this.hasBasicLands = true;
 
+        this.enablePlayBooster(305);
+
         cards.add(new SetCardInfo("Aberrant Manawurm", 138, Rarity.UNCOMMON, mage.cards.a.AberrantManawurm.class));
         cards.add(new SetCardInfo("Abigale, Poet Laureate", 170, Rarity.UNCOMMON, mage.cards.a.AbigalePoetLaureate.class));
         cards.add(new SetCardInfo("Abstract Paintmage", 171, Rarity.UNCOMMON, mage.cards.a.AbstractPaintmage.class));

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1157,10 +1157,10 @@ public class VerifyCardDataTest {
                 if (ignoreBoosterSets.contains(set.getName())) {
                     continue;
                 }
-                // error example: wrong booster settings (set MUST HAVE booster, but haven't) - 2020 - J22 - Jumpstart 2022 - boosters: [jumpstart]
-                errorsList.add(String.format("Error: wrong booster settings (set %s booster, but %s) - %s%s",
-                        (needBooster ? "MUST HAVE" : "MUST HAVEN'T"),
-                        (set.hasBoosters() ? "have" : "haven't"),
+                // error example: wrong booster settings (set must have boosters, but it does not) - 2020 - J22 - Jumpstart 2022 - boosters: [jumpstart]
+                errorsList.add(String.format("Error: wrong booster settings (set %s have boosters, but it %s) - %s%s",
+                    (needBooster ? "must" : "must not"),
+                    (set.hasBoosters() ? "does" : "does not"),
                         set.getReleaseYear() + " - " + set.getCode() + " - " + set.getName(),
                         (jsonSet.booster == null ? "" : " - boosters: " + jsonSet.booster.keySet())
                 ));


### PR DESCRIPTION
CI is failing right now, the phrasing could do with improvement, and address the thing causing CI to trip.

```
Error: wrong booster settings (set MUST HAVE booster, but haven't) - 2026 - SOS - Secrets of Strixhaven - boosters: [play, collector]
```