### PR TITLE
Add: MKC cards: True Identity, Veiled ascension

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TrueIdentity.java
+++ b/Mage.Sets/src/mage/cards/t/TrueIdentity.java
@@ -1,0 +1,52 @@
+package mage.cards.t;
+
+import mage.abilities.Ability;
+import mage.abilities.common.TurnedFaceUpAllTriggeredAbility;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.keyword.ScryEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.keyword.DisguiseAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.filter.FilterPermanentThisOrAnother;
+import mage.filter.StaticFilters;
+
+
+import java.util.UUID;
+
+/**
+ * @author greenlovecat
+ * 
+ * 
+ * Whenever this enchantment or another permanent you control is turned face up, scry 1, then draw a card. This ability triggers only once each turn.
+ * 
+ * Disguise {W} (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)
+ */
+
+public final class TrueIdentity extends CardImpl {
+    
+    private static final FilterPermanentThisOrAnother filter = new FilterPermanentThisOrAnother(StaticFilters.FILTER_CONTROLLED_CREATURE, true);
+
+    public TrueIdentity(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");
+
+        // Whenever this enchantment or another permanent you control is turned face up, scry 1, then draw a card. This ability triggers only once each turn.
+        Ability ability = new TurnedFaceUpAllTriggeredAbility(new ScryEffect(1, false), filter, true).setTriggersLimitEachTurn(1);
+        ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy(", then"));
+        this.addAbility(ability);
+
+        // Disguise {W}
+        this.addAbility(new DisguiseAbility(this, new ManaCostsImpl<>("{W}")));
+    }
+
+    private TrueIdentity(final TrueIdentity card) {
+        super(card);
+    }
+
+    @Override
+    public TrueIdentity copy() {
+        return new TrueIdentity(this);
+    }
+
+}

--- a/Mage.Sets/src/mage/cards/t/TrueIdentity.java
+++ b/Mage.Sets/src/mage/cards/t/TrueIdentity.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 public final class TrueIdentity extends CardImpl {
     
-    private static final FilterPermanentThisOrAnother filter = new FilterPermanentThisOrAnother(StaticFilters.FILTER_CONTROLLED_CREATURE, true);
+    private static final FilterPermanentThisOrAnother filter = new FilterPermanentThisOrAnother(StaticFilters.FILTER_CONTROLLED_PERMANENT, true);
 
     public TrueIdentity(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{1}{W}");

--- a/Mage.Sets/src/mage/cards/v/VeiledAscension.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledAscension.java
@@ -8,19 +8,12 @@ import mage.abilities.effects.common.counter.AddCountersAllEffect;
 import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.counters.CounterType;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.card.FaceDownPredicate;
-import mage.abilities.Ability;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.constants.*;
-import mage.game.Game;
-import mage.game.events.EntersTheBattlefieldEvent;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
+import mage.abilities.effects.common.EntersWithCountersControlledEffect;
+
 
 import java.util.UUID;
 
@@ -37,7 +30,7 @@ import java.util.UUID;
 
 public final class VeiledAscension extends CardImpl {
     
-    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("a face-down creature");
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("face-down creature you control");
 
     static {
         filter.add(FaceDownPredicate.instance);
@@ -52,10 +45,12 @@ public final class VeiledAscension extends CardImpl {
         ));
 
         // Face-down creatures you control enter the battlefield with a flying counter on them.
-        this.addAbility(new SimpleStaticAbility(new VeiledAscensionEffect()));
+        this.addAbility(new SimpleStaticAbility(Zone.BATTLEFIELD, new EntersWithCountersControlledEffect(
+                filter, CounterType.FLYING.createInstance(), false
+        ).setText("Face-down creatures you control enter the battlefield with a flying counter on them.")));
 
         // At the beginning of your upkeep, you may cloak the top card of your library.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new ManifestEffect(StaticValue.get(1), true, true), true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new ManifestEffect(StaticValue.get(1), false, true), true));
     }
 
     private VeiledAscension(final VeiledAscension card) {
@@ -67,47 +62,4 @@ public final class VeiledAscension extends CardImpl {
         return new VeiledAscension(this);
     }
 
-}
-
-class VeiledAscensionEffect extends ReplacementEffectImpl {
-
-    VeiledAscensionEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.BoostCreature);
-        staticText = "Face-down creatures you control enter the battlefield with a flying counter on them.";
-    }
-
-    private VeiledAscensionEffect(VeiledAscensionEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
-        return creature != null && creature.isControlledBy(source.getControllerId())
-                && creature.isCreature(game)
-                && creature.isFaceDown(game)
-                && !event.getTargetId().equals(source.getSourceId());
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
-        Player controller = game.getPlayer(source.getControllerId());
-        if (creature == null || controller == null) {
-            return false;
-        }
-        creature.addCounters(CounterType.FLYING.createInstance(), source.getControllerId(), source, game);
-
-        return false;
-    }
-
-    @Override
-    public VeiledAscensionEffect copy() {
-        return new VeiledAscensionEffect(this);
-    }
 }

