### PR TITLE
[fix] Correct prepare spell cost for Jadzi

### DIFF
--- a/Mage.Sets/src/mage/cards/j/JadziStewardOfFate.java
+++ b/Mage.Sets/src/mage/cards/j/JadziStewardOfFate.java
@@ -27,7 +27,7 @@ public final class JadziStewardOfFate extends PrepareCard {
     private static final FilterPermanent filter = new FilterControlledPermanent(SubType.FRACTAL);
 
     public JadziStewardOfFate(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}", "Oracle's Gift", new CardType[]{CardType.SORCERY}, "{X}{U}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}", "Oracle's Gift", new CardType[]{CardType.SORCERY}, "{X}{X}{U}");
 
         this.supertype.add(SuperType.LEGENDARY);
         this.subtype.add(SubType.HUMAN);


### PR DESCRIPTION
Spotted on a local build where I'd enabled the Prepare cards; the spell cost here was incorrect. `{X}{X}{U}` is correct; https://scryfall.com/card/sos/55/jadzi-steward-of-fate-oracles-gift