### PR TITLE
[don't merge] Add support for 702.190b with Sneak'ed creatures entering tapped and attacking

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SneakTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SneakTest.java
@@ -88,6 +88,40 @@ public class SneakTest extends CardTestCommanderDuelBase {
     }
 
     @Test
+    public void testCreatureSneakPlaneswalkerBouncedOnStack() {
+        // When the attacked planeswalker is bounced while the sneak spell is on the
+        // stack, the sneaked creature should enter tapped but NOT be assigned to any
+        // combat group (since the original defender no longer exists).
+        String sorin = "Sorin, Solemn Visitor";
+
+        addCard(Zone.BATTLEFIELD, playerA, "Godless Shrine", 4);
+        addCard(Zone.BATTLEFIELD, playerA, goblin);
+        addCard(Zone.HAND, playerA, karai);
+        addCard(Zone.BATTLEFIELD, playerB, sorin);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 2);
+        addCard(Zone.HAND, playerB, "Boomerang");
+
+        attack(1, playerA, goblin, sorin);
+
+        // playerA casts karai with Sneak targeting sorin's combat group
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerA, karai + " with Sneak");
+        setChoice(playerA, goblin);
+        // playerB responds by bouncing their own planeswalker (Boomerang hits any permanent)
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerB, "Boomerang", sorin);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerA, goblin, 1);       // goblin returned as sneak cost
+        assertPermanentCount(playerA, karai, 1);
+        assertTappedCount(karai, true, 1);          // entered tapped via Sneak
+        assertPermanentCount(playerB, sorin, 0);
+        assertHandCount(playerB, sorin, 1);         // sorin successfully bounced
+        assertLife(playerB, 40);                    // karai not in combat, goblin returned to hand
+    }
+
+    @Test
     public void testCreatureSneakFromCommandZoneEntersTappedAndAttacking() {
         addCard(Zone.BATTLEFIELD, playerA, "Godless Shrine", 4);
         addCard(Zone.BATTLEFIELD, playerA, goblin);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SneakTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/SneakTest.java
@@ -1,0 +1,112 @@
+package org.mage.test.cards.abilities.keywords;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommanderDuelBase;
+
+public class SneakTest extends CardTestCommanderDuelBase {
+
+    private static final String karai = "Karai, Future of the Foot";
+    private static final String goblin = "Raging Goblin";
+    private static final String leonardosTechnique = "Leonardo's Technique";
+
+    @Test
+    public void testNonCreatureSneakSpellResolvesEffect() {
+        // Leonardo's Technique is a sorcery — the Sneak cost should still work,
+        // the spell resolves its effect, but the tapped-and-attacking replacement
+        // effect must NOT apply to other permanents (Grizzly Bears) that enter
+        // as part of the spell's resolution.
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+        addCard(Zone.BATTLEFIELD, playerA, goblin);
+        addCard(Zone.HAND, playerA, leonardosTechnique);
+        addCard(Zone.GRAVEYARD, playerA, "Grizzly Bears");
+
+        attack(1, playerA, goblin, playerB);
+
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerA, leonardosTechnique + " with Sneak", "Grizzly Bears");
+        setChoice(playerA, goblin);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerA, goblin, 1);
+        assertGraveyardCount(playerA, leonardosTechnique, 1);
+        assertPermanentCount(playerA, "Grizzly Bears", 1);
+        assertTappedCount("Grizzly Bears", false, 1); // replacement effect did not fire for returned creature
+        assertLife(playerB, 40); // no combat damage — goblin returned to hand, Bears did not attack
+    }
+
+    @Test
+    public void testCreatureSneakFromHandEntersTappedAndAttacking() {
+        addCard(Zone.BATTLEFIELD, playerA, "Godless Shrine", 4);
+        addCard(Zone.BATTLEFIELD, playerA, goblin);
+        addCard(Zone.HAND, playerA, karai);
+
+        attack(1, playerA, goblin, playerB);
+
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerA, karai + " with Sneak");
+        setChoice(playerA, goblin);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.COMBAT_DAMAGE);
+        execute();
+
+        assertHandCount(playerA, goblin, 1);
+        assertPermanentCount(playerA, karai, 1);
+        assertTappedCount(karai, true, 1);
+        assertAttacking(karai, true);
+        assertLife(playerB, 37);
+    }
+
+    @Test
+    public void testCreatureSneakAttackingPlaneswalkerEntersAttackingIt() {
+        String sorin = "Sorin, Solemn Visitor";
+
+        addCard(Zone.BATTLEFIELD, playerA, "Godless Shrine", 4);
+        addCard(Zone.BATTLEFIELD, playerA, goblin);
+        addCard(Zone.HAND, playerA, karai);
+        addCard(Zone.BATTLEFIELD, playerB, sorin);
+
+        attack(1, playerA, goblin, sorin);
+
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerA, karai + " with Sneak");
+        setChoice(playerA, goblin);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.COMBAT_DAMAGE);
+        execute();
+
+        assertHandCount(playerA, goblin, 1);
+        assertPermanentCount(playerA, karai, 1);
+        assertTappedCount(karai, true, 1);
+        assertAttacking(karai, true);
+        assertCounterCount(sorin, CounterType.LOYALTY, 1);
+        assertLife(playerB, 40); // no direct damage taken
+    }
+
+    @Test
+    public void testCreatureSneakFromCommandZoneEntersTappedAndAttacking() {
+        addCard(Zone.BATTLEFIELD, playerA, "Godless Shrine", 4);
+        addCard(Zone.BATTLEFIELD, playerA, goblin);
+        addCard(Zone.COMMAND, playerA, karai);
+
+        attack(1, playerA, goblin, playerB);
+
+        castSpell(1, PhaseStep.DECLARE_BLOCKERS, playerA, karai + " with Sneak");
+        setChoice(playerA, goblin);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.COMBAT_DAMAGE);
+        execute();
+
+        assertCommandZoneCount(playerA, karai, 0);
+        assertHandCount(playerA, goblin, 1);
+        assertPermanentCount(playerA, karai, 1);
+        assertTappedCount(karai, true, 1);
+        assertAttacking(karai, true);
+        assertLife(playerB, 37);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
@@ -66,12 +66,6 @@ public class SneakAbility extends SpellAbility {
 
     @Override
     public boolean activate(Game game, Set<MageIdentifier> allowedIdentifiers, boolean noMana) {
-        // Step check must run before super.activate() to avoid paying costs
-        // (returning the attacker to hand) if the timing is invalid
-        if (game.getStep() == null
-                || game.getStep().getType() != PhaseStep.DECLARE_BLOCKERS) {
-            return false;
-        }
         // Lazily sync the mode's effects and targets from the card's spell ability.
         // This allows SneakAbility to be declared before addEffect/addTarget are
         // called on the card's spell ability (i.e. construction order doesn't matter).

--- a/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
@@ -31,6 +31,19 @@ import java.util.UUID;
 
 /**
  * @author TheElk801
+ *
+ * 702.190. Sneak
+ *
+ * 702.190a Sneak is a keyword that represents a static ability that functions
+ * while the spell with sneak is on the stack. “Sneak [cost]” means “Any time
+ * you could cast an instant during your declare blockers step, you may cast
+ * this spell by paying [cost] and returning an unblocked creature you control
+ * to its owner’s hand rather than paying this spell’s mana cost.”
+ *
+ * 702.190b A permanent spell whose sneak cost was paid enters the battlefield
+ * tapped and attacking (see rule 506.3a). It will be attacking the same
+ * player, planeswalker, or battle as the creature that was returned to its
+ * owner’s hand to pay the sneak cost of the spell that became that permanent.
  */
 public class SneakAbility extends SpellAbility {
 

--- a/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
@@ -113,24 +113,7 @@ public class SneakAbility extends SpellAbility {
         // can find the synced targets on the ability. The adjustTargets override above
         // prevents the second run (inside super) from overwriting those selections.
         adjustTargets(game);
-        if (!super.activate(game, allowedIdentifiers, noMana)) {
-            return false;
-        }
-        for (Cost cost : this.getCosts()) {
-            if (cost instanceof SneakReturnAttackerToHandCost) {
-                this.setCostsTag(SNEAK_ACTIVATION_VALUE_KEY, null);
-                UUID defenderId = ((SneakReturnAttackerToHandCost) cost).getDefenderId();
-                if (defenderId != null) {
-                    MageObjectReference sneakSpellMOR = new MageObjectReference(this.getSourceId(), game);
-                    game.getState().addEffect(
-                            new SneakEntersTappedAndAttackingEffect(sneakSpellMOR, defenderId),
-                            this
-                    );
-                }
-                break;
-            }
-        }
-        return true;
+        return super.activate(game, allowedIdentifiers, noMana);
     }
 
     @Override
@@ -249,6 +232,23 @@ class SneakReturnAttackerToHandCost extends ReturnToHandChosenControlledPermanen
     }
 
     @Override
+    public boolean pay(Ability ability, Game game, Ability source, UUID controllerId, boolean noMana, Cost costToPay) {
+        if (!super.pay(ability, game, source, controllerId, noMana, costToPay)) {
+            return false;
+        }
+        // Register the ETB effect now that defenderId is known (set in addReturnTarget during super.pay())
+        ability.setCostsTag(SneakAbility.SNEAK_ACTIVATION_VALUE_KEY, null);
+        if (defenderId != null) {
+            MageObjectReference sneakSpellMOR = new MageObjectReference(ability.getSourceId(), game);
+            game.getState().addEffect(
+                    new SneakEntersTappedAndAttackingEffect(sneakSpellMOR, defenderId),
+                    ability
+            );
+        }
+        return true;
+    }
+
+    @Override
     protected void addReturnTarget(Game game, Permanent permanent) {
         super.addReturnTarget(game, permanent);
         defenderId = game.getCombat().getDefenderId(permanent.getId());
@@ -257,9 +257,5 @@ class SneakReturnAttackerToHandCost extends ReturnToHandChosenControlledPermanen
     @Override
     public SneakReturnAttackerToHandCost copy() {
         return new SneakReturnAttackerToHandCost(this);
-    }
-
-    UUID getDefenderId() {
-        return defenderId;
     }
 }

--- a/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
@@ -30,7 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * @author TheElk801
+ * @author TheElk801, muz
  *
  * 702.190. Sneak
  *
@@ -62,6 +62,22 @@ public class SneakAbility extends SpellAbility {
         this.addCost(new SneakReturnAttackerToHandCost());
 
         this.setRuleAtTheTop(true);
+
+        // Sync targets and effects from the card's spell ability at target-selection
+        // time. This allows SneakAbility to be constructed before addEffect/addTarget
+        // are called on the card's spell ability (construction order doesn't matter).
+        this.setTargetAdjuster((ability, game) -> {
+            Card sourceCard = game.getCard(ability.getSourceId());
+            if (sourceCard == null) {
+                return;
+            }
+            Mode sneakMode = ability.getModes().getMode();
+            Mode cardMode = sourceCard.getSpellAbility().getModes().getMode();
+            sneakMode.getTargets().clear();
+            cardMode.getTargets().forEach(t -> sneakMode.addTarget(t.copy()));
+            sneakMode.getEffects().clear();
+            cardMode.getEffects().forEach(e -> sneakMode.addEffect(e.copy()));
+        });
     }
 
     protected SneakAbility(final SneakAbility ability) {
@@ -78,19 +94,25 @@ public class SneakAbility extends SpellAbility {
     }
 
     @Override
-    public boolean activate(Game game, Set<MageIdentifier> allowedIdentifiers, boolean noMana) {
-        // Lazily sync the mode's effects and targets from the card's spell ability.
-        // This allows SneakAbility to be declared before addEffect/addTarget are
-        // called on the card's spell ability (i.e. construction order doesn't matter).
-        Card card = game.getCard(this.getSourceId());
-        if (card != null) {
-            Mode sneakMode = this.getModes().getMode();
-            Mode cardMode = card.getSpellAbility().getModes().getMode();
-            sneakMode.getTargets().clear();
-            cardMode.getTargets().forEach(t -> sneakMode.addTarget(t.copy()));
-            sneakMode.getEffects().clear();
-            cardMode.getEffects().forEach(e -> sneakMode.addEffect(e.copy()));
+    public void adjustTargets(Game game) {
+        // Skip the second run (inside AbilityImpl.activate's mode loop) if
+        // test-mode addTargets has already stored selections on the targets.
+        // For non-test mode the second run is allowed to proceed normally,
+        // since no selections exist yet and the targets need to be rebuilt.
+        boolean hasSelections = getModes().getMode().getTargets().stream()
+                .anyMatch(t -> !t.getTargets().isEmpty());
+        if (!hasSelections) {
+            super.adjustTargets(game);
         }
+    }
+
+    @Override
+    public boolean activate(Game game, Set<MageIdentifier> allowedIdentifiers, boolean noMana) {
+        // Pre-run target adjustment before super.activate() so that the test-mode
+        // addTargets call (which fires before adjustTargets inside AbilityImpl.activate)
+        // can find the synced targets on the ability. The adjustTargets override above
+        // prevents the second run (inside super) from overwriting those selections.
+        adjustTargets(game);
         if (!super.activate(game, allowedIdentifiers, noMana)) {
             return false;
         }

--- a/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SneakAbility.java
@@ -1,21 +1,33 @@
 package mage.abilities.keyword;
 
 import mage.MageIdentifier;
+import mage.MageObjectReference;
+import mage.abilities.Ability;
+import mage.abilities.Mode;
 import mage.abilities.SpellAbility;
+import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.ReturnToHandChosenControlledPermanentCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.ReplacementEffectImpl;
 import mage.cards.Card;
+import mage.constants.Duration;
+import mage.constants.Outcome;
 import mage.constants.PhaseStep;
 import mage.constants.SpellAbilityType;
 import mage.constants.TimingRule;
 import mage.constants.Zone;
-import mage.filter.common.FilterControlledPermanent;
-import mage.filter.predicate.permanent.AttackingPredicate;
+import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.permanent.UnblockedPredicate;
 import mage.game.Game;
+import mage.game.combat.CombatGroup;
+import mage.game.events.EntersTheBattlefieldEvent;
+import mage.game.events.GameEvent;
+import mage.game.permanent.Permanent;
+import mage.game.stack.Spell;
 import mage.target.common.TargetControlledPermanent;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * @author TheElk801
@@ -23,13 +35,6 @@ import java.util.Set;
 public class SneakAbility extends SpellAbility {
 
     public static final String SNEAK_ACTIVATION_VALUE_KEY = "sneakActivation";
-    private static final FilterControlledPermanent filter = new FilterControlledPermanent("unblocked attacker you control");
-
-    static {
-        filter.add(UnblockedPredicate.instance);
-        filter.add(AttackingPredicate.instance);
-    }
-
     public SneakAbility(Card card, String manaString) {
         super(card.getSpellAbility());
         this.newId();
@@ -41,7 +46,7 @@ public class SneakAbility extends SpellAbility {
         this.clearManaCosts();
         this.clearManaCostsToPay();
         this.addCost(new ManaCostsImpl<>(manaString));
-        this.addCost(new ReturnToHandChosenControlledPermanentCost(new TargetControlledPermanent(filter)).setText(""));
+        this.addCost(new SneakReturnAttackerToHandCost());
 
         this.setRuleAtTheTop(true);
     }
@@ -51,12 +56,51 @@ public class SneakAbility extends SpellAbility {
     }
 
     @Override
+    public ActivationStatus canActivate(UUID playerId, Game game) {
+        if (game.getStep() == null
+                || game.getStep().getType() != PhaseStep.DECLARE_BLOCKERS) {
+            return ActivationStatus.getFalse();
+        }
+        return super.canActivate(playerId, game);
+    }
+
+    @Override
     public boolean activate(Game game, Set<MageIdentifier> allowedIdentifiers, boolean noMana) {
-        if (!super.activate(game, allowedIdentifiers, noMana)
+        // Step check must run before super.activate() to avoid paying costs
+        // (returning the attacker to hand) if the timing is invalid
+        if (game.getStep() == null
                 || game.getStep().getType() != PhaseStep.DECLARE_BLOCKERS) {
             return false;
         }
-        this.setCostsTag(SNEAK_ACTIVATION_VALUE_KEY, null);
+        // Lazily sync the mode's effects and targets from the card's spell ability.
+        // This allows SneakAbility to be declared before addEffect/addTarget are
+        // called on the card's spell ability (i.e. construction order doesn't matter).
+        Card card = game.getCard(this.getSourceId());
+        if (card != null) {
+            Mode sneakMode = this.getModes().getMode();
+            Mode cardMode = card.getSpellAbility().getModes().getMode();
+            sneakMode.getTargets().clear();
+            cardMode.getTargets().forEach(t -> sneakMode.addTarget(t.copy()));
+            sneakMode.getEffects().clear();
+            cardMode.getEffects().forEach(e -> sneakMode.addEffect(e.copy()));
+        }
+        if (!super.activate(game, allowedIdentifiers, noMana)) {
+            return false;
+        }
+        for (Cost cost : this.getCosts()) {
+            if (cost instanceof SneakReturnAttackerToHandCost) {
+                this.setCostsTag(SNEAK_ACTIVATION_VALUE_KEY, null);
+                UUID defenderId = ((SneakReturnAttackerToHandCost) cost).getDefenderId();
+                if (defenderId != null) {
+                    MageObjectReference sneakSpellMOR = new MageObjectReference(this.getSourceId(), game);
+                    game.getState().addEffect(
+                            new SneakEntersTappedAndAttackingEffect(sneakSpellMOR, defenderId),
+                            this
+                    );
+                }
+                break;
+            }
+        }
         return true;
     }
 
@@ -73,5 +117,120 @@ public class SneakAbility extends SpellAbility {
         sb.append(getManaCosts().getText());
         sb.append(" if you also return an unblocked attacker you control to hand during the declare blockers step.)</i>");
         return sb.toString();
+    }
+}
+
+class SneakEntersTappedAndAttackingEffect extends ReplacementEffectImpl {
+
+    private final MageObjectReference sneakSpellMOR;
+    private final UUID defenderId;
+
+    SneakEntersTappedAndAttackingEffect(MageObjectReference sneakSpellMOR, UUID defenderId) {
+        super(Duration.OneUse, Outcome.Benefit);
+        this.sneakSpellMOR = sneakSpellMOR;
+        this.defenderId = defenderId;
+    }
+
+    private SneakEntersTappedAndAttackingEffect(final SneakEntersTappedAndAttackingEffect effect) {
+        super(effect);
+        this.sneakSpellMOR = effect.sneakSpellMOR;
+        this.defenderId = effect.defenderId;
+    }
+
+    @Override
+    public SneakEntersTappedAndAttackingEffect copy() {
+        return new SneakEntersTappedAndAttackingEffect(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.ENTERS_THE_BATTLEFIELD;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        Spell morSpell = sneakSpellMOR.getSpell(game);
+        if (morSpell == null) {
+            discard();
+            return false;
+        }
+        // The permanent entering must be the sneaked card itself (same card ID).
+        // This prevents the effect from firing when a non-creature sneak spell
+        // (e.g. a sorcery) puts OTHER permanents onto the battlefield via its effect.
+        if (!morSpell.getSourceId().equals(event.getTargetId())) {
+            return false;
+        }
+        Spell spell = game.getSpell(event.getSourceId());
+        return spell != null
+                && morSpell.getSourceId().equals(spell.getSourceId());
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        Permanent permanent = ((EntersTheBattlefieldEvent) event).getTarget();
+        if (permanent == null || game.getCombat() == null) {
+            return false;
+        }
+        // Enter tapped
+        permanent.setTapped(true);
+        // Enter attacking — build a CombatGroup directly, since addAttackerToCombat
+        // needs game.getPermanent() which returns null while the permanent is still entering
+        Permanent defender = game.getPermanent(defenderId);
+        UUID defendingPlayerId;
+        if (defender == null) {
+            if (game.getPlayer(defenderId) == null) {
+                // The original attack target (planeswalker/battle) no longer exists;
+                // enter tapped but skip the attacking assignment
+                return false;
+            }
+            defendingPlayerId = defenderId; // defender is a player
+        } else if (defender.isPlaneswalker(game)) {
+            defendingPlayerId = defender.getControllerId();
+        } else if (defender.isBattle(game)) {
+            defendingPlayerId = defender.getProtectorId();
+        } else {
+            return false; // not a valid defender
+        }
+        CombatGroup combatGroup = new CombatGroup(defenderId, defender != null, defendingPlayerId);
+        combatGroup.getAttackers().add(permanent.getId());
+        permanent.setAttacking(new MageObjectReference(defenderId, game));
+        game.getCombat().getGroups().add(combatGroup);
+        return false; // modify but don't replace the ETB event
+    }
+}
+
+class SneakReturnAttackerToHandCost extends ReturnToHandChosenControlledPermanentCost {
+
+    private static final FilterControlledCreaturePermanent sneakFilter = new FilterControlledCreaturePermanent("unblocked attacker you control");
+
+    static {
+        sneakFilter.add(UnblockedPredicate.instance);
+    }
+
+    private UUID defenderId;
+
+    SneakReturnAttackerToHandCost() {
+        super(new TargetControlledPermanent(sneakFilter));
+        this.setText("");
+    }
+
+    private SneakReturnAttackerToHandCost(final SneakReturnAttackerToHandCost cost) {
+        super(cost);
+        this.defenderId = cost.defenderId;
+    }
+
+    @Override
+    protected void addReturnTarget(Game game, Permanent permanent) {
+        super.addReturnTarget(game, permanent);
+        defenderId = game.getCombat().getDefenderId(permanent.getId());
+    }
+
+    @Override
+    public SneakReturnAttackerToHandCost copy() {
+        return new SneakReturnAttackerToHandCost(this);
+    }
+
+    UUID getDefenderId() {
+        return defenderId;
     }
 }


### PR DESCRIPTION
Linked to #14006 
Fixes https://github.com/magefree/mage/issues/14895

> 702.190b A permanent spell cast using sneak enters the battlefield tapped and attacking (see rule
506.3a). It will be attacking the same player, planeswalker, or battle as the creature that was
returned to its owner’s hand to pay the sneak cost of the spell that became that permanent.