### PR TITLE
[dev] Sync scryfall data to mtg-cards-data.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Mage.Verify/*.zip
 Mage.Verify/*.json
 
 # Utils
+__pycache__
+Utils/*-data.txt
+Utils/*-scryfall.json
 # TODO: remove outdated files and scripts
 releases
 Utils/author.txt

--- a/Utils/mtg-cards-data-scryfall.py
+++ b/Utils/mtg-cards-data-scryfall.py
@@ -1,0 +1,134 @@
+import json
+import os
+import re
+import time
+import unicodedata
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+# Function to fetch data from a given URL
+def fetch_data(url):
+    all_data = []
+    while url:
+        req = Request(
+            url,
+            headers={
+                'User-Agent': 'mage-scryfall-sync/1.0',
+                'Accept': 'application/json'
+            }
+        )
+        try:
+            with urlopen(req) as response:
+                payload = json.loads(response.read().decode('utf-8'))
+        except HTTPError as e:
+            raise RuntimeError(f"HTTP error {e.code} for {url}") from e
+        except URLError as e:
+            raise RuntimeError(f"Network error for {url}: {e.reason}") from e
+
+        all_data.extend(payload['data'])
+        url = payload.get('next_page')
+    return {'data': all_data}
+
+# Function to check if file is stale (older than 12 hours)
+def is_file_stale(file_path, hours=12):
+    if not os.path.exists(file_path):
+        return True  # File doesn't exist, so it's "stale"
+
+    file_mod_time = os.path.getmtime(file_path)
+    file_age = time.time() - file_mod_time
+    return file_age > (hours * 3600)  # Convert hours to seconds
+
+# Convert collector number to int
+def extract_collector_number(card_json):
+    try:
+        string = re.sub(r'\D', '', card_json['collector_number'])
+        if not string:
+            return 0
+        return int(string)
+    except KeyError:
+        return 0
+
+# Function to replace accented characters with ASCII equivalents
+def replace_accented_chars(text):
+    """
+    Replace accented characters with their ASCII equivalents
+    e.g., ā -> a, é -> e, ñ -> n, etc.
+    """
+    # Normalize to NFD (decomposed form) and remove combining characters
+    normalized = unicodedata.normalize('NFD', text)
+    ascii_text = ''.join(char for char in normalized if unicodedata.category(char) != 'Mn')
+    return ascii_text
+
+# Function to create a card output line
+def create_face_line(set_name, collector_number, rarity, card, power, toughness):
+    name = replace_accented_chars(card.get('name', '').replace('"', ''))
+    mana_cost = card.get('mana_cost', '')
+    type_line = card.get('type_line', '').replace('—', '-')
+    if not power:
+        power = card.get('power', '')
+    if not toughness:
+        toughness = card.get('toughness', '')
+    oracle_text = (
+        card.get('oracle_text', '')
+        .replace('\n', '$')
+        .replace('—', '--')
+        .replace('•', '*')
+        .strip()
+    )
+    oracle_text = re.sub(r" \(.*?\)", "", oracle_text)
+    # Replace accented characters in oracle text
+    oracle_text = replace_accented_chars(oracle_text)
+
+    if card.get('loyalty'):
+        toughness = card.get('loyalty', '')
+        return f"{name}|{set_name}|{collector_number}|{rarity}|{mana_cost}|{type_line}|{toughness}|{oracle_text}|\n"
+    else:
+        return f"{name}|{set_name}|{collector_number}|{rarity}|{mana_cost}|{type_line}|{power}|{toughness}|{oracle_text}|\n"
+
+def create_card_line(set_name, collector_number, rarity, card):
+    return create_face_line(set_name, collector_number, rarity, card, card.get('power', ''), card.get('toughness', ''))
+
+rarity_map = {
+    'common': 'C',
+    'uncommon': 'U',
+    'rare': 'R',
+    'mythic': 'M'
+}
+
+# Loop through each set
+sets_data = ['msh', 'msc', 'mar']
+for set_code in sets_data:
+    file_path = set_code.upper() + "-scryfall.json"
+
+    # Check if file doesn't exist or is stale (older than 24 hours)
+    if is_file_stale(file_path, 24):
+        print(f"Fetching fresh data for {set_code} (file is stale or doesn't exist)...")
+        query = urlencode({'q': f'set:{set_code} order:set unique:prints'})
+        jsn = fetch_data(f"https://api.scryfall.com/cards/search?{query}")
+        with open(file_path, 'w') as file:
+            json.dump(jsn, file)
+        print(f"Saved fresh data to {file_path}")
+    else:
+        print(f"Using existing data for {set_code} (file is fresh)")
+
+    output = ""
+    with open(file_path, 'r', encoding='utf-8') as file:
+        cards_data = json.load(file)['data']
+
+    # Loop through each set, handling pagination
+    # cards_data.sort(key=extract_collector_number)
+    # cards_data_sorted = sorted(cards_data['data'], key=lambda x: int(x['collector_number']))
+    for card in cards_data:
+        rarity = rarity_map.get(card['rarity'].lower(), 'C')
+        p = card.get('power', '')
+        t = card.get('toughness', '')
+        if 'card_faces' in card:
+            for face in card['card_faces']:
+                output += create_face_line(card['set_name'], card['collector_number'], rarity, face, p, t)
+        else:
+            output += create_card_line(card['set_name'], card['collector_number'], rarity, card)
+
+    # Save the output to a file
+    with open(f"{set_code}.txt", 'w', encoding='utf-8') as file:
+        file.write(output)

--- a/Utils/mtg-cards-data-scryfall.py
+++ b/Utils/mtg-cards-data-scryfall.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import sys
 import time
 import unicodedata
 from urllib.error import HTTPError, URLError
@@ -96,8 +97,26 @@ rarity_map = {
     'mythic': 'M'
 }
 
+def parse_set_codes(argv):
+    if len(argv) > 1:
+        candidates = argv[1:]
+    else:
+        user_input = input("Enter space-separated set codes: ").strip()
+        if not user_input:
+            raise SystemExit("No set codes provided.")
+        candidates = user_input.split()
+
+    set_codes = []
+    for code in candidates:
+        normalized = code.strip().lower()
+        if not re.fullmatch(r'[a-z0-9]+', normalized):
+            raise SystemExit(f"Invalid set code: {code}")
+        set_codes.append(normalized)
+
+    return set_codes
+
 # Loop through each set
-sets_data = ['msh', 'msc', 'mar']
+sets_data = parse_set_codes(sys.argv)
 for set_code in sets_data:
     file_path = set_code.upper() + "-scryfall.json"
 
@@ -130,5 +149,7 @@ for set_code in sets_data:
             output += create_card_line(card['set_name'], card['collector_number'], rarity, card)
 
     # Save the output to a file
-    with open(f"{set_code}.txt", 'w', encoding='utf-8') as file:
+    output_file_path = f"{set_code}.txt"
+    with open(output_file_path, 'w', encoding='utf-8') as file:
         file.write(output)
+    print(f"Saved output to {os.path.abspath(output_file_path)}")

--- a/Utils/mtg-cards-data-scryfall.py
+++ b/Utils/mtg-cards-data-scryfall.py
@@ -149,7 +149,7 @@ for set_code in sets_data:
             output += create_card_line(card['set_name'], card['collector_number'], rarity, card)
 
     # Save the output to a file
-    output_file_path = f"{set_code}.txt"
+    output_file_path = f"{set_code}-data.txt"
     with open(output_file_path, 'w', encoding='utf-8') as file:
         file.write(output)
     print(f"Saved output to {os.path.abspath(output_file_path)}")

--- a/Utils/readme.txt
+++ b/Utils/readme.txt
@@ -8,9 +8,10 @@ update-list-implemented-cards.pl
   - newList.txt: list of cards implemented since the last time the script was ran
 gen-list-cards-for-set.pl - generates the file for cards for a set
 gen-list-unimplemented-cards-for-set.pl - generates the file for unimplemented cards for a set
+mtg-cards-data-scryfall.py - generates mtg-cards-data.txt based on Scryfall
 
 Files used:
  - author.txt - one line file that contains the author name you want to appear in the generated java files
  - keywords.txt - list of keywords that have an implementation and are automatically added to the card implementation
- - mtg-cards-data.txt - MTG cards data (generated from the Gatherer database)
+ - mtg-cards-data.txt - MTG cards data, used for card implementation trackers and generating release notes
  - mtg-sets-data.txt - list of sets in MTG, the 3 letters code, and mage class name if available


### PR DESCRIPTION
Took a script shared by @Jmlundeen that would sync a single set's worth of data into the `mtg-cards-data.txt` format. Made some small edits to make it use stdlib and not rely on `requests` to increase portabilty. 

Committing this and sharing because historically there's been other scripts used by folks that aren't committed, thus creating a single point of success for this workflow effectively. 

Even if this script isn't 100% perfect, I reckon it's good enough and having it puts us collectively in a better place than before 