### PR TITLE
Call GUI Refresh on EDT

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -1896,6 +1896,8 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
      * Use it after new images downloaded, new fonts or theme settings selected.
      */
     public void refreshGUIAndCards() {
+        ThreadUtils.ensureRunInGUISwingThread();
+
         ImageCaches.clearAll();
 
         setGUISize();

--- a/Mage.Client/src/main/java/mage/client/util/GUISizeHelper.java
+++ b/Mage.Client/src/main/java/mage/client/util/GUISizeHelper.java
@@ -87,9 +87,18 @@ public final class GUISizeHelper {
      * Reset all caches and reload all GUI with actual settings.
      * Use it after GUI settings change like colors/fonts/sizes.
      *
-     * @param reloadTheme use it after theme changes only
+     * This function is safe to call outsides the EDT!
+     *
+     * @param reloadTheme Use it after theme changes only
      */
     public static void refreshGUIAndCards(boolean reloadTheme) {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            SwingUtilities.invokeLater(() -> {
+                GUISizeHelper.refreshGUIAndCards(reloadTheme);
+            });
+            return;
+        }
+
         calculateGUISizes();
         if (reloadTheme) {
             GuiDisplayUtil.refreshThemeSettings();


### PR DESCRIPTION
This PR ensures that `refreshGUIAndCards` is always called on the EDT.

(`refreshGUIAndCards` gets called by the card image download thread after completion from a raw-thread for instance.)
