### PR TITLE
Do not generate a new ID when playing mana abilities

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/TyvarTheBellicoseTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mat/TyvarTheBellicoseTest.java
@@ -1,0 +1,24 @@
+package org.mage.test.cards.single.mat;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class TyvarTheBellicoseTest extends CardTestPlayerBase {
+
+    @Test
+    public void testBasic() {
+        addCard(Zone.BATTLEFIELD, playerA, "Tyvar the Bellicose");
+        addCard(Zone.BATTLEFIELD, playerA, "Llanowar Elves");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Add {G}");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Llanowar Elves", 2, 2);
+    }
+
+}

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1519,7 +1519,6 @@ public abstract class PlayerImpl implements Player, Serializable {
         int bookmark = game.bookmarkState();
         //20260116 - 109.4a
         //The controller of a mana ability is determined as though it were on the stack.
-        ability.newId();
         ability.setControllerId(playerId);
         if (ability.activate(game, false) && ability.resolve(game)) {
             if (ability.isUndoPossible()) {


### PR DESCRIPTION
It seems that `playManaAbility()` is called at a different time (earier) than `playAbility()` and thus its events (`MANA_ADDED` etc) get the new ID in them and not the old one, whereas this is not the case for events fired by playing non-mana abilities.  Since no stack object is created for mana abilities, generating a new ID should not be necessary.

Fixes: https://github.com/magefree/mage/commit/b814837eb8
See: https://github.com/magefree/mage/pull/14382
See: https://github.com/magefree/mage/issues/14381