### PR TITLE
[don't merge] `.dck` importer correctly parse `*` in card numbers

### DIFF
--- a/Mage.Common/src/main/java/mage/utils/SystemUtil.java
+++ b/Mage.Common/src/main/java/mage/utils/SystemUtil.java
@@ -784,7 +784,7 @@ public final class SystemUtil {
      * @return added cards list
      */
     private static Set<Card> addNewCardsToGame(Game game, String cardName, String setCode, int amount, Player owner) {
-        CardInfo cardInfo = CardLookup.instance.lookupCardInfo(cardName, setCode, null);
+        CardInfo cardInfo = CardLookup.instance.lookupCardInfo(new CardCriteria().name(cardName).setCodes(setCode)).stream().findAny().orElse(null);
         if (cardInfo == null || amount <= 0) {
             return null;
         }

--- a/Mage/src/main/java/mage/cards/decks/importer/CardLookup.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/CardLookup.java
@@ -3,10 +3,8 @@ package mage.cards.decks.importer;
 import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
-import mage.util.CardUtil;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Deck import: helper class to mock cards repository
@@ -22,33 +20,6 @@ public class CardLookup {
     public List<CardInfo> lookupCardInfo(CardCriteria criteria) {
         // can be override to make fake lookup, e.g. for tests
         return CardRepository.instance.findCards(criteria);
-    }
-
-    public CardInfo lookupCardInfo(String name, String set, String cardNumber) {
-        CardCriteria cardCriteria = new CardCriteria();
-        cardCriteria.name(name);
-        if (set != null) {
-            cardCriteria.setCodes(set);
-        }
-        if (cardNumber != null) {
-            int intCardNumber = CardUtil.parseCardNumberAsInt(cardNumber);
-            cardCriteria.minCardNumber(intCardNumber);
-            cardCriteria.maxCardNumber(intCardNumber);
-        }
-        List<CardInfo> foundCards = lookupCardInfo(cardCriteria);
-
-        CardInfo res = null;
-
-        // if possible then use strict card number
-        if (cardNumber != null) {
-            res = foundCards.stream().filter(c -> Objects.equals(c.getCardNumber(), cardNumber)).findAny().orElse(null);
-        }
-
-        if (res == null) {
-            res = foundCards.stream().findAny().orElse(null);
-        }
-
-        return res;
     }
 
 }

--- a/Mage/src/main/java/mage/cards/decks/importer/DckDeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/DckDeckImporter.java
@@ -4,6 +4,7 @@ import mage.cards.decks.CardNameUtil;
 import mage.cards.decks.DeckCardInfo;
 import mage.cards.decks.DeckCardLayout;
 import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
 
@@ -27,7 +28,7 @@ public class DckDeckImporter extends PlainTextDeckImporter {
 
     private static final Pattern layoutStackPattern = Pattern.compile("\\(([^)]*)\\)");
 
-    private static final Pattern layoutStackEntryPattern = Pattern.compile("\\[(\\w+[^:]*\\w*):(\\w+\\w*)]"); // test cases: [JR:64ab],[JR:64],[MPSAK1321:43],[MPSAKH:9],[MPS123-AKH:32],[MPS-13AKH:30],[MPS-AKH:49],[MPS-AKH:11], [PUMA:U16]
+    private static final Pattern layoutStackEntryPattern = Pattern.compile("\\[(\\w+[^:]*\\w*):(\\w+[\\w\\*\\+]*)]"); // test cases: [JR:64ab],[JR:64],[MPSAK1321:43],[MPSAKH:9],[MPS123-AKH:32],[MPS-13AKH:30],[MPS-AKH:49],[MPS-AKH:11], [PUMA:U16], [WAR:2*], [ODY:72+]
 
     // possible fixes for card numbers: [code:123] -> [code:456]
     // possible fixes for card numbers with name: [code:123] card1 -> [code:456] card2
@@ -82,7 +83,9 @@ public class DckDeckImporter extends PlainTextDeckImporter {
             DeckCardInfo deckCardInfo = null;
 
             // search by set/number
-            CardInfo foundedCard = CardRepository.instance.findCard(setCode, cardNum, true);
+            CardInfo foundedCard = this.getCardLookup().lookupCardInfo(
+                new CardCriteria().setCodes(setCode).cardNumber(cardNum).nightCard(false)
+            ).stream().findAny().orElse(null);
             boolean wasOutdated = false;
             if ((foundedCard != null) && !foundedCard.getName().equals(cardName)) {
                 sbMessage.append("Line ").append(lineCount).append(": ").append("found outdated card number or name, will try to replace: ").append(line).append('\n');

--- a/Mage/src/main/java/mage/cards/decks/importer/DraftLogImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/DraftLogImporter.java
@@ -2,6 +2,7 @@ package mage.cards.decks.importer;
 
 import mage.cards.decks.DeckCardInfo;
 import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 
 import java.util.regex.Matcher;
@@ -29,7 +30,7 @@ public class DraftLogImporter extends PlainTextDeckImporter {
         Matcher pickMatcher = PICK_PATTERN.matcher(line);
         if (pickMatcher.matches()) {
             String name = pickMatcher.group(1);
-            CardInfo cardInfo = getCardLookup().lookupCardInfo(name, currentSet, null);
+            CardInfo cardInfo = getCardLookup().lookupCardInfo(new CardCriteria().name(name).setCodes(currentSet)).stream().findAny().orElse(null);
             if (cardInfo != null) {
                 deckList.getCards().add(new DeckCardInfo(cardInfo.getName(), cardInfo.getCardNumber(), cardInfo.getSetCode()));
             } else {

--- a/Mage/src/main/java/mage/cards/decks/importer/MWSDeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/MWSDeckImporter.java
@@ -2,6 +2,7 @@ package mage.cards.decks.importer;
 
 import mage.cards.decks.DeckCardInfo;
 import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 
 /**
@@ -34,13 +35,12 @@ public class MWSDeckImporter extends PlainTextDeckImporter {
         String lineName = line.substring(delim + 1).trim();
         try {
             int num = Integer.parseInt(lineNum);
-            CardInfo cardInfo = null;
-            if (setCode.isEmpty()) {
-                cardInfo = getCardLookup().lookupCardInfo(lineName, setCode, null);
-            } else {
-                cardInfo = getCardLookup().lookupCardInfo(lineName);
+            final CardCriteria criteria = new CardCriteria().name(lineName);
+            if (!setCode.isEmpty()) {
+                criteria.setCodes(setCode);
             }
 
+            final CardInfo cardInfo = this.getCardLookup().lookupCardInfo(criteria).stream().findAny().orElse(null);
             if (cardInfo == null) {
                 sbMessage.append("Could not find card: '").append(lineName).append("' at line ").append(lineCount).append('\n');
             } else {

--- a/Mage/src/main/java/mage/cards/decks/importer/MtgaImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/MtgaImporter.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import mage.cards.decks.CardNameUtil;
 import mage.cards.decks.DeckCardInfo;
 import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 
 import java.util.Collections;
@@ -62,17 +63,16 @@ public class MtgaImporter extends PlainTextDeckImporter {
             return;
         }
 
-        CardInfo found;
         int count = Integer.parseInt(pattern.group(1));
         String name = pattern.group(2);
+        final CardCriteria criteria = new CardCriteria().name(name);
         if (pattern.group(3) != null) {
             String set = SET_REMAPPING.getOrDefault(pattern.group(3), pattern.group(3));
             String cardNumber = pattern.groupCount() >= 4 ? pattern.group(4) : null;
-            found = lookup.lookupCardInfo(name, set, cardNumber);
-        } else {
-            found = lookup.lookupCardInfo(name, null, null);
-        }
+            criteria.setCodes(set).cardNumber(cardNumber);
+        };
 
+        final CardInfo found = this.getCardLookup().lookupCardInfo(criteria).stream().findAny().orElse(null);
         if (found == null) {
             sbMessage.append("Could not find card for '").append(line).append("'\n");
             return;

--- a/Mage/src/main/java/mage/cards/decks/importer/MtgjsonDeckImporter.java
+++ b/Mage/src/main/java/mage/cards/decks/importer/MtgjsonDeckImporter.java
@@ -4,11 +4,11 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import mage.cards.decks.DeckCardInfo;
 import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardCriteria;
 import mage.cards.repository.CardInfo;
 import mage.util.JsonUtil;
 
 import java.util.List;
-import java.util.Optional;
 
 
 /**
@@ -63,7 +63,7 @@ public class MtgjsonDeckImporter extends JsonDeckImporter {
             }
 
             int num = JsonUtil.getAsInt(card, "count");
-            CardInfo cardInfo = getCardLookup().lookupCardInfo(name, setCode, null);
+            CardInfo cardInfo = getCardLookup().lookupCardInfo(new CardCriteria().name(name).setCodes(setCode)).stream().findAny().orElse(null);
             if (cardInfo == null) {
                 sbMessage.append("Could not find card: '").append(name).append("'\n");
             } else {

--- a/Mage/src/main/java/mage/cards/repository/CardCriteria.java
+++ b/Mage/src/main/java/mage/cards/repository/CardCriteria.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author North
@@ -46,6 +47,8 @@ public class CardCriteria {
     // compare numerical card numbers (123b -> 123)
     private int minCardNumber;
     private int maxCardNumber;
+    // compare exact card numbers (overrides minCardNumber, maxCardNumber)
+    private String cardNumber;
 
     public CardCriteria() {
         this.setCodes = new ArrayList<>();
@@ -154,7 +157,7 @@ public class CardCriteria {
     }
 
     public CardCriteria setCodes(List<String> setCodes) {
-        this.setCodes.addAll(setCodes);
+        setCodes.stream().filter(Objects::nonNull).forEach(this.setCodes::add);
         return this;
     }
 
@@ -205,6 +208,11 @@ public class CardCriteria {
 
     public CardCriteria maxCardNumber(int maxCardNumber) {
         this.maxCardNumber = maxCardNumber;
+        return this;
+    }
+
+    public CardCriteria cardNumber(String cardNumber) {
+        this.cardNumber = cardNumber;
         return this;
     }
 
@@ -342,14 +350,20 @@ public class CardCriteria {
             clausesCount++;
         }
 
-        if (minCardNumber != Integer.MIN_VALUE) {
-            where.ge("cardNumberAsInt", minCardNumber);
+        if (cardNumber != null) {
+            where.eq("cardNumber", new SelectArg(cardNumber));
             clausesCount++;
         }
+        else {
+            if (minCardNumber != Integer.MIN_VALUE) {
+                where.ge("cardNumberAsInt", minCardNumber);
+                clausesCount++;
+            }
 
-        if (maxCardNumber != Integer.MAX_VALUE) {
-            where.le("cardNumberAsInt", maxCardNumber);
-            clausesCount++;
+            if (maxCardNumber != Integer.MAX_VALUE) {
+                where.le("cardNumberAsInt", maxCardNumber);
+                clausesCount++;
+            }
         }
 
         if (clausesCount > 0) {
@@ -504,6 +518,10 @@ public class CardCriteria {
 
     public int getMaxCardNumber() {
         return maxCardNumber;
+    }
+
+    public String getCardNumber() {
+        return cardNumber;
     }
 
 }

--- a/Mage/src/main/java/mage/game/command/emblems/EmblemOfCard.java
+++ b/Mage/src/main/java/mage/game/command/emblems/EmblemOfCard.java
@@ -10,7 +10,6 @@ import mage.cards.repository.CardInfo;
 import mage.cards.repository.CardRepository;
 import mage.constants.Zone;
 import mage.game.command.Emblem;
-import mage.util.CardUtil;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,11 +28,9 @@ public final class EmblemOfCard extends Emblem {
             String setCode,
             String infoTypeForError
     ) {
-        int intCardNumber = CardUtil.parseCardNumberAsInt(cardNumber);
         List<CardInfo> found = CardRepository.instance.findCards(new CardCriteria()
                 .name(cardName)
-                .minCardNumber(intCardNumber)
-                .maxCardNumber(intCardNumber)
+                .cardNumber(cardNumber)
                 .setCodes(setCode));
         return found.stream()
                 .filter(ci -> ci.getCardNumber().equals(cardNumber))

--- a/Mage/src/test/data/importer/testdeck.dck
+++ b/Mage/src/test/data/importer/testdeck.dck
@@ -1,0 +1,4 @@
+1 [WAR:2*] Ugin, the Ineffable
+1 [ODY:72+] Cephalid Looter
+LAYOUT MAIN:(1,2)(CARD_TYPE,false,0)|([WAR:2*])([ODY:72+])
+LAYOUT SIDEBOARD:(0,0)(NONE,false,50)|

--- a/Mage/src/test/java/mage/cards/decks/importer/DckDeckImportTest.java
+++ b/Mage/src/test/java/mage/cards/decks/importer/DckDeckImportTest.java
@@ -1,0 +1,53 @@
+package mage.cards.decks.importer;
+
+import mage.cards.decks.DeckCardLists;
+import mage.cards.repository.CardCriteria;
+import mage.cards.repository.CardInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DckDeckImportTest {
+
+    @Test
+    public void testImport() {
+        StringBuilder errors = new StringBuilder();
+        DckDeckImporter importer = new DckDeckImporter() {
+            @Override
+            public CardLookup getCardLookup() {
+                return new CardLookup() {
+                    @Override
+                    public List<CardInfo> lookupCardInfo(CardCriteria criteria) {
+                        return Collections.singletonList(new CardInfo() {{
+                            name = new HashMap<String, String>() {{
+                                this.put("2*", "Ugin, the Ineffable");
+                                this.put("72+", "Cephalid Looter");
+                            }}.get(criteria.getCardNumber());
+                            setCode = criteria.getSetCodes().get(0);
+                            cardNumber = criteria.getCardNumber();
+                        }});
+                    }
+                };
+            }
+        };
+
+        DeckCardLists deck = importer.importDeck(
+                Paths.get("src", "test", "data", "importer", "testdeck.dck").toString(),
+                errors,
+                false
+        );
+
+        Assert.assertEquals("", errors.toString());
+        TestDeckChecker.checker()
+            .addMain("Ugin, the Ineffable", 1)
+            .addMain("Cephalid Looter", 1)
+        .verify(deck, 2, 0);
+    }
+
+}


### PR DESCRIPTION
This should avoid warnings on opening up `.dck` files in the editor e.g.
"Layout mismatch: Expected 99 cards, but got 98" with cards that have a
`*` or `*` character in their card number.

Adds a test for the `.dck` importer.

Refactors `CardLookup` to exclusively take a `CardCriteria`, to unify
this logic across all deck importers.  This means we need this to
correctly expose a way to filter on a specific collector number (which
previously the postprocessing bit in `CardLookup` was doing).  Exposes
this in `CardCriteria`.

Fixes https://github.com/magefree/mage/issues/7305

Fixes https://github.com/magefree/mage/issues/12846