### PR TITLE
Add feedback hint on converge abilities

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArcaneOmens.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneOmens.java
@@ -21,7 +21,7 @@ public final class ArcaneOmens extends CardImpl {
         // Converge -- Target player discards X cards, where X is the number of colors of mana spent to cast this spell.
         this.getSpellAbility().addEffect(new DiscardTargetEffect(ColorsOfManaSpentToCastCount.getInstance()));
         this.getSpellAbility().addTarget(new TargetPlayer());
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private ArcaneOmens(final ArcaneOmens card) {

--- a/Mage.Sets/src/mage/cards/a/ArchaicsAgony.java
+++ b/Mage.Sets/src/mage/cards/a/ArchaicsAgony.java
@@ -27,7 +27,7 @@ public final class ArchaicsAgony extends CardImpl {
         // Converge -- Archaic's Agony deals X damage to target creature, where X is the number of colors of mana spent to cast this spell. Exile cards from the top of your library equal to the excess damage dealt to that creature this way. You may play those cards until the end of your next turn.
         this.getSpellAbility().addEffect(new ArchaicsAgonyEffect());
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private ArchaicsAgony(final ArchaicsAgony card) {

--- a/Mage.Sets/src/mage/cards/b/BrilliantSpectrum.java
+++ b/Mage.Sets/src/mage/cards/b/BrilliantSpectrum.java
@@ -21,7 +21,7 @@ public final class BrilliantSpectrum extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{U}");
 
         // <i>Converge</i> &mdash; Draw X cards, where X is the number of colors of mana spent to cast Brilliant Spectrum. Then discard two cards.
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         Effect effect = new DrawCardSourceControllerEffect(ColorsOfManaSpentToCastCount.getInstance());
         effect.setText("Draw X cards, where X is the number of colors of mana spent to cast this spell");
         this.getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/b/BringToLight.java
+++ b/Mage.Sets/src/mage/cards/b/BringToLight.java
@@ -29,7 +29,7 @@ public final class BringToLight extends CardImpl {
         // cost less than or equal to the number of colors of mana spent to cast Bring to Light, exile that card,
         // then shuffle your library. You may cast that card without paying its mana cost.
         this.getSpellAbility().addEffect(new BringToLightEffect());
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private BringToLight(final BringToLight card) {

--- a/Mage.Sets/src/mage/cards/c/CrystallineCrawler.java
+++ b/Mage.Sets/src/mage/cards/c/CrystallineCrawler.java
@@ -34,6 +34,7 @@ public final class CrystallineCrawler extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Remove a +1/+1 counter from Crystalline Crawler: Add one mana of any color.
         this.addAbility(new AnyColorManaAbility(new RemoveCountersSourceCost(CounterType.P1P1.createInstance(1)),

--- a/Mage.Sets/src/mage/cards/e/ExertInfluence.java
+++ b/Mage.Sets/src/mage/cards/e/ExertInfluence.java
@@ -28,7 +28,7 @@ public final class ExertInfluence extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{4}{U}");
 
         // <i>Converge</i>-Gain control of target creature if its power is less than or equal to the number of colors spent to cast Exert Influence.
-        getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         getSpellAbility().addEffect(new ExertInfluenceEffect());
         getSpellAbility().addTarget(new TargetCreaturePermanent());
 

--- a/Mage.Sets/src/mage/cards/g/GlintingCreeper.java
+++ b/Mage.Sets/src/mage/cards/g/GlintingCreeper.java
@@ -34,6 +34,7 @@ public final class GlintingCreeper extends CardImpl {
                 CounterType.P1P1.createInstance(), xValue, true
         ), null, "<i>Converge</i> &mdash; {this} enters " +
                 "with two +1/+1 counters on it for each color of mana spent to cast it.", null));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Glinting Creeper can't be blocked by creatures with power 2 or less.
         this.addAbility(new DauntAbility());

--- a/Mage.Sets/src/mage/cards/i/InfuseWithTheElements.java
+++ b/Mage.Sets/src/mage/cards/i/InfuseWithTheElements.java
@@ -25,7 +25,7 @@ public final class InfuseWithTheElements extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{G}");
 
         // <i>Converge</i> &mdash; Put X +1/+1 counters on target creature, where X is the number of colors of mana spent to cast Infuse with the Elements.
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance(0), ColorsOfManaSpentToCastCount.getInstance());
         effect.setText("Put X +1/+1 counters on target creature, where X is the number of colors of mana spent to cast this spell");
         this.getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/k/Kaleidoscorch.java
+++ b/Mage.Sets/src/mage/cards/k/Kaleidoscorch.java
@@ -25,7 +25,7 @@ public final class Kaleidoscorch extends CardImpl {
         this.getSpellAbility().addEffect(new DamageTargetEffect(ColorsOfManaSpentToCastCount.getInstance())
                 .setText("{this} deals X damage to any target, where X is the number of colors of mana spent to cast this spell"));
         this.getSpellAbility().addTarget(new TargetAnyTarget());
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Flashback {4}{R}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{4}{R}")));

--- a/Mage.Sets/src/mage/cards/m/MagmabloodArchaic.java
+++ b/Mage.Sets/src/mage/cards/m/MagmabloodArchaic.java
@@ -51,12 +51,13 @@ public final class MagmabloodArchaic extends CardImpl {
             ), null, AbilityWord.CONVERGE.formatWord() + "{this} enters with a +1/+1 counter " +
             "on it for each color of mana spent to cast it.", null
         ));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Whenever you cast an instant or sorcery spell, creatures you control get +1/+0 until end of turn for each color of mana spent to cast that spell.
         this.addAbility(new SpellCastControllerTriggeredAbility(
             new BoostControlledEffect(MagmabloodArchaicManaSpentValue.instance, StaticValue.get(0), Duration.EndOfTurn),
             StaticFilters.FILTER_SPELL_AN_INSTANT_OR_SORCERY, false
-        ));
+        ).addHint(ColorsOfManaSpentToCastCount.getHint()));
     }
 
     private MagmabloodArchaic(final MagmabloodArchaic card) {

--- a/Mage.Sets/src/mage/cards/p/PainfulTruths.java
+++ b/Mage.Sets/src/mage/cards/p/PainfulTruths.java
@@ -23,7 +23,7 @@ public final class PainfulTruths extends CardImpl {
                 .setText("you draw X cards"));
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(ColorsOfManaSpentToCastCount.getInstance())
                 .setText("and lose X life, where X is the number of colors of mana spent to cast this spell"));
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private PainfulTruths(final PainfulTruths card) {

--- a/Mage.Sets/src/mage/cards/p/PrismArray.java
+++ b/Mage.Sets/src/mage/cards/p/PrismArray.java
@@ -30,6 +30,7 @@ public final class PrismArray extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.CRYSTAL.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
                 null, "<i>Converge</i> &mdash; {this} enters with a crystal counter on it for each color of mana spent to cast it.", null));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Remove a crystal counter from Prism Array: Tap target creature.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/p/PrismaticEnding.java
