### PR TITLE
Corrects a bug where mdfc zone changes failed to return to command zone

### DIFF
--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -239,7 +239,7 @@
             <!-- database support - sqlite db engine (additional db for game records and stats) -->
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.45.0.0</version>
+            <version>3.32.3.2</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/Mage.Server/pom.xml
+++ b/Mage.Server/pom.xml
@@ -239,7 +239,7 @@
             <!-- database support - sqlite db engine (additional db for game records and stats) -->
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.32.3.2</version>
+            <version>3.45.0.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/GlimpseOfTomorrowTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/GlimpseOfTomorrowTest.java
@@ -38,11 +38,11 @@ public class GlimpseOfTomorrowTest extends CardTestCommanderDuelBase {
         //   onto the battlefield, then the same for Auras, then the rest on the bottom.
         addCard(Zone.LIBRARY, playerA, "Glimpse of Tomorrow", 1);
 
-        // cast the commander from the command zone (no tax on first cast)
+        // cast the commander from the command zone
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Plargg, Dean of Chaos");
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
 
-        // activate the impulse ability -> reveals + casts Glimpse of Tomorrow for free
+        // activate the ability -> reveal + casts Glimpse of Tomorrow for free
         activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{4}{R}, {T}: Reveal");
         setChoice(playerA, "Yes"); // yes, cast the revealed Glimpse of Tomorrow
 

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/GlimpseOfTomorrowTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/GlimpseOfTomorrowTest.java
@@ -1,0 +1,63 @@
+package org.mage.test.commander.duel;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommanderDuelBase;
+
+/**
+ * Pins the bug: Glimpse of Tomorrow shuffles all permanents you own into your
+ * library, but when one of those permanents is your commander the commander
+ * replacement effect ("...may put it into the command zone instead") is never
+ * offered. The commander just gets shuffled away (and re-deployed by Glimpse).
+ */
+public class GlimpseOfTomorrowTest extends CardTestCommanderDuelBase {
+
+    @Test
+    public void test_CommanderShuffledByGlimpseCanReturnToCommandZone() {
+        // Plargg, Dean of Chaos {1}{R} Legendary Creature — Orc Shaman 2/2
+        // {4}{R}, {T}: Reveal cards from the top of your library until you reveal a
+        //   nonlegendary, nonland card with mana value 3 or less. You may cast that
+        //   card without paying its mana cost. Put all revealed cards not cast this
+        //   way on the bottom of your library in a random order.
+        addCard(Zone.COMMAND, playerA, "Plargg, Dean of Chaos // Augusta, Dean of Order");
+        // {1}{R} to cast + {4}{R} to activate = 7 mana
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 7);
+        // haste, so Plargg can tap for its ability the turn it enters
+        addCard(Zone.BATTLEFIELD, playerA, "Fervor");
+
+        // nothing else
+        removeAllCardsFromLibrary(playerA);
+
+
+        // Glimpse of Tomorrow (Suspend 3—{R}{R}, mana value 0) is the ONLY nonland,
+        // nonlegendary card in the library, so Plargg's reveal-until ability is
+        // guaranteed to find and cast it no matter how the deck is ordered.
+        // Sorcery: Shuffle all permanents you own into your library, then reveal that
+        //   many cards from the top. Put all non-Aura permanent cards revealed this way
+        //   onto the battlefield, then the same for Auras, then the rest on the bottom.
+        addCard(Zone.LIBRARY, playerA, "Glimpse of Tomorrow", 1);
+
+        // cast the commander from the command zone (no tax on first cast)
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Plargg, Dean of Chaos");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        // activate the impulse ability -> reveals + casts Glimpse of Tomorrow for free
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{4}{R}, {T}: Reveal");
+        setChoice(playerA, "Yes"); // yes, cast the revealed Glimpse of Tomorrow
+
+        // Glimpse resolves and shuffles every permanent you own — including Plargg, the
+        // commander — into the library. The commander replacement SHOULD prompt here.
+        // It currently does not, so this choice goes unused and the asserts below fail.
+        setChoice(playerA, true); // return commander to command zone
+
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertCommandZoneCount(playerA, "Plargg, Dean of Chaos", 1);
+        assertPermanentCount(playerA, "Plargg, Dean of Chaos", 0);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/GlimpseOfTomorrowTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/GlimpseOfTomorrowTest.java
@@ -48,7 +48,6 @@ public class GlimpseOfTomorrowTest extends CardTestCommanderDuelBase {
 
         // Glimpse resolves and shuffles every permanent you own — including Plargg, the
         // commander — into the library. The commander replacement SHOULD prompt here.
-        // It currently does not, so this choice goes unused and the asserts below fail.
         setChoice(playerA, true); // return commander to command zone
 
         waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN);

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
@@ -100,7 +100,17 @@ public class CommanderReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
-        if (!commanderId.equals(event.getTargetId())) {
+        // A commander is registered by its main card id, but a permanent leaving the
+        // battlefield reports the id of the object that was on the battlefield. For an
+        // MDFC commander that's the half card id, not the main card id, so a raw
+        // commanderId.equals(targetId) never matches and the replacement is skipped.
+        // Normalize the event target to its main card id before comparing.
+        UUID eventCardId = event.getTargetId();
+        Card eventCard = game.getCard(eventCardId);
+        if (eventCard != null) {
+            eventCardId = eventCard.getMainCard().getId();
+        }
+        if (!commanderId.equals(eventCardId)) {
             return false;
         }
 
@@ -129,7 +139,6 @@ public class CommanderReplacementEffect extends ReplacementEffectImpl {
         }
         return false;
     }
-
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ZoneChangeEvent zEvent = (ZoneChangeEvent) event;

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/CommanderReplacementEffect.java
@@ -139,6 +139,7 @@ public class CommanderReplacementEffect extends ReplacementEffectImpl {
         }
         return false;
     }
+
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         ZoneChangeEvent zEvent = (ZoneChangeEvent) event;


### PR DESCRIPTION
closes https://github.com/magefree/mage/issues/14991

Original example was fairly complex, so there were a few candidate problems I looked at.

Replication was: MDFC commanders' half ids on the battlefield are different from their commander ids. As we currently don't check this, that means that replacement effects can miss them and they won't get returned to the command zone when they should.

This PR corrects that. I'd imagine it will prevent some other potential bugs with MDFC commanders.

