### PR TITLE
Store LKI about what a permanent was attacking/blocking; fix Gomazoa

### DIFF
--- a/Mage.Sets/src/mage/cards/c/Camouflage.java
+++ b/Mage.Sets/src/mage/cards/c/Camouflage.java
@@ -95,7 +95,7 @@ class CamouflageEffect extends ContinuousRuleModifyingEffectImpl {
                     }
                     // This shouldn't be necessary, but just in case
                     for (Permanent permanent : game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), defenderId, game)) {
-                        permanent.setBlocking(0);
+                        permanent.clearBlocking();
                     }
 
                     boolean declinedChoice = false;
@@ -146,7 +146,7 @@ class CamouflageEffect extends ContinuousRuleModifyingEffectImpl {
                     }
                     // Clear all test Blocking values before assigning piles
                     for (Permanent permanent : game.getBattlefield().getAllActivePermanents(new FilterCreaturePermanent(), defenderId, game)) {
-                        permanent.setBlocking(0);
+                        permanent.clearBlocking();
                     }
                     masterMap.put(defenderId, masterList);
                 }

--- a/Mage.Sets/src/mage/cards/g/GeneralJarkeld.java
+++ b/Mage.Sets/src/mage/cards/g/GeneralJarkeld.java
@@ -153,7 +153,7 @@ class GeneralJarkeldSwitchBlockersEffect extends OneShotEffect {
     private void handleSingleBlockers(Set<Permanent> blockers, CombatGroup chosenGroup, CombatGroup otherGroup, Player controller, Game game) {
         for (Permanent blocker : blockers) {
             chosenGroup.remove(blocker.getId());
-            blocker.setBlocking(0);
+            blocker.clearBlocking();
             // 10/4/2004 	The new blocker does not trigger any abilities which trigger on creatures becoming blockers, because the creatures were already blockers and the simple change of who is blocking does not trigger such abilities.
             otherGroup.addBlockerToGroup(blocker.getId(), controller.getId(), game);
         }

--- a/Mage.Sets/src/mage/cards/g/Gomazoa.java
+++ b/Mage.Sets/src/mage/cards/g/Gomazoa.java
@@ -1,9 +1,5 @@
-
 package mage.cards.g;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
@@ -14,24 +10,22 @@ import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
-import mage.constants.WatcherScope;
+import mage.constants.SubType;
 import mage.constants.Zone;
 import mage.game.Game;
-import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
-import mage.watchers.Watcher;
+
+import java.util.*;
 
 /**
- *
  * @author jeffwadsworth
  */
 public final class Gomazoa extends CardImpl {
 
     public Gomazoa(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.CREATURE},"{2}{U}");
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
         this.subtype.add(SubType.JELLYFISH);
 
         this.power = new MageInt(0);
@@ -44,7 +38,7 @@ public final class Gomazoa extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // {tap}: Put Gomazoa and each creature it's blocking on top of their owners' libraries, then those players shuffle their libraries.
-        this.addAbility(new SimpleActivatedAbility(new GomazoaEffect(), new TapSourceCost()), new BlockedByWatcher());
+        this.addAbility(new SimpleActivatedAbility(new GomazoaEffect(), new TapSourceCost()));
 
     }
 
@@ -77,63 +71,34 @@ class GomazoaEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        if (controller != null) {
-            List<UUID> players = new ArrayList<>();
-            Permanent gomazoa = game.getPermanent(source.getSourceId());
-            if (gomazoa != null) {
-                controller.moveCardToLibraryWithInfo(gomazoa, source, game, Zone.BATTLEFIELD, true, true);
-                players.add(gomazoa.getOwnerId());
-            }
-
-            BlockedByWatcher watcher = game.getState().getWatcher(BlockedByWatcher.class, source.getSourceId());
-
-            for (UUID blockedById : watcher.getBlockedByWatcher()) {
-                Permanent blockedByGomazoa = game.getPermanent(blockedById);
-                if (blockedByGomazoa != null && blockedByGomazoa.isAttacking()) {
-                    players.add(blockedByGomazoa.getOwnerId());
-                    Player owner = game.getPlayer(blockedByGomazoa.getOwnerId());
-                    if (owner != null) {
-                        owner.moveCardToLibraryWithInfo(blockedByGomazoa, source, game, Zone.BATTLEFIELD, true, true);
-                    }
-                }
-            }
-            for (UUID player : players) {
-                Player owner = game.getPlayer(player);
-                if (owner != null) {
-                    owner.shuffleLibrary(source, game);
-                }
-            }
-            return true;
+        if (controller == null) {
+            return false;
         }
-        return false;
-
-    }
-}
-
-class BlockedByWatcher extends Watcher {
-
-    public List<UUID> getBlockedByWatcher() {
-        return blockedByWatcher;
-    }
-
-    private List<UUID> blockedByWatcher = new ArrayList<>();
-
-    public BlockedByWatcher() {
-        super(WatcherScope.CARD);
-    }
-
-    @Override
-    public void watch(GameEvent event, Game game) {
-        if (event.getType() == GameEvent.EventType.BLOCKER_DECLARED) {
-            if (sourceId.equals(event.getSourceId()) && !blockedByWatcher.contains(event.getTargetId())) {
-                blockedByWatcher.add(event.getTargetId());
-            }
+        List<Permanent> permanents = new ArrayList<>();
+        Set<UUID> playersToShuffle = new HashSet<>();
+        Permanent gomazoa = source.getSourcePermanentIfItStillExists(game);
+        if (gomazoa != null) {
+            permanents.add(gomazoa);
+            playersToShuffle.add(gomazoa.getOwnerId());
+        } else {
+            gomazoa = source.getSourcePermanentOrLKI(game);
         }
-    }
-
-    @Override
-    public void reset() {
-        super.reset();
-        blockedByWatcher.clear();
+        if (gomazoa != null) {
+            gomazoa.getBlockingRefs().stream()
+                    .map(mor -> mor.getPermanent(game))
+                    .filter(Objects::nonNull)
+                    .forEach(blocked -> {
+                        permanents.add(blocked);
+                        playersToShuffle.add(blocked.getOwnerId());
+                    });
+        }
+        for (Permanent permanent : permanents) {
+            controller.moveCardToLibraryWithInfo(permanent, source, game, Zone.BATTLEFIELD, true, true);
+        }
+        playersToShuffle.stream()
+                .map(game::getPlayer)
+                .filter(Objects::nonNull)
+                .forEach(p -> p.shuffleLibrary(source, game));
+        return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/o/ObservedStasis.java
+++ b/Mage.Sets/src/mage/cards/o/ObservedStasis.java
@@ -97,7 +97,7 @@ class ObservedStasisEffect extends OneShotEffect {
         if (permanent == null) {
             return false;
         }
-        game.getCombat().removeAttacker(permanent.getId(), game);
+        permanent.removeFromCombat(game);
         int count = game.getBattlefield().count(filter, permanent.getControllerId(), source, game);
         if (count > 0) {
             Optional.ofNullable(source.getControllerId())

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/zen/GomazoaTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/zen/GomazoaTest.java
@@ -1,0 +1,168 @@
+package org.mage.test.cards.single.zen;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author xenohedron
+ */
+public class GomazoaTest extends CardTestPlayerBase {
+
+    // see issue #13774
+
+    private static final String gomazoa = "Gomazoa"; // 0/3 defender flying
+    // {T}: Put this creature and each creature it’s blocking on top of their owners’ libraries, then those players shuffle.
+
+    private static final String aetherplasm = "Aetherplasm";
+    // Whenever this creature blocks a creature, you may return this creature to its owner’s hand.
+    // If you do, you may put a creature card from your hand onto the battlefield blocking that creature.
+
+    private static final String crab = "Fortress Crab"; // 1/6
+    private static final String wishcoin = "Wishcoin Crab"; // 2/5
+
+    private static final String labyrinth = "Labyrinth of Skophos";
+    // {4}, {T}: Remove target attacking or blocking creature from combat.
+
+    private static final String warlord = "Balduvian Warlord";
+    // {T}: Remove target blocking creature from combat. Creatures it was blocking that hadn’t become blocked
+    // by another creature this combat become unblocked, then it blocks an attacking creature of your choice.
+    // Activate only during the declare blockers step.
+
+    @Test
+    public void testSimple() {
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerB, gomazoa);
+
+        attack(1, playerA, crab, playerB);
+        block(1, playerB, gomazoa, crab);
+
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "{T}: Put");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLibraryCount(playerB, gomazoa, 1);
+        assertLibraryCount(playerA, crab, 1);
+    }
+
+    @Test
+    public void testRemoveAttackerFromCombat() {
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerB, gomazoa);
+        addCard(Zone.BATTLEFIELD, playerA, labyrinth);
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 4);
+
+        attack(1, playerA, crab, playerB);
+        block(1, playerB, gomazoa, crab);
+
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerA, "{4}, {T}: Remove", crab);
+        waitStackResolved(1, PhaseStep.DECLARE_BLOCKERS);
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "{T}: Put");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLibraryCount(playerB, gomazoa, 1);
+        assertPermanentCount(playerA, crab, 1);
+    }
+
+    @Test
+    public void testRemoveGomazoaFromCombat() {
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerB, gomazoa);
+        addCard(Zone.BATTLEFIELD, playerA, labyrinth);
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 4);
+
+        attack(1, playerA, crab, playerB);
+        block(1, playerB, gomazoa, crab);
+
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerA, "{4}, {T}: Remove", gomazoa);
+        waitStackResolved(1, PhaseStep.DECLARE_BLOCKERS);
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "{T}: Put");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLibraryCount(playerB, gomazoa, 1);
+        assertPermanentCount(playerA, crab, 1);
+    }
+
+
+    @Test
+    public void testRemoveGomazoaInResponse() {
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerB, gomazoa);
+        addCard(Zone.BATTLEFIELD, playerB, "Blood Bairn");
+
+        attack(1, playerA, crab, playerB);
+        block(1, playerB, gomazoa, crab);
+
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "{T}: Put");
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "Sacrifice");
+        setChoice(playerB, gomazoa);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerB, gomazoa, 1);
+        assertLibraryCount(playerA, crab, 1);
+    }
+
+    @Test
+    public void testWithAetherplasm() {
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerB, aetherplasm);
+        addCard(Zone.HAND, playerB, gomazoa);
+        addCard(Zone.BATTLEFIELD, playerB, "Fervor"); // creatures you control have haste
+
+        attack(1, playerA, crab, playerB);
+        block(1, playerB, aetherplasm, crab);
+
+        setChoice(playerB, true); // yes to ability
+        setChoice(playerB, true); // yes to put creature
+        setChoice(playerB, gomazoa); // from hand to blocker
+
+        waitStackResolved(1, PhaseStep.DECLARE_BLOCKERS);
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "{T}: Put");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLibraryCount(playerB, gomazoa, 1);
+        assertLibraryCount(playerA, crab, 1);
+        assertHandCount(playerB, aetherplasm, 1);
+    }
+
+    @Test
+    public void testWithBalduvianWarlord() {
+        addCard(Zone.BATTLEFIELD, playerA, crab);
+        addCard(Zone.BATTLEFIELD, playerA, wishcoin);
+        addCard(Zone.BATTLEFIELD, playerA, warlord);
+        addCard(Zone.BATTLEFIELD, playerB, gomazoa);
+
+        attack(1, playerA, crab, playerB);
+        attack(1, playerA, wishcoin, playerB);
+        block(1, playerB, gomazoa, crab);
+
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerA, "{T}: Remove", gomazoa);
+        addTarget(playerA, wishcoin);
+        waitStackResolved(1, PhaseStep.DECLARE_BLOCKERS);
+        activateAbility(1, PhaseStep.DECLARE_BLOCKERS, playerB, "{T}: Put");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLibraryCount(playerB, gomazoa, 1);
+        assertPermanentCount(playerA, crab, 1);
+        assertLibraryCount(playerA, wishcoin, 1);
+    }
+
+}

