### PR TITLE
Fix wrong boolean check hiding server crash trace

### DIFF
--- a/Mage/src/main/java/mage/game/GameImpl.java
+++ b/Mage/src/main/java/mage/game/GameImpl.java
@@ -1804,7 +1804,7 @@ public abstract class GameImpl implements Game {
 
                         // count total errors
                         Player activePlayer = this.getPlayer(getActivePlayerId());
-                        if (activePlayer != null && !activePlayer.isTestMode() && !activePlayer.isFastFailInTestMode()) {
+                        if (activePlayer != null && (!activePlayer.isTestMode() || !activePlayer.isFastFailInTestMode())) {
                             // real game - try to continue
                             priorityErrorsCount++;
                             continue;


### PR DESCRIPTION
The default option for a player is to fail fast in unit tests, even though this is only relevant for `TestPlayer`. The check was asserting all three and thus never succeeding.  It should instead check that it's not a test player OR that fail fast is disabled.  This also brings back the old behavior of allowing the game to proceed up to 15 errors, but at least this allows us to see tracebacks in crash reports again.

If possible, I think we should consolidate and/or close all of the reports with hidden crash traces as they are virtually un-actionable.