### PR TITLE
Update GHA actions/labeler to move update to a newer node runtime

### DIFF
--- a/.github/workflows/labeler-auto.yml
+++ b/.github/workflows/labeler-auto.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: label-the-PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@v6
         with:
           configuration-path: '.github/labeler.yml'

--- a/.github/workflows/labeler-manual.yml
+++ b/.github/workflows/labeler-manual.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: label-the-PR
-        uses: actions/labeler@v5
+        uses: actions/labeler@v6
         with:
           configuration-path: '.github/labeler.yml'
           pr-number: |


### PR DESCRIPTION
Legacy node versions are deprecated on GHA. This version of the action uses Node 24 instead and should be backwards compatible with action configs.