### PR TITLE
Remove activatorId from ActivatedAbilityImpl

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LightningStorm.java
+++ b/Mage.Sets/src/mage/cards/l/LightningStorm.java
@@ -1,7 +1,6 @@
 package mage.cards.l;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.DiscardTargetCost;
 import mage.abilities.dynamicvalue.DynamicValue;
@@ -115,7 +114,7 @@ class LightningStormAddCounterEffect extends OneShotEffect {
         Spell spell = game.getStack().getSpell(source.getSourceId());
         if (spell != null) {
             spell.addCounters(CounterType.CHARGE.createInstance(2), source.getControllerId(), source, game);
-            spell.chooseNewTargets(game, ((ActivatedAbilityImpl) source).getActivatorId(), false, false, null);
+            spell.chooseNewTargets(game, source.getControllerId(), false, false, null);
             return true;
         }
         return false;

--- a/Mage.Sets/src/mage/cards/l/LostInThought.java
+++ b/Mage.Sets/src/mage/cards/l/LostInThought.java
@@ -1,8 +1,6 @@
 package mage.cards.l;
 
-import java.util.UUID;
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.SpecialAction;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.ExileFromGraveCost;
@@ -20,6 +18,8 @@ import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCardInYourGraveyard;
 import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
 
 /**
  *
@@ -173,7 +173,15 @@ class LostInThoughtIgnoreEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + LostInThought.keyString + game.getTurnNum() + ((ActivatedAbilityImpl) source).getActivatorId();
+        Permanent enchantment = source.getSourcePermanentOrLKI(game);
+        if (enchantment == null) {
+            return false;
+        }
+        Permanent enchanted = game.getPermanent(enchantment.getAttachedTo());
+        if (enchanted == null) {
+            return false;
+        }
+        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + LostInThought.keyString + game.getTurnNum() + enchanted.getControllerId();
         game.getState().setValue(key, true);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/l/LostInThought.java
+++ b/Mage.Sets/src/mage/cards/l/LostInThought.java
@@ -173,15 +173,7 @@ class LostInThoughtIgnoreEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent enchantment = source.getSourcePermanentOrLKI(game);
-        if (enchantment == null) {
-            return false;
-        }
-        Permanent enchanted = game.getPermanent(enchantment.getAttachedTo());
-        if (enchanted == null) {
-            return false;
-        }
-        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + LostInThought.keyString + game.getTurnNum() + enchanted.getControllerId();
+        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + LostInThought.keyString + game.getTurnNum() + source.getControllerId();
         game.getState().setValue(key, true);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/v/VolrathsCurse.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsCurse.java
@@ -175,15 +175,7 @@ class VolrathsCurseIgnoreEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent enchantment = source.getSourcePermanentOrLKI(game);
-        if (enchantment == null) {
-            return false;
-        }
-        Permanent enchanted = game.getPermanent(enchantment.getAttachedTo());
-        if (enchanted == null) {
-            return false;
-        }
-        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + VolrathsCurse.keyString + game.getTurnNum() + enchanted.getControllerId();
+        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + VolrathsCurse.keyString + game.getTurnNum() + source.getControllerId();
         game.getState().setValue(key, true);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/v/VolrathsCurse.java
+++ b/Mage.Sets/src/mage/cards/v/VolrathsCurse.java
@@ -1,7 +1,6 @@
 package mage.cards.v;
 
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.SpecialAction;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -144,7 +143,7 @@ class VolrathsCurseSpecialAction extends SpecialAction {
     public VolrathsCurseSpecialAction() {
         super(Zone.BATTLEFIELD);
         this.addCost(new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT));
-        this.addEffect(new VolrathsCurseIgnoreEffect(VolrathsCurse.keyString));
+        this.addEffect(new VolrathsCurseIgnoreEffect());
         this.setMayActivate(TargetController.CONTROLLER_ATTACHED_TO);
     }
 
@@ -160,7 +159,7 @@ class VolrathsCurseSpecialAction extends SpecialAction {
 
 class VolrathsCurseIgnoreEffect extends OneShotEffect {
 
-    VolrathsCurseIgnoreEffect(final String keyString) {
+    VolrathsCurseIgnoreEffect() {
         super(Outcome.Benefit);
         this.staticText = "That creature's controller may sacrifice a permanent for that player to ignore this effect until end of turn";
     }
@@ -176,7 +175,15 @@ class VolrathsCurseIgnoreEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + VolrathsCurse.keyString + game.getTurnNum() + ((ActivatedAbilityImpl) source).getActivatorId();
+        Permanent enchantment = source.getSourcePermanentOrLKI(game);
+        if (enchantment == null) {
+            return false;
+        }
+        Permanent enchanted = game.getPermanent(enchantment.getAttachedTo());
+        if (enchanted == null) {
+            return false;
+        }
+        String key = source.getSourceId().toString() + source.getStackMomentSourceZCC() + VolrathsCurse.keyString + game.getTurnNum() + enchanted.getControllerId();
         game.getState().setValue(key, true);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/w/WellOfKnowledge.java
+++ b/Mage.Sets/src/mage/cards/w/WellOfKnowledge.java
@@ -1,17 +1,14 @@
 package mage.cards.w;
 
-import mage.ApprovingObject;
-import mage.abilities.Ability;
 import mage.abilities.ActivatedAbilityImpl;
-import mage.abilities.condition.common.IsStepCondition;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.Effects;
-import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.*;
+import mage.constants.CardType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
 import mage.game.Game;
-import mage.players.Player;
 
 import java.util.UUID;
 
@@ -24,7 +21,7 @@ public final class WellOfKnowledge extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // {2}: Draw a card. Any player may activate this ability but only during their draw step.
-        this.addAbility(new WellOfKnowledgeConditionalActivatedAbility());
+        this.addAbility(new WellOfKnowledgeActivatedAbility());
 
     }
 
@@ -38,74 +35,34 @@ public final class WellOfKnowledge extends CardImpl {
     }
 }
 
-class WellOfKnowledgeConditionalActivatedAbility extends ActivatedAbilityImpl {
+class WellOfKnowledgeActivatedAbility extends ActivatedAbilityImpl {
 
-    public WellOfKnowledgeConditionalActivatedAbility() {
-        super(Zone.BATTLEFIELD, new WellOfKnowledgeEffect(), new GenericManaCost(2));
-        condition = new IsStepCondition(PhaseStep.DRAW, false);
+    WellOfKnowledgeActivatedAbility() {
+        super(Zone.BATTLEFIELD, new DrawCardSourceControllerEffect(1), new GenericManaCost(2));
     }
 
-    private WellOfKnowledgeConditionalActivatedAbility(final WellOfKnowledgeConditionalActivatedAbility ability) {
+    private WellOfKnowledgeActivatedAbility(final WellOfKnowledgeActivatedAbility ability) {
         super(ability);
-        this.condition = ability.condition;
-    }
-
-    @Override
-    public Effects getEffects(Game game, EffectType effectType) {
-        if (!condition.apply(game, this)) {
-            return new Effects();
-        }
-        return super.getEffects(game, effectType);
     }
 
     @Override
     public ActivationStatus canActivate(UUID playerId, Game game) {
-        if (condition.apply(game, this)
-                && getCosts().canPay(this, this, playerId, game)
-                && game.isActivePlayer(playerId)) {
-            this.activatorId = playerId;
-            return new ActivationStatus(new ApprovingObject(this, game));
+        // note: does not call the super, because needs to be both more and less permissive
+        if (game.getTurnStepType() == PhaseStep.DRAW
+                && game.isActivePlayer(playerId)
+                && getCosts().canPay(this, this, playerId, game)) {
+            return ActivationStatus.withoutApprovingObject(true);
         }
         return ActivationStatus.getFalse();
-
     }
 
     @Override
-    public WellOfKnowledgeConditionalActivatedAbility copy() {
-        return new WellOfKnowledgeConditionalActivatedAbility(this);
+    public WellOfKnowledgeActivatedAbility copy() {
+        return new WellOfKnowledgeActivatedAbility(this);
     }
 
     @Override
     public String getRule() {
         return "{2}: Draw a card. Any player may activate this ability but only during their draw step.";
-    }
-}
-
-class WellOfKnowledgeEffect extends OneShotEffect {
-
-    WellOfKnowledgeEffect() {
-        super(Outcome.DrawCard);
-    }
-
-    private WellOfKnowledgeEffect(final WellOfKnowledgeEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public WellOfKnowledgeEffect copy() {
-        return new WellOfKnowledgeEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        if (source instanceof ActivatedAbilityImpl) {
-            Player activator = game.getPlayer(((ActivatedAbilityImpl) source).getActivatorId());
-            if (activator != null) {
-                activator.drawCards(1, source, game);
-                return true;
-            }
-
-        }
-        return false;
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/sacrifice/SacrificeTargetCostTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/sacrifice/SacrificeTargetCostTest.java
@@ -1,13 +1,7 @@
 package org.mage.test.cards.cost.sacrifice;
 
-import mage.abilities.common.LicidAbility;
-import mage.abilities.costs.mana.ColoredManaCost;
-import mage.abilities.keyword.HasteAbility;
-import mage.constants.CardType;
-import mage.constants.ColoredManaSymbol;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -124,7 +118,7 @@ public class SacrificeTargetCostTest extends CardTestPlayerBase {
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Volrath's Curse");
         addTarget(playerA, "Memnarch");
 
-        activateAbility(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Sacrifice a ", "Volrath's Curse");
+        activateAbility(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Sacrifice a ");
         setChoice(playerB, "Memnite");
 
         setStrictChooseMode(true);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/scg/LethalVaporsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/scg/LethalVaporsTest.java
@@ -1,0 +1,63 @@
+package org.mage.test.cards.single.scg;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class LethalVaporsTest extends CardTestPlayerBase {
+
+    // Lethal Vapors {2}{B}{B}
+    // Enchantment
+    // Whenever a creature enters, destroy it.
+    // {0}: Destroy this enchantment. You skip your next turn. Any player may activate this ability.
+    private static final String vapors = "Lethal Vapors";
+    private static final String ability = "{0}: Destroy";
+
+    // At the beginning of your upkeep, you may gain 1 life.
+    private static final String mantra = "Ajani's Mantra";
+
+    @Test
+    public void testPlayerADestroys(){
+        addCard(Zone.BATTLEFIELD, playerA, vapors);
+        addCard(Zone.BATTLEFIELD, playerA, mantra);
+        addCard(Zone.BATTLEFIELD, playerB, mantra);
+
+        setChoice(playerA, true);
+        setChoice(playerB, true);
+        setChoice(playerA, true);
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, ability);
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        setStrictChooseMode(true);
+        setStopAt(5, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 22);
+        assertLife(playerB, 23);
+    }
+
+    @Test
+    public void testPlayerBDestroys(){
+        addCard(Zone.BATTLEFIELD, playerA, vapors);
+        addCard(Zone.BATTLEFIELD, playerA, mantra);
+        addCard(Zone.BATTLEFIELD, playerB, mantra);
+
+        setChoice(playerA, true);
+        setChoice(playerB, true);
+        setChoice(playerA, true);
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerB, ability);
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 23);
+        assertLife(playerB, 21);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/tmp/VolrathsCurseTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/tmp/VolrathsCurseTest.java
@@ -1,0 +1,46 @@
+package org.mage.test.cards.single.tmp;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class VolrathsCurseTest extends CardTestPlayerBase {
+
+    private static final String curse = "Volrath's Curse";
+    // Enchanted creature can’t attack or block, and its activated abilities can’t be activated.
+    // That creature’s controller may sacrifice a permanent of their choice
+    // for that player to ignore this effect until end of turn.
+    private static final String soulmender = "Soulmender";
+    // {T}: You gain 1 life
+
+    @Test
+    public void testActivation() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.HAND, playerA, curse);
+        addCard(Zone.BATTLEFIELD, playerB, soulmender);
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, curse, soulmender);
+
+        checkPlayableAbility("can't activate", 2, PhaseStep.UPKEEP, playerB, "{T}: You gain", false);
+
+        activateAbility(2, PhaseStep.BEGIN_COMBAT, playerB, "Sacrifice");
+        setChoice(playerB, "Mountain");
+
+        activateAbility(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "{T}: You gain");
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 20);
+        assertLife(playerB, 21);
+        assertTapped(soulmender, true);
+        assertAttachedTo(playerB, curse, soulmender, true);
+    }
+
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/wth/WellOfKnowledgeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/wth/WellOfKnowledgeTest.java
@@ -1,0 +1,117 @@
+package org.mage.test.cards.single.wth;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class WellOfKnowledgeTest extends CardTestPlayerBase {
+
+    // {2}: Draw a card. Any player may activate this ability but only during their draw step.
+    private static final String well = "Well of Knowledge";
+    private static final String ability = "{2}: Draw";
+
+    @Test
+    public void testController() {
+        addCard(Zone.BATTLEFIELD, playerA, well);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        activateAbility(3, PhaseStep.DRAW, playerA, ability);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerA, 2); // draw step and well
+        assertHandCount(playerB, 1); // draw step
+
+    }
+
+    @Test
+    public void testNotController() {
+        addCard(Zone.BATTLEFIELD, playerA, well);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        activateAbility(2, PhaseStep.DRAW, playerB, ability);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerA, 1); // draw step
+        assertHandCount(playerB, 2); // draw step and well
+    }
+
+    @Test
+    public void testControllerNotActive() {
+        addCard(Zone.BATTLEFIELD, playerA, well);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        activateAbility(2, PhaseStep.DRAW, playerA, ability);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertEquals(
+                    "Correctly can't activate",
+                    "Can't find ability to activate command: " + ability, e.getMessage()
+            );
+            return;
+        }
+        Assert.fail("Was able to activate ability, but shouldn't");
+    }
+
+    @Test
+    public void testNotControllerNotActive() {
+        addCard(Zone.BATTLEFIELD, playerA, well);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        activateAbility(3, PhaseStep.DRAW, playerB, ability);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertEquals(
+                    "Correctly can't activate",
+                    "Can't find ability to activate command: " + ability, e.getMessage()
+            );
+            return;
+        }
+        Assert.fail("Was able to activate ability, but shouldn't");
+    }
+
+    @Test
+    public void testControllerNotDrawStep() {
+        addCard(Zone.BATTLEFIELD, playerA, well);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        activateAbility(3, PhaseStep.UPKEEP, playerA, ability);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
+        try {
+            execute();
+        } catch (AssertionError e) {
+            Assert.assertEquals(
+                    "Correctly can't activate",
+                    "Can't find ability to activate command: " + ability, e.getMessage()
+            );
+            return;
+        }
+        Assert.fail("Was able to activate ability, but shouldn't");
+    }
+
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/wth/WellOfKnowledgeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/wth/WellOfKnowledgeTest.java
@@ -2,7 +2,6 @@ package org.mage.test.cards.single.wth;
 
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
@@ -16,10 +15,19 @@ public class WellOfKnowledgeTest extends CardTestPlayerBase {
     private static final String ability = "{2}: Draw";
 
     @Test
-    public void testController() {
+    public void testActivations() {
         addCard(Zone.BATTLEFIELD, playerA, well);
         addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
         addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+
+        checkPlayableAbility("", 1, PhaseStep.PRECOMBAT_MAIN, playerA, ability, false);
+        checkPlayableAbility("", 1, PhaseStep.PRECOMBAT_MAIN, playerB, ability, false);
+
+        checkPlayableAbility("", 2, PhaseStep.DRAW, playerA, ability, false);
+        checkPlayableAbility("", 2, PhaseStep.DRAW, playerB, ability, true);
+
+        checkPlayableAbility("", 3, PhaseStep.DRAW, playerA, ability, true);
+        checkPlayableAbility("", 3, PhaseStep.DRAW, playerB, ability, false);
 
         activateAbility(3, PhaseStep.DRAW, playerA, ability);
 
@@ -30,88 +38,6 @@ public class WellOfKnowledgeTest extends CardTestPlayerBase {
         assertHandCount(playerA, 2); // draw step and well
         assertHandCount(playerB, 1); // draw step
 
-    }
-
-    @Test
-    public void testNotController() {
-        addCard(Zone.BATTLEFIELD, playerA, well);
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
-        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
-
-        activateAbility(2, PhaseStep.DRAW, playerB, ability);
-
-        setStrictChooseMode(true);
-        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
-        execute();
-
-        assertHandCount(playerA, 1); // draw step
-        assertHandCount(playerB, 2); // draw step and well
-    }
-
-    @Test
-    public void testControllerNotActive() {
-        addCard(Zone.BATTLEFIELD, playerA, well);
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
-        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
-
-        activateAbility(2, PhaseStep.DRAW, playerA, ability);
-
-        setStrictChooseMode(true);
-        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
-        try {
-            execute();
-        } catch (AssertionError e) {
-            Assert.assertEquals(
-                    "Correctly can't activate",
-                    "Can't find ability to activate command: " + ability, e.getMessage()
-            );
-            return;
-        }
-        Assert.fail("Was able to activate ability, but shouldn't");
-    }
-
-    @Test
-    public void testNotControllerNotActive() {
-        addCard(Zone.BATTLEFIELD, playerA, well);
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
-        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
-
-        activateAbility(3, PhaseStep.DRAW, playerB, ability);
-
-        setStrictChooseMode(true);
-        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
-        try {
-            execute();
-        } catch (AssertionError e) {
-            Assert.assertEquals(
-                    "Correctly can't activate",
-                    "Can't find ability to activate command: " + ability, e.getMessage()
-            );
-            return;
-        }
-        Assert.fail("Was able to activate ability, but shouldn't");
-    }
-
-    @Test
-    public void testControllerNotDrawStep() {
-        addCard(Zone.BATTLEFIELD, playerA, well);
-        addCard(Zone.BATTLEFIELD, playerA, "Island", 2);
-        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
-
-        activateAbility(3, PhaseStep.UPKEEP, playerA, ability);
-
-        setStrictChooseMode(true);
-        setStopAt(3, PhaseStep.PRECOMBAT_MAIN);
-        try {
-            execute();
-        } catch (AssertionError e) {
-            Assert.assertEquals(
-                    "Correctly can't activate",
-                    "Can't find ability to activate command: " + ability, e.getMessage()
-            );
-            return;
-        }
-        Assert.fail("Was able to activate ability, but shouldn't");
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -449,18 +449,13 @@ public abstract class AbilityImpl implements Ability {
             game.getContinuousEffects().costModification(this, game);
         }
 
-        UUID activatorId = controllerId;
-        if ((this instanceof ActivatedAbilityImpl) && ((ActivatedAbilityImpl) this).getActivatorId() != null) {
-            activatorId = ((ActivatedAbilityImpl) this).getActivatorId();
-        }
-
         //20100716 - 601.2f  (noMana is not used here, because mana costs were cleared for this ability before adding additional costs and applying cost modification effects)
-        if (!getManaCostsToPay().pay(this, game, this, activatorId, false, null)) {
+        if (!getManaCostsToPay().pay(this, game, this, controllerId, false, null)) {
             return false; // cancel during mana payment
         }
 
         //20100716 - 601.2g
-        if (!getCosts().pay(this, game, this, activatorId, noMana, null)) {
+        if (!getCosts().pay(this, game, this, controllerId, noMana, null)) {
             logger.debug("activate failed - non mana costs");
             return false;
         }

--- a/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java
@@ -42,7 +42,6 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
     protected Condition condition;
     protected TimingRule timing = TimingRule.INSTANT;
     protected TargetController mayActivate = TargetController.YOU;
-    protected UUID activatorId;
 
     protected ActivatedAbilityImpl(AbilityType abilityType, Zone zone) {
         super(abilityType, zone);
@@ -52,7 +51,6 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
         super(ability);
         timing = ability.timing;
         mayActivate = ability.mayActivate;
-        activatorId = ability.activatorId;
         maxActivationsPerTurn = ability.maxActivationsPerTurn;
         maxActivationsPerGame = ability.maxActivationsPerGame;
         condition = ability.condition;
@@ -148,11 +146,6 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
         }
 
         // all fine, can be activated
-        // TODO: WTF, must be rework to remove data change in canActivate call
-        //  (it can be called from any place by any player or card).
-        //  game.inCheckPlayableState() can't be a help here cause some cards checking activating status,
-        //  activatorId must be removed
-        this.activatorId = playerId;
 
         if (approvingObjects.isEmpty()) {
             return ActivationStatus.withoutApprovingObject(true);
@@ -185,10 +178,6 @@ public abstract class ActivatedAbilityImpl extends AbilityImpl implements Activa
     public ActivatedAbilityImpl setMayActivate(TargetController mayActivate) {
         this.mayActivate = mayActivate;
         return this;
-    }
-
-    public UUID getActivatorId() {
-        return this.activatorId;
     }
 
     public TimingRule getTiming() {

--- a/Mage/src/main/java/mage/abilities/effects/common/turn/SkipNextTurnSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/turn/SkipNextTurnSourceEffect.java
@@ -1,9 +1,6 @@
 package mage.abilities.effects.common.turn;
 
-import java.util.UUID;
-
 import mage.abilities.Ability;
-import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.constants.Outcome;
 import mage.game.Game;
@@ -39,15 +36,8 @@ public class SkipNextTurnSourceEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        UUID playerId = null;
-        if (source instanceof ActivatedAbilityImpl) {
-            playerId = ((ActivatedAbilityImpl) source).getActivatorId(); // for Lethal Vapors
-        }
-        if (playerId == null) {
-            playerId = source.getControllerId();
-        }
         for (int i = 0; i < numberOfTurns; i++) {
-            game.getState().getTurnMods().add(new TurnMod(playerId).withSkipTurn());
+            game.getState().getTurnMods().add(new TurnMod(source.getControllerId()).withSkipTurn());
         }
         return true;
     }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1597,6 +1597,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         if (!game.replaceEvent(GameEvent.getEvent(GameEvent.EventType.TAKE_SPECIAL_MANA_PAYMENT,
                 action.getId(), action, getId()))) {
             int bookmark = game.bookmarkState();
+            action.setControllerId(playerId);
             if (action.activate(game, false)) {
                 game.fireEvent(GameEvent.getEvent(GameEvent.EventType.TAKEN_SPECIAL_MANA_PAYMENT,
                         action.getId(), action, getId()));

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1574,6 +1574,7 @@ public abstract class PlayerImpl implements Player, Serializable {
         if (!game.replaceEvent(GameEvent.getEvent(GameEvent.EventType.TAKE_SPECIAL_ACTION,
                 action.getId(), action, getId()))) {
             int bookmark = game.bookmarkState();
+            action.setControllerId(playerId); // for Volrath's Curse / Lost in Thought
             if (action.activate(game, false)) {
                 game.fireEvent(GameEvent.getEvent(GameEvent.EventType.TAKEN_SPECIAL_ACTION,
                         action.getId(), action, getId()));


### PR DESCRIPTION
Resolves #12888

Tests written for the small number of cards that unnecessarily relied on activatorId param, which was being set in a method that shouldn't be changing state. 

https://github.com/magefree/mage/blob/72551143a3c91a92a050500add186b35e39e53b5/Mage/src/main/java/mage/abilities/ActivatedAbilityImpl.java#L151-L155

The engine sets controller id to the activator upon activation (of what is a copy of the activated ability), so the manual checks for activatorId could be replaced by source controllerId for all usages, and this code turns out to not be needed at all

The only additional change required was due to the strange cards Volrath's Curse and Lost in Thought, which set up special actions for the controller of enchanted creature to activate to ignore a restriction until end of turn. In order to use controller id instead of activator id, it is necessary to set controller id to the activator of a special action, same as for activated ability and mana ability. This is fine as it is also a copy of the special action that gets activated.

Interestingly, setting the controller id of special actions caused an existing test to fail. That test incorrectly added a target where no target should have been present. I'm not entirely sure why not setting controller id allowed it to silently drop the extraneous target without error, but it always should have been failing as written, so that indicates that the updated behavior is correct, and the test has been corrected as well. No other existing tests failures were found as a result of removing this parameter.