### PR TITLE
[MSC] Sync reprints 27/05/26

### DIFF
--- a/Mage.Sets/src/mage/sets/MarvelSuperHeroesCommander.java
+++ b/Mage.Sets/src/mage/sets/MarvelSuperHeroesCommander.java
@@ -21,6 +21,7 @@ public final class MarvelSuperHeroesCommander extends ExpansionSet {
         this.hasBasicLands = false; // temporary
 
         cards.add(new SetCardInfo("Captain America, Team Leader", 5, Rarity.MYTHIC, mage.cards.c.CaptainAmericaTeamLeader.class));
+        cards.add(new SetCardInfo("Dark Ritual", 793, Rarity.UNCOMMON, mage.cards.d.DarkRitual.class));
         cards.add(new SetCardInfo("Human Torch", 3, Rarity.MYTHIC, mage.cards.h.HumanTorch.class));
         cards.add(new SetCardInfo("Invisible Woman", 1, Rarity.MYTHIC, mage.cards.i.InvisibleWoman.class));
         cards.add(new SetCardInfo("Lucky the Pizza Dog", 726, Rarity.RARE, mage.cards.l.LuckyThePizzaDog.class));


### PR DESCRIPTION
Linked to #14119 

Just one reprint so far and a bunch of new cards spoiled today that I'll add separately. Feels silly to PR this I know but 🤷 

<img width="400" height="559" alt="image" src="https://github.com/user-attachments/assets/9c1bdc6c-30ec-4f09-9c06-5e13a5873e95" />
