### PR TITLE
Centralize all-zone attribute modification effects

### DIFF
--- a/Mage.Sets/src/mage/cards/a/ArcaneAdaptation.java
+++ b/Mage.Sets/src/mage/cards/a/ArcaneAdaptation.java
@@ -8,9 +8,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreatureSpell;
-import mage.filter.common.FilterOwnedCreatureCard;
 
 import java.util.UUID;
 
@@ -19,9 +16,6 @@ import java.util.UUID;
  */
 public final class ArcaneAdaptation extends CardImpl {
 
-    public static final FilterControlledCreatureSpell filterSpells = new FilterControlledCreatureSpell("creature spells you control");
-    public static final FilterOwnedCreatureCard filterCards = new FilterOwnedCreatureCard("creature cards you own");
-
     public ArcaneAdaptation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{U}");
 
@@ -29,11 +23,7 @@ public final class ArcaneAdaptation extends CardImpl {
         this.addAbility(new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.Neutral)));
 
         // Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.
-        this.addAbility(new SimpleStaticAbility(new AddCreatureSubTypeAllMultiZoneEffect(
-                StaticFilters.FILTER_CONTROLLED_CREATURES,
-                filterSpells,
-                filterCards
-        )));
+        this.addAbility(new SimpleStaticAbility(new AddCreatureSubTypeAllMultiZoneEffect()));
     }
 
     private ArcaneAdaptation(final ArcaneAdaptation card) {

--- a/Mage.Sets/src/mage/cards/b/Biotransference.java
+++ b/Mage.Sets/src/mage/cards/b/Biotransference.java
@@ -3,25 +3,17 @@ package mage.cards.b;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
-import mage.cards.Card;
+import mage.abilities.effects.common.continuous.ModifyObjectAllMultiZoneEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.game.Game;
-import mage.game.command.CommandObject;
-import mage.game.command.Commander;
-import mage.game.permanent.Permanent;
+import mage.filter.common.FilterControlledCreatureSpell;
+import mage.filter.common.FilterOwnedCreatureCard;
 import mage.game.permanent.token.NecronWarriorToken;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
-import mage.players.Player;
 
-import java.util.List;
 import java.util.UUID;
 
 public final class Biotransference extends CardImpl {
@@ -48,12 +40,16 @@ public final class Biotransference extends CardImpl {
     }
 }
 
-class BiotransferenceEffect extends ContinuousEffectImpl {
+class BiotransferenceEffect extends ModifyObjectAllMultiZoneEffect {
 
     BiotransferenceEffect() {
-        super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
-        staticText = "Creatures you control are artifacts in addition to their other types. " +
-                "The same is true for creature spells you control and creature cards you own that aren't on the battlefield";
+        super(
+            StaticFilters.FILTER_CONTROLLED_CREATURES,
+            new FilterControlledCreatureSpell("creature spells you control"),
+            new FilterOwnedCreatureCard("creature cards you own"),
+            (obj, source, game) -> { game.getState().getCreateMageObjectAttribute(obj, game).getCardType().add(CardType.ARTIFACT); },
+            CardType.ARTIFACT.getPluralName() + " in addition to their other types"
+        );
         this.dependencyTypes.add(DependencyType.ArtifactAddingRemoving); // March of the Machines
     }
 
@@ -66,69 +62,4 @@ class BiotransferenceEffect extends ContinuousEffectImpl {
         return new BiotransferenceEffect(this);
     }
 
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null) {
-            return false;
-        }
-        // Creature cards you own that aren't on the battlefield
-        // in graveyard
-        for (UUID cardId : controller.getGraveyard()) {
-            Card card = game.getCard(cardId);
-            if (card != null && card.isCreature(game) && !card.isArtifact(game)) {
-                card.addCardType(game, CardType.ARTIFACT);
-            }
-        }
-        // on Hand
-        for (UUID cardId : controller.getHand()) {
-            Card card = game.getCard(cardId);
-            if (card != null && card.isCreature(game) && !card.isArtifact(game)) {
-                card.addCardType(game, CardType.ARTIFACT);
-            }
-        }
-        // in Exile
-        for (Card card : game.getState().getExile().getCardsOwned(game, source.getControllerId())) {
-            if (card.isCreature(game) && !card.isArtifact(game)) {
-                card.addCardType(game, CardType.ARTIFACT);
-            }
-        }
-        // in Library (e.g. for Mystical Teachings)
-        for (Card card : controller.getLibrary().getCards(game)) {
-            if (card.isOwnedBy(controller.getId()) && card.isCreature(game) && !card.isArtifact(game)) {
-                card.addCardType(game, CardType.ARTIFACT);
-            }
-        }
-        // commander in command zone
-        for (CommandObject commandObject : game.getState().getCommand()) {
-            if (commandObject instanceof Commander) {
-                Card card = game.getCard((commandObject).getId());
-                if (card != null && card.isOwnedBy(controller.getId())
-                        && card.isCreature(game) && !card.isArtifact(game)) {
-                    card.addCardType(game, CardType.ARTIFACT);
-                }
-            }
-        }
-
-        // creature spells you control
-        for (StackObject stackObject : game.getStack()) {
-            if (stackObject instanceof Spell
-                    && stackObject.isControlledBy(source.getControllerId())
-                    && stackObject.isCreature(game)
-                    && !stackObject.isArtifact(game)) {
-                Card card = ((Spell) stackObject).getCard();
-                card.addCardType(game, CardType.ARTIFACT);
-            }
-        }
-        // creatures you control
-        List<Permanent> creatures = game.getBattlefield().getAllActivePermanents(
-                new FilterControlledCreaturePermanent(), source.getControllerId(), game);
-        for (Permanent creature : creatures) {
-            if (creature != null) {
-                creature.addCardType(game, CardType.ARTIFACT);
-            }
-        }
-        return true;
-
-    }
 }

