### PR TITLE
Fire targeted events when AI chooses targets

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/main/java/mage/player/ai/ComputerPlayer.java
@@ -36,6 +36,7 @@ import org.apache.log4j.Logger;
 import java.io.Serializable;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.function.Consumer;
 
 /**
  * AI: basic server side bot with simple actions support (game, draft, construction/sideboarding).
@@ -159,9 +160,13 @@ public class ComputerPlayer extends PlayerImpl {
             return false;
         }
 
+        final Consumer<MageItem> targetAdder = target.isNotTarget() ?
+            (MageItem item) -> { target.add(item.getId(), game); } :
+            (MageItem item) -> { target.addTarget(item.getId(), source, game); };
+
         // good targets -- choose as much as possible
         for (MageItem item : possibleTargetsSelector.getGoodTargets()) {
-            target.add(item.getId(), game);
+            targetAdder.accept(item);
             if (target.isChoiceCompleted(abilityControllerId, source, game, fromCards)) {
                 return true;
             }
@@ -171,7 +176,7 @@ public class ComputerPlayer extends PlayerImpl {
             if (target.isChosen(game)) {
                 break;
             }
-            target.add(item.getId(), game);
+            targetAdder.accept(item);
         }
 
         return target.isChosen(game) && !target.getTargets().isEmpty();

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetAmountAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/TargetAmountAITest.java
@@ -50,4 +50,21 @@ public class TargetAmountAITest extends CardTestPlayerBaseWithAIHelps {
         assertPowerToughness(playerA, "Balduvian Bears", 2 + 1, 2 + 1); // boost each possible creatures
         assertPowerToughness(playerB, "Balduvian Bears", 2, 2); // no boost for enemy
     }
+
+    @Test
+    public void test_AI_TriggersTargets() {
+        addCard(Zone.BATTLEFIELD, playerB, "Roaming Throne");
+        addCard(Zone.HAND, playerA, "Acidic Slime");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 5);
+
+        setChoice(playerB, "Bear");
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Roaming Throne", 1);
+        assertPermanentCount(playerA, "Acidic Slime", 1);
+    }
 }


### PR DESCRIPTION
AI player is not triggering ward when it targets opponent creatures because it was unconditionally using `Target.add()` when choosing targets instead of `Target.addTarget()` in the situations when it should be targeting.