### PR TITLE
Include ZCC in TDFC transform flag

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AccursedWitch.java
+++ b/Mage.Sets/src/mage/cards/a/AccursedWitch.java
@@ -111,7 +111,7 @@ class AccursedWitchReturnTransformedEffect extends OneShotEffect {
             return false;
         }
 
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         game.getState().setValue("attachTo:" + card.getOtherSide().getId(), attachTo.getId());
         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             attachTo.addAttachment(card.getOtherSide().getId(), source, game);

--- a/Mage.Sets/src/mage/cards/a/AclazotzDeepestBetrayal.java
+++ b/Mage.Sets/src/mage/cards/a/AclazotzDeepestBetrayal.java
@@ -190,7 +190,7 @@ class AclazotzDeepestBetrayalTransformEffect extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/b/BiolumeEgg.java
+++ b/Mage.Sets/src/mage/cards/b/BiolumeEgg.java
@@ -93,7 +93,7 @@ class BiolumeEggEffect extends OneShotEffect {
         }
         Card card = game.getCard(getTargetPointer().getFirst(game, source));
         if (card != null) {
-            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId(), Boolean.TRUE);
+            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game), Boolean.TRUE);
             controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, true, null);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/c/ContainmentPriest.java
+++ b/Mage.Sets/src/mage/cards/c/ContainmentPriest.java
@@ -86,8 +86,8 @@ class ContainmentPriestReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         if (((ZoneChangeEvent) event).getToZone() == Zone.BATTLEFIELD) {
-            Object entersTransformed = game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + event.getTargetId());
             Card card = game.getCard(event.getTargetId());
+            Object entersTransformed = game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + event.getTargetId() + card.getZoneChangeCounter(game));
             if (card != null && entersTransformed instanceof Boolean && (Boolean) entersTransformed && card.getSecondCardFace() != null) {
                 card = card.getSecondCardFace();
             }

