### PR TITLE
Extend original ID concept to apply to effects as well as abilities

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/CloneTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/CloneTest.java
@@ -286,5 +286,38 @@ public class CloneTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 2);
         assertPowerToughness(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 2, 2, Filter.ComparisonScope.All);
     }
-    
+
+    @Test
+    public void testSivitri() {
+        addCard(Zone.BATTLEFIELD, playerA, "Oath of Teferi");
+        addCard(Zone.BATTLEFIELD, playerA, "Sivitri, Dragon Master");
+        addCard(Zone.HAND, playerA, "Spark Double");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+        addCard(Zone.HAND, playerA, "Fateful Absence");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Spark Double");
+        setChoice(playerA, true);
+        setChoice(playerA, "Sivitri, Dragon Master");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fateful Absence");
+        addTarget(playerA, "Sivitri, Dragon Master[no copy]");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+1: Until");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "+1: Until");
+
+        attack(2, playerB, "Balduvian Bears", playerA);
+        setChoice(playerB, "Sivitri");
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 18);
+        assertLife(playerB, 16);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/replacement/PropagandaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/replacement/PropagandaTest.java
@@ -57,4 +57,33 @@ public class PropagandaTest extends CardTestPlayerBase {
         assertTappedCount("Plains", true, 4);
     }
 
+    // https://github.com/magefree/mage/issues/10372
+    // https://github.com/magefree/mage/issues/14754
+    @Test
+    public void testClone() {
+        addCard(Zone.BATTLEFIELD, playerB, "Archangel of Tithes");
+        addCard(Zone.HAND, playerA, "Clone");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes");
+        addCard(Zone.HAND, playerA, "Fell");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Clone");
+        setChoice(playerA, true);
+        setChoice(playerA, "Archangel of Tithes");
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Fell");
+        addTarget(playerA, "Archangel of Tithes[no copy]");
+
+        attack(2, playerB, "Balduvian Bears");
+        setChoice(playerB, true);
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 18);
+        assertTappedCount("Balduvian Bears", true, 1);
+    }
+
 }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -855,8 +855,8 @@ public class ContinuousEffects implements Serializable {
             // Remove all consumed effects (ability dependant)
             for (Iterator<ReplacementEffect> it1 = rEffects.keySet().iterator(); it1.hasNext(); ) {
                 ReplacementEffect entry = it1.next();
-                if (consumed.containsKey(entry.getId()) /*&& !(entry instanceof CommanderReplacementEffect) */) { // 903.9.
-                    Set<UUID> consumedAbilitiesIds = consumed.get(entry.getId());
+                if (consumed.containsKey(entry.getOriginalId()) /*&& !(entry instanceof CommanderReplacementEffect) */) { // 903.9.
+                    Set<UUID> consumedAbilitiesIds = consumed.get(entry.getOriginalId());
                     if (rEffects.get(entry) == null || consumedAbilitiesIds.size() == rEffects.get(entry).size()) {
                         it1.remove();
                     } else {
@@ -944,8 +944,8 @@ public class ContinuousEffects implements Serializable {
 
             // add the applied effect to the consumed effects
             if (rEffect != null) {
-                if (consumed.containsKey(rEffect.getId())) {
-                    Set<UUID> set = consumed.get(rEffect.getId());
+                if (consumed.containsKey(rEffect.getOriginalId())) {
+                    Set<UUID> set = consumed.get(rEffect.getOriginalId());
                     if (rAbility != null) {
                         set.add(rAbility.getId());
 
@@ -955,7 +955,7 @@ public class ContinuousEffects implements Serializable {
                     if (rAbility != null) { // in case of AuraReplacementEffect or PlaneswalkerReplacementEffect there is no Ability
                         set.add(rAbility.getId());
                     }
-                    consumed.put(rEffect.getId(), set);
+                    consumed.put(rEffect.getOriginalId(), set);
                 }
             }
             // Must be called here for some effects to be able to work correctly

--- a/Mage/src/main/java/mage/abilities/effects/Effect.java
+++ b/Mage/src/main/java/mage/abilities/effects/Effect.java
@@ -19,6 +19,8 @@ public interface Effect extends Serializable, Copyable<Effect> {
 
     UUID getId();
 
+    UUID getOriginalId();
+
     void newId();
 
     /**

--- a/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
+++ b/Mage/src/main/java/mage/abilities/effects/EffectImpl.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 public abstract class EffectImpl implements Effect {
 
     protected UUID id;
+    protected UUID originalId;
     protected Outcome outcome;
     protected EffectType effectType;
 
@@ -30,6 +31,7 @@ public abstract class EffectImpl implements Effect {
 
     public EffectImpl(Outcome outcome) {
         this.id = UUID.randomUUID();
+        this.originalId = this.id;
         this.outcome = outcome;
 
         initNewTargetPointer();
@@ -37,6 +39,7 @@ public abstract class EffectImpl implements Effect {
 
     protected EffectImpl(final EffectImpl effect) {
         this.id = effect.id;
+        this.originalId = effect.id;
         this.outcome = effect.outcome;
         this.staticText = effect.staticText;
         this.effectType = effect.effectType;
@@ -59,6 +62,11 @@ public abstract class EffectImpl implements Effect {
     @Override
     public UUID getId() {
         return id;
+    }
+
+    @Override
+    public UUID getOriginalId() {
+        return originalId;
     }
 
     @Override


### PR DESCRIPTION
The root cause of the issue here is that when a permanent with a replacement effect is copied, this is applied via a continuous `CopyEffect`.  Normally this is not a problem, but for attack taxers, part of choosing whether the replacement effect applies or not is tapping mana sources, which triggers `applyEffects()` to run.  The `CopyEffect` is then reapplied, and as part of it, it clears the copied abilities and generates new ones with new IDs from the blueprint.  Thus, the loop checking whether all replacement effects have been consumed never terminates, because it sees a new replacement effect with a new ID it needs to apply.

This extends the concept of `originalId`, which abilities already have, to also apply to effects.  It can be used in any scenarios which need an effect's ID to remain stable even when it is destroyed and recreated via a copy from a continuous effect.

Fixes https://github.com/magefree/mage/issues/10372

Fixes https://github.com/magefree/mage/issues/14754