### PR TITLE
Bail out of human mode selection when list empty

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2506,6 +2506,12 @@ public class HumanPlayer extends PlayerImpl {
                 }
             }
 
+            // skip dialog when choice is mandatory but no remaining options are valild
+            // https://github.com/magefree/mage/issues/14805
+            if (modeMap.size() == 0 && !modes.isMayChooseNone()) {
+                return null;
+            }
+
             // done button for "for up" choices only
             boolean canEndChoice = (modes.getSelectedModes().size() >= modes.getMinModes() && modes.getMaxPawPrints() == 0) ||
                     (modes.getSelectedPawPrints() >= modes.getMaxPawPrints() && modes.getMaxPawPrints() > 0) ||

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ModeChoiceAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ModeChoiceAITest.java
@@ -1,0 +1,34 @@
+package org.mage.test.AI.basic;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommander4PlayersWithAIHelps;
+
+public class ModeChoiceAITest extends CardTestCommander4PlayersWithAIHelps {
+
+    // Make sure that AI mode selection does not freeze when there are zero available choices
+    // https://github.com/magefree/mage/pull/14901
+    @Test
+    public void test_AI_SkipInvalidModes() {
+        addCard(Zone.BATTLEFIELD, playerA, "Parapet Thrasher");
+        addCard(Zone.BATTLEFIELD, playerA, "Brimstone Dragon");
+        addCard(Zone.BATTLEFIELD, playerA, "Volcanic Dragon");
+
+        attack(1, playerA, "Parapet Thrasher", playerB);
+        attack(1, playerA, "Brimstone Dragon", playerC);
+        attack(1, playerA, "Volcanic Dragon", playerD);
+
+        aiPlayStep(1, PhaseStep.DECLARE_BLOCKERS, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertExileCount(playerA, 1);
+        assertLife(playerB, 16);
+        assertLife(playerC, 10);
+        assertLife(playerD, 12);
+    }
+
+}


### PR DESCRIPTION
I originally wrote this by changing the engine to filter modes with no valid targets before even passing them to `Player.chooseMode()`, however that blew up the tests as they all assume that mode number selection is chosen from the complete list of nodes, and narrowing that down to only valid modes completely threw off the numbering scheme.  So instead fix it in the human player plugin by simply bailing out early if all modes have been stripped out.

Fixes https://github.com/magefree/mage/issues/14805