### PR TITLE
Move Card Animations to the EDT

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -1896,6 +1896,8 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
      * Use it after new images downloaded, new fonts or theme settings selected.
      */
     public void refreshGUIAndCards() {
+        ThreadUtils.ensureRunInGUISwingThread();
+
         ImageCaches.clearAll();
 
         setGUISize();

--- a/Mage.Client/src/main/java/mage/client/game/BattlefieldPanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/BattlefieldPanel.java
@@ -249,7 +249,7 @@ public class BattlefieldPanel extends javax.swing.JLayeredPane {
         for (Iterator<Entry<UUID, MageCard>> iterator = permanents.entrySet().iterator(); iterator.hasNext();) {
             Entry<UUID, MageCard> entry = iterator.next();
             if (!battlefield.containsKey(entry.getKey()) || !battlefield.get(entry.getKey()).isPhasedIn()) {
-                removePermanent(entry.getKey(), 1);
+                removePermanent(entry.getKey());
                 iterator.remove();
                 changed = true;
             }
@@ -293,9 +293,12 @@ public class BattlefieldPanel extends javax.swing.JLayeredPane {
 
         permanents.put(permanent.getId(), perm);
 
+        perm.setAlpha(0f);
         this.jPanel.add(perm, (Integer) 10);
         moveToFront(jPanel);
-        Plugins.instance.onAddCard(perm, 1);
+        Plugins.instance.onAddCard(perm).thenRunAsync(() -> {
+            perm.setAlpha(1f);
+        }, SwingUtilities::invokeLater);
 
         if (permanent.isArtifact()) {
             addedArtifact = true;
@@ -306,19 +309,17 @@ public class BattlefieldPanel extends javax.swing.JLayeredPane {
         }
     }
 
-    private void removePermanent(UUID permanentId, final int count) {
+    private void removePermanent(UUID permanentId) {
         for (Component comp : this.jPanel.getComponents()) {
             if (comp instanceof MageCard) {
                 MageCard mageCard = (MageCard) comp;
                 if (mageCard.getMainPanel() instanceof MagePermanent) {
                     MagePermanent magePermanent = (MagePermanent) mageCard.getMainPanel();
                     if (magePermanent.getOriginal().getId().equals(permanentId)) {
-                        Thread t = new Thread(() -> {
-                            Plugins.instance.onRemoveCard(mageCard, count);
+                        Plugins.instance.onRemoveCard(mageCard).thenRunAsync(() -> {
                             mageCard.setVisible(false);
                             this.jPanel.remove(mageCard);
-                        });
-                        t.start();
+                        }, SwingUtilities::invokeLater);
                     }
                     if (magePermanent.getOriginal().isCreature()) {
                         removedCreature = true;

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -30,12 +30,11 @@ import mage.constants.*;
 import mage.game.events.PlayerQueryEvent;
 import mage.players.PlayableObjectStats;
 import mage.players.PlayableObjectsList;
-import mage.util.CardUtil;
 import mage.util.DebugUtil;
 import mage.util.MultiAmountMessage;
-import mage.util.StreamUtils;
 import mage.view.*;
 import org.apache.log4j.Logger;
+import org.mage.card.arcane.Animation;
 import org.mage.plugins.card.utils.impl.ImageManagerImpl;
 
 import javax.swing.Timer;
@@ -392,6 +391,7 @@ public final class GamePanel extends javax.swing.JPanel {
     }
 
     public void cleanUp() {
+        Animation.cancelRunningAnimations(gameId);
         MageFrame.removeGame(gameId);
 
         this.gameChatPanel.cleanUp();

--- a/Mage.Client/src/main/java/mage/client/plugins/MagePlugins.java
+++ b/Mage.Client/src/main/java/mage/client/plugins/MagePlugins.java
@@ -12,6 +12,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 public interface MagePlugins {
 
@@ -41,9 +42,9 @@ public interface MagePlugins {
 
     void addGamesPlayed();
 
-    void onAddCard(MageCard card, int count);
+    CompletableFuture<Void> onAddCard(MageCard card);
 
-    void onRemoveCard(MageCard card, int count);
+    CompletableFuture<Void> onRemoveCard(MageCard card);
 
     JComponent getCardInfoPane();
 

--- a/Mage.Client/src/main/java/mage/client/plugins/impl/Plugins.java
+++ b/Mage.Client/src/main/java/mage/client/plugins/impl/Plugins.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mage.plugins.card.utils.CardImageUtils.getImagesDir;
 
@@ -186,17 +187,21 @@ public enum Plugins implements MagePlugins {
     }
 
     @Override
-    public void onAddCard(MageCard card, int count) {
-        if (this.cardPlugin != null) {
-            this.cardPlugin.onAddCard(card, count);
+    public CompletableFuture<Void> onAddCard(MageCard card) {
+        if (cardPlugin != null) {
+            return cardPlugin.onAddCard(card);
         }
+
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override
-    public void onRemoveCard(MageCard card, int count) {
-        if (this.cardPlugin != null) {
-            this.cardPlugin.onRemoveCard(card, count);
+    public CompletableFuture<Void> onRemoveCard(MageCard card) {
+        if (cardPlugin != null) {
+            return cardPlugin.onRemoveCard(card);
         }
+
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/Mage.Client/src/main/java/mage/client/util/GUISizeHelper.java
+++ b/Mage.Client/src/main/java/mage/client/util/GUISizeHelper.java
@@ -3,6 +3,7 @@ package mage.client.util;
 import mage.client.MageFrame;
 import mage.client.dialog.PreferencesDialog;
 import mage.client.util.gui.GuiDisplayUtil;
+import mage.util.ThreadUtils;
 import org.mage.card.arcane.CardRenderer;
 
 import javax.swing.*;
@@ -90,6 +91,8 @@ public final class GUISizeHelper {
      * @param reloadTheme use it after theme changes only
      */
     public static void refreshGUIAndCards(boolean reloadTheme) {
+        ThreadUtils.ensureRunInGUISwingThread();
+
         calculateGUISizes();
         if (reloadTheme) {
             GuiDisplayUtil.refreshThemeSettings();

--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -1,9 +1,12 @@
 package org.mage.card.arcane;
 
+import mage.cards.Card;
 import mage.cards.MageCard;
 
 import javax.swing.*;
+import javax.swing.Timer;
 import java.awt.*;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class Animation {
@@ -20,16 +23,33 @@ public abstract class Animation {
     private static CardPanel enlargedAnimationPanel;
     private static final Object enlargeLock = new Object();
 
+    /**
+     * Global registry of all running animations with a non-null target.
+     * This registry is used to cancel running animations for a target when
+     * a new animation is scheduled. Example: tapping a permanent that is still
+     * fading-in will cancel the fade animation and start the tap animation.
+     *
+     * Note: Animations register themselves during construction and deregister
+     * when finish() gets called.
+     */
+    private static final Map<UUID, Set<Animation>> activeByGameId = new HashMap<>();
+    private static final Map<Object, Animation> activeByTarget = new HashMap<>();
+
     private final Timer animationTimer;
     private FrameTimer frameTimer;
     private long elapsed;
     private boolean finished;
+    private final Object target;
+    private final UUID gameId;
 
-    public Animation(final long duration) {
-        this(duration, 0);
+    public Animation(UUID gameId, Object target, long duration) {
+        this(gameId, target, duration, 0);
     }
 
-    public Animation(long duration, long delay) {
+    public Animation(UUID gameId, Object target, long duration, long delay) {
+        this.target = target;
+        this.gameId = gameId;
+
         if (!ENABLED) {
             UI.invokeLater(() -> {
                 start();
@@ -63,6 +83,20 @@ public abstract class Animation {
                 finish();
             }
         });
+
+        cancelRunningAnimation(this.target);
+        if (this.target != null) {
+            activeByTarget.put(this.target, this);
+        }
+        if (this.gameId != null) {
+            Set<Animation> set = activeByGameId.getOrDefault(this.gameId, null);
+            if (set == null) {
+                set = new HashSet<Animation>();
+                activeByGameId.put(this.gameId, set);
+            }
+            set.add(this);
+        }
+
         animationTimer.setInitialDelay((int) Math.max(0, delay));
         animationTimer.start();
     }
@@ -84,6 +118,15 @@ public abstract class Animation {
             return;
         }
         finished = true;
+        if (target != null) {
+            activeByTarget.remove(target);
+        }
+        if (gameId != null) {
+            Set<Animation> set = activeByGameId.getOrDefault(gameId, null);
+            if (set != null) {
+                set.remove(this);
+            }
+        }
         if (animationTimer != null) {
             animationTimer.stop();
         }
@@ -135,11 +178,45 @@ public abstract class Animation {
         }
     }
 
+    /**
+     * Cancel all running animations associated with the given game id.
+     *
+     * @param gameId Game identifier.
+     */
+    public static void cancelRunningAnimations(UUID gameId) {
+        Set<Animation> animations = new HashSet<>(activeByGameId.getOrDefault(gameId, Collections.emptySet()));
+
+        // We need to iterate over a copy because the animations
+        // remove themselves from the original set.
+        for (Animation animation : animations) {
+            animation.cancel();
+        }
+        activeByGameId.remove(gameId);
+    }
+
+    /**
+     * Cancel running animations for the given target.
+     *
+     * Canceling a running animation directly calls the end/finish
+     * function (jumping to percentage 1.0) and marks the animation as complete.
+     *
+     * @param target Target key of the animation to cancel.
+     */
+    private static void cancelRunningAnimation(Object target) {
+        if (target == null)
+            return;
+
+        Animation running = activeByTarget.getOrDefault(target, null);
+        if (running != null) {
+            running.cancel();
+        }
+    }
+
     public static void tapCardToggle(final CardPanel source, final boolean tapped, final boolean flipped) {
         CardPanel mainPanel = source;
         MageCard parentPanel = mainPanel.getTopPanelRef();
 
-        new Animation(CARD_TAP_DURATION_MS) {
+        new Animation(mainPanel.gameId, parentPanel, CARD_TAP_DURATION_MS) {
             @Override
             protected void start() {
                 parentPanel.onBeginAnimation();
@@ -184,7 +261,7 @@ public abstract class Animation {
 
         CompletableFuture<Void> done = new CompletableFuture<Void>();
 
-        new Animation(TRANSFORM_CARD_DURATION_MS) {
+        new Animation(mainPanel.gameId, parentPanel, TRANSFORM_CARD_DURATION_MS) {
             private boolean state = false;
 
             @Override
@@ -247,7 +324,7 @@ public abstract class Animation {
                 layeredPane.setLayer(mainPanel, JLayeredPane.MODAL_LAYER);
             }
 
-            new Animation(700) {
+            new Animation(cardPanel.gameId, cardToAnimate, 700) {
                 @Override
                 protected void update(float percentage) {
                     float percent = percentage;
@@ -312,7 +389,7 @@ public abstract class Animation {
                 layeredPane.setLayer(mainPanel, JLayeredPane.MODAL_LAYER);
             }
 
-            new Animation(speed) {
+            new Animation(cardPanel.gameId, cardToAnimate, speed) {
                 @Override
                 protected void update(float percentage) {
                     int currentX = startX + Math.round((endX - startX) * percentage);
@@ -359,7 +436,7 @@ public abstract class Animation {
         final int endWidth = overPanel.getCardWidth();
         final int endHeight = Math.round(endWidth * CardPanel.ASPECT_RATIO);
 
-        new Animation(200) {
+        new Animation(animationPanel.gameId, animationPanel, 200) {
             @Override
             protected void update(float percentage) {
                 int currentWidth = startWidth + Math.round((endWidth - startWidth) * percentage);
@@ -405,7 +482,11 @@ public abstract class Animation {
 
         CompletableFuture<Void> done = new CompletableFuture<Void>();
 
-        new Animation(durationMs) {
+        UUID gameId = null;
+        if (card.getMainPanel() != null) {
+            gameId = ((CardPanel)card.getMainPanel()).gameId;
+        }
+        new Animation(gameId, card, durationMs) {
             @Override
             protected void start() {
                 card.setAlpha(from);

--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -2,6 +2,7 @@ package org.mage.card.arcane;
 
 import mage.cards.Card;
 import mage.cards.MageCard;
+import mage.util.ThreadUtils;
 
 import javax.swing.*;
 import javax.swing.Timer;
@@ -38,6 +39,7 @@ public abstract class Animation {
     private final Timer animationTimer;
     private FrameTimer frameTimer;
     private long elapsed;
+    private final long duration;
     private boolean finished;
     private final Object target;
     private final UUID gameId;
@@ -49,6 +51,7 @@ public abstract class Animation {
     public Animation(UUID gameId, Object target, long duration, long delay) {
         this.target = target;
         this.gameId = gameId;
+        this.duration = Math.max(1, duration);
 
         if (!ENABLED) {
             UI.invokeLater(() -> {
@@ -61,7 +64,6 @@ public abstract class Animation {
             return;
         }
 
-        final long safeDuration = Math.max(1, duration);
         animationTimer = new Timer((int) TARGET_MILLIS_PER_FRAME, e -> {
             if (finished) {
                 return;
@@ -73,13 +75,13 @@ public abstract class Animation {
             }
 
             elapsed += frameTimer.getTimeSinceLastFrame();
-            if (elapsed >= safeDuration) {
-                elapsed = safeDuration;
+            if (elapsed >= this.duration) {
+                elapsed = this.duration;
             }
 
-            update(elapsed / (float) safeDuration);
+            update(elapsed / (float) this.duration);
 
-            if (elapsed == safeDuration) {
+            if (elapsed == this.duration) {
                 finish();
             }
         });
@@ -104,6 +106,11 @@ public abstract class Animation {
     protected abstract void update(float percentage);
 
     protected void cancel() {
+        if (elapsed < duration && !finished) {
+            // Update to the final animation state if not already finished.
+            elapsed = duration;
+            update(1f);
+        }
         finish();
     }
 
@@ -184,6 +191,8 @@ public abstract class Animation {
      * @param gameId Game identifier.
      */
     public static void cancelRunningAnimations(UUID gameId) {
+        ThreadUtils.ensureRunInGUISwingThread();
+
         Set<Animation> animations = new HashSet<>(activeByGameId.getOrDefault(gameId, Collections.emptySet()));
 
         // We need to iterate over a copy because the animations
@@ -203,6 +212,8 @@ public abstract class Animation {
      * @param target Target key of the animation to cancel.
      */
     private static void cancelRunningAnimation(Object target) {
+        ThreadUtils.ensureRunInGUISwingThread();
+
         if (target == null)
             return;
 

--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -4,30 +4,32 @@ import mage.cards.MageCard;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.Timer;
-import java.util.TimerTask;
+import java.util.concurrent.CompletableFuture;
 
 public abstract class Animation {
 
     private static final boolean ENABLED = true;
 
-    private static final long TARGET_MILLIS_PER_FRAME = 30;
+    private static final long TRANSFORM_CARD_DURATION_MS = 600;
+    private static final long CARD_SHOW_HIDE_DURATION_MS = 250;
+    private static final long CARD_TAP_DURATION_MS = 300;
 
-    private static final Timer timer = new Timer("Animation", true);
+    private static final long TARGET_MILLIS_PER_FRAME = 30;
 
     private static CardPanel enlargedCardPanel;
     private static CardPanel enlargedAnimationPanel;
     private static final Object enlargeLock = new Object();
 
-    private final TimerTask timerTask;
+    private final Timer animationTimer;
     private FrameTimer frameTimer;
     private long elapsed;
+    private boolean finished;
 
     public Animation(final long duration) {
         this(duration, 0);
     }
 
-    public Animation(final long duration, long delay) {
+    public Animation(long duration, long delay) {
         if (!ENABLED) {
             UI.invokeLater(() -> {
                 start();
@@ -35,42 +37,57 @@ public abstract class Animation {
                 end();
             });
 
-            timerTask = null;
+            animationTimer = null;
             return;
         }
 
-        timerTask = new TimerTask() {
-            @Override
-            public void run() {
-                if (frameTimer == null) {
-                    start();
-                    frameTimer = new FrameTimer();
-                }
-                elapsed += frameTimer.getTimeSinceLastFrame();
-                if (elapsed >= duration) {
-                    cancel();
-                    elapsed = duration;
-                }
-                update(elapsed / (float) duration);
-                if (elapsed == duration) {
-                    end();
-                }
+        final long safeDuration = Math.max(1, duration);
+        animationTimer = new Timer((int) TARGET_MILLIS_PER_FRAME, e -> {
+            if (finished) {
+                return;
             }
-        };
-        timer.scheduleAtFixedRate(timerTask, delay, TARGET_MILLIS_PER_FRAME);
+
+            if (frameTimer == null) {
+                start();
+                frameTimer = new FrameTimer();
+            }
+
+            elapsed += frameTimer.getTimeSinceLastFrame();
+            if (elapsed >= safeDuration) {
+                elapsed = safeDuration;
+            }
+
+            update(elapsed / (float) safeDuration);
+
+            if (elapsed == safeDuration) {
+                finish();
+            }
+        });
+        animationTimer.setInitialDelay((int) Math.max(0, delay));
+        animationTimer.start();
     }
 
     protected abstract void update(float percentage);
 
     protected void cancel() {
-        timerTask.cancel();
-        end();
+        finish();
     }
 
     protected void start() {
     }
 
     protected void end() {
+    }
+
+    private void finish() {
+        if (finished) {
+            return;
+        }
+        finished = true;
+        if (animationTimer != null) {
+            animationTimer.stop();
+        }
+        end();
     }
 
     /**
@@ -122,7 +139,7 @@ public abstract class Animation {
         CardPanel mainPanel = source;
         MageCard parentPanel = mainPanel.getTopPanelRef();
 
-        new Animation(300) {
+        new Animation(CARD_TAP_DURATION_MS) {
             @Override
             protected void start() {
                 parentPanel.onBeginAnimation();
@@ -160,12 +177,14 @@ public abstract class Animation {
         };
     }
 
-    public static void transformCard(final CardPanel source) {
+    public static CompletableFuture<Void> transformCard(final CardPanel source) {
 
         CardPanel mainPanel = source;
         MageCard parentPanel = mainPanel.getTopPanelRef();
 
-        new Animation(600) {
+        CompletableFuture<Void> done = new CompletableFuture<Void>();
+
+        new Animation(TRANSFORM_CARD_DURATION_MS) {
             private boolean state = false;
 
             @Override
@@ -201,8 +220,11 @@ public abstract class Animation {
 
                 parentPanel.onEndAnimation();
                 parentPanel.repaint();
+                done.complete(null);
             }
         };
+
+        return done;
     }
 
     public static void moveCardToPlay(final int startX, final int startY, final int startWidth, final int endX, final int endY,
@@ -368,49 +390,50 @@ public abstract class Animation {
         }
     }
 
-    public static void showCard(final MageCard card, int count) {
-        if (count == 0) {
-            return;
-        }
-        new Animation(600 / count) {
+    /**
+     * Schedule a linear alpha-fade animation for a card.
+     *
+     * @param card The card to animate
+     * @param durationMs Duration in milliseconds
+     * @param from Starting alpha value
+     * @param to Destination alpha value
+     * @return A future object that gets completed when the animation is done
+     */
+    static private CompletableFuture<Void> linearFade(final MageCard card, long durationMs, float from, float to) {
+        if (card == null || from == to)
+            return CompletableFuture.completedFuture(null);
+
+        CompletableFuture<Void> done = new CompletableFuture<Void>();
+
+        new Animation(durationMs) {
             @Override
             protected void start() {
+                card.setAlpha(from);
+                card.repaint();
             }
 
             @Override
             protected void update(float percentage) {
-                float alpha = percentage;
-                card.setAlpha(alpha);
+                card.setAlpha(from + percentage * (to - from));
                 card.repaint();
             }
 
             @Override
             protected void end() {
-                card.setAlpha(1.f);
+                card.setAlpha(to);
+                card.repaint();
+                done.complete(null);
             }
         };
+
+        return done;
     }
 
-    public static void hideCard(final MageCard card, int count) {
-        if (count == 0) {
-            return;
-        }
-        new Animation(600 / count) {
-            @Override
-            protected void start() {
-            }
+    public static CompletableFuture<Void> showCard(final MageCard card) {
+        return linearFade(card, CARD_SHOW_HIDE_DURATION_MS, 0f, 1f);
+    }
 
-            @Override
-            protected void update(float percentage) {
-                float alpha = 1 - percentage;
-                card.setAlpha(alpha);
-                card.repaint();
-            }
-
-            @Override
-            protected void end() {
-                card.setAlpha(0f);
-            }
-        };
+    public static CompletableFuture<Void> hideCard(final MageCard card) {
+        return linearFade(card, CARD_SHOW_HIDE_DURATION_MS, 1f, 0f);
     }
 }

--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -34,6 +34,8 @@ public abstract class Animation {
                 //update(1.0f);
                 end();
             });
+
+            timerTask = null;
             return;
         }
 

--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -1,6 +1,5 @@
 package org.mage.card.arcane;
 
-import mage.cards.Card;
 import mage.cards.MageCard;
 import mage.util.ThreadUtils;
 
@@ -9,6 +8,8 @@ import javax.swing.Timer;
 import java.awt.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public abstract class Animation {
 
@@ -33,8 +34,8 @@ public abstract class Animation {
      * Note: Animations register themselves during construction and deregister
      * when finish() gets called.
      */
-    private static final Map<UUID, Set<Animation>> activeByGameId = new HashMap<>();
-    private static final Map<Object, Animation> activeByTarget = new HashMap<>();
+    private static final ConcurrentMap<UUID, Set<Animation>> activeByGameId = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Object, Animation> activeByTarget = new ConcurrentHashMap<>();
 
     private final Timer animationTimer;
     private FrameTimer frameTimer;

--- a/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/Animation.java
@@ -6,20 +6,25 @@ import mage.util.ThreadUtils;
 import javax.swing.*;
 import javax.swing.Timer;
 import java.awt.*;
+import java.awt.event.ActionListener;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 
 public abstract class Animation {
 
     private static final boolean ENABLED = true;
+    private static final long MS_TO_NANO = 1000000;
 
     private static final long TRANSFORM_CARD_DURATION_MS = 600;
     private static final long CARD_SHOW_HIDE_DURATION_MS = 250;
     private static final long CARD_TAP_DURATION_MS = 300;
 
     private static final long TARGET_MILLIS_PER_FRAME = 30;
+    private static final long MAX_MILLIS_PER_FRAME = 100;
 
     private static CardPanel enlargedCardPanel;
     private static CardPanel enlargedAnimationPanel;
@@ -32,18 +37,69 @@ public abstract class Animation {
      * fading-in will cancel the fade animation and start the tap animation.
      *
      * Note: Animations register themselves during construction and deregister
-     * when finish() gets called.
+     * when cleanup() gets called.
      */
     private static final ConcurrentMap<UUID, Set<Animation>> activeByGameId = new ConcurrentHashMap<>();
     private static final ConcurrentMap<Object, Animation> activeByTarget = new ConcurrentHashMap<>();
 
-    private final Timer animationTimer;
-    private FrameTimer frameTimer;
-    private long elapsed;
-    private final long duration;
-    private boolean finished;
-    private final Object target;
-    private final UUID gameId;
+    /**
+     * List of animations to add/schedule. Can be accessesd thread-safe.
+     */
+    private static final ConcurrentLinkedQueue<Animation> pendingAdd = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Shared Swing timer that processes ticks on the EDT. All animation callbacks must
+     * be run from the animation timer.
+     */
+    private static final Timer timer =  new Timer((int)TARGET_MILLIS_PER_FRAME, timeTick());
+
+    /**
+     * List of currently running animations. Private to the timer tick handler!
+     */
+    private static final List<Animation> animations = new ArrayList<>();
+
+    private Object target;
+    private UUID gameId;
+    private final long duration; // relative in ms
+    private final long delay; // relative in ms
+    private long lastProcessTime; // in ns
+    private long scheduledAtTime; // in ns
+    private long startedAtTime; // in ns
+
+    enum State {
+        Starting,
+        Running,
+        Finished,
+        Canceled,
+    };
+    private State state = State.Starting;
+
+    private static ActionListener timeTick() {
+        return e -> {
+            // Move all pending animations to the animations list that
+            // is safe to iterate on the EDT.
+            animations.addAll(pendingAdd);
+            pendingAdd.clear();
+
+            List<Animation> pendingRemove = new ArrayList<>();
+
+            final long time = System.nanoTime();
+            for (Animation animation : animations) {
+                State state = animation.process(time);
+                if (state == State.Finished) {
+                    pendingRemove.add(animation);
+                }
+            }
+
+            // Remove all finished animations
+            animations.removeAll(pendingRemove);
+            pendingRemove.forEach(Animation::cleanup);
+
+            // Stop the timer if not needed
+            if (animations.isEmpty())
+                timer.stop();
+        };
+    }
 
     public Animation(UUID gameId, Object target, long duration) {
         this(gameId, target, duration, 0);
@@ -52,67 +108,84 @@ public abstract class Animation {
     public Animation(UUID gameId, Object target, long duration, long delay) {
         this.target = target;
         this.gameId = gameId;
-        this.duration = Math.max(1, duration);
+        this.duration = duration * MS_TO_NANO;
+        this.delay = delay * MS_TO_NANO;
 
-        if (!ENABLED) {
+        if (!ENABLED || duration <= 0) {
             UI.invokeLater(() -> {
                 start();
-                //update(1.0f);
+                update(1f);
                 end();
             });
 
-            animationTimer = null;
+            // We never added this animation to any list, so we can just return
             return;
         }
-
-        animationTimer = new Timer((int) TARGET_MILLIS_PER_FRAME, e -> {
-            if (finished) {
-                return;
-            }
-
-            if (frameTimer == null) {
-                start();
-                frameTimer = new FrameTimer();
-            }
-
-            elapsed += frameTimer.getTimeSinceLastFrame();
-            if (elapsed >= this.duration) {
-                elapsed = this.duration;
-            }
-
-            update(elapsed / (float) this.duration);
-
-            if (elapsed == this.duration) {
-                finish();
-            }
-        });
 
         cancelRunningAnimation(this.target);
         if (this.target != null) {
             activeByTarget.put(this.target, this);
         }
         if (this.gameId != null) {
-            Set<Animation> set = activeByGameId.getOrDefault(this.gameId, null);
-            if (set == null) {
-                set = new HashSet<Animation>();
-                activeByGameId.put(this.gameId, set);
-            }
-            set.add(this);
+            activeByGameId.computeIfAbsent(this.gameId, ignore -> new HashSet<>()).add(this);
         }
 
-        animationTimer.setInitialDelay((int) Math.max(0, delay));
-        animationTimer.start();
+        pendingAdd.add(this);
+        if (!timer.isRunning())
+            timer.start();
+    }
+
+    /**
+     * Returns the animation state [0,1] for the time in ms.
+     * @param time Current time in nanoseconds
+     * @return The state/percentage of the animation
+     */
+    public float getPercentageForTime(long time) {
+        return (float)Math.min(duration, Math.max(0, time - startedAtTime)) / (float)duration;
+    }
+
+    /**
+     * Process a single animation tick by advancing the animations state and percentage.
+     * @param time System time in nanoseconds
+     * @return State of the animation
+     */
+    private State process(long time) {
+        if (state == State.Starting) {
+            if (scheduledAtTime == 0) {
+                scheduledAtTime = time + delay;
+            }
+
+            if (scheduledAtTime <= time) {
+                startedAtTime = time;
+                start();
+                state = State.Running;
+            }
+        } else {
+            if (time - startedAtTime >= duration || state == State.Canceled) {
+                update(1f);
+                end();
+                state = State.Finished;
+            } else {
+                // To smooth animations while the EDT is busy, we
+                // limit time "jumps" to MAX_MILLIS_PER_FRAME, but we
+                // still end animations on time, to not stress the EDT even more.
+                long timeElapsed = time - lastProcessTime;
+                long smoothedTime = lastProcessTime + Math.min(timeElapsed, MAX_MILLIS_PER_FRAME * MS_TO_NANO);
+                update(getPercentageForTime(smoothedTime));
+            }
+        }
+
+        lastProcessTime = time;
+        return state;
     }
 
     protected abstract void update(float percentage);
 
     protected void cancel() {
-        if (elapsed < duration && !finished) {
-            // Update to the final animation state if not already finished.
-            elapsed = duration;
-            update(1f);
-        }
-        finish();
+        // The animation timer + process will do the cleanup
+        // safely on the EDT for us.
+        state = State.Canceled;
+        cleanup();
     }
 
     protected void start() {
@@ -121,69 +194,22 @@ public abstract class Animation {
     protected void end() {
     }
 
-    private void finish() {
-        if (finished) {
-            return;
-        }
-        finished = true;
+    private void cleanup() {
         if (target != null) {
             activeByTarget.remove(target);
         }
+        target = null;
+
         if (gameId != null) {
-            Set<Animation> set = activeByGameId.getOrDefault(gameId, null);
-            if (set != null) {
-                set.remove(this);
-            }
-        }
-        if (animationTimer != null) {
-            animationTimer.stop();
-        }
-        end();
-    }
-
-    /**
-     * Uses averaging of the time between the past few frames to provide smooth
-     * animation.
-     */
-    private static class FrameTimer {
-
-        private static final int SAMPLES = 6;
-        private static final long MAX_FRAME = 100; // Max time for one frame, to weed out spikes.
-
-        private final long[] samples = new long[SAMPLES];
-        private int sampleIndex;
-
-        public FrameTimer() {
-            long currentTime = System.currentTimeMillis();
-            for (int i = SAMPLES - 1; i >= 0; i--) {
-                samples[i] = currentTime - (SAMPLES - i) * TARGET_MILLIS_PER_FRAME;
-            }
-        }
-
-        public long getTimeSinceLastFrame() {
-            long currentTime = System.currentTimeMillis();
-
-            int id = sampleIndex - 1;
-            if (id < 0) {
-                id += SAMPLES;
-            }
-
-            long timeSinceLastSample = currentTime - samples[id];
-
-            // If the slice was too big, advance all the previous times by the diff.
-            if (timeSinceLastSample > MAX_FRAME) {
-                long diff = timeSinceLastSample - MAX_FRAME;
-                for (int i = 0; i < SAMPLES; i++) {
-                    samples[i] += diff;
+            Set<Animation> byGameId = activeByGameId.getOrDefault(gameId, null);
+            if (byGameId != null) {
+                byGameId.remove(this);
+                if (byGameId.isEmpty()) {
+                    activeByGameId.remove(gameId);
                 }
             }
-
-            long timeSinceOldestSample = currentTime - samples[sampleIndex];
-            samples[sampleIndex] = currentTime;
-            sampleIndex = (sampleIndex + 1) % SAMPLES;
-
-            return timeSinceOldestSample / (long) SAMPLES;
         }
+        gameId = null;
     }
 
     /**
@@ -201,7 +227,6 @@ public abstract class Animation {
         for (Animation animation : animations) {
             animation.cancel();
         }
-        activeByGameId.remove(gameId);
     }
 
     /**

--- a/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeMTGO.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/CardPanelRenderModeMTGO.java
@@ -166,6 +166,11 @@ public class CardPanelRenderModeMTGO extends CardPanel {
 
     @Override
     protected void paintCard(Graphics2D g) {
+        final float alpha = getAlpha();
+        if (alpha != 1.0f) {
+            g.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_ATOP, alpha));
+        }
+
         // Render the card if we don't have an image ready to use
         if (cardImage == null) {
             // Try to get card image from cache based on our card characteristics

--- a/Mage.Client/src/main/java/org/mage/card/arcane/MageLayer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/MageLayer.java
@@ -245,20 +245,29 @@ public class MageLayer extends MageCard {
     }
 
     private static MageCardSpace getAnimationOuterSpace(int width, int height) {
+        // We add some padding to the card to not clip icons sitting on the card's border
+        // (commander crown, reach)This is a generous approximation that leaves a lot of space.
+        final double paddingFactor = 0.25;
+        int paddingX = (int) (width * paddingFactor);
+        int paddingY = (int) (height * paddingFactor);
+
         // Cards are rotate around (width / 2, height - width / 2).
         double originX = width / 2d;
         double originY = height - originX;
 
         // We compute the distance from origin to the outermost point, which is the maximum radius
-        // of a rotation.
-        double maxRadius = Math.hypot(originX, originY);
+        // of a rotation for the topRadius and the distance to the bottom left point for the bottomRadius.
+        double topRadius = Math.hypot(originX, originY);
+        int right = (int) Math.ceil(Math.max(0d, topRadius - (width - originX)));
+        int top = (int) Math.ceil(Math.max(0d, topRadius - originY));
 
-        int left = (int) Math.ceil(Math.max(0d, maxRadius - originX));
-        int right = (int) Math.ceil(Math.max(0d, maxRadius - (width - originY)));
-        int top = (int) Math.ceil(Math.max(0d, maxRadius - originY));
-        int bottom = (int) Math.ceil(Math.max(0d, maxRadius - (height - originY)));
+        // A card never rotates outsides [0, 90] degree, so we do not need the big radius
+        // padding on the bottom and left side.
+        double bottomRadius = Math.hypot(width - originX, height - originY);
+        int left = (int) Math.ceil(Math.max(0d, bottomRadius - originX));
+        int bottom = (int) Math.ceil(Math.max(0d, bottomRadius - (height - originY)));
 
-        return new MageCardSpace(left, right, top, bottom);
+        return new MageCardSpace(left + paddingX, right + paddingX, top + paddingY, bottom + paddingY);
     }
 
     @Override
@@ -269,7 +278,7 @@ public class MageLayer extends MageCard {
         // * scale the current layer to fit additional elemenst like icons
         // * draw child layer with new sizes
         //
-        // animation logic (maybe it can be change in the future):
+        // animation logic (maybe it can be changed in the future):
         // * animation implemented as g2d graphic context scale in Paint() method
         // * all layers and elements must be moved as one object
         // * only the main panel (child) can do a calcs for the animation (so send parent sizes to recalc it)
@@ -282,7 +291,6 @@ public class MageLayer extends MageCard {
 
             // extra space for animation and other drawing
             MageCardSpace outerSpace = getAnimationOuterSpace(width, height);
-            //MageCardSpace outerSpace = new MageCardSpace(50, 30, 150, 20);
             this.lastOuterSpace = outerSpace;
 
             // construct new spaces (outer + inner)

--- a/Mage.Client/src/main/java/org/mage/card/arcane/MageLayer.java
+++ b/Mage.Client/src/main/java/org/mage/card/arcane/MageLayer.java
@@ -244,6 +244,23 @@ public class MageLayer extends MageCard {
         return new MageCardSpace(0, 0, Math.round(renderHeight * 0f), 0);
     }
 
+    private static MageCardSpace getAnimationOuterSpace(int width, int height) {
+        // Cards are rotate around (width / 2, height - width / 2).
+        double originX = width / 2d;
+        double originY = height - originX;
+
+        // We compute the distance from origin to the outermost point, which is the maximum radius
+        // of a rotation.
+        double maxRadius = Math.hypot(originX, originY);
+
+        int left = (int) Math.ceil(Math.max(0d, maxRadius - originX));
+        int right = (int) Math.ceil(Math.max(0d, maxRadius - (width - originY)));
+        int top = (int) Math.ceil(Math.max(0d, maxRadius - originY));
+        int bottom = (int) Math.ceil(Math.max(0d, maxRadius - (height - originY)));
+
+        return new MageCardSpace(left, right, top, bottom);
+    }
+
     @Override
     public void setCardBounds(int x, int y, int width, int height) {
         // base idea: child layers should not know about parent layer
@@ -264,8 +281,7 @@ public class MageLayer extends MageCard {
             MageCardSpace innerSpace = getAdditionalSpaces(width, height);
 
             // extra space for animation and other drawing
-            // WTF, I'm tired with render calcs, so make BIG draw spaces for any needs
-            MageCardSpace outerSpace = new MageCardSpace(width * 2, width * 2, height * 2, height * 2);
+            MageCardSpace outerSpace = getAnimationOuterSpace(width, height);
             //MageCardSpace outerSpace = new MageCardSpace(50, 30, 150, 20);
             this.lastOuterSpace = outerSpace;
 

--- a/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/CardPluginImpl.java
@@ -33,6 +33,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.List;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static mage.client.util.CardRenderMode.*;
@@ -733,31 +734,13 @@ public class CardPluginImpl implements CardPlugin {
     }
 
     @Override
-    public void onAddCard(MageCard card, int count) {
-        if (card != null) {
-            Animation.showCard(card, count > 0 ? count : 1);
-            try {
-                while ((card).getAlpha() + 0.05f < 1) {
-                    TimeUnit.MILLISECONDS.sleep(30);
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+    public CompletableFuture<Void> onAddCard(MageCard card) {
+        return Animation.showCard(card);
     }
 
     @Override
-    public void onRemoveCard(MageCard card, int count) {
-        if (card != null) {
-            Animation.hideCard(card, count > 0 ? count : 1);
-            try {
-                while ((card).getAlpha() - 0.05f > 0) {
-                    TimeUnit.MILLISECONDS.sleep(30);
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
+    public CompletableFuture<Void> onRemoveCard(MageCard card) {
+        return Animation.hideCard(card);
     }
 
     @Override

--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/DownloadPicturesService.java
@@ -740,7 +740,9 @@ public class DownloadPicturesService extends DefaultBoundedRangeModel implements
         enableDialogButtons();
 
         // reset GUI and cards to use new images
-        GUISizeHelper.refreshGUIAndCards(false);
+        SwingUtilities.invokeLater(() -> {
+            GUISizeHelper.refreshGUIAndCards(false);
+        });
     }
 
     private final class DownloadTask implements Runnable {

--- a/Mage.Common/src/main/java/mage/interfaces/plugin/CardPlugin.java
+++ b/Mage.Common/src/main/java/mage/interfaces/plugin/CardPlugin.java
@@ -11,6 +11,7 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Interface for card plugins
@@ -37,18 +38,16 @@ public interface CardPlugin extends Plugin {
     /**
      * Uses for show/hide animation on the battlefield
      *
-     * @param card
-     * @param count
+     * @param card The card that got added
      */
-    void onAddCard(MageCard card, int count);
+    CompletableFuture<Void> onAddCard(MageCard card);
 
     /**
      * Uses for show/hide animation on the battlefield
      *
-     * @param card
-     * @param count
+     * @param card The card that got removed
      */
-    void onRemoveCard(MageCard card, int count);
+    CompletableFuture<Void> onRemoveCard(MageCard card);
 
     JComponent getCardInfoPane();
 


### PR DESCRIPTION
# Issues Solved
- Fix alpha-blending for the MTGO-style renderer
- Moved animations to a single Swing Timer that processes all animations per tick-callback
- Ported the idea of smoothing (limiting animation time-skips because of a busy EDT to a certain maximum) to the new implementation, removing the sampling
- Animations no longer busy-wait when waiting for them to finish
- Make sure the image download thread calls `refreshGUIAndCards` on the EDT

# Further Changes
- Animation API now returns `CompletableFuture` to schedule actions after animations complete (see use in `BattlefieldPanel.java`)
- Decreased show/hide duration from 600 ms to 250 ms to make fade animations look “snappier”