### PR TITLE
Tapped for mana events should still fire when no mana produced

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/mana/TappedForManaRelatedTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/mana/TappedForManaRelatedTest.java
@@ -1,6 +1,7 @@
 package org.mage.test.cards.mana;
 
 import mage.abilities.mana.ManaOptions;
+import mage.constants.ManaType;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import mage.counters.CounterType;
@@ -22,8 +23,7 @@ public class TappedForManaRelatedTest extends CardTestPlayerBase {
      * This is a new rule that slightly changes how we resolve abilities that
      * trigger whenever a permanent is tapped for mana or for mana of a
      * specified type. Now, you look at what was actually produced after the
-     * activated mana ability resolves. So, tapping a Gaea's Cradle while you no
-     * control no creatures won't cause a Wild Growth attached to it to trigger.
+     * activated mana ability resolves.
      */
     @Test
     public void TestCradleWithWildGrowthNoCreatures() {
@@ -323,5 +323,25 @@ public class TappedForManaRelatedTest extends CardTestPlayerBase {
         Assert.assertEquals("mana variations don't fit", 1, manaOptions.size());
         assertManaOptions("{Any}", manaOptions);
     }    
-    
+
+    // https://github.com/magefree/mage/issues/15362
+    @Test
+    public void TestEnchantedGaeasCradle() {
+        addCard(Zone.BATTLEFIELD, playerA, "Upwelling");
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 2);
+        addCard(Zone.HAND, playerA, "Fertile Ground");
+        addCard(Zone.BATTLEFIELD, playerA, "Gaea's Cradle");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fertile Ground");
+        addTarget(playerA, "Gaea's Cradle");
+
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{T}: Add {G} for each");
+        setChoice(playerA, "Green");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertManaPool(playerA, ManaType.GREEN, 1);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/mana/ManaEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/mana/ManaEffect.java
@@ -43,9 +43,17 @@ public abstract class ManaEffect extends OneShotEffect {
             return true; // No need to add mana to pool during checkPlayable   
         }
         Mana manaToAdd = produceMana(game, source);
-        if (manaToAdd != null && manaToAdd.count() > 0) {
+        if (manaToAdd != null) {
+            // 20260417 - 605.2
+            // A mana ability remains a mana ability even if the game state doesn't allow it to produce mana.
+            // https://www.tumblr.com/magicjudge/71264631258/if-i-have-a-gaeas-cradle-enchanted-with-wild
+            // Q: If I have a Gaea's Cradle enchanted with Wild Growth, and no creatures in play, can I tap it for {G}?
+            // A: Yes. Gae's Cradle always has a mana ability, even if you have no creatures.
+            // https://github.com/magefree/mage/issues/15362
             checkToFirePossibleEvents(manaToAdd, game, source);
-            addManaToPool(player, manaToAdd, game, source);
+            if (manaToAdd.count() > 0) {
+                addManaToPool(player, manaToAdd, game, source);
+            }
         }
         return true;
     }


### PR DESCRIPTION
> 605.2. A mana ability remains a mana ability even if the game state doesn’t allow it to produce mana.
> Example: A permanent has an ability that reads “{T}: Add {G} for each creature you control.” The ability is still a mana ability even if you control no creatures or if the permanent is already tapped.

https://www.tumblr.com/magicjudge/71264631258/if-i-have-a-gaeas-cradle-enchanted-with-wild

> If I have a Gaea's Cradle enchanted with Wild Growth, and no creatures in play, can I tap it for {G}?
> Yes. Gaea's Cradle always has a mana ability, even if you have no creatures.

Fixes https://github.com/magefree/mage/issues/15362

I believe that since `ManaOptions` uses different logic, this won't take the potential mana you could make into account when highlighting cards as playable/not playable, but you can at least manually activate it and pay from floating.