+++ b/Mage.Sets/src/mage/cards/p/PrismaticEnding.java
@@ -5,6 +5,7 @@ import mage.abilities.dynamicvalue.common.ColorsOfManaSpentToCastCount;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
+import mage.constants.AbilityWord;
 import mage.constants.CardType;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -24,6 +25,7 @@ public final class PrismaticEnding extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{X}{W}");
 
         // Converge — Exile target nonland permanent if its mana value is less than or equal to the number of colors of mana spent to cast this spell.
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         this.getSpellAbility().addEffect(new PrismaticEndingEffect());
         this.getSpellAbility().addTarget(new TargetNonlandPermanent());
     }

--- a/Mage.Sets/src/mage/cards/r/RadiantEpicure.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantEpicure.java
@@ -4,6 +4,7 @@ import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.dynamicvalue.common.ColorsOfManaSpentToCastCount;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DamagePlayersEffect;
 import mage.cards.CardImpl;
@@ -32,7 +33,7 @@ public final class RadiantEpicure extends CardImpl {
         // Converge — When Radiant Epicure enters the battlefield, each opponent loses X life and you gain X life, where X is the number of colors of mana spent to cast this spell.
         this.addAbility(new EntersBattlefieldTriggeredAbility(
                 new RadiantEpicureEffect(), false)
-                .setAbilityWord(AbilityWord.CONVERGE)
+                .setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint())
         );
     }
 

--- a/Mage.Sets/src/mage/cards/r/RadiantFlames.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantFlames.java
@@ -20,7 +20,7 @@ public final class RadiantFlames extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{R}");
 
         // Converge — Radiant Flames deals X damage to each creature, where X is the number of colors of mana spent to cast Radiant Flames.
-        getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         getSpellAbility().addEffect(new DamageAllEffect(ColorsOfManaSpentToCastCount.getInstance(), new FilterCreaturePermanent()));
     }
 

