### PR TITLE
722.3a only Cards with prepare spells can become prepared

### DIFF
--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -18,6 +18,7 @@ import mage.abilities.hint.HintUtils;
 import mage.abilities.keyword.*;
 import mage.cards.Card;
 import mage.cards.CardImpl;
+import mage.cards.PrepareCard;
 import mage.constants.*;
 import mage.counters.Counter;
 import mage.counters.CounterType;
@@ -1804,6 +1805,14 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
 
     @Override
     public void setPrepared(boolean prepared, Game game) {
+        // 722.3a Some spells and abilities cause a permanent with a prepare spell to become prepared or state that a permanent enters prepared.
+        // If that permanent has the alternative characteristics of a prepare spell, this gives the permanent the “prepared” designation.
+        // Prepared is a designation that acts as a marker which rules and effects can identify.
+        // A permanent can’t gain this designation unless it has a prepare spell,
+        // Additionally, a permanent can’t gain this designation if the permanent already has it.
+        if (prepared && !(getMainCard() instanceof PrepareCard)) {
+            return;
+        }
         if (this.prepared == prepared) {
             return;
         }


### PR DESCRIPTION
I know there's a lot more to getting Prepare working, but tackling this bit by bit, from a local branch I think this is safe to adopt.

There's rulings around what can be designated as prepared or not. While it doesn't affect targeting rules (i.e. [Skycoach Waypoint](https://scryfall.com/card/sos/261/skycoach-waypoint) can target any creature), the net result would not be applying the designation to the creature if it lacks a Prepare spell. 