### PR TITLE
Do not allow alt costs when existing alt cost is in effect

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/OverloadTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/OverloadTest.java
@@ -169,4 +169,20 @@ public class OverloadTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Ornithopter", 4);
         assertPermanentCount(playerA, "Food Token", 2);
     }
+
+    @Test
+    public void test_CyclonicRift_CantUseAlternativeSpellOnAlternateCast() {
+        removeAllCardsFromLibrary(playerA);
+        addCard(Zone.LIBRARY, playerA, "Cyclonic Rift");
+        addCard(Zone.BATTLEFIELD, playerA, "Bolas's Citadel");
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears");
+
+        checkPlayableAbility("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Cyclonic Rift", true);
+        checkPlayableAbility("before", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Cyclonic Rift with overload", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+    }
+
 }

--- a/Mage/src/main/java/mage/abilities/SpellAbility.java
+++ b/Mage/src/main/java/mage/abilities/SpellAbility.java
@@ -195,9 +195,9 @@ public class SpellAbility extends ActivatedAbilityImpl {
             if (getSpellAbilityType() == SpellAbilityType.BASE_ALTERNATE) {
                 Player player = game.getPlayer(playerId);
                 if (player != null
-                        && player.getCastSourceIdWithAlternateMana()
+                        && !player.getCastSourceIdWithAlternateMana()
                         .getOrDefault(getSourceId(), Collections.emptySet())
-                        .contains(MageIdentifier.Default)
+                        .isEmpty()
                 ) {
                     return ActivationStatus.getFalse();
                 }


### PR DESCRIPTION
The current code looks specifically for `MageIdentifier.Default` to prevent built-in alternate casting costs like Overload, but some cards like Bolas's Citadel use their own specific `MageIdentifier` enums. Prohibit all alternate casting costs when any of these is in effect.