--- a/Mage.Sets/src/mage/cards/c/Conspiracy.java
+++ b/Mage.Sets/src/mage/cards/c/Conspiracy.java
@@ -1,26 +1,17 @@
 package mage.cards.c;
 
-import mage.MageObject;
-import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.ChooseCreatureTypeEffect;
-import mage.cards.Card;
+import mage.abilities.effects.common.continuous.ModifyObjectAllMultiZoneEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.game.Game;
-import mage.game.command.CommandObject;
-import mage.game.command.Commander;
-import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
-import mage.players.Player;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterControlledCreatureSpell;
+import mage.filter.common.FilterOwnedCreatureCard;
 import mage.util.SubTypes;
 
-import java.util.Iterator;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -49,98 +40,34 @@ public final class Conspiracy extends CardImpl {
         return new Conspiracy(this);
     }
 
-    static class ConspiracyEffect extends ContinuousEffectImpl {
+}
 
-        private ConspiracyEffect() {
-            super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Neutral);
-            staticText = "Creatures you control are the chosen type. The same is "
-                    + "true for creature spells you control and creature cards "
-                    + "you own that aren't on the battlefield.";
+class ConspiracyEffect extends ModifyObjectAllMultiZoneEffect {
 
-            this.dependendToTypes.add(DependencyType.BecomeCreature);  // Opalescence and Starfield of Nyx
-        }
+    ConspiracyEffect() {
+        super(
+            StaticFilters.FILTER_CONTROLLED_CREATURES,
+            new FilterControlledCreatureSpell("creature spells you control"),
+            new FilterOwnedCreatureCard("creature cards you own"),
+            (obj, source, game) -> {
+                final SubTypes subTypes = game.getState().getCreateMageObjectAttribute(obj, game).getSubtype();
+                subTypes.setIsAllCreatureTypes(false);
+                subTypes.removeAll(SubType.getCreatureTypes());
+                subTypes.add(ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game));
+            },
+            "the chosen type"
+        );
 
