### PR TITLE
Fix card reveal selection on Taster of Wares

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TasterOfWares.java
+++ b/Mage.Sets/src/mage/cards/t/TasterOfWares.java
@@ -12,6 +12,8 @@ import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.constants.Outcome;
 import mage.constants.SubType;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
 import mage.filter.common.FilterControlledPermanent;
@@ -104,9 +106,9 @@ class TasterOfWaresEffect extends OneShotEffect {
                 card = cards.getRandom(game);
                 break;
             default:
-                TargetCard targetCard = new TargetCardInHand(1, StaticFilters.FILTER_CARD);
+                TargetCard targetCard = new TargetCard(Zone.HAND, new FilterCard());
                 targetCard.withChooseHint("to exile");
-                controller.choose(outcome, cards, target, source, game);
+                controller.choose(outcome, cards, targetCard, source, game);
                 card = game.getCard(targetCard.getFirstTarget());
         }
         if (card == null) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ecl/TasterOfWaresTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ecl/TasterOfWaresTest.java
@@ -1,0 +1,33 @@
+package org.mage.test.cards.single.ecl;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class TasterOfWaresTest extends CardTestPlayerBase {
+
+    @Test
+    public void testBasic() {
+        addCard(Zone.HAND, playerB, "Lightning Bolt", 3);
+        addCard(Zone.HAND, playerA, "Taster of Wares");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Goblin Assailant", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Taster of Wares");
+        addTarget(playerA, playerB);
+        setChoice(playerB, "Lightning Bolt");
+        setChoice(playerB, "Lightning Bolt");
+        setChoice(playerB, "Lightning Bolt");
+        setChoice(playerA, "Lightning Bolt");
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Lightning Bolt");
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertLife(playerB, 17);
+    }
+
+}


### PR DESCRIPTION
Two separate issues here:

* `TargetCardInHand` is limited to card in the hand of the ability's controller, need to use generic `TargetCard(Zone.HAND)` instead
* Was passing the wrong variable to `controller.choose()`, reusing the old one from the reveal choice