--- a/Mage.Sets/src/mage/cards/r/RancorousArchaic.java
+++ b/Mage.Sets/src/mage/cards/r/RancorousArchaic.java
@@ -40,6 +40,7 @@ public final class RancorousArchaic extends CardImpl {
                 ), null, AbilityWord.CONVERGE.formatWord() + "{this} enters with a +1/+1 counter " +
                 "on it for each color of mana spent to cast it.", null
         ));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private RancorousArchaic(final RancorousArchaic card) {

--- a/Mage.Sets/src/mage/cards/r/RoilmagesTrick.java
+++ b/Mage.Sets/src/mage/cards/r/RoilmagesTrick.java
@@ -27,7 +27,7 @@ public final class RoilmagesTrick extends CardImpl {
 
         // <i>Converge</i> &mdash; Creatures your opponents control get -X/-0 until end of turn,
         // where X is the number of colors of mana spent to cast this spell.
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         this.getSpellAbility().addEffect(new BoostAllEffect(
                 xValue, StaticValue.get(0), Duration.EndOfTurn,
                 StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURES, false, null

--- a/Mage.Sets/src/mage/cards/s/SkyriderElf.java
+++ b/Mage.Sets/src/mage/cards/s/SkyriderElf.java
@@ -34,6 +34,7 @@ public final class SkyriderElf extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
     }
 

--- a/Mage.Sets/src/mage/cards/s/SnarlSong.java
+++ b/Mage.Sets/src/mage/cards/s/SnarlSong.java
@@ -24,7 +24,7 @@ public final class SnarlSong extends CardImpl {
                 ". Put X +1/+1 counters on each of them"
         ));
         this.getSpellAbility().addEffect(new GainLifeEffect(ColorsOfManaSpentToCastCount.getInstance()).concatBy("and"));
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private SnarlSong(final SnarlSong card) {

--- a/Mage.Sets/src/mage/cards/s/SunderingArchaic.java
+++ b/Mage.Sets/src/mage/cards/s/SunderingArchaic.java
@@ -49,7 +49,7 @@ public final class SunderingArchaic extends CardImpl {
         // Converge -- When this creature enters, exile target nonland permanent an opponent controls with mana value less than or equal to the number of colors of mana spent to cast this creature.
         Ability ability = new EntersBattlefieldTriggeredAbility(new ExileTargetEffect());
         ability.addTarget(new TargetPermanent(filter));
-        ability.setAbilityWord(AbilityWord.CONVERGE);
+        ability.setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         this.addAbility(ability);
 
         // {2}: Put target card from a graveyard on the bottom of its owner's library.

--- a/Mage.Sets/src/mage/cards/s/SweepTheSkies.java
+++ b/Mage.Sets/src/mage/cards/s/SweepTheSkies.java
@@ -21,6 +21,7 @@ public final class SweepTheSkies extends CardImpl {
         this.getSpellAbility().addEffect(new CreateTokenEffect(
                 new ThopterColorlessToken(), ColorsOfManaSpentToCastCount.getInstance()
         ).setText("<i>Converge</i> &mdash; Create a 1/1 colorless Thopter artifact creature token with flying for each color of mana spent to cast this spell"));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private SweepTheSkies(final SweepTheSkies card) {

--- a/Mage.Sets/src/mage/cards/t/TajuruStalwart.java
+++ b/Mage.Sets/src/mage/cards/t/TajuruStalwart.java
@@ -30,6 +30,7 @@ public final class TajuruStalwart extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
     }
 

--- a/Mage.Sets/src/mage/cards/t/TogetherAsOne.java
+++ b/Mage.Sets/src/mage/cards/t/TogetherAsOne.java
@@ -31,7 +31,7 @@ public final class TogetherAsOne extends CardImpl {
         this.getSpellAbility().addTarget(new TargetAnyTarget().withChooseHint("deal damage"));
         this.getSpellAbility().addEffect(new GainLifeEffect(ColorsOfManaSpentToCastCount.getInstance())
                 .concatBy(", and"));
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private TogetherAsOne(final TogetherAsOne card) {

--- a/Mage.Sets/src/mage/cards/t/TranscendentArchaic.java
+++ b/Mage.Sets/src/mage/cards/t/TranscendentArchaic.java
@@ -35,7 +35,7 @@ public final class TranscendentArchaic extends CardImpl {
 
         // Converge -- When this creature enters, you may draw X cards, where X is the number of colors of mana spent to cast this spell. If you draw one or more cards this way, discard two cards.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TranscendentArchaicEffect(), true);
-        ability.setAbilityWord(AbilityWord.CONVERGE);
+        ability.setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UnclesMusings.java
+++ b/Mage.Sets/src/mage/cards/u/UnclesMusings.java
@@ -27,7 +27,7 @@ public final class UnclesMusings extends CardImpl {
                         "where X is the number of colors of mana spent to cast this spell"));
         this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(0, 1, StaticFilters.FILTER_CARD_PERMANENT));
         this.getSpellAbility().setTargetAdjuster(new TargetsCountAdjuster(ColorsOfManaSpentToCastCount.getInstance()));
-        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        this.getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Exile Uncle's Musings.
         this.getSpellAbility().addEffect(new ExileSpellEffect().concatBy("<br>"));

--- a/Mage.Sets/src/mage/cards/u/UnifiedFront.java
+++ b/Mage.Sets/src/mage/cards/u/UnifiedFront.java
@@ -21,7 +21,7 @@ public final class UnifiedFront extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{W}");
 
         // <i>Converge</i> &mdash; Create a 1/1 white Kor Ally creature token for each color of mana spent to cast Unified Front.
-        getSpellAbility().setAbilityWord(AbilityWord.CONVERGE);
+        getSpellAbility().setAbilityWord(AbilityWord.CONVERGE).addHint(ColorsOfManaSpentToCastCount.getHint());
         Effect effect = new CreateTokenEffect(new KorAllyToken(), ColorsOfManaSpentToCastCount.getInstance());
         effect.setText("Create a 1/1 white Kor Ally creature token for each color of mana spent to cast this spell");
         getSpellAbility().addEffect(effect);

--- a/Mage.Sets/src/mage/cards/w/WildgrowthArchaic.java
+++ b/Mage.Sets/src/mage/cards/w/WildgrowthArchaic.java
@@ -52,6 +52,7 @@ public final class WildgrowthArchaic extends CardImpl {
             ), null, AbilityWord.CONVERGE.formatWord() + "{this} enters with a +1/+1 counter " +
             "on it for each color of mana spent to cast it.", null
         ));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 
         // Whenever you cast a creature spell, that creature enters with X additional +1/+1
         // counters on it, where X is the number of colors of mana spent to cast it.
@@ -59,7 +60,7 @@ public final class WildgrowthArchaic extends CardImpl {
             new WildgrowthArchaicEffect(),
             StaticFilters.FILTER_SPELL_A_CREATURE,
             false, SetTargetPointer.SPELL
-        ));
+        ).addHint(ColorsOfManaSpentToCastCount.getHint()));
 
     }
 

