### PR TITLE
[fix] Correct Zaffai and the Tempests to restrict to casting spells from its controller's hand

### DIFF
--- a/Mage.Sets/src/mage/cards/z/ZaffaiAndTheTempests.java
+++ b/Mage.Sets/src/mage/cards/z/ZaffaiAndTheTempests.java
@@ -15,7 +15,6 @@ import mage.abilities.hint.common.ConditionPermanentHint;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.constants.WatcherScope;
-import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
@@ -121,8 +120,7 @@ class ZaffaiAndTheTempestsEffect extends AsThoughEffectImpl {
                 || watcher.isAbilityUsed(new MageObjectReference(sourceObject, game))) {
             return false;
         }
-        Zone zone = game.getState().getZone(card.getId());
-        if (!Zone.HAND.match(zone)) {
+        if (!controller.getHand().contains(card.getId())) {
             return false;
         }
 


### PR DESCRIPTION
Reported on Discord;

<img width="796" height="354" alt="Screenshot 2026-05-02 at 7 01 37 PM" src="https://github.com/user-attachments/assets/7168ed12-b7f0-4f29-9b38-a8d0b47f1b12" />
