### PR TITLE
[fix] Sensational Spider-Man not removing counters or drawing cards

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SensationalSpiderMan.java
+++ b/Mage.Sets/src/mage/cards/s/SensationalSpiderMan.java
@@ -95,7 +95,7 @@ class SensationalSpiderManEffect extends OneShotEffect {
         // TODO: this ideally would be able to prevent the player from choosing a number greater than the number of stun counters available to remove
         TargetPermanentAmount target = new TargetPermanentAmount(3, 0, filter);
         target.withNotTarget(true);
-        player.chooseTarget(outcome, target, source, game);
+        player.chooseTargetAmount(outcome, target, source, game);
         int amountRemoved = target
                 .getTargets()
                 .stream()
@@ -105,10 +105,9 @@ class SensationalSpiderManEffect extends OneShotEffect {
                         CounterType.STUN.createInstance(target.getTargetAmount(permanent.getId())), source, game
                 ))
                 .sum();
-        if (amountRemoved > 1) {
+        if (amountRemoved > 0) {
             player.drawCards(amountRemoved, source, game);
-            return true;
         }
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
<img width="905" height="125" alt="Screenshot 2026-04-28 at 9 37 04 PM" src="https://github.com/user-attachments/assets/a4af9299-422f-4dc3-995b-31e4853650d7" />

Reproduced locally. Couple of things;

* Replace player.chooseTarget with player.chooseTargetAmount for the counter removal step, so counter removals are actually stored against each chosen permanent
* Fix draw conditionso removing a single stun counter correctly draws 