### PR TITLE
Reverse order in Opus conditional effects

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/sos/ExhibitionTidecallerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/sos/ExhibitionTidecallerTest.java
@@ -1,0 +1,46 @@
+package org.mage.test.cards.single.sos;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class ExhibitionTidecallerTest extends CardTestPlayerBase {
+
+    @Test
+    public void testBig() {
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerB, "Darksteel Relic", 10);
+        addCard(Zone.BATTLEFIELD, playerA, "Exhibition Tidecaller");
+        addCard(Zone.HAND, playerA, "Aether Snap");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Aether Snap");
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerB, "Darksteel Relic", 10);
+    }
+
+    @Test
+    public void testSmall() {
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerB, "Darksteel Relic", 10);
+        addCard(Zone.BATTLEFIELD, playerA, "Exhibition Tidecaller");
+        addCard(Zone.HAND, playerA, "Reach Through Mists");
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Reach Through Mists");
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerB, "Darksteel Relic", 3);
+    }
+
+}

--- a/Mage/src/main/java/mage/abilities/abilityword/OpusAbility.java
+++ b/Mage/src/main/java/mage/abilities/abilityword/OpusAbility.java
@@ -25,7 +25,7 @@ public class OpusAbility extends SpellCastControllerTriggeredAbility {
         super(null, StaticFilters.FILTER_SPELL_AN_INSTANT_OR_SORCERY, false);
         if (doInstead) {
             this.addEffect(new ConditionalOneShotEffect(
-                    wrapEffect(mainEffect), wrapEffect(extraEffect), OpusCondition.instance, text
+                    wrapEffect(extraEffect), wrapEffect(mainEffect), OpusCondition.instance, text
             ));
         } else {
             this.addEffect(mainEffect);


### PR DESCRIPTION
This is backwards, the Opus condition is true if 5 or more mana was spent, in which case the extra effect should occur, not the main effect. Spot checked several cards with Opus and all of them were using it this way.