-        private ConspiracyEffect(final ConspiracyEffect effect) {
-            super(effect);
-        }
-
-        @Override
-        public ConspiracyEffect copy() {
-            return new ConspiracyEffect(this);
-        }
-
-        @Override
-        public boolean apply(Game game, Ability source) {
-            Player controller = game.getPlayer(source.getControllerId());
-            SubType subType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
-            if (controller == null || subType == null) {
-                return true;
-            }
-            // Creature cards you own that aren't on the battlefield
-            // in graveyard
-            for (UUID cardId : controller.getGraveyard()) {
-                Card card = game.getCard(cardId);
-                if (card != null && card.isCreature(game)) {
-                    setCreatureSubtype(card, subType, game);
-                }
-            }
-            // on Hand
-            for (UUID cardId : controller.getHand()) {
-                Card card = game.getCard(cardId);
-                if (card != null && card.isCreature(game)) {
-                    setCreatureSubtype(card, subType, game);
-                }
-            }
-            // in Exile
-            for (Card card : game.getState().getExile().getCardsOwned(game, controller.getId())) {
-                if (card.isCreature(game)) {
-                    setCreatureSubtype(card, subType, game);
-                }
-            }
-            // in Library (e.g. for Mystical Teachings)
-            for (Card card : controller.getLibrary().getCards(game)) {
-                if (card.isCreature(game)) {
-                    setCreatureSubtype(card, subType, game);
-                }
-            }
-            // in command zone
-            for (CommandObject commandObject : game.getState().getCommand()) {
-                if (commandObject instanceof Commander) {
-                    Card card = game.getCard(((Commander) commandObject).getId());
-                    if (card != null && card.isCreature(game) && card.isOwnedBy(controller.getId())) {
-                        setCreatureSubtype(card, subType, game);
-                    }
-                }
-            }
-            // creature spells you control
-            for (Iterator<StackObject> iterator = game.getStack().iterator(); iterator.hasNext(); ) {
-                StackObject stackObject = iterator.next();
-                if (stackObject instanceof Spell
-                        && stackObject.isControlledBy(controller.getId())
-                        && stackObject.isCreature(game)) {
-                    setCreatureSubtype(stackObject, subType, game);
-                    setCreatureSubtype(((Spell) stackObject).getCard(), subType, game);
-                }
-            }
-            // creatures you control
-            List<Permanent> permanents = game.getBattlefield().getAllActivePermanents(controller.getId());
-            for (Permanent permanent : permanents) {
-                if (permanent.isCreature(game)) {
-                    permanent.removeAllCreatureTypes(game);
-                    permanent.addSubType(game, subType);
-                }
-            }
-            return true;
-        }
-
-        private void setCreatureSubtype(MageObject object, SubType subtype, Game game) {
-            if (object == null) {
-                return;
-            }
-            SubTypes subTypes = game.getState().getCreateMageObjectAttribute(object, game).getSubtype();
-            subTypes.setIsAllCreatureTypes(false);
-            subTypes.removeAll(SubType.getCreatureTypes());
-            subTypes.add(subtype);
-        }
+        this.dependendToTypes.add(DependencyType.BecomeCreature);  // Opalescence and Starfield of Nyx
     }
+
+    private ConspiracyEffect(final ConspiracyEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public ConspiracyEffect copy() {
+        return new ConspiracyEffect(this);
+    }
+
 }

--- a/Mage.Sets/src/mage/cards/l/LeylineOfTransformation.java
+++ b/Mage.Sets/src/mage/cards/l/LeylineOfTransformation.java
@@ -9,9 +9,6 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Outcome;
-import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreatureSpell;
-import mage.filter.common.FilterOwnedCreatureCard;
 
 import java.util.UUID;
 
