### PR TITLE
New CardUtil method to handle double zone changes

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -3949,7 +3949,7 @@ public class TestPlayer implements Player {
     }
 
     @Override
-    public boolean moveCardsToExile(Set<Card> cards, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName) {
+    public boolean moveCardsToExile(Set<? extends Card> cards, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName) {
         return computerPlayer.moveCardsToExile(cards, source, game, withName, exileId, exileZoneName);
     }
 

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileReturnBattlefieldNextEndStepTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileReturnBattlefieldNextEndStepTargetEffect.java
@@ -8,6 +8,7 @@ import mage.abilities.effects.OneShotEffect;
 import mage.cards.Card;
 import mage.constants.Outcome;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTargets;
 import mage.util.CardUtil;
@@ -61,7 +62,7 @@ public class ExileReturnBattlefieldNextEndStepTargetEffect extends OneShotEffect
         if (controller == null) {
             return false;
         }
-        Set<Card> toExile = getTargetPointer().getTargets(game, source)
+        Set<Permanent> toExile = getTargetPointer().getTargets(game, source)
                 .stream()
                 .map(game::getPermanent)
                 .filter(Objects::nonNull)
@@ -73,10 +74,7 @@ public class ExileReturnBattlefieldNextEndStepTargetEffect extends OneShotEffect
         Effect effect = yourControl
                 ? new ReturnToBattlefieldUnderYourControlTargetEffect(exiledOnly)
                 : new ReturnToBattlefieldUnderOwnerControlTargetEffect(false, exiledOnly);
-        effect.setTargetPointer(new FixedTargets(toExile
-                .stream()
-                .map(Card::getMainCard)
-                .collect(Collectors.toSet()), game));
+        effect.setTargetPointer(new FixedTargets(CardUtil.getAllCardsFromPermanentsLeftBattlefield(toExile, game), game));
         game.addDelayedTriggeredAbility(new AtTheBeginOfNextEndStepDelayedTriggeredAbility(effect), source);
         return true;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileThenReturnTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileThenReturnTargetEffect.java
@@ -8,6 +8,7 @@ import mage.constants.Outcome;
 import mage.constants.PutCards;
 import mage.constants.Zone;
 import mage.game.Game;
+import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTargets;
 import mage.util.CardUtil;
@@ -62,7 +63,7 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
         if (controller == null) {
             return false;
         }
-        Set<Card> toFlicker = getTargetPointer().getTargets(game, source)
+        Set<Permanent> toFlicker = getTargetPointer().getTargets(game, source)
                 .stream()
                 .map(game::getPermanent)
                 .filter(Objects::nonNull)
@@ -72,7 +73,7 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
         }
         controller.moveCards(toFlicker, Zone.EXILED, source, game);
         game.processAction();