--- a/Mage/src/main/java/mage/game/combat/Combat.java
+++ b/Mage/src/main/java/mage/game/combat/Combat.java
@@ -1505,7 +1505,7 @@ public class Combat implements Serializable, Copyable<Combat> {
         }
         CombatGroup newGroup = new CombatGroup(defenderId, defender != null, defendingPlayerId);
         newGroup.attackers.add(attackerId);
-        attacker.setAttacking(true);
+        attacker.setAttacking(new MageObjectReference(defenderId, game));
         groups.add(newGroup);
         return true;
     }
@@ -1623,8 +1623,12 @@ public class Combat implements Serializable, Copyable<Combat> {
         }
         boolean result = false;
         if (withEvent) {
-            creature.setAttacking(false);
-            creature.setBlocking(0);
+            creature.setAttacking(null);
+            creature.clearBlocking();
+            getBlockers().stream()
+                    .map(game::getPermanent)
+                    .filter(Objects::nonNull)
+                    .forEach(p -> p.removeBlocking(creatureId, game));
         }
         for (CombatGroup group : groups) {
             for (UUID attackerId : group.attackers) {
@@ -1653,16 +1657,16 @@ public class Combat implements Serializable, Copyable<Combat> {
             for (UUID attacker : group.attackers) {
                 creature = game.getPermanent(attacker);
                 if (creature != null) {
-                    creature.setAttacking(false);
-                    creature.setBlocking(0);
+                    creature.setAttacking(null);
+                    creature.clearBlocking();
                     creature.clearBandedCards();
                 }
             }
             for (UUID blocker : group.blockers) {
                 creature = game.getPermanent(blocker);
                 if (creature != null) {
-                    creature.setAttacking(false);
-                    creature.setBlocking(0);
+                    creature.setAttacking(null);
+                    creature.clearBlocking();
                     creature.clearBandedCards();
                 }
             }
@@ -1810,7 +1814,7 @@ public class Combat implements Serializable, Copyable<Combat> {
                 }
                 Permanent creature = game.getPermanent(attackerId);
                 if (creature != null) {
-                    creature.setAttacking(false);
+                    creature.setAttacking(null);
                     if (attackersTappedByAttack.contains(creature.getId())) {
                         creature.setTapped(false);
                         attackersTappedByAttack.remove(creature.getId());
@@ -1918,7 +1922,7 @@ public class Combat implements Serializable, Copyable<Combat> {
         }
         Permanent creature = game.getPermanent(blockerId);
         if (creature != null) {
-            creature.setBlocking(0);
+            creature.clearBlocking();
         }
     }
 

--- a/Mage/src/main/java/mage/game/combat/CombatGroup.java
+++ b/Mage/src/main/java/mage/game/combat/CombatGroup.java
@@ -1,5 +1,6 @@
 package mage.game.combat;
 
+import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.common.ControllerAssignCombatDamageToBlockersAbility;
 import mage.abilities.common.ControllerDivideCombatDamageAbility;
@@ -584,6 +585,9 @@ public class CombatGroup implements Serializable, Copyable<CombatGroup> {
         Permanent blocker = game.getPermanent(blockerId);
         if (blockerId != null && blocker != null) {
             blocker.setBlocking(blocker.getBlocking() + 1);
+            for (UUID attackerId : attackers) {
+                blocker.addBlocking(attackerId, game);
+            }
             blockers.add(blockerId);
             this.blocked = true;
             this.players.put(blockerId, playerId);
@@ -782,6 +786,7 @@ public class CombatGroup implements Serializable, Copyable<CombatGroup> {
                 }
             }
             attacker.clearBandedCards();
+            attacker.setAttacking(new MageObjectReference(newDefenderId, game));
         }
         Permanent permanent = game.getPermanent(newDefenderId);
         if (permanent != null) {

--- a/Mage/src/main/java/mage/game/permanent/Permanent.java
+++ b/Mage/src/main/java/mage/game/permanent/Permanent.java
@@ -298,9 +298,19 @@ public interface Permanent extends Card, Controllable {
 
     int getBlocking();
 
-    void setAttacking(boolean attacking);
+    void setAttacking(MageObjectReference defender);
+
+    MageObjectReference getAttacking();
 
     void setBlocking(int blocking);
+
+    void addBlocking(UUID attackerId, Game game);
+
+    void removeBlocking(UUID attackerId, Game game);
+
+    void clearBlocking();
+
+    Set<MageObjectReference> getBlockingRefs();
 
     int getMaxBlocks();
 

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -94,8 +94,9 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     protected boolean phasedIn = true;
     protected boolean indirectPhase = false;
     protected boolean faceDown;
-    protected boolean attacking;
+    protected MageObjectReference attacking; // refers to defenderId if attacking, null if not attacking
     protected int blocking;
+    protected final Set<MageObjectReference> blockingSet = new HashSet<>(); // refers to blocked creatures
     // number of creatures the permanent can block
     protected int maxBlocks = 1;
     // minimal number of creatures the creature can be blocked by
@@ -161,6 +162,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         this.faceDown = permanent.faceDown;
         this.attacking = permanent.attacking;
         this.blocking = permanent.blocking;
+        this.blockingSet.addAll(permanent.blockingSet);
         this.maxBlocks = permanent.maxBlocks;
         this.deathtouched = permanent.deathtouched;
         this.solved = permanent.solved;
@@ -797,7 +799,7 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
 
     @Override
     public boolean isAttacking() {
-        return attacking;
+        return attacking != null;
     }
 
     @Override
@@ -1630,13 +1632,39 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     }
 
     @Override
-    public void setAttacking(boolean attacking) {
-        this.attacking = attacking;
+    public void setAttacking(MageObjectReference defender) {
+        this.attacking = defender;
+    }
+
+    @Override
+    public MageObjectReference getAttacking() {
+        return this.attacking;
     }
 
     @Override
     public void setBlocking(int blocking) {
         this.blocking = blocking;
+    }
+
+    @Override
+    public void addBlocking(UUID attackerId, Game game) {
+        this.blockingSet.add(new MageObjectReference(attackerId, game));
+    }
+
+    @Override
+    public void removeBlocking(UUID attackerId, Game game) {
+        this.blockingSet.remove(new MageObjectReference(attackerId, game));
+    }
+
+    @Override
+    public void clearBlocking() {
+        this.blockingSet.clear();
+        this.blocking = 0;
+    }
+
+    @Override
+    public Set<MageObjectReference> getBlockingRefs() {
+        return new HashSet<>(blockingSet);
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/turn/Turn.java
+++ b/Mage/src/main/java/mage/game/turn/Turn.java
@@ -339,7 +339,6 @@ public class Turn implements Serializable {
             if (permanent != null) {
                 permanent.removeFromCombat(game);
             }
-            game.getCombat().removeAttacker(attackerId, game);
         }
         for (UUID blockerId : game.getCombat().getBlockers()) {
             Permanent permanent = game.getPermanent(blockerId);


### PR DESCRIPTION
Was investigating one of the items in #13774 and turns out [[Gomazoa]] has a unique sort of effect. I added tests for a variety of edge cases. Although I tried various approaches with new/existing watchers, no easy combination of watched events was going to work in all my test cases. My conclusion is that the info needed to be stored in the LKI of the permanent, and after implementing that functionality it works nicely.

Previously, a permanent only stored a boolean for whether it was attacking. Now, it stores a MageObjectReference referring to what it's attacking (not just UUID, because e.g. planeswalker could be blinked). Null for not attacking, so testing for null reproduces existing behavior. Added a line to update the reference in the edge case of reselecting defender. This reference isn't actually used yet by any card I know of but since I was adding the functionality for blockers I thought it was good to make it consistent.

A permanent also stores an integer for the number of creatures it's blocking, with 0 for not blocking. This is used in some weird ways to check if further blocks are possible and didn't seem to be updated on every usage I would need, and I didn't want to change existing behavior. So I added a separate set of MageObjectReference to refer to the things it's blocking. This needed a special check for when creatures are explicitly removed from combat. It still holds references to permanents that have left the battlefield, which is what we need for LKI usage. It's not for the purpose of counting, that's handled by existing watchers.

The existing combat code is pretty messy and could likely be cleaned up with some investigation, but I kept these adjustments minimal here. All tests pass.