### PR TITLE
Fix MTGO Card-Renderer Alpha Blending

### DIFF
--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -34,6 +34,8 @@ public abstract class Animation {
                 //update(1.0f);
                 end();
             });
+
+            timerTask = null;
             return;
         }
 

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeMTGO.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeMTGO.java
@@ -166,6 +166,11 @@ public class CardPanelRenderModeMTGO extends CardPanel {
 
     @Override
     protected void paintCard(Graphics2D g) {
+        final float alpha = getAlpha();
+        if (alpha != 1.0f) {
+            g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, alpha));
+        }
+
         // Render the card if we don't have an image ready to use
         if (cardImage == null) {
             // Try to get card image from cache based on our card characteristics


### PR DESCRIPTION
This fix enables alpha values when rendering mtgo-style cards and thus fixes show/hide animations for cards.