### PR TITLE
[dev] Make find_new_cards.pl Unix/Windows portable

### DIFF
--- a/Utils/find_new_cards.pl
+++ b/Utils/find_new_cards.pl
@@ -4,9 +4,11 @@
 
 use strict;
 use Data::Dumper;
+use File::Find qw(find);
+use File::Spec;
 
 my $addedCards;
-my $GIT_CMD = "git.exe";
+my $GIT_CMD = $ENV{GIT_CMD} || ($^O eq 'MSWin32' ? 'git.exe' : 'git');
 
 my $text = `\"$GIT_CMD\" tag`;
 print "Assuming the tag command is on: \"$GIT_CMD\" tag\n";
@@ -56,17 +58,26 @@ chomp $cmd;
 my %cn_classes;
 sub read_all_card_names
 {
-    print ("find \"add\" ..\\Mage.Sets\\src\\mage\\sets\\*.java\n");
-    my $all_cards = `find \"add\" ..\\Mage.Sets\\src\\mage\\sets\\*.java`;
-    my @cards = split /\n/, $all_cards;
-    my $card;
-    foreach $card (sort @cards)
-    {
-        if ($card =~ m/.*SetCardInfo."([^"]+)".*\.([^\.]+).class/)
+    my $sets_path = File::Spec->catdir('..', 'Mage.Sets', 'src', 'mage', 'sets');
+    print ("Scanning $sets_path for SetCardInfo entries\n");
+
+    find(
         {
-            $cn_classes {$2} = $1;
-        }
-    }
+            no_chdir => 1,
+            wanted => sub {
+                return unless -f $_ && /\.java\z/;
+
+                open my $card_fh, '<', $_ or return;
+                while (my $card = <$card_fh>) {
+                    if ($card =~ m/.*SetCardInfo\("([^"]+)".*\.([^\.]+)\.class/) {
+                        $cn_classes {$2} = $1;
+                    }
+                }
+                close $card_fh;
+            }
+        },
+        $sets_path
+    );
 }
 read_all_card_names();
 
@@ -171,13 +182,13 @@ if (exists ($new_order{$cmd}))
 				$set = $setname;
                 #print ($line, " in ", $setname, "\n");
             }
-			
+
 			my $cards = $cards_by_sets{$set};
 			if(!$cards){$cards=();$cards_by_sets{$set} = \@{$cards};}
 			push @{$cards}, $card;
         }
     }
-	
+
 	# print in markdown format for release notes
 	print ("\n\n\n");
 	my $set;


### PR DESCRIPTION
Honestly never ran this script before, because I wasn't cutting releases, and because it was Windows specific.

I'm not cutting releases, but I can make it more portable across OSes;

 * Check the OS and use that to set the `git` executable/binary name
 * Import stdlib Perl modules for File/Directory functions
 * Traverse file trees using said stdlib modules
 
 Tested this locally on MacOS 26.5 and it seems OK