### PR TITLE
Fix CI verify checks

### DIFF
--- a/Mage.Sets/src/mage/cards/h/HYDRAAssaultRobot.java
+++ b/Mage.Sets/src/mage/cards/h/HYDRAAssaultRobot.java
@@ -2,13 +2,16 @@ package mage.cards.h;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
 import mage.abilities.effects.common.DamagePlayersEffect;
+import mage.abilities.effects.common.DamageTargetEffect;
 import mage.constants.SubType;
 import mage.constants.TargetController;
 import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AnotherPredicate;
+import mage.target.common.TargetOpponent;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -39,10 +42,12 @@ public final class HYDRAAssaultRobot extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Whenever another Villain and/or artifact you control enters, this creature deals 1 damage to target opponent.
-        this.addAbility(new EntersBattlefieldAllTriggeredAbility(
-            new DamagePlayersEffect(1, TargetController.OPPONENT),
+        Ability ability = new EntersBattlefieldAllTriggeredAbility(
+            new DamageTargetEffect(1),
             filter
-        ));
+        );
+        ability.addTarget(new TargetOpponent());
+        this.addAbility(ability);
 
     }
 

--- a/Mage.Sets/src/mage/cards/v/VisionOfLove.java
+++ b/Mage.Sets/src/mage/cards/v/VisionOfLove.java
@@ -21,7 +21,7 @@ import mage.filter.StaticFilters;
 public final class VisionOfLove extends CardImpl {
 
     public VisionOfLove(UUID ownerId, CardSetInfo setInfo) {
-        super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{1}{R}");
+        super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{1}{R}");
 
         // You may sacrifice an artifact or discard a card. If you do, draw two cards.
         this.getSpellAbility().addEffect(new DoIfCostPaid(


### PR DESCRIPTION
```
Error: (abilities) target count text discrepancy: 1 in reference but 0 in card. for MSH - HYDRA Assault Robot - 137
Error: (types) [Sorcery] != [Instant] for MSH - Vision of Love - 158
```