### PR TITLE
[utils] Validate input from mtg-cards-data

### DIFF
--- a/Utils/gen-card.pl
+++ b/Utils/gen-card.pl
@@ -16,6 +16,23 @@ my %sets;
 my %knownSets;
 my %keywords;
 
+sub parseCardDataLine {
+    my ($line, $lineNumber) = @_;
+    chomp $line;
+    my @data = split('\|', $line, -1);
+
+    if (@data == 10 && $data[9] eq '') {
+        pop @data;
+    }
+
+    if (@data != 9) {
+        die "$dataFile line $lineNumber has " . scalar(@data)
+            . " pipe-separated fields; expected 9: $line\n";
+    }
+
+    return @data;
+}
+
 sub toCamelCase {
     my $string = $_[0];
     $string =~ s/\b([\w']+)\b/ucfirst($1)/ge;
@@ -43,7 +60,11 @@ if (-e $authorFile) {
 open(DATA, $dataFile) || die "can't open $dataFile : $!";
 while (my $line = <DATA>) {
     my @data = split('\\|', $line);
-    $cards{$data[0]}{$data[1]}{$data[2]} = \@data;
+    $cards{$data[0]}{$data[1]}{$data[2]} = {
+        data => [@data],
+        line => $line,
+        lineNumber => $.
+    };
 }
 close(DATA);
 
@@ -141,7 +162,8 @@ foreach my $setName (keys %{$cards{$originalName}}) {
     }
     foreach my $cardNumber (sort keys %{$cards{$originalName}{$setName}}) {
         my $setFileName = "../Mage.Sets/src/mage/sets/" . $knownSets{$setName} . ".java";
-        @card = @{${cards {$originalName}{ $setName }{$cardNumber}}};
+        my $cardData = $cards{$originalName}{$setName}{$cardNumber};
+        @card = parseCardDataLine($cardData->{line}, $cardData->{lineNumber});
         my $line = "        cards.add(new SetCardInfo(\"" . $card[0] . "\", " . $card[2] . ", Rarity." . $raritiesConversion{$card[3]} . ", mage.cards." . $vars{'cardNameFirstLetter'} . "." . $vars{'className'} . ".class" . $printingString . "));\n";
         @ARGV = ($setFileName);
         $^I = '.bak';


### PR DESCRIPTION
A typical workflow for me involves importing the card data from Scryfall into mtg-cards-data.txt so I can run `gen-card.pl` against it.

Sometimes there are mistakes in this process. The Perl script attempts to pass what fields it does extract through to the template which then results in a hilariously malformed base of a card implementation. 

We can guard against this in the perl script by validating it extracts the right number of card fields