### PR TITLE
Set X costs tag when exiling card with CMC X as cost

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/alternate/UseAlternateSourceCostsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/alternate/UseAlternateSourceCostsTest.java
@@ -203,4 +203,26 @@ public class UseAlternateSourceCostsTest extends CardTestPlayerBase {
         setStopAt(1, PhaseStep.END_TURN);
         execute();
     }
+
+    @Test
+    public void testSetXOnStack() {
+        skipInitShuffling();
+
+        addCard(Zone.LIBRARY, playerA, "Balduvian Bears", 4);
+        addCard(Zone.HAND, playerA, "Harmonize");
+        addCard(Zone.HAND, playerA, "Nourishing Shoal");
+        addCard(Zone.BATTLEFIELD, playerA, "Geometer's Arthropod");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Nourishing Shoal");
+        setChoice(playerA, "Cast with alternative cost: Exile a green card with mana value X from your hand (source: Nourishing Shoal");
+        setChoice(playerA, "Harmonize");
+        addTarget(playerA, "Balduvian Bears");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertLife(playerA, 24);
+        assertHandCount(playerA, "Balduvian Bears", 1);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/costs/common/ExileFromHandCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/ExileFromHandCost.java
@@ -75,6 +75,8 @@ public class ExileFromHandCost extends CostImpl {
                 vmc.setAmount(cmc, cmc, false);
                 vmc.setPaid();
                 ability.addManaCostsToPay(vmc);
+
+                ability.setCostsTag("X", cmc);
             }
         }
         return paid;


### PR DESCRIPTION
Stuff like Geometer's Arthropod tries to read the value of X out of the costs tag, so set this in addition to the mana value on the stack when paying an X-cost spell with alternative cost.