--- a/Mage.Sets/src/mage/cards/e/EdgarCharmedGroom.java
+++ b/Mage.Sets/src/mage/cards/e/EdgarCharmedGroom.java
@@ -96,7 +96,7 @@ class EdgarCharmedGroomEffect extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, true, null);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/e/EsperOrigins.java
+++ b/Mage.Sets/src/mage/cards/e/EsperOrigins.java
@@ -114,7 +114,7 @@ class EsperOriginsEffect extends OneShotEffect {
         Card card = spell.getCard();
         player.moveCards(card, Zone.EXILED, source, game);
         game.setEnterWithCounters(card.getId(), new Counters(CounterType.FINALITY.createInstance()));
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         player.moveCards(
                 card, Zone.BATTLEFIELD, source, game, false,
                 false, true, null

--- a/Mage.Sets/src/mage/cards/g/GarlandKnightOfCornelia.java
+++ b/Mage.Sets/src/mage/cards/g/GarlandKnightOfCornelia.java
@@ -94,7 +94,7 @@ class GarlandKnightOfCorneliaEffect extends OneShotEffect {
         if (player == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         return player.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/g/GoldenGuardian.java
+++ b/Mage.Sets/src/mage/cards/g/GoldenGuardian.java
@@ -119,8 +119,11 @@ class GoldenGuardianReturnTransformedEffect extends OneShotEffect {
         if (controller == null || game.getState().getZone(source.getSourceId()) != Zone.GRAVEYARD) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
         Card card = game.getCard(source.getSourceId());
-        return card != null && controller.moveCards(card, Zone.BATTLEFIELD, source, game);
+        if (card == null) {
+            return false;
+        }
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
+        return controller.moveCards(card, Zone.BATTLEFIELD, source, game);
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HarvestHand.java
+++ b/Mage.Sets/src/mage/cards/h/HarvestHand.java
@@ -88,7 +88,7 @@ class HarvestHandReturnTransformedEffect extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/j/JourneyToEternity.java
+++ b/Mage.Sets/src/mage/cards/j/JourneyToEternity.java
@@ -93,7 +93,7 @@ class JourneyToEternityReturnTransformedSourceEffect extends OneShotEffect {
             if (zone == Zone.BATTLEFIELD || !zone.isPublicZone()) {
                 return true;
             }
-            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
             controller.moveCards(card, Zone.BATTLEFIELD, source, game, false, false, false, null);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/l/LoyalCathar.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalCathar.java
@@ -110,7 +110,7 @@ class ReturnLoyalCatharEffect extends OneShotEffect {
         }
         Card card = game.getCard(getTargetPointer().getFirst(game, source));
         if (card != null) {
-            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId(), Boolean.TRUE);
+            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game), Boolean.TRUE);
             controller.moveCards(card, Zone.BATTLEFIELD, source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/Mistcaller.java
+++ b/Mage.Sets/src/mage/cards/m/Mistcaller.java
@@ -88,7 +88,7 @@ class ContainmentPriestReplacementEffect extends ReplacementEffectImpl {
         if (((ZoneChangeEvent) event).getToZone() == Zone.BATTLEFIELD) {
             Card card = game.getCard(event.getTargetId());
             if (card != null) {
-                Object entersTransformed = game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + event.getTargetId());
+                Object entersTransformed = game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + event.getTargetId() + card.getZoneChangeCounter(game));
                 if (entersTransformed instanceof Boolean && (Boolean) entersTransformed && card.getSecondCardFace() != null) {
                     card = card.getSecondCardFace();
                 }

--- a/Mage.Sets/src/mage/cards/o/OjerAxonilDeepestMight.java
+++ b/Mage.Sets/src/mage/cards/o/OjerAxonilDeepestMight.java
@@ -104,7 +104,7 @@ class OjerAxonilDeepestMightTransformEffect extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/o/OjerKaslemDeepestGrowth.java
+++ b/Mage.Sets/src/mage/cards/o/OjerKaslemDeepestGrowth.java
@@ -95,7 +95,7 @@ class OjerKaslemDeepestGrowthTransformEffect extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/o/OjerPakpatiqDeepestEpoch.java
+++ b/Mage.Sets/src/mage/cards/o/OjerPakpatiqDeepestEpoch.java
@@ -166,7 +166,7 @@ class OjerPakpatiqDeepestEpochTrigger extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         game.setEnterWithCounters(card.getId(), new Counters().addCounter(CounterType.TIME.createInstance(3)));
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
         return true;

--- a/Mage.Sets/src/mage/cards/o/OjerTaqDeepestFoundation.java
+++ b/Mage.Sets/src/mage/cards/o/OjerTaqDeepestFoundation.java
@@ -93,7 +93,7 @@ class OjerTaqDeepestFoundationTransformEffect extends OneShotEffect {
         if (controller == null || card == null) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         controller.moveCards(card, Zone.BATTLEFIELD, source, game, true, false, true, null);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/o/OptimusPrimeHero.java
+++ b/Mage.Sets/src/mage/cards/o/OptimusPrimeHero.java
@@ -105,7 +105,7 @@ class OptimusPrimeHeroEffect extends OneShotEffect {
         if (backSide == null) {
             return true;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + backSide.getId(), true);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + backSide.getId() + backSide.getZoneChangeCounter(game), true);
         controller.moveCards(backSide, Zone.BATTLEFIELD, source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/r/RadiantGrace.java
+++ b/Mage.Sets/src/mage/cards/r/RadiantGrace.java
@@ -115,7 +115,7 @@ class RadiantGraceEffect extends OneShotEffect {
             return false;
         }
 
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         game.getState().setValue("attachTo:" + card.getOtherSide().getId(), player.getId());
         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             player.addAttachment(card.getId(), source, game);

--- a/Mage.Sets/src/mage/cards/s/SkinInvasion.java
+++ b/Mage.Sets/src/mage/cards/s/SkinInvasion.java
@@ -81,7 +81,7 @@ class SkinInvasionEffect extends OneShotEffect {
         Card card = game.getCard(source.getSourceId());
         Player controller = game.getPlayer(source.getControllerId());
         if (card != null && controller != null) {
-            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
             controller.moveCards(card, Zone.BATTLEFIELD, source, game);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/s/StartledAwake.java
+++ b/Mage.Sets/src/mage/cards/s/StartledAwake.java
@@ -95,7 +95,7 @@ class StartledAwakeReturnTransformedEffect extends OneShotEffect {
         if (backSide == null) {
             return true;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + backSide.getId(), true);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + backSide.getId() + backSide.getZoneChangeCounter(game), true);
         controller.moveCards(backSide, Zone.BATTLEFIELD, source, game);
         return true;
     }

--- a/Mage.Sets/src/mage/cards/v/VengefulStrangler.java
+++ b/Mage.Sets/src/mage/cards/v/VengefulStrangler.java
@@ -106,7 +106,7 @@ class VengefulStranglerEffect extends OneShotEffect {
             return false;
         }
 
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         game.getState().setValue("attachTo:" + card.getOtherSide().getId(), permanent);
         if (controller.moveCards(card, Zone.BATTLEFIELD, source, game)) {
             permanent.addAttachment(card.getOtherSide().getId(), source, game);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EarthbendTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/EarthbendTest.java
@@ -27,4 +27,24 @@ public class EarthbendTest extends CardTestPlayerBase {
         assertType("Forest", CardType.CREATURE, true);
     }
 
+    @Test
+    public void testEarthbendTDFC() {
+        addCard(Zone.BATTLEFIELD, playerA, "Azusa's Many Journeys");
+        addCard(Zone.BATTLEFIELD, playerA, "Ashaya, Soul of the Wild");
+        addCard(Zone.HAND, playerA, "Earthbending Lesson");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 4);
+        addCard(Zone.HAND, playerA, "Fell");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
+
+        castSpell(7, PhaseStep.PRECOMBAT_MAIN, playerA, "Earthbending Lesson");
+        addTarget(playerA, "Likeness of the Seeker");
+        castSpell(7, PhaseStep.POSTCOMBAT_MAIN, playerA, "Fell");
+        addTarget(playerA, "Likeness of the Seeker");
+
+        setStrictChooseMode(true);
+        setStopAt(7, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Azusa's Many Journeys", 1);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/common/SpellTransformedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/SpellTransformedAbility.java
@@ -60,7 +60,11 @@ public class SpellTransformedAbility extends SpellAbility {
     @Override
     public boolean activate(Game game, Set<MageIdentifier> allowedIdentifiers, boolean noMana) {
         if (super.activate(game, allowedIdentifiers, noMana)) {
-            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + getSourceId(), Boolean.TRUE);
+            final Card card = game.getCard(this.getSourceId());
+            if (card == null) {
+                return false;
+            }
+            game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/AuraReplacementEffect.java
@@ -184,7 +184,7 @@ public class AuraReplacementEffect extends ReplacementEffectImpl {
             return false;
         }
         // in case of transformable enchantments
-        if (Boolean.TRUE.equals(game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId()))
+        if (Boolean.TRUE.equals(game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game)))
                 && card.getSecondCardFace() != null) {
             card = card.getSecondCardFace();
         }

--- a/Mage/src/main/java/mage/abilities/keyword/CraftAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/CraftAbility.java
@@ -173,7 +173,7 @@ class CraftEffect extends OneShotEffect {
         if (player == null || card == null || card.getZoneChangeCounter(game) != source.getStackMomentSourceZCC() + 1) {
             return false;
         }
-        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId(), Boolean.TRUE);
+        game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + source.getSourceId() + card.getZoneChangeCounter(game), Boolean.TRUE);
         player.moveCards(card, Zone.BATTLEFIELD, source, game);
         return true;
     }

--- a/Mage/src/main/java/mage/constants/PutCards.java
+++ b/Mage/src/main/java/mage/constants/PutCards.java
@@ -95,7 +95,7 @@ public enum PutCards {
                 if (card instanceof TransformingDoubleFacedCard) {
                     card = ((TransformingDoubleFacedCard) card).getRightHalfCard();
                 }
-                game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId(), Boolean.TRUE);
+                game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game), Boolean.TRUE);
             case BATTLEFIELD:
             case EXILED:
             case HAND:
@@ -133,7 +133,7 @@ public enum PutCards {
             case SHUFFLE:
                 return player.shuffleCardsToLibrary(cards, game, source);
             case BATTLEFIELD_TRANSFORMED:
-                cards.stream().forEach(uuid -> game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + uuid, Boolean.TRUE));
+                cards.stream().forEach(uuid -> game.getState().setValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + uuid + cards.get(uuid, game).getZoneChangeCounter(game), Boolean.TRUE));
             case BATTLEFIELD:
             case EXILED:
             case HAND:

--- a/Mage/src/main/java/mage/game/ZonesHandler.java
+++ b/Mage/src/main/java/mage/game/ZonesHandler.java
@@ -90,7 +90,7 @@ public final class ZonesHandler {
                 Card card = game.getCard(info.event.getTargetId());
                 if (card instanceof DoubleFacedCard || card instanceof DoubleFacedCardHalf) {
                     boolean forceToMainSide = false;
-                    Boolean enterTransformed = (Boolean) game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId());
+                    Boolean enterTransformed = (Boolean) game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game));
                     if (enterTransformed == null) {
                         enterTransformed = false;
                     }
@@ -380,7 +380,7 @@ public final class ZonesHandler {
              * it enters the battlefield with its back face up. If a player is instructed to put a card that isn't a double-faced card
              * onto the battlefield transformed or converted, that card stays in its current zone.
              */
-            boolean wantToTransform = Boolean.TRUE.equals(game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId()));
+            boolean wantToTransform = Boolean.TRUE.equals(game.getState().getValue(TransformingDoubleFacedCard.VALUE_KEY_ENTER_TRANSFORMED + card.getId() + card.getZoneChangeCounter(game)));
             if (wantToTransform && !(card instanceof DoubleFacedCardHalf)) {
                 isGoodToMove = card.isTransformable() && card.getSecondCardFace().isPermanent(game);
             } else {


### PR DESCRIPTION
The TDFC transform flag should only last for one zone change, so it needs to include the ZCC in the string key in addition to the card ID.