### PR TITLE
Switch Scryfall Bulk Data handling to JSONL

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallApiBulkData.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallApiBulkData.java
@@ -15,5 +15,5 @@ public class ScryfallApiBulkData {
     public String type;
     public Date updated_at;
     public long size;
-    public String download_uri;
+    public String jsonl_download_uri;
 }

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -389,7 +389,7 @@ public class ScryfallImageSource implements CardImageSource {
                     logger.info("Scryfall: unpacking files...");
                     Path zippedBulkPath = Paths.get(getBulkTempFileName());
                     Path textBulkPath = Paths.get(getBulkStaticFileName());
-                    Files.deleteIfExists(textBulkPath);
+                    deleteBulkFilesWithLegacyCleanup(textBulkPath);
                     try (GZIPInputStream in = new GZIPInputStream(Files.newInputStream(zippedBulkPath));
                          FileOutputStream out = new FileOutputStream(textBulkPath.toString())) {
                         byte[] buffer = new byte[5 * 1024 * 1024];
@@ -399,7 +399,7 @@ public class ScryfallImageSource implements CardImageSource {
                             // fast cancel
                             if (downloadServiceInfo.isNeedCancel()) {
                                 out.flush();
-                                Files.deleteIfExists(textBulkPath);
+                                deleteBulkFilesWithLegacyCleanup(textBulkPath);
                                 return false;
                             }
 
@@ -505,13 +505,15 @@ public class ScryfallImageSource implements CardImageSource {
                 bulkCardsDatabaseDefault.put(key, card);
                 bulkCardsDatabaseAll.add(card);
             }
+            bufferedReader.close();
+
             return bulkCardsDatabaseAll.size() > 0;
         } catch (Exception e) {
             logger.error("Can't read bulk file (possible reason: broken scryfall format), details: " + e, e);
             try {
                 // clean up
                 if (!SCRYFALL_BULK_FILES_DEBUG_READ_ONLY_MODE) {
-                    Files.deleteIfExists(textBulkPath);
+                    deleteBulkFilesWithLegacyCleanup(textBulkPath);
                 }
             } catch (IOException ignore) {
             }
@@ -686,6 +688,21 @@ public class ScryfallImageSource implements CardImageSource {
 
     private String getBulkStaticFileName() {
         return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.jsonl";
+    }
+
+    private String getLegacyBulkTempFileName() {
+        return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.json.gz";
+    }
+
+    private String getLegacyBulkStaticFileName() {
+        return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.json";
+    }
+
+    private void deleteBulkFilesWithLegacyCleanup(Path textBulkPath) throws IOException {
+        Files.deleteIfExists(textBulkPath);
+        // TODO: cleaning outdated file format, remove after few releases, 2026-07-05
+        Files.deleteIfExists(Paths.get(getLegacyBulkTempFileName()));
+        Files.deleteIfExists(Paths.get(getLegacyBulkStaticFileName()));
     }
 
     private TFile prepareTempFileForBulkData() {

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -473,7 +473,7 @@ public class ScryfallImageSource implements CardImageSource {
                     return false;
                 }
 
-                if (line.isBlank()) {
+                if (line.trim().isEmpty()) {
                     continue;
                 }
 

--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSource.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.google.gson.stream.JsonReader;
 import mage.MageException;
 import mage.client.remote.XmageURLConnection;
 import mage.client.util.CardLanguage;
@@ -341,8 +340,8 @@ public class ScryfallImageSource implements CardImageSource {
         }
         ScryfallApiBulkData bulkData = new Gson().fromJson(s, ScryfallApiBulkData.class);
         if (bulkData == null
-                || bulkData.download_uri == null
-                || bulkData.download_uri.isEmpty()
+                || bulkData.jsonl_download_uri == null
+                || bulkData.jsonl_download_uri.isEmpty()
                 || bulkData.size == 0) {
             logger.error("Unknown bulk info format from scryfall api " + SCRYFALL_BULK_FILES_DATABASE_SOURCE_API);
             return false;
@@ -351,7 +350,7 @@ public class ScryfallImageSource implements CardImageSource {
         // download
         if (!SCRYFALL_BULK_FILES_DEBUG_READ_ONLY_MODE) {
             logger.info("Scryfall: downloading additional data files, size " + bulkData.size / (1024 * 1024) + " MB");
-            String url = bulkData.download_uri;
+            String url = bulkData.jsonl_download_uri;
             InputStream inputStream = XmageURLConnection.downloadBinary(url, true);
             OutputStream outputStream = null;
             try {
@@ -458,22 +457,27 @@ public class ScryfallImageSource implements CardImageSource {
 
         // bulk files are too big, so must read and parse it in stream mode only
         // 500k reprints in diff languages
+        // jsonl format: one json object per line, no root array wrapping
         Set<String> usedCards = new HashSet<>();
         Gson gson = new Gson();
         try (TFileInputStream inputStream = new TFileInputStream(textBulkPath.toFile());
              InputStreamReader inputReader = new InputStreamReader(inputStream);
-             JsonReader jsonReader = new JsonReader(inputReader)) {
+             BufferedReader bufferedReader = new BufferedReader(inputReader, 1024 * 1024)) {
 
             bulkCardsDatabaseAll.clear();
             bulkCardsDatabaseDefault.clear();
 
-            jsonReader.beginArray();
-            while (jsonReader.hasNext()) {
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
                 if (downloadServiceInfo.isNeedCancel()) {
                     return false;
                 }
 
-                ScryfallApiCard card = gson.fromJson(jsonReader, ScryfallApiCard.class);
+                if (line.isBlank()) {
+                    continue;
+                }
+
+                ScryfallApiCard card = gson.fromJson(line, ScryfallApiCard.class);
 
                 // prepare data
                 // memory optimization: fewer data, from 1145 MB to 470 MB
@@ -501,7 +505,6 @@ public class ScryfallImageSource implements CardImageSource {
                 bulkCardsDatabaseDefault.put(key, card);
                 bulkCardsDatabaseAll.add(card);
             }
-            jsonReader.close();
             return bulkCardsDatabaseAll.size() > 0;
         } catch (Exception e) {
             logger.error("Can't read bulk file (possible reason: broken scryfall format), details: " + e, e);
@@ -678,11 +681,11 @@ public class ScryfallImageSource implements CardImageSource {
     }
 
     private String getBulkTempFileName() {
-        return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.json.gz";
+        return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.jsonl.gz";
     }
 
     private String getBulkStaticFileName() {
-        return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.json";
+        return getImagesDir() + File.separator + "downloading" + File.separator + "scryfall_bulk_cards.jsonl";
     }
 
     private TFile prepareTempFileForBulkData() {


### PR DESCRIPTION
Linked to #15550 

 * Point to new property at top level API call
 * Write JSONL files instead of JSON (it's just the filename changing but for cleanliness we should do this)
 * Switch to reading the written file line by line and skip needing to parse the document in its entirety as a JSON doc. Each line is its own JSON object now.
 
 Functionally it should then retain doing  the same stuff it always did with the extracted individual objects from Scryfall (validating, writing to the bulkDataDatabase, and subsequently using it) 