### PR TITLE
Don't call `getMainCard()` when transforming Esper Origins

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EsperOrigins.java
+++ b/Mage.Sets/src/mage/cards/e/EsperOrigins.java
@@ -111,7 +111,7 @@ class EsperOriginsEffect extends OneShotEffect {
         if (player == null || spell == null) {
             return false;
         }
-        Card card = spell.getMainCard();
+        Card card = spell.getCard();
         player.moveCards(card, Zone.EXILED, source, game);
         game.setEnterWithCounters(card.getId(), new Counters(CounterType.FINALITY.createInstance()));
         game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId(), Boolean.TRUE);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/fin/EsperOriginsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/fin/EsperOriginsTest.java
@@ -1,0 +1,30 @@
+package org.mage.test.cards.single.fin;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.player.TestPlayer;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class EsperOriginsTest extends CardTestPlayerBase {
+
+    @Test
+    public void testTransform() {
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerA, "Balduvian Bears");
+        addCard(Zone.GRAVEYARD, playerA, "Esper Origins");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Flashback");
+        addTarget(playerA, TestPlayer.TARGET_SKIP);
+        setChoice(playerA, "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Summon: Esper Maduin", 1);
+        assertExileCount(playerA, 0);
+    }
+
+}


### PR DESCRIPTION
If using `VALUE_KEY_ENTER_TRANSFORMED` to return a card transformed, then it needs to be passed the front side of the card rather than the main card, to let the `ZonesHandler` logic take care of transforming it.

Fixes https://github.com/magefree/mage/issues/14903