### PR TITLE
New method for checking if a permanent is a token

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AetherSnap.java
+++ b/Mage.Sets/src/mage/cards/a/AetherSnap.java
@@ -11,7 +11,6 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.players.Player;
 
 import java.util.UUID;
@@ -62,7 +61,7 @@ class AetherSnapEffect extends OneShotEffect {
         }
         Cards tokens = new CardsImpl();
         for (Permanent permanent : game.getBattlefield().getActivePermanents(source.getControllerId(), game)) {
-            if (permanent instanceof PermanentToken) {
+            if (permanent.isToken()) {
                 tokens.add(permanent);
             }
             permanent.removeAllCounters(source, game);

--- a/Mage.Sets/src/mage/cards/a/AeveProgenitorOoze.java
+++ b/Mage.Sets/src/mage/cards/a/AeveProgenitorOoze.java
@@ -16,7 +16,6 @@ import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 
 import java.util.UUID;
 
@@ -81,7 +80,7 @@ class AeveProgenitorOozeNonLegendaryEffect extends ContinuousEffectImpl {
     @Override
     public boolean apply(Game game, Ability source) {
         Permanent permanent = game.getPermanent(source.getSourceId());
-        if (permanent instanceof PermanentToken) {
+        if (permanent.isToken()) {
             permanent.removeSuperType(game, SuperType.LEGENDARY);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
+++ b/Mage.Sets/src/mage/cards/a/AnafenzaTheForemost.java
@@ -1,4 +1,3 @@
-
 package mage.cards.a;
 
 import mage.MageInt;
@@ -19,7 +18,6 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 
@@ -87,7 +85,7 @@ class AnafenzaTheForemostEffect extends ReplacementEffectImpl {
         if (controller != null) {
             if (((ZoneChangeEvent) event).getFromZone() == Zone.BATTLEFIELD) {
                 Permanent permanent = ((ZoneChangeEvent) event).getTarget();
-                if (permanent != null && !(permanent instanceof PermanentToken)) {
+                if (permanent != null && !permanent.isToken()) {
                     return controller.moveCards(permanent, Zone.EXILED, source, game);
                 }
             } else {

--- a/Mage.Sets/src/mage/cards/b/BloodMoney.java
+++ b/Mage.Sets/src/mage/cards/b/BloodMoney.java
@@ -9,7 +9,6 @@ import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.TreasureToken;
 
 import java.util.UUID;
@@ -59,7 +58,7 @@ class BloodMoneyEffect extends OneShotEffect {
                 StaticFilters.FILTER_PERMANENT_CREATURE,
                 source.getControllerId(), source, game
         )) {
-            if (permanent.destroy(source, game) && !(permanent instanceof PermanentToken)) {
+            if (permanent.destroy(source, game) && !permanent.isToken()) {
                 count++;
             }
         }

--- a/Mage.Sets/src/mage/cards/c/CallerOfTheClaw.java
+++ b/Mage.Sets/src/mage/cards/c/CallerOfTheClaw.java
@@ -1,6 +1,5 @@
 package mage.cards.c;
 
-import java.util.UUID;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
@@ -18,9 +17,10 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.BearToken;
 import mage.watchers.Watcher;
+
+import java.util.UUID;
 
 /**
  *
@@ -72,7 +72,7 @@ class CallerOfTheClawWatcher extends Watcher {
     public void watch(GameEvent event, Game game) {
         if (event.getType() == GameEvent.EventType.ZONE_CHANGE && ((ZoneChangeEvent) event).isDiesEvent()) {
             Permanent card = (Permanent) game.getLastKnownInformation(event.getTargetId(), Zone.BATTLEFIELD);
-            if (card != null && card.isOwnedBy(this.controllerId) && card.isCreature(game) && !(card instanceof PermanentToken)) {
+            if (card != null && card.isOwnedBy(this.controllerId) && card.isCreature(game) && !card.isToken()) {
                 creaturesCount++;
             }
         }

--- a/Mage.Sets/src/mage/cards/c/CeaselessConflict.java
+++ b/Mage.Sets/src/mage/cards/c/CeaselessConflict.java
@@ -1,7 +1,5 @@
 package mage.cards.c;
 
-import java.util.UUID;
-
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
 import mage.cards.CardImpl;
@@ -11,8 +9,9 @@ import mage.constants.Outcome;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.Spirit32Token;
+
+import java.util.UUID;
 
 /**
  *
@@ -39,7 +38,7 @@ public final class CeaselessConflict extends CardImpl {
 
 class CeaselessConflictEffect extends OneShotEffect {
 
-    public CeaselessConflictEffect() {
+    CeaselessConflictEffect() {
         super(Outcome.DestroyPermanent);
         this.staticText = "destroy all creatures. Then create a 3/2 red and white Spirit creature token for each nontoken creature you controlled that was destroyed this way";
     }
@@ -62,7 +61,7 @@ class CeaselessConflictEffect extends OneShotEffect {
         )) {
             if (permanent.destroy(source, game) &&
                 permanent.isControlledBy(source.getControllerId()) &&
-                !(permanent instanceof PermanentToken)
+                !permanent.isToken()
             ) {
                 count++;
             }

--- a/Mage.Sets/src/mage/cards/d/DeclarationInStone.java
+++ b/Mage.Sets/src/mage/cards/d/DeclarationInStone.java
@@ -13,7 +13,6 @@ import mage.constants.Zone;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.players.Player;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetpointer.FixedTarget;
@@ -70,12 +69,12 @@ class DeclarationInStoneEffect extends OneShotEffect {
         int nonTokenCount = 0;
         if (CardUtil.haveEmptyName(targetPermanent)) { // face down creature
             cardsToExile.add(targetPermanent);
-            if (!(targetPermanent instanceof PermanentToken)) {
+            if (!targetPermanent.isToken()) {
                 nonTokenCount++;
             }
         } else {
             if (cardsToExile.add(targetPermanent)
-                    && !(targetPermanent instanceof PermanentToken)) {
+                    && !targetPermanent.isToken()) {
                 nonTokenCount++;
             }
             for (Permanent permanent : game.getBattlefield().getAllActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURES, targetPermanent.getControllerId(), game)) {
@@ -83,15 +82,15 @@ class DeclarationInStoneEffect extends OneShotEffect {
                         && CardUtil.haveSameNames(permanent, targetPermanent)) {
                     cardsToExile.add(permanent);
                     // exiled count only matters for non-tokens
-                    if (!(permanent instanceof PermanentToken)) {
+                    if (!targetPermanent.isToken()) {
                         nonTokenCount++;
                     }
                 }
             }
         }
         controller.moveCards(cardsToExile, Zone.EXILED, source, game);
-        game.processAction();
         if (nonTokenCount > 0) {
+            game.processAction();
             new InvestigateTargetEffect(nonTokenCount)
                     .setTargetPointer(new FixedTarget(targetPermanent.getControllerId()))
                     .apply(game, source);

--- a/Mage.Sets/src/mage/cards/e/ElspethTirel.java
+++ b/Mage.Sets/src/mage/cards/e/ElspethTirel.java
@@ -1,4 +1,3 @@
-
 package mage.cards.e;
 
 import java.util.UUID;
@@ -15,7 +14,6 @@ import mage.constants.SuperType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.SoldierToken;
 import mage.players.Player;
 
@@ -89,7 +87,7 @@ class ElspethTirelThirdEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         for (Permanent perm : game.getBattlefield().getActivePermanents(source.getControllerId(), game)) {
-            if (!perm.getId().equals(source.getSourceId()) && !(perm instanceof PermanentToken) && !(perm.isLand(game))) {
+            if (!perm.getId().equals(source.getSourceId()) && !perm.isToken() && !(perm.isLand(game))) {
                 perm.destroy(source, game, false);
             }
         }

--- a/Mage.Sets/src/mage/cards/g/GadrakTheCrownScourge.java
+++ b/Mage.Sets/src/mage/cards/g/GadrakTheCrownScourge.java
@@ -19,7 +19,6 @@ import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.TreasureToken;
 import mage.watchers.Watcher;
 
@@ -109,7 +108,7 @@ class GadrakTheCrownScourgeWatcher extends Watcher {
         if (zEvent.isDiesEvent()
                 && zEvent.getTarget() != null
                 && zEvent.getTarget().isCreature(game)
-                && !(zEvent.getTarget() instanceof PermanentToken)) {
+                && !zEvent.getTarget().isToken()) {
             diedThisTurn++;
         }
     }

--- a/Mage.Sets/src/mage/cards/g/GnawingCrescendo.java
+++ b/Mage.Sets/src/mage/cards/g/GnawingCrescendo.java
@@ -11,7 +11,6 @@ import mage.constants.Duration;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.RatCantBlockToken;
 
 import java.util.UUID;
@@ -66,6 +65,6 @@ class GnawingCrescendoTriggeredAbility extends DelayedTriggeredAbility {
         return zEvent.isDiesEvent() && zEvent.getTarget() != null
                 && zEvent.getTarget().isControlledBy(getControllerId())
                 && zEvent.getTarget().isCreature(game)
-                && !(zEvent.getTarget() instanceof PermanentToken);
+                && !zEvent.getTarget().isToken();
     }
 }

--- a/Mage.Sets/src/mage/cards/i/InfestedThrinax.java
+++ b/Mage.Sets/src/mage/cards/i/InfestedThrinax.java
@@ -17,7 +17,6 @@ import mage.constants.SubType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.SaprolingToken;
 
 import java.util.UUID;
@@ -78,7 +77,7 @@ class InfestedThrinaxTriggeredAbility extends DelayedTriggeredAbility {
     public boolean checkTrigger(GameEvent event, Game game) {
         ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
         if (!zEvent.isDiesEvent()
-                || zEvent.getTarget() instanceof PermanentToken
+                || zEvent.getTarget().isToken()
                 || !zEvent.getTarget().isCreature(game)
                 || !zEvent.getTarget().isControlledBy(getControllerId())) {
             return false;

--- a/Mage.Sets/src/mage/cards/i/InfiniteReflection.java
+++ b/Mage.Sets/src/mage/cards/i/InfiniteReflection.java
@@ -1,10 +1,7 @@
-
 package mage.cards.i;
 
-import java.util.UUID;
 import mage.MageObject;
 import mage.abilities.Ability;
-import mage.abilities.Mode;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.OneShotEffect;
@@ -14,10 +11,9 @@ import mage.abilities.keyword.EnchantAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
-import mage.constants.Zone;
+import mage.constants.SubType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
@@ -28,6 +24,8 @@ import mage.game.permanent.PermanentToken;
 import mage.target.TargetPermanent;
 import mage.target.common.TargetCreaturePermanent;
 import mage.util.functions.EmptyCopyApplier;
+
+import java.util.UUID;
 
 /**
  *
@@ -88,7 +86,7 @@ class InfiniteReflectionTriggeredEffect extends OneShotEffect {
             Permanent toCopyFromPermanent = game.getPermanent(sourcePermanent.getAttachedTo());
             if (toCopyFromPermanent != null) {
                 for (Permanent toCopyToPermanent : game.getBattlefield().getAllActivePermanents(filter, source.getControllerId(), game)) {
-                    if (!toCopyToPermanent.equals(toCopyFromPermanent) && !(toCopyToPermanent instanceof PermanentToken)) {
+                    if (!toCopyToPermanent.equals(toCopyFromPermanent) && !toCopyToPermanent.isToken()) {
                         game.copyPermanent(toCopyFromPermanent, toCopyToPermanent.getId(), source, new EmptyCopyApplier());
                     }
                 }

--- a/Mage.Sets/src/mage/cards/j/JerrenCorruptedBishop.java
+++ b/Mage.Sets/src/mage/cards/j/JerrenCorruptedBishop.java
@@ -22,7 +22,6 @@ import mage.filter.common.FilterControlledPermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.HumanToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
@@ -132,7 +131,7 @@ class JerrenCorruptedBishopTriggeredAbility extends TriggeredAbilityImpl {
                         && zEvent.getTarget() != null
                         && !zEvent.getTarget().getId().equals(getSourceId())
                         && zEvent.getTarget().isControlledBy(getControllerId())
-                        && !(zEvent.getTarget() instanceof PermanentToken)
+                        && !zEvent.getTarget().isToken()
                         && zEvent.getTarget().hasSubtype(SubType.HUMAN, game);
             default:
                 return false;

--- a/Mage.Sets/src/mage/cards/l/LegionLoyalist.java
+++ b/Mage.Sets/src/mage/cards/l/LegionLoyalist.java
@@ -17,7 +17,6 @@ import mage.constants.SubType;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 
 import java.util.UUID;
 
@@ -83,7 +82,7 @@ class LegionLoyalistCantBeBlockedByTokensEffect extends RestrictionEffect {
 
     @Override
     public boolean canBeBlocked(Permanent attacker, Permanent blocker, Ability source, Game game, boolean canUseChooseDialogs) {
-        return !(blocker instanceof PermanentToken);
+        return !blocker.isToken();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/m/MirkwoodBats.java
+++ b/Mage.Sets/src/mage/cards/m/MirkwoodBats.java
@@ -12,7 +12,6 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 
 import java.util.UUID;
 
@@ -77,7 +76,7 @@ class MirkwoodBatsTriggeredAbility extends TriggeredAbilityImpl {
                 return true;
             case SACRIFICED_PERMANENT:
                 Permanent permanent = game.getPermanentOrLKIBattlefield(event.getTargetId());
-                return permanent instanceof PermanentToken;
+                return permanent != null && permanent.isToken();
             default:
                 return false;
         }

--- a/Mage.Sets/src/mage/cards/m/MutagenManLivingOoze.java
+++ b/Mage.Sets/src/mage/cards/m/MutagenManLivingOoze.java
@@ -1,15 +1,6 @@
 package mage.cards.m;
 
-import java.util.UUID;
 import mage.MageInt;
-import mage.constants.SubType;
-import mage.constants.SuperType;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
-import mage.game.permanent.token.MutagenToken;
-import mage.players.Player;
-import mage.util.CardUtil;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
@@ -19,10 +10,14 @@ import mage.abilities.effects.common.cost.CostModificationEffectImpl;
 import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.constants.CardType;
-import mage.constants.CostModificationType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.token.MutagenToken;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.UUID;
 
 
 /**
@@ -92,7 +87,7 @@ class MutagenManLivingOozeEffect extends CostModificationEffectImpl {
         Permanent permanent = game.getPermanentOrLKIBattlefield(abilityToModify.getSourceId());
         return permanent != null
             && permanent.isArtifact(game)
-            && (permanent instanceof PermanentToken)
+            && permanent.isToken()
             && permanent.isControlledBy(source.getControllerId());
     }
 

--- a/Mage.Sets/src/mage/cards/n/NeyaliSunsVanguard.java
+++ b/Mage.Sets/src/mage/cards/n/NeyaliSunsVanguard.java
@@ -18,7 +18,6 @@ import mage.filter.predicate.permanent.TokenPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.players.Player;
 import mage.util.CardUtil;
 import mage.watchers.Watcher;
@@ -120,7 +119,7 @@ class NeyaliSunsVanguardWatcher extends Watcher {
             return;
         }
         Permanent permanent = game.getPermanent(event.getSourceId());
-        if (permanent instanceof PermanentToken) {
+        if (permanent != null && permanent.isToken()) {
             set.add(permanent.getControllerId());
         }
     }

--- a/Mage.Sets/src/mage/cards/p/Psychomancer.java
+++ b/Mage.Sets/src/mage/cards/p/Psychomancer.java
@@ -13,7 +13,6 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.target.common.TargetOpponent;
 
 import java.util.UUID;
@@ -81,7 +80,7 @@ class PsychomancerTriggeredAbility extends TriggeredAbilityImpl {
                 && (zEvent.getToZone() == Zone.GRAVEYARD || zEvent.getToZone() == Zone.EXILED)
                 && zEvent.getTarget() != null
                 && (zEvent.getTargetId().equals(getSourceId())
-                || zEvent.getTarget().isArtifact(game) && !(zEvent.getTarget() instanceof PermanentToken)
+                || zEvent.getTarget().isArtifact(game) && !zEvent.getTarget().isToken()
                 && zEvent.getTarget().getControllerId().equals(getControllerId()));
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RiseOfTheDreadMarn.java
+++ b/Mage.Sets/src/mage/cards/r/RiseOfTheDreadMarn.java
@@ -14,7 +14,6 @@ import mage.constants.WatcherScope;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.ZombieBerserkerToken;
 import mage.watchers.Watcher;
 
@@ -97,7 +96,7 @@ class RiseOfTheDreadMarnWatcher extends Watcher {
         ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
         if (zEvent.isDiesEvent()
                 && zEvent.getTarget().isCreature(game)
-                && !(zEvent.getTarget() instanceof PermanentToken)) {
+                && !zEvent.getTarget().isToken()) {
             creaturesDied += 1;
         }
     }

--- a/Mage.Sets/src/mage/cards/s/SkullSkaab.java
+++ b/Mage.Sets/src/mage/cards/s/SkullSkaab.java
@@ -12,7 +12,6 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.ZombieToken;
 
 import java.util.UUID;
@@ -74,7 +73,7 @@ class SkullSkaabTriggeredAbility extends TriggeredAbilityImpl {
                 && exploiter.isCreature(game)
                 && exploited.isCreature(game)
                 && exploiter.isControlledBy(getControllerId())
-                && !(exploited instanceof PermanentToken);
+                && !exploited.isToken();
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/s/SlagstoneRefinery.java
+++ b/Mage.Sets/src/mage/cards/s/SlagstoneRefinery.java
@@ -10,7 +10,6 @@ import mage.constants.Zone;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.PowerstoneToken;
 
 import java.util.UUID;
@@ -64,11 +63,11 @@ class SlagstoneRefineryTriggeredAbility extends TriggeredAbilityImpl {
 
         // Filters ZC events for only battlefield => graveyard or battlefield => exile.
         if (zEvent.getFromZone() == Zone.BATTLEFIELD && (zEvent.getToZone() == Zone.GRAVEYARD || zEvent.getToZone() == Zone.EXILED)) {
-            if(zEvent.getTargetId().equals(getSourceId())) {                             // {this}
+            if (zEvent.getTargetId().equals(getSourceId())) {                            // {this}
                 return true;
             } else {                                                                     // another
                 return zEvent.getTarget().isArtifact(game)                               // artifact
-                    && !(zEvent.getTarget() instanceof PermanentToken)                   // nontoken
+                    && !zEvent.getTarget().isToken()                                     // nontoken
                     && (zEvent.getTarget().getControllerId().equals(getControllerId())); // you control
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SunpearlKirin.java
+++ b/Mage.Sets/src/mage/cards/s/SunpearlKirin.java
@@ -14,7 +14,6 @@ import mage.filter.common.FilterNonlandPermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 
@@ -85,9 +84,10 @@ class SunpearlKirinEffect extends OneShotEffect {
         if (player == null || permanent == null) {
             return false;
         }
-        boolean isToken = permanent instanceof PermanentToken;
+        boolean isToken = permanent.isToken();
         player.moveCards(permanent, Zone.HAND, source, game);
         if (isToken) {
+            game.processAction();
             player.drawCards(1, source, game);
         }
         return true;

--- a/Mage.Sets/src/mage/cards/t/TobiasDoomedConqueror.java
+++ b/Mage.Sets/src/mage/cards/t/TobiasDoomedConqueror.java
@@ -18,7 +18,6 @@ import mage.constants.WatcherScope;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.ZombieToken;
 import mage.util.CardUtil;
 import mage.watchers.Watcher;
@@ -105,7 +104,7 @@ class TobiasDoomedConquerorWatcher extends Watcher {
         if (!zEvent.isDiesEvent()
                 || zEvent.getTarget() == null
                 || !zEvent.getTarget().isCreature(game)
-                || zEvent.getTarget() instanceof PermanentToken) {
+                || zEvent.getTarget().isToken()) {
             return;
         }
         playerMap.compute(zEvent.getTarget().getControllerId(), CardUtil::setOrIncrementValue);

--- a/Mage.Sets/src/mage/cards/v/VileRedeemer.java
+++ b/Mage.Sets/src/mage/cards/v/VileRedeemer.java
@@ -13,13 +13,12 @@ import mage.abilities.keyword.FlashAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.SubType;
 import mage.constants.Outcome;
+import mage.constants.SubType;
 import mage.constants.WatcherScope;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
-import mage.game.permanent.PermanentToken;
 import mage.game.permanent.token.EldraziScionToken;
 import mage.players.Player;
 import mage.watchers.Watcher;
@@ -107,7 +106,7 @@ class VileRedeemerNonTokenCreaturesDiedWatcher extends Watcher {
             ZoneChangeEvent zEvent = (ZoneChangeEvent) event;
             if (zEvent.isDiesEvent() && zEvent.getTarget() != null
                     && zEvent.getTarget().isCreature(game)
-                    && !(zEvent.getTarget() instanceof PermanentToken)) {
+                    && !zEvent.getTarget().isToken()) {
                 int count = getAmountOfNontokenCreatureDiedThisTurn(zEvent.getTargetId());
                 amountOfCreaturesThatDied.put(zEvent.getTarget().getControllerId(), ++count);
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/GraveyardFromAnywhereExileReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/GraveyardFromAnywhereExileReplacementEffect.java
@@ -12,7 +12,6 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.events.ZoneChangeEvent;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 import mage.util.CardUtil;
 
 /**
@@ -85,7 +84,7 @@ public class GraveyardFromAnywhereExileReplacementEffect extends ReplacementEffe
             return true;
         }
         Permanent token = game.getPermanent(event.getTargetId());
-        if (tokens && (token instanceof PermanentToken && (!onlyYou || token.isOwnedBy(source.getControllerId())))) {
+        if (tokens && (token.isToken() && (!onlyYou || token.isOwnedBy(source.getControllerId())))) {
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/filter/predicate/permanent/TokenPredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/TokenPredicate.java
@@ -3,7 +3,6 @@ package mage.filter.predicate.permanent;
 import mage.filter.predicate.Predicate;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.game.permanent.PermanentToken;
 
 /**
  * @author North
@@ -19,7 +18,7 @@ public enum TokenPredicate implements Predicate<Permanent> {
 
     @Override
     public boolean apply(Permanent input, Game game) {
-        return value == input instanceof PermanentToken;
+        return value == input.isToken();
     }
 
     @Override

--- a/Mage/src/main/java/mage/game/permanent/Permanent.java
+++ b/Mage/src/main/java/mage/game/permanent/Permanent.java
@@ -69,6 +69,8 @@ public interface Permanent extends Card, Controllable {
 
     boolean phaseOut(Game game, boolean indirectPhase);
 
+    boolean isToken();
+
     boolean isMonstrous();
 
     void setMonstrous(boolean value);

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -1744,6 +1744,11 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
     }
 
     @Override
+    public boolean isToken() {
+        return this instanceof PermanentToken;
+    }
+
+    @Override
     public boolean isMonstrous() {
         return this.monstrous;
     }


### PR DESCRIPTION
This is a necessary precondition for mutate ability #14900. This PR implements a nonfunctional change, but allows for `PermanentImpl::isToken` to be updated to include logic to check the top of a mutate stack.

I updated many usages of `instanceof PermanentToken` that were clearly for card logic purpose. There are still several usages internal to engine that are correct, and some usages in card logic that would need more attention to fix edge cases after mutate ability is implemented.