### PR TITLE
[tests] Ignore spellbook boosters as they're not draftable

### DIFF
--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -983,6 +983,10 @@ public class VerifyCardDataTest {
         ignoreBoosterSets.add("Unhinged");
         ignoreBoosterSets.add("Unstable");
         ignoreBoosterSets.add("Unfinity");
+        // spellbook boosters, not for draft
+        ignoreBoosterSets.add("Signature Spellbook: Jace");
+        ignoreBoosterSets.add("Signature Spellbook: Gideon");
+        ignoreBoosterSets.add("Signature Spellbook: Chandra");
         // other
         ignoreBoosterSets.add("Secret Lair Drop"); // cards shop
         ignoreBoosterSets.add("Ugin's Fate"); // promo, not draftable


### PR DESCRIPTION
Looks like MTGJson updated with syndicated data from Scryfall to mark these spellbooks as boosters;

```
Error: wrong booster settings (set must have boosters, but it does not) - 2018 - SS1 - Signature Spellbook: Jace - boosters: [default]
Error: wrong booster settings (set must have boosters, but it does not) - 2019 - SS2 - Signature Spellbook: Gideon - boosters: [default]
Error: wrong booster settings (set must have boosters, but it does not) - 2020 - SS3 - Signature Spellbook: Chandra - boosters: [default]
```

They're not draftable boosters and are fixed, kind of like the Jumpstart ones. Let's skip the verify test on them for now.