-        for (Card card : toFlicker) {
+        for (Card card : CardUtil.getAllCardsFromPermanentsLeftBattlefield(toFlicker, game)) {
             putCards.moveCard(
                     yourControl ? controller : game.getPlayer(card.getOwnerId()),
                     card.getMainCard(), source, game, "card");

--- a/Mage/src/main/java/mage/abilities/keyword/PersistAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/PersistAbility.java
@@ -1,23 +1,20 @@
-
 package mage.abilities.keyword;
 
-import mage.abilities.Ability;
 import mage.abilities.common.DiesSourceTriggeredAbility;
-import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ReturnSourceFromGraveyardToBattlefieldEffect;
-import mage.constants.Outcome;
+import mage.abilities.effects.common.ReturnToBattlefieldUnderOwnerControlWithCounterTargetEffect;
 import mage.counters.CounterType;
-import mage.counters.Counters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
+import mage.target.targetpointer.FixedTargets;
+import mage.util.CardUtil;
 
 public class PersistAbility extends DiesSourceTriggeredAbility {
 
     public PersistAbility() {
-        super(new PersistEffect());
-        this.addEffect(new ReturnSourceFromGraveyardToBattlefieldEffect(false, true));
+        super(new ReturnToBattlefieldUnderOwnerControlWithCounterTargetEffect(
+                CounterType.M1M1.createInstance(), false));
     }
 
     protected PersistAbility(final PersistAbility ability) {
@@ -30,15 +27,12 @@ public class PersistAbility extends DiesSourceTriggeredAbility {
     }
 
     @Override
-    public boolean checkEventType(GameEvent event, Game game) {
-        return super.checkEventType(event, game);
-    }
-
-    @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         if (super.checkTrigger(event, game)) {
             Permanent permanent = ((ZoneChangeEvent) event).getTarget();
             if (permanent.getCounters(game).getCount(CounterType.M1M1) == 0) {
+                this.getEffects().setTargetPointer(new FixedTargets(
+                        CardUtil.getAllCardsFromPermanentLeftBattlefield(permanent, game), game));
                 return true;
             }
         }
@@ -48,30 +42,5 @@ public class PersistAbility extends DiesSourceTriggeredAbility {
     @Override
     public String getRule() {
         return "persist <i>(When this creature dies, if it had no -1/-1 counters on it, return it to the battlefield under its owner's control with a -1/-1 counter on it.)</i>";
-    }
-}
-
-class PersistEffect extends OneShotEffect {
-
-    public PersistEffect() {
-        super(Outcome.Benefit);
-        this.staticText = "";
-    }
-
-    protected PersistEffect(final PersistEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public PersistEffect copy() {
-        return new PersistEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Counters countersToAdd = new Counters();
-        countersToAdd.addCounter(CounterType.M1M1.createInstance());
-        game.setEnterWithCounters(source.getSourceId(), countersToAdd);
-        return true;
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/UndyingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/UndyingAbility.java
@@ -1,16 +1,14 @@
 package mage.abilities.keyword;
 
-import mage.abilities.Ability;
 import mage.abilities.common.DiesSourceTriggeredAbility;
-import mage.abilities.effects.OneShotEffect;
-import mage.abilities.effects.common.ReturnSourceFromGraveyardToBattlefieldEffect;
-import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.abilities.effects.common.ReturnToBattlefieldUnderOwnerControlWithCounterTargetEffect;
 import mage.counters.CounterType;
-import mage.counters.Counters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
+import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
+import mage.target.targetpointer.FixedTargets;
+import mage.util.CardUtil;
 
 /**
  * @author Loki
@@ -18,8 +16,8 @@ import mage.game.permanent.Permanent;
 public class UndyingAbility extends DiesSourceTriggeredAbility {
 
     public UndyingAbility() {
-        super(new UndyingEffect());
-        this.addEffect(new ReturnSourceFromGraveyardToBattlefieldEffect(false, true));
+        super(new ReturnToBattlefieldUnderOwnerControlWithCounterTargetEffect(
+                CounterType.P1P1.createInstance(), false));
     }
 
     protected UndyingAbility(final UndyingAbility ability) {
@@ -34,8 +32,10 @@ public class UndyingAbility extends DiesSourceTriggeredAbility {
     @Override
     public boolean checkTrigger(GameEvent event, Game game) {
         if (super.checkTrigger(event, game)) {
-            Permanent permanent = (Permanent) game.getLastKnownInformation(event.getTargetId(), Zone.BATTLEFIELD);
-            if (!permanent.getCounters(game).containsKey(CounterType.P1P1) || permanent.getCounters(game).getCount(CounterType.P1P1) == 0) {
+            Permanent permanent = ((ZoneChangeEvent) event).getTarget();
+            if (permanent.getCounters(game).getCount(CounterType.P1P1) == 0) {
+                this.getEffects().setTargetPointer(new FixedTargets(
+                        CardUtil.getAllCardsFromPermanentLeftBattlefield(permanent, game), game));
                 return true;
             }
         }
@@ -45,30 +45,5 @@ public class UndyingAbility extends DiesSourceTriggeredAbility {
     @Override
     public String getRule() {
         return "undying <i>(When this creature dies, if it had no +1/+1 counters on it, return it to the battlefield under its owner's control with a +1/+1 counter on it.)</i>";
-    }
-}
-
-class UndyingEffect extends OneShotEffect {
-
-    public UndyingEffect() {
-        super(Outcome.Benefit);
-        this.staticText = "";
-    }
-
-    protected UndyingEffect(final UndyingEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public UndyingEffect copy() {
-        return new UndyingEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Counters countersToAdd = new Counters();
-        countersToAdd.addCounter(CounterType.P1P1.createInstance());
-        game.setEnterWithCounters(source.getSourceId(), countersToAdd);
-        return true;
     }
 }

--- a/Mage/src/main/java/mage/players/Player.java
+++ b/Mage/src/main/java/mage/players/Player.java
@@ -1009,7 +1009,7 @@ public interface Player extends MageItem, Copyable<Player> {
 
     boolean moveCardsToExile(Card card, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName);
 
-    boolean moveCardsToExile(Set<Card> cards, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName);
+    boolean moveCardsToExile(Set<? extends Card> cards, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName);
 
     /**
      * Uses card.moveToZone and posts a inform message about moving the card

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -5087,7 +5087,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     }
 
     @Override
-    public boolean moveCardsToExile(Set<Card> cards, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName) {
+    public boolean moveCardsToExile(Set<? extends Card> cards, Ability source, Game game, boolean withName, UUID exileId, String exileZoneName) {
         if (cards.isEmpty()) {
             return true;
         }

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -1294,6 +1294,18 @@ public final class CardUtil {
         return game.getPermanent(CardUtil.getDefaultCardSideForBattlefield(game, card).getId());
     }
 
+    public static Set<Card> getAllCardsFromPermanentLeftBattlefield(Permanent target, Game game) {
+        return getAllCardsFromPermanentsLeftBattlefield(Collections.singletonList(target), game);
+    }
+
+    public static Set<Card> getAllCardsFromPermanentsLeftBattlefield(Collection<Permanent> targets, Game game) {
+        Set<Card> toReturn = new LinkedHashSet<>();
+        targets.forEach(card -> {
+            toReturn.add(card.getMainCard());
+        });
+        return toReturn;
+    }
+
     /**
      * Return card name for same name searching
      *


### PR DESCRIPTION
This is a necessary precondition for mutate ability #14900. This PR implements the method for effects and triggers to use with a few example implementations.

After merge:
1. Mutate ability implementation only needs to adjust this one method to account for mutated permanents
2. Followup fixes to individual card implementations to use this method. Example: instead of returning source, need to return fixed targets (source + anything merged with it).