### PR TITLE
[dev] Add nightly CI run to GHA akin to TravisCI's set up

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,6 +13,8 @@ on:
     branches: [ "master", "main" ]
   pull_request:
     branches: [ "master", "main" ]
+  schedule:
+    - cron: '0 1 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
From a PR comment, [one gap between GHA and Travis is the nightly runs that we have on the default branch](https://github.com/magefree/mage/pull/14847#issuecomment-4365032557). 

So let's give GHA a similar schedule.

I called out that the notification policy isn't great - but arguably the policy on Travis isn't either and it's just as likely to get actioned on in GHA as failing nightly Travis runs do...