### PR TITLE
[dev] Slim down the issue tracking template

### DIFF
--- a/Utils/gen-list-unimplemented-cards-for-set.pl
+++ b/Utils/gen-list-unimplemented-cards-for-set.pl
@@ -116,13 +116,13 @@ foreach my $card (sort cardSort @setCards) {
     my $currentFileName = "../Mage.Sets/src/mage/cards/" . lc(substr($className, 0, 1)) . "/" . $className . ".java";
     my $cardNameForUrl = $cardName;
     $cardNameForUrl =~ s/ //g;
-    $cardNameForUrl =~ s/\&/%26/g; # URL encode ampersands
-    my $cardEntry = "- [ ] In progress -- [$cardName](https://scryfall.com/search?q=!\"$cardNameForUrl\"&nbsp;e:$setAbbr)";
+    $cardNameForUrl =~ s/[^a-zA-Z0-9]//g;
+    my $cardEntry = "- [ ] In progress -- [$cardName](https://scryfall.com/search?q=!$cardNameForUrl%20e:$setAbbr)";
 
     if(-e $currentFileName) {
         # Card is implemented
         $cardNames{$cardName} = 1;
-        my $implementedEntry = "- [x] Done -- [$cardName](https://scryfall.com/search?q=!\"$cardNameForUrl\"&nbsp;e:$setAbbr)";
+        my $implementedEntry = "- [$cardName](https://scryfall.com/search?q=!$cardNameForUrl%20e:$setAbbr)";
         push(@implementedCards, $implementedEntry);
     } else {
         # Card is not implemented

--- a/Utils/gen-list-unimplemented-cards-for-set.pl
+++ b/Utils/gen-list-unimplemented-cards-for-set.pl
@@ -147,6 +147,9 @@ $unimplementedUrl .= join("or", @unimplementedNames) . "&unique=cards";
 
 # Read template file
 my $template = Text::Template->new(TYPE => 'FILE', SOURCE => $templateFile, DELIMITERS => [ '[=', '=]' ]);
+$vars{'unimplementedCount'} = scalar(@unimplementedCards);
+$vars{'implementedCount'} = scalar(@implementedCards);
+$vars{'totalCount'} = scalar(@unimplementedCards) + scalar(@implementedCards);
 $vars{'unimplemented'} = join("\n", sort @unimplementedCards);
 $vars{'implemented'} = join("\n", sort @implementedCards);
 $vars{'setName'} = $setName;

--- a/Utils/issue_tracker.tmpl
+++ b/Utils/issue_tracker.tmpl
@@ -1,10 +1,8 @@
-This checklist is here to help manage the implementation of [=$setName=]. If a card is marked as being in progress then someone is working on it.
+This checklist is here to help manage the implementation of [=$setName=]. If a card is marked as in progress then someone is working on it.
 
-If you're new to implementing cards then you likely don't have permission to check things off. This is totally fine! We still appreciate your contributions so just leave a comment to let us know that you're working on it.
+If you're new to implementing cards then you likely don't have permission to check things off. This is fine! We still appreciate your contributions so just leave a comment to let us know that you're working on it.
 
-Don't worry about moving things from in progress to completed either, there's a script that handles that, and don't worry about fixing text issues as those are usually handled when the set is done.
-
-[All Sets](https://github.com/magefree/mage/wiki/Set-implementation-list)
+Don't worry about moving things from in progress to completed either, there's a script that handles that. Don't worry about fixing text issues as those are usually handled when the set is done.
 
 # Unimplemented Cards
 

--- a/Utils/issue_tracker.tmpl
+++ b/Utils/issue_tracker.tmpl
@@ -4,6 +4,12 @@ If you're new to implementing cards then you likely don't have permission to che
 
 Don't worry about moving things from in progress to completed either, there's a script that handles that. Don't worry about fixing text issues as those are usually handled when the set is done.
 
+# Set Statistics
+
+- Tracked cards: [=$totalCount=]
+- Unimplemented cards: [=$unimplementedCount=]
+- Implemented cards: [=$implementedCount=]
+
 # Unimplemented Cards
 
 [=$unimplemented=]


### PR DESCRIPTION
Github has an issue body text limit of 65536 characters. With the size of Commander sets like MSC, and all the reprints that come in it, we're able to generate bodies that exceed that. So let's slim down the text we generate, there's some redundancy and superfluous bits.

 * Minor clean up to the boilerplate header
 * Drop the `All Sets` link. That page is so woefully out of date anyway, it's of questionable value.
 * When generating the card name for Scryfall `!CardName` searches, we can omit all non alphanumeric values and Scryfall will locate the card correctly. So, strip hyphens, commas, don't bother URL encoding ampersands etc.
 * Use a URL encoded `%20` over `&nbsp;`. 3 characters saved per card line adds up. Especially when there's 700~ cards in the set! That's 2100 characters 🫨 
 * Drop the escaped quotes, there's no need for them if we're using alphanumerics only. Another 2800 characters saved.
 * For cards that are Done, there's no value in a checkbox and saying it's done. It's under the implemented section already. Again, shaves 12 characters per card. Or 8400 characters in the above example.

Between all of this, the MSC tracker that's generated actually fits now. Previously I was getting bodies of over 70000 characters. Shaving off over 13000 characters gets it to fit now 😂 

With all the saved space, why not add a little tracker to the top that makes it super easy to see just how much of a set is done too...