### PR TITLE
[fix] Correct Jin Sakai attack trigger check

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JinSakaiGhostOfTsushima.java
+++ b/Mage.Sets/src/mage/cards/j/JinSakaiGhostOfTsushima.java
@@ -82,7 +82,7 @@ class JinSakaiGhostOfTsushimaTriggeredAbility extends TriggeredAbilityImpl {
 
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
-        Permanent permanent = game.getPermanent(event.getTargetId());
+        Permanent permanent = game.getPermanent(event.getSourceId());
         if (permanent == null
                 || !permanent.isControlledBy(getControllerId())
                 || game.getPlayer(game.getCombat().getDefenderId(permanent.getId())) == null) {


### PR DESCRIPTION
Reported on Discord that the attack trigger never fired. Reproduced on `main`. We're binding the wrong item into the permanent variable, so it always returned `null` and bailed out early.

Re-tested with a local build. Seems to work now.