--- a/Mage.Sets/src/mage/cards/w/WoodlandWanderer.java
+++ b/Mage.Sets/src/mage/cards/w/WoodlandWanderer.java
@@ -34,6 +34,7 @@ public final class WoodlandWanderer extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
+        this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
     }
 
     private WoodlandWanderer(final WoodlandWanderer card) {

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -10,6 +10,7 @@ import mage.abilities.common.*;
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.ColorsOfManaSpentToCastCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.ExileUntilSourceLeavesEffect;
 import mage.abilities.effects.common.FightTargetsEffect;
@@ -2578,6 +2579,7 @@ public class VerifyCardDataTest {
         cardHints.put(MonarchHint.class, "the monarch");
         cardHints.put(InitiativeHint.class, "the initiative");
         cardHints.put(CurrentDungeonHint.class, "venture into");
+        cardHints.put(ColorsOfManaSpentToCastCount.getHint().getClass(), "Converge —");
         for (Class hintClass : cardHints.keySet()) {
             String lookupText = cardHints.get(hintClass);
             boolean needHint = ref.text.contains(lookupText);

--- a/Mage/src/main/java/mage/abilities/dynamicvalue/common/ColorsOfManaSpentToCastCount.java
+++ b/Mage/src/main/java/mage/abilities/dynamicvalue/common/ColorsOfManaSpentToCastCount.java
@@ -6,6 +6,8 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.stack.Spell;
@@ -17,6 +19,7 @@ import mage.game.stack.Spell;
 public class ColorsOfManaSpentToCastCount implements DynamicValue {
 
     private static final ColorsOfManaSpentToCastCount instance = new ColorsOfManaSpentToCastCount();
+    private static final Hint hint = new ValueHint("Colors of mana spent", instance);
 
     private Object readResolve() throws ObjectStreamException {
         return instance;
@@ -76,6 +79,10 @@ public class ColorsOfManaSpentToCastCount implements DynamicValue {
     @Override
     public String getMessage() {
         return "the number of colors of mana spent to cast this spell";
+    }
+
+    public static Hint getHint() {
+        return hint;
     }
 
 }


### PR DESCRIPTION
Adds a little hint showing what value for number of colors of mana spent is used for converge abilities.

Fixes https://github.com/magefree/mage/issues/14758