### PR TITLE
[fix] Correct Invasion of Muraganda targeting up to one target creature

### DIFF
--- a/Mage.Sets/src/mage/cards/i/InvasionOfMuraganda.java
+++ b/Mage.Sets/src/mage/cards/i/InvasionOfMuraganda.java
@@ -42,7 +42,7 @@ public final class InvasionOfMuraganda extends TransformingDoubleFacedCard {
         Ability ability = new EntersBattlefieldTriggeredAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()));
         ability.addEffect(new FightTargetsEffect().setText("Then that creature fights up to one target creature you don't control"));
         ability.addTarget(new TargetControlledCreaturePermanent());
-        ability.addTarget(new TargetPermanent(StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL));
+        ability.addTarget(new TargetPermanent(0, 1, StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL));
         this.getLeftHalfCard().addAbility(ability);
 
         // Primordial Plasm


### PR DESCRIPTION
```
        // When Invasion of Muraganda enters the battlefield, put a +1/+1 counter on target creature you control. Then that creature fights up to one target creature you don't control.
```

The fight effect stipulates up to one. Spotted this while implementing #15034 