--- a/Mage.Sets/src/mage/cards/v/VeiledAscension.java
+++ b/Mage.Sets/src/mage/cards/v/VeiledAscension.java
@@ -1,0 +1,113 @@
+package mage.cards.v;
+
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.common.StaticValue;
+import mage.abilities.effects.keyword.ManifestEffect;
+import mage.abilities.effects.common.counter.AddCountersAllEffect;
+import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.counters.CounterType;
+import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.predicate.card.FaceDownPredicate;
+import mage.abilities.Ability;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.events.EntersTheBattlefieldEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+
+import java.util.UUID;
+
+/**
+ * @author greenlovecat
+ * 
+ * 
+ * When this enchantment enters, put a flying counter on each face-down creature you control.
+ *
+ * Face-down creatures you control enter with a flying counter on them.
+ * 
+ * At the beginning of your upkeep, you may cloak the top card of your library.
+ */
+
+public final class VeiledAscension extends CardImpl {
+    
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("a face-down creature");
+
+    static {
+        filter.add(FaceDownPredicate.instance);
+    }
+
+    public VeiledAscension(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{W}");
+
+        // When Veiled Ascension enters the battlefield, put a flying counter on each face-down creature you control.
+        this.addAbility(new EntersBattlefieldTriggeredAbility(
+                new AddCountersAllEffect(CounterType.FLYING.createInstance(), filter)
+        ));
+
+        // Face-down creatures you control enter the battlefield with a flying counter on them.
+        this.addAbility(new SimpleStaticAbility(new VeiledAscensionEffect()));
+
+        // At the beginning of your upkeep, you may cloak the top card of your library.
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new ManifestEffect(StaticValue.get(1), true, true), true));
+    }
+
+    private VeiledAscension(final VeiledAscension card) {
+        super(card);
+    }
+
+    @Override
+    public VeiledAscension copy() {
+        return new VeiledAscension(this);
+    }
+
+}
+
+class VeiledAscensionEffect extends ReplacementEffectImpl {
+
+    VeiledAscensionEffect() {
+        super(Duration.WhileOnBattlefield, Outcome.BoostCreature);
+        staticText = "Face-down creatures you control enter the battlefield with a flying counter on them.";
+    }
+
+    private VeiledAscensionEffect(VeiledAscensionEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
+        return creature != null && creature.isControlledBy(source.getControllerId())
+                && creature.isCreature(game)
+                && creature.isFaceDown(game)
+                && !event.getTargetId().equals(source.getSourceId());
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent creature = ((EntersTheBattlefieldEvent) event).getTarget();
+        Player controller = game.getPlayer(source.getControllerId());
+        if (creature == null || controller == null) {
+            return false;
+        }
+        creature.addCounters(CounterType.FLYING.createInstance(), source.getControllerId(), source, game);
+
+        return false;
+    }
+
+    @Override
+    public VeiledAscensionEffect copy() {
+        return new VeiledAscensionEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
+++ b/Mage.Sets/src/mage/sets/MurdersAtKarlovManorCommander.java
@@ -315,12 +315,16 @@ public final class MurdersAtKarlovManorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Tranquil Thicket", 309, Rarity.COMMON, mage.cards.t.TranquilThicket.class));
         cards.add(new SetCardInfo("Trouble in Pairs", 15, Rarity.RARE, mage.cards.t.TroubleInPairs.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Trouble in Pairs", 326, Rarity.RARE, mage.cards.t.TroubleInPairs.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("True Identity", 16, Rarity.RARE, mage.cards.t.TrueIdentity.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("True Identity", 327, Rarity.RARE, mage.cards.t.TrueIdentity.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Twilight Prophet", 143, Rarity.MYTHIC, mage.cards.t.TwilightProphet.class));
         cards.add(new SetCardInfo("Ugin's Mastery", 53, Rarity.RARE, mage.cards.u.UginsMastery.class));
         cards.add(new SetCardInfo("Ulvenwald Mysteries", 193, Rarity.UNCOMMON, mage.cards.u.UlvenwaldMysteries.class));
         cards.add(new SetCardInfo("Unexplained Absence", 17, Rarity.RARE, mage.cards.u.UnexplainedAbsence.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Unexplained Absence", 328, Rarity.RARE, mage.cards.u.UnexplainedAbsence.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Unshakable Tail", 29, Rarity.RARE, mage.cards.u.UnshakableTail.class));
+        cards.add(new SetCardInfo("Veiled Ascension", 18, Rarity.RARE, mage.cards.v.VeiledAscension.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Veiled Ascension", 329, Rarity.RARE, mage.cards.v.VeiledAscension.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Vengeful Ancestor", 163, Rarity.RARE, mage.cards.v.VengefulAncestor.class));
         cards.add(new SetCardInfo("Vizier of Many Faces", 123, Rarity.RARE, mage.cards.v.VizierOfManyFaces.class));
         cards.add(new SetCardInfo("Vow of Duty", 89, Rarity.UNCOMMON, mage.cards.v.VowOfDuty.class));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mkc/VeiledAscensionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mkc/VeiledAscensionTest.java
@@ -1,7 +1,9 @@
 package org.mage.test.cards.single.mkc;
 
+import mage.constants.EmptyNames;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.counters.CounterType;
 
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -53,7 +55,8 @@ public class VeiledAscensionTest extends CardTestPlayerBase {
 
         execute();
 
-        //assertCounterCount("face down creature", CounterType.FLYING, 1); // doesn't work because the creature is face down and has no name, so it can't be found by the test framework
+        assertCounterCount(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), CounterType.FLYING, 1);
+
     }
 
     @Test
@@ -75,6 +78,6 @@ public class VeiledAscensionTest extends CardTestPlayerBase {
 
         execute();
 
-        //assertCounterCount("face down creature", CounterType.FLYING, 1); // doesn't work because the creature is face down and has no name, so it can't be found by the test framework
+        assertCounterCount(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), CounterType.FLYING, 1);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/mkc/VeiledAscensionTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/mkc/VeiledAscensionTest.java
@@ -1,0 +1,80 @@
+package org.mage.test.cards.single.mkc;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class VeiledAscensionTest extends CardTestPlayerBase {
+
+    /*
+    Veiled Ascension
+    {1}{U}
+    Enchantment
+    Face-down creatures you control enter the battlefield with a flying counter on them.
+    At the beginning of your upkeep, you may cloak the top card of your library.
+     */
+    private static final String veiledAscension = "Veiled Ascension";
+
+    @Test
+    public void testCloakTheTopCardOfYourLibrary() {
+        skipInitShuffling();
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, veiledAscension);
+        addCard(Zone.LIBRARY, playerA, "Boltbender");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 6);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 6);
+        setChoice(playerA, true); // yes to cloak
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        showBattlefield(ACTIVATE_ABILITY, 1, stopAtStep, playerA);
+
+        execute();
+    }
+
+    @Test
+    public void testPutAFlyingCounterOnFaceDownCreature() {
+        skipInitShuffling();
+        setStrictChooseMode(true);
+
+        addCard(Zone.HAND, playerA, veiledAscension);
+        addCard(Zone.HAND, playerA, "Boltbender");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 6);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 6);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Boltbender using Disguise", true);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, veiledAscension, true);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        showBattlefield(ACTIVATE_ABILITY, 1, stopAtStep, playerA);
+
+        execute();
+
+        //assertCounterCount("face down creature", CounterType.FLYING, 1); // doesn't work because the creature is face down and has no name, so it can't be found by the test framework
+    }
+
+    @Test
+    public void testFaceDownCreatureEnterWithFlyingCounter() {
+        skipInitShuffling();
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, veiledAscension);
+        addCard(Zone.HAND, playerA, "Boltbender");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 6);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 6);
+        setChoice(playerA, false); // no to cloak
+
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Boltbender using Disguise", true);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        showBattlefield(ACTIVATE_ABILITY, 1, stopAtStep, playerA);
+
+        execute();
+
+        //assertCounterCount("face down creature", CounterType.FLYING, 1); // doesn't work because the creature is face down and has no name, so it can't be found by the test framework
+    }
+}


### PR DESCRIPTION
Implemented MKC cards: True Identity and Veiled Ascension. 
Tested in local game against bots.
Couldn't implement proper testing for counter count for Veiled Ascension, since face-down cards have no name. 