@@ -19,9 +16,6 @@ import java.util.UUID;
  * @author PurpleCrowbar
  */
 public final class LeylineOfTransformation extends CardImpl {
-
-    public static final FilterControlledCreatureSpell filterSpells = new FilterControlledCreatureSpell("creature spells you control");
-    public static final FilterOwnedCreatureCard filterCards = new FilterOwnedCreatureCard("creature cards you own");
 
     public LeylineOfTransformation(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{2}{U}{U}");
@@ -33,11 +27,7 @@ public final class LeylineOfTransformation extends CardImpl {
         this.addAbility(new AsEntersBattlefieldAbility(new ChooseCreatureTypeEffect(Outcome.Neutral)));
 
         // Creatures you control are the chosen type in addition to their other types. The same is true for creature spells you control and creature cards you own that aren't on the battlefield.
-        this.addAbility(new SimpleStaticAbility(new AddCreatureSubTypeAllMultiZoneEffect(
-                StaticFilters.FILTER_CONTROLLED_CREATURES,
-                filterSpells,
-                filterCards
-        )));
+        this.addAbility(new SimpleStaticAbility(new AddCreatureSubTypeAllMultiZoneEffect()));
     }
 
     private LeylineOfTransformation(final LeylineOfTransformation card) {

--- a/Mage.Sets/src/mage/cards/m/MaskwoodNexus.java
+++ b/Mage.Sets/src/mage/cards/m/MaskwoodNexus.java
@@ -1,33 +1,21 @@
 package mage.cards.m;
 
-import mage.MageItem;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.CreateTokenEffect;
-import mage.cards.Card;
+import mage.abilities.effects.common.continuous.ModifyObjectAllMultiZoneEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.command.Commander;
-import mage.game.permanent.Permanent;
+import mage.filter.common.FilterControlledCreatureSpell;
+import mage.filter.common.FilterOwnedCreatureCard;
 import mage.game.permanent.token.ShapeshifterBlueToken;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
-import mage.players.Player;
-import mage.util.CardUtil;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * @author TheElk801
@@ -56,16 +44,19 @@ public final class MaskwoodNexus extends CardImpl {
     public MaskwoodNexus copy() {
         return new MaskwoodNexus(this);
     }
+
 }
 
-class MaskwoodNexusEffect extends ContinuousEffectImpl {
+class MaskwoodNexusEffect extends ModifyObjectAllMultiZoneEffect {
 
     MaskwoodNexusEffect() {
-        super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
-        staticText = "Creatures you control are every creature type. "
-                + "The same is true for creature spells you control "
-                + "and creature cards you own that aren't on the battlefield.";
-        this.dependendToTypes.add(DependencyType.BecomeCreature);
+        super(
+            StaticFilters.FILTER_CONTROLLED_CREATURES,
+            new FilterControlledCreatureSpell("creature spells you control"),
+            new FilterOwnedCreatureCard("creature cards you own"),
+            (obj, source, game) -> { game.getState().getCreateMageObjectAttribute(obj, game).getSubtype().setIsAllCreatureTypes(true); },
+            "every creature type"
+        );
     }
 
     private MaskwoodNexusEffect(final MaskwoodNexusEffect effect) {
@@ -77,79 +68,4 @@ class MaskwoodNexusEffect extends ContinuousEffectImpl {
         return new MaskwoodNexusEffect(this);
     }
 
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        if (controller == null) {
-            return false;
-        }
-        // Creature cards you own that aren't on the battlefield
-        // in graveyard
-        Set<Card> affectedCards = controller.getGraveyard().stream()
-                .map(game::getCard)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-        // on Hand
-        controller.getHand().stream()
-                .map(game::getCard)
-                .filter(Objects::nonNull)
-                .forEach(affectedCards::add);
-
-        // in Exile
-        game.getState().getExile().getCardsOwned(game, controller.getId()).stream()
-                .filter(card -> card.isOwnedBy(controller.getId()))
-                .forEach(affectedCards::add);
-
-        // in Library (e.g. for Mystical Teachings)
-        affectedCards.addAll(controller.getLibrary().getCards(game));
-
-        // commander in command zone
-        game.getState().getCommand().stream()
-                .filter(Commander.class::isInstance)
-                .map(MageItem::getId)
-                .map(game::getCard)
-                .filter(Objects::nonNull)
-                .filter(c -> c.isOwnedBy(controller.getId()))
-                .forEach(affectedCards::add);
-
-        // Apply to all affected cards by object parts
-        affectedCards.stream()
-                .map(card -> game.getObject(card.getId()))
-                .filter(Objects::nonNull)
-                .forEach(mageObject -> {
-                    if (mageObject.isCreature(game)) {
-                        game.getState().getCreateMageObjectAttribute(mageObject, game).getSubtype().setIsAllCreatureTypes(true);
-                    }
-                    CardUtil.getObjectParts(mageObject).stream()
-                            .filter(Objects::nonNull)
-                            .forEach(objectId -> {
-                                MageObject partObject = game.getObject(objectId);
-                                if (partObject != null && partObject.isCreature(game)) {
-                                    game.getState().getCreateMageObjectAttribute(partObject, game).getSubtype().setIsAllCreatureTypes(true);
-                                }
-                            });
-                });
-
-        // creature spells you control
-        for (StackObject stackObject : game.getStack()) {
-            if (stackObject instanceof Spell
-                    && stackObject.isControlledBy(source.getControllerId())
-                    && stackObject.isCreature(game)) {
-                Card card = ((Spell) stackObject).getCard();
-                game.getState().getCreateMageObjectAttribute(card, game).getSubtype().setIsAllCreatureTypes(true);
-            }
-        }
-
-        // creatures you control
-        List<Permanent> creatures = game.getBattlefield().getAllActivePermanents(
-                StaticFilters.FILTER_CONTROLLED_CREATURE, source.getControllerId(), game);
-        for (Permanent creature : creatures) {
-            if (creature != null) {
-                creature.setIsAllCreatureTypes(game, true);
-            }
-        }
-
-        return true;
-
-    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/modaldoublefaced/ModalDoubleFacedCardsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/modaldoublefaced/ModalDoubleFacedCardsTest.java
@@ -1267,4 +1267,23 @@ public class ModalDoubleFacedCardsTest extends CardTestPlayerBase {
         assertTappedCount("Snow-Covered Forest", true, 1);
         assertLife(playerB, 20 - 3);
     }
+
+    // https://github.com/magefree/mage/issues/14817
+    @Test
+    public void test_Graveyard_MustApplyCardTypes() {
+        addCard(Zone.GRAVEYARD, playerA, "Akoum Warrior");
+        addCard(Zone.BATTLEFIELD, playerA, "Biotransference");
+        addCard(Zone.HAND, playerA, "Refurbish");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Refurbish");
+        addTarget(playerA, "Akoum Warrior");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Akoum Warrior", 1);
+        assertType("Akoum Warrior", CardType.ARTIFACT, true);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCreatureSubTypeAllMultiZoneEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/AddCreatureSubTypeAllMultiZoneEffect.java
@@ -1,30 +1,33 @@
 package mage.abilities.effects.common.continuous;
 
-import mage.abilities.Ability;
-import mage.abilities.effects.ContinuousEffectImpl;
 import mage.abilities.effects.common.ChooseCreatureTypeEffect;
-import mage.cards.Card;
 import mage.constants.*;
+import mage.filter.StaticFilters;
 import mage.filter.common.*;
-import mage.game.Game;
-import mage.game.command.CommandObject;
-import mage.game.command.Commander;
-import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
-import mage.game.stack.StackObject;
-import mage.players.Player;
 
-import java.util.List;
-import java.util.UUID;
+import java.util.Optional;
 
 /**
  * @author TheElk801, Susucr
  */
-public class AddCreatureSubTypeAllMultiZoneEffect extends ContinuousEffectImpl {
+public class AddCreatureSubTypeAllMultiZoneEffect extends ModifyObjectAllMultiZoneEffect {
     private final FilterControlledCreaturePermanent filterPermanent;
     private final FilterControlledCreatureSpell filterSpell;
     private final FilterOwnedCreatureCard filterCard;
     private final SubType chosenType;
+
+    public AddCreatureSubTypeAllMultiZoneEffect() {
+        this((SubType)null);
+    }
+
+    public AddCreatureSubTypeAllMultiZoneEffect(SubType chosenType) {
+        this(
+            StaticFilters.FILTER_CONTROLLED_CREATURES,
+            new FilterControlledCreatureSpell("creature spells you control"),
+            new FilterOwnedCreatureCard("creature cards you own"),
+            chosenType
+        );
+    }
 
     public AddCreatureSubTypeAllMultiZoneEffect(
             FilterControlledCreaturePermanent filterPermanent,
@@ -40,21 +43,25 @@ public class AddCreatureSubTypeAllMultiZoneEffect extends ContinuousEffectImpl {
             FilterOwnedCreatureCard filterCard,
             SubType chosenType
     ) {
-        super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
+        super(filterPermanent, filterSpell, filterCard,
+            chosenType == null ?
+                (obj, source, game) -> {
+                    Optional.ofNullable(
+                        ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game)
+                    ).ifPresent(type -> {
+                        game.getState().getCreateMageObjectAttribute(obj, game).getSubtype().add(type);
+                    });
+                } :
+                (obj, source, game) -> { game.getState().getCreateMageObjectAttribute(obj, game).getSubtype().add(chosenType); },
+            (chosenType == null ? "the chosen type" : chosenType.getPluralName()) + " in addition to their other types"
+        );
 
         this.filterPermanent = filterPermanent;
         this.filterSpell = filterSpell;
         this.filterCard = filterCard;
         this.chosenType = chosenType;
 
-        String typeMessage = "the chosen type";
-        if (chosenType != null) {
-            typeMessage = chosenType.getPluralName();
-        }
-
-        staticText = filterPermanent.getMessage() + " are " + typeMessage + " in addition to their other types. "
-                + "The same is true for " + filterSpell.getMessage()
-                + " and " + filterCard.getMessage() + " that aren't on the battlefield";
+        this.dependendToTypes.add(DependencyType.BecomeCreature);  // Opalescence and Starfield of Nyx
     }
 
     private AddCreatureSubTypeAllMultiZoneEffect(final AddCreatureSubTypeAllMultiZoneEffect effect) {
@@ -68,74 +75,5 @@ public class AddCreatureSubTypeAllMultiZoneEffect extends ContinuousEffectImpl {
     @Override
     public AddCreatureSubTypeAllMultiZoneEffect copy() {
         return new AddCreatureSubTypeAllMultiZoneEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        UUID controllerId = source.getControllerId();
-        Player controller = game.getPlayer(controllerId);
-        SubType subType = this.chosenType;
-        if (subType == null) {
-            subType = ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game);
-        }
-        if (controller == null || subType == null) {
-            return false;
-        }
-
-        // creatures cards you own that aren't on the battlefield
-        // in graveyard
-        for (UUID cardId : controller.getGraveyard()) {
-            Card card = game.getCard(cardId);
-            if (filterCard.match(card, controllerId, source, game) && !card.hasSubtype(subType, game)) {
-                game.getState().getCreateMageObjectAttribute(card, game).getSubtype().add(subType);
-            }
-        }
-        // on Hand
-        for (UUID cardId : controller.getHand()) {
-            Card card = game.getCard(cardId);
-            if (filterCard.match(card, controllerId, source, game) && !card.hasSubtype(subType, game)) {
-                game.getState().getCreateMageObjectAttribute(card, game).getSubtype().add(subType);
-            }
-        }
-        // in Exile
-        for (Card card : game.getState().getExile().getCardsOwned(game, controllerId)) {
-            if (filterCard.match(card, controllerId, source, game) && !card.hasSubtype(subType, game)) {
-                game.getState().getCreateMageObjectAttribute(card, game).getSubtype().add(subType);
-            }
-        }
-        // in Library (e.g. for Mystical Teachings)
-        for (Card card : controller.getLibrary().getCards(game)) {
-            if (filterCard.match(card, controllerId, source, game) && !card.hasSubtype(subType, game)) {
-                game.getState().getCreateMageObjectAttribute(card, game).getSubtype().add(subType);
-            }
-        }
-        // commander in command zone
-        for (CommandObject commandObject : game.getState().getCommand()) {
-            if (commandObject instanceof Commander) {
-                Card card = game.getCard((commandObject).getId());
-                if (filterCard.match(card, controllerId, source, game) && !card.hasSubtype(subType, game)) {
-                    game.getState().getCreateMageObjectAttribute(card, game).getSubtype().add(subType);
-                }
-            }
-        }
-
-        // creature spells you control
-        for (StackObject stackObject : game.getStack()) {
-            if (stackObject instanceof Spell
-                    && filterSpell.match(stackObject, controllerId, source, game)
-                    && !stackObject.hasSubtype(subType, game)) {
-                Card card = ((Spell) stackObject).getCard();
-                game.getState().getCreateMageObjectAttribute(card, game).getSubtype().add(subType);
-            }
-        }
-        // creatures you control
-        List<Permanent> creatures = game.getBattlefield().getAllActivePermanents(
-                filterPermanent, controllerId, game);
-        for (Permanent creature : creatures) {
-            if (creature != null) {
-                creature.addSubType(game, subType);
-            }
-        }
-        return true;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/ModifyObjectAllMultiZoneEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/ModifyObjectAllMultiZoneEffect.java
@@ -1,0 +1,139 @@
+package mage.abilities.effects.common.continuous;
+
+import mage.MageItem;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.cards.Card;
+import mage.constants.Duration;
+import mage.constants.Layer;
+import mage.constants.Outcome;
+import mage.constants.SubLayer;
+import mage.filter.FilterCard;
+import mage.filter.FilterPermanent;
+import mage.filter.FilterSpell;
+import mage.game.Game;
+import mage.game.command.Commander;
+import mage.game.stack.Spell;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class ModifyObjectAllMultiZoneEffect extends ContinuousEffectImpl {
+    @FunctionalInterface
+    public interface ObjectModifier {
+        void modify(MageObject obj, Ability source, Game game);
+    }
+
+    private final FilterPermanent filterPermanent;
+    private final FilterSpell filterSpell;
+    private final FilterCard filterCard;
+    private final ObjectModifier function;
+
+    public ModifyObjectAllMultiZoneEffect(
+        FilterPermanent filterPermanent,
+        FilterSpell filterSpell,
+        FilterCard filterCard,
+        ObjectModifier function,
+        String modification
+    ) {
+        super(Duration.WhileOnBattlefield, Layer.TypeChangingEffects_4, SubLayer.NA, Outcome.Benefit);
+
+        this.filterPermanent = filterPermanent;
+        this.filterSpell = filterSpell;
+        this.filterCard = filterCard;
+        this.function = function;
+
+        this.staticText = filterPermanent.getMessage() + " are " + modification + ". "
+                + "The same is true for " + filterSpell.getMessage()
+                + " and " + filterCard.getMessage() + " that aren't on the battlefield";
+    }
+
+    protected ModifyObjectAllMultiZoneEffect(final ModifyObjectAllMultiZoneEffect effect) {
+        super(effect);
+        this.filterPermanent = effect.filterPermanent;
+        this.filterSpell = effect.filterSpell;
+        this.filterCard = effect.filterCard;
+        this.function = effect.function;
+    }
+
+    @Override
+    public ModifyObjectAllMultiZoneEffect copy() {
+        return new ModifyObjectAllMultiZoneEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        final UUID controllerId = source.getControllerId();
+        if (controllerId == null) {
+            return false;
+        }
+        final Player controller = game.getPlayer(controllerId);
+        if (controller == null) {
+            return false;
+        }
+
+        // cards that aren't on the battlefield
+        // in graveyard
+        Set<Card> affectedCards = controller.getGraveyard().stream()
+                .map(game::getCard)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        // on Hand
+        controller.getHand().stream()
+                .map(game::getCard)
+                .filter(Objects::nonNull)
+                .forEach(affectedCards::add);
+
+        // in Exile
+        game.getState().getExile().getCardsOwned(game, controller.getId()).stream()
+                .filter(card -> card.isOwnedBy(controller.getId()))
+                .forEach(affectedCards::add);
+
+        // in Library (e.g. for Mystical Teachings)
+        affectedCards.addAll(controller.getLibrary().getCards(game));
+
+        // commander in command zone
+        game.getState().getCommand().stream()
+                .filter(Commander.class::isInstance)
+                .map(MageItem::getId)
+                .map(game::getCard)
+                .filter(Objects::nonNull)
+                .filter(c -> c.isOwnedBy(controller.getId()))
+                .forEach(affectedCards::add);
+
+        // Apply to all affected cards by object parts
+        affectedCards.stream()
+                .filter(card -> this.filterCard.match(card, controllerId, source, game))
+                .forEach(mageObject -> {
+                    this.function.modify(mageObject, source, game);
+                    CardUtil.getObjectParts(mageObject).stream()
+                            .filter(Objects::nonNull)
+                            .map(game::getCard)
+                            .filter(Objects::nonNull)
+                            .filter(part -> this.filterCard.match(part, controllerId, source, game))
+                            .forEach(part -> { this.function.modify(part, source, game); });
+                });
+
+        // spells
+        game.getStack().stream()
+            .filter(Spell.class::isInstance)
+            .filter(spell -> this.filterSpell.match(spell, controllerId, source, game))
+            .map(Spell.class::cast)
+            .filter(Objects::nonNull)
+            .map(spell -> spell.getCard())
+            .forEach(card -> { this.function.modify(card, source, game); });
+
+        // permanents
+        game.getBattlefield().getAllActivePermanents(this.filterPermanent, controllerId, game)
+            .stream()
+            .filter(Objects::nonNull)
+            .forEach(permanent -> { this.function.modify(permanent, source, game); });
+
+        return true;
+    }
+}


### PR DESCRIPTION
This centralizes into a pair of common effects the various cards with all-zone attribute modification effects e.g. Arcane Adaptation, Biotransference, Conspiracy, Leyline of Transformation, and Maskwood Nexus.  A few others will continue to work with no chnges.  Specifically I want to make sure that the code breaking objects into parts and applying individually to each part is always reused for any future implementations, so I've made the constructor fairly open-ended, taking an arbitrary modifier lambda.  All of these cards can now correctly take advantage of the shared code rather than having to implement it individually.
    
Fixes https://github.com/magefree/mage/issues/14817