### PR TITLE
[MSC] Implement Council of Reeds

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -3013,8 +3013,8 @@ public class ScryfallImageSupportTokens {
             put("MSC/Bird/2", "https://api.scryfall.com/cards/tmsc/21?format=image");
             put("MSC/Construct/1", "https://api.scryfall.com/cards/tmsc/14?format=image");
             put("MSC/Construct/2", "https://api.scryfall.com/cards/tmsc/30?format=image");
-            // put("MSC/Council of Reeds/1", "https://api.scryfall.com/cards/tmsc/8?format=image");
-            // put("MSC/Council of Reeds/2", "https://api.scryfall.com/cards/tmsc/24?format=image");
+            put("MSC/Council of Reeds/1", "https://api.scryfall.com/cards/tmsc/8?format=image");
+            put("MSC/Council of Reeds/2", "https://api.scryfall.com/cards/tmsc/24?format=image");
             put("MSC/Elephant/1", "https://api.scryfall.com/cards/tmsc/12?format=image");
             put("MSC/Elephant/2", "https://api.scryfall.com/cards/tmsc/28?format=image");
             put("MSC/Goat/1", "https://api.scryfall.com/cards/tmsc/6?format=image");

--- a/Mage.Sets/src/mage/cards/c/CouncilOfReeds.java
+++ b/Mage.Sets/src/mage/cards/c/CouncilOfReeds.java
@@ -1,0 +1,50 @@
+package mage.cards.c;
+
+import java.util.UUID;
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.CastNoncreatureSpellThisTurnCondition;
+import mage.abilities.effects.CreateTokenCopySourceEffect;
+import mage.abilities.effects.common.ruleModifying.LegendRuleDoesntApplyEffect;
+import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.StaticFilters;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ * @author muz
+ */
+public final class CouncilOfReeds extends CardImpl {
+
+    public CouncilOfReeds(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.SCIENTIST);
+        this.subtype.add(SubType.HERO);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(2);
+
+        // The "legend rule" doesn't apply to creatures you control.
+        this.addAbility(new SimpleStaticAbility(new LegendRuleDoesntApplyEffect(StaticFilters.FILTER_CONTROLLED_CREATURES)));
+
+        // At the beginning of combat on your turn, if you've cast a noncreature spell this turn, create a token that's a copy of Council of Reeds.
+        Ability ability = new BeginningOfCombatTriggeredAbility(new CreateTokenCopySourceEffect())
+            .withInterveningIf(CastNoncreatureSpellThisTurnCondition.instance);
+        this.addAbility(ability);
+    }
+
+    private CouncilOfReeds(final CouncilOfReeds card) {
+        super(card);
+    }
+
+    @Override
+    public CouncilOfReeds copy() {
+        return new CouncilOfReeds(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MarvelSuperHeroesCommander.java
+++ b/Mage.Sets/src/mage/sets/MarvelSuperHeroesCommander.java
@@ -126,6 +126,8 @@ public final class MarvelSuperHeroesCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Containment Construct", 284, Rarity.UNCOMMON, mage.cards.c.ContainmentConstruct.class));
         cards.add(new SetCardInfo("Contract Hero", 683, Rarity.COMMON, mage.cards.c.ContractHero.class));
         cards.add(new SetCardInfo("Costume Closet", 770, Rarity.UNCOMMON, mage.cards.c.CostumeCloset.class));
+        cards.add(new SetCardInfo("Council of Reeds", 28, Rarity.RARE, mage.cards.c.CouncilOfReeds.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Council of Reeds", 327, Rarity.RARE, mage.cards.c.CouncilOfReeds.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Count Nefaria", 651, Rarity.UNCOMMON, mage.cards.c.CountNefaria.class));
         cards.add(new SetCardInfo("Coveted Jewel", 196, Rarity.RARE, mage.cards.c.CovetedJewel.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Coveted Jewel", 429, Rarity.RARE, mage.cards.c.CovetedJewel.class, NON_FULL_USE_VARIOUS));

--- a/Mage/src/main/java/mage/game/permanent/token/CouncilofReedsToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/CouncilofReedsToken.java
@@ -1,0 +1,50 @@
+package mage.game.permanent.token;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.CastNoncreatureSpellThisTurnCondition;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.CreateTokenCopySourceEffect;
+import mage.abilities.effects.common.ruleModifying.LegendRuleDoesntApplyEffect;
+import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.StaticFilters;
+
+/**
+ * @author muz
+ */
+public final class CouncilofReedsToken extends TokenImpl {
+
+    public CouncilofReedsToken() {
+        super("Council of Reeds", "Council of Reeds token");
+        manaCost = new ManaCostsImpl<>("{2}{U}");
+        cardType.add(CardType.CREATURE);
+        color.setBlue(true);
+        supertype.add(SuperType.LEGENDARY);
+        subtype.add(SubType.HUMAN);
+        subtype.add(SubType.SCIENTIST);
+        subtype.add(SubType.HERO);
+        power = new MageInt(2);
+        toughness = new MageInt(2);
+
+        // The "legend rule" doesn't apply to creatures you control.
+        this.addAbility(new SimpleStaticAbility(new LegendRuleDoesntApplyEffect(StaticFilters.FILTER_CONTROLLED_CREATURES)));
+
+        // At the beginning of combat on your turn, if you've cast a noncreature spell this turn, create a token that's a copy of Council of Reeds.
+        Ability ability = new BeginningOfCombatTriggeredAbility(new CreateTokenCopySourceEffect())
+            .withInterveningIf(CastNoncreatureSpellThisTurnCondition.instance);
+        this.addAbility(ability);
+    }
+
+    private CouncilofReedsToken(final CouncilofReedsToken token) {
+        super(token);
+    }
+
+    @Override
+    public CouncilofReedsToken copy() {
+        return new CouncilofReedsToken(this);
+    }
+}

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -3048,8 +3048,8 @@
 |TOK:MSC|Bird|2|BirdToken|
 |TOK:MSC|Construct|1|FantasticarConstructToken|
 |TOK:MSC|Construct|2|FantasticarConstructToken|
-#|TOK:MSC|Council of Reeds|1|CouncilofReedsToken|
-#|TOK:MSC|Council of Reeds|2|CouncilofReedsToken|
+|TOK:MSC|Council of Reeds|1|CouncilofReedsToken|
+|TOK:MSC|Council of Reeds|2|CouncilofReedsToken|
 |TOK:MSC|Elephant|1|ElephantToken|
 |TOK:MSC|Elephant|2|ElephantToken|
 |TOK:MSC|Goat|1|GoatToken|


### PR DESCRIPTION
Linked to #14119 

Yes, I know I implemented the token but didn't use it in this card implementation. Technically, the card makes a copy of itself, and not "create a Council of Reeds". This matters for say, mutate. Nevertheless, it was "free" to implement the token for the sake of completeness matching the card implementation. 

One minor upside of this is that anyone using the Card Viewer and filtering to this set's tokens can't complain about it "missing". 