### PR TITLE
[don't merge] Implement miracle-granting cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AminatouVeilPiercer.java
+++ b/Mage.Sets/src/mage/cards/a/AminatouVeilPiercer.java
@@ -1,0 +1,72 @@
+package mage.cards.a;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.MiracleGrantedAbility;
+import mage.abilities.effects.common.cost.MiracleCostModifier;
+import mage.abilities.effects.keyword.SurveilEffect;
+import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.CostModificationType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+public final class AminatouVeilPiercer extends CardImpl {
+
+    public AminatouVeilPiercer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W}{U}{B}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.WIZARD);
+        this.power = new MageInt(2);
+        this.toughness = new MageInt(4);
+
+        // At the beginning of your upkeep, surveil 2.
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new SurveilEffect(2)));
+
+        // Each enchantment card in your hand has miracle. Its miracle cost is equal to its mana cost reduced by {4}.
+        this.addAbility(new MiracleGrantedAbility(StaticFilters.FILTER_CARD_ENCHANTMENTS,
+            () -> new AminatouVeilPiercerEffect(),
+            "its mana cost reduced by {4}"
+        ));
+    }
+
+    private AminatouVeilPiercer(final AminatouVeilPiercer card) {
+        super(card);
+    }
+
+    @Override
+    public AminatouVeilPiercer copy() {
+        return new AminatouVeilPiercer(this);
+    }
+}
+
+class AminatouVeilPiercerEffect extends MiracleCostModifier {
+    public AminatouVeilPiercerEffect() {
+        super(Outcome.Benefit, CostModificationType.REDUCE_COST);
+    }
+
+    private AminatouVeilPiercerEffect(AminatouVeilPiercerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public AminatouVeilPiercerEffect copy() {
+        return new AminatouVeilPiercerEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, Ability abilityToModify) {
+        CardUtil.reduceCost(abilityToModify, 4);
+        return true;
+    }
+}

--- a/Mage.Sets/src/mage/cards/l/LoreholdTheHistorian.java
+++ b/Mage.Sets/src/mage/cards/l/LoreholdTheHistorian.java
@@ -1,0 +1,61 @@
+package mage.cards.l;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.MiracleGrantedAbility;
+import mage.abilities.costs.common.DiscardCardCost;
+import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.mana.ManaCosts;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.DoIfCostPaid;
+import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.cost.MiracleCostModifierFlat;
+import mage.abilities.keyword.FlyingAbility;
+import mage.abilities.keyword.HasteAbility;
+import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.CostModificationType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.constants.TargetController;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+
+import java.util.UUID;
+
+public final class LoreholdTheHistorian extends CardImpl {
+
+    public LoreholdTheHistorian(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{3}{R}{W}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.ELDER);
+        this.subtype.add(SubType.DRAGON);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Flying
+        this.addAbility(FlyingAbility.getInstance());
+
+        // Haste
+        this.addAbility(HasteAbility.getInstance());
+
+        // Instant and sorcery cards in your hand have miracle {2}.
+        this.addAbility(new MiracleGrantedAbility(StaticFilters.FILTER_CARDS_INSTANT_AND_SORCERY, () -> new MiracleCostModifierFlat("{2}"), "{2}"));
+
+        // At the beginning of each opponent’s upkeep, you may discard a card. If you do, draw a card.
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(TargetController.OPPONENT, new DoIfCostPaid(new DrawCardSourceControllerEffect(1), new DiscardCardCost()), false));
+    }
+
+    private LoreholdTheHistorian(final LoreholdTheHistorian card) {
+        super(card);
+    }
+
+    @Override
+    public LoreholdTheHistorian copy() {
+        return new LoreholdTheHistorian(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/m/MoleculeMan.java
+++ b/Mage.Sets/src/mage/cards/m/MoleculeMan.java
@@ -1,0 +1,45 @@
+package mage.cards.m;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.MiracleGrantedAbility;
+import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.mana.ManaCosts;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.abilities.effects.common.cost.MiracleCostModifierFlat;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.CostModificationType;
+import mage.constants.Outcome;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.filter.StaticFilters;
+import mage.game.Game;
+
+import java.util.UUID;
+
+public final class MoleculeMan extends CardImpl {
+
+    public MoleculeMan(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.VILLAIN);
+        this.power = new MageInt(5);
+        this.toughness = new MageInt(5);
+
+        // Nonland cards in your hand have miracle {0}.
+        this.addAbility(new MiracleGrantedAbility(StaticFilters.FILTER_CARDS_NON_LAND, () -> new MiracleCostModifierFlat("{0}"), "{0}"));
+    }
+
+    private MoleculeMan(final MoleculeMan card) {
+        super(card);
+    }
+
+    @Override
+    public MoleculeMan copy() {
+        return new MoleculeMan(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/DuskmournHouseOfHorrorCommander.java
+++ b/Mage.Sets/src/mage/sets/DuskmournHouseOfHorrorCommander.java
@@ -23,6 +23,7 @@ public final class DuskmournHouseOfHorrorCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Aesi, Tyrant of Gyre Strait", 210, Rarity.MYTHIC, mage.cards.a.AesiTyrantOfGyreStrait.class));
         cards.add(new SetCardInfo("Aether Gale", 109, Rarity.RARE, mage.cards.a.AetherGale.class));
         cards.add(new SetCardInfo("Aminatou's Augury", 71, Rarity.RARE, mage.cards.a.AminatousAugury.class));
+        cards.add(new SetCardInfo("Aminatou, Veil Piercer", 1, Rarity.MYTHIC, mage.cards.a.AminatouVeilPiercer.class));
         cards.add(new SetCardInfo("Ancient Cellarspawn", 16, Rarity.RARE, mage.cards.a.AncientCellarspawn.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Ancient Cellarspawn", 47, Rarity.RARE, mage.cards.a.AncientCellarspawn.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Arachnogenesis", 169, Rarity.RARE, mage.cards.a.Arachnogenesis.class));

--- a/Mage.Sets/src/mage/sets/MarvelSuperHeroesCommander.java
+++ b/Mage.Sets/src/mage/sets/MarvelSuperHeroesCommander.java
@@ -364,6 +364,8 @@ public final class MarvelSuperHeroesCommander extends ExpansionSet {
         cards.add(new SetCardInfo("Mob Lookout", 821, Rarity.COMMON, mage.cards.m.MobLookout.class));
         cards.add(new SetCardInfo("Mockingbird, Bobbi Morse", 522, Rarity.COMMON, mage.cards.m.MockingbirdBobbiMorse.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Mockingbird, Bobbi Morse", 842, Rarity.COMMON, mage.cards.m.MockingbirdBobbiMorse.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Molecule Man", 9, Rarity.RARE, mage.cards.m.MoleculeMan.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Molecule Man", 292, Rarity.RARE, mage.cards.m.MoleculeMan.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Molly Hayes, Runaway", 698, Rarity.COMMON, mage.cards.m.MollyHayesRunaway.class));
         cards.add(new SetCardInfo("Monologue Tax", 139, Rarity.RARE, mage.cards.m.MonologueTax.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Monologue Tax", 317, Rarity.RARE, mage.cards.m.MonologueTax.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
+++ b/Mage.Sets/src/mage/sets/SecretsOfStrixhaven.java
@@ -193,6 +193,8 @@ public final class SecretsOfStrixhaven extends ExpansionSet {
         cards.add(new SetCardInfo("Lluwen, Exchange Student", 199, Rarity.UNCOMMON, mage.cards.l.LluwenExchangeStudent.class));
         cards.add(new SetCardInfo("Lorehold Charm", 200, Rarity.UNCOMMON, mage.cards.l.LoreholdCharm.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Lorehold Charm", 363, Rarity.UNCOMMON, mage.cards.l.LoreholdCharm.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lorehold, the Historian", 201, Rarity.MYTHIC, mage.cards.l.LoreholdTheHistorian.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Lorehold, the Historian", 284, Rarity.MYTHIC, mage.cards.l.LoreholdTheHistorian.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Lumaret's Favor", 153, Rarity.UNCOMMON, mage.cards.l.LumaretsFavor.class));
         cards.add(new SetCardInfo("Maelstrom Artisan", 122, Rarity.RARE, mage.cards.m.MaelstromArtisan.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Maelstrom Artisan", 334, Rarity.RARE, mage.cards.m.MaelstromArtisan.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MiracleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MiracleTest.java
@@ -87,4 +87,172 @@ public class MiracleTest extends CardTestPlayerBase {
         assertLife(playerB, 15);
 
     }
+
+    @Test
+    public void testGrantedMiracle() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerB, "Molecule Man");
+        addCard(Zone.LIBRARY, playerA, "Balduvian Bears");
+        addCard(Zone.LIBRARY, playerB, "Balduvian Bears");
+
+        // can successfully cast the bears when we draw our first card
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerB, "Balduvian Bears", 0);
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
+
+        // opponent did not get to cast their bears
+        assertHandCount(playerA, "Balduvian Bears", 1);
+        assertPermanentCount(playerA, "Balduvian Bears", 0);
+    }
+
+    @Test
+    public void testDoubleGrantedMiracle() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerB, "Molecule Man");
+        addCard(Zone.BATTLEFIELD, playerA, "Molecule Man");
+        addCard(Zone.LIBRARY, playerA, "Balduvian Bears");
+        addCard(Zone.LIBRARY, playerB, "Balduvian Bears");
+
+        // can successfully cast the bears when we draw our first card
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        // opponent also gets miracle
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerB, "Balduvian Bears", 0);
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
+
+        assertHandCount(playerA, "Balduvian Bears", 0);
+        assertPermanentCount(playerA, "Balduvian Bears", 1);
+    }
+
+    @Test
+    public void testGrantedWithRegularMiracle() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerB, "Molecule Man");
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain");
+        addCard(Zone.LIBRARY, playerA, "Thunderous Wrath");
+        addCard(Zone.LIBRARY, playerB, "Balduvian Bears");
+
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertHandCount(playerB, "Balduvian Bears", 0);
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
+        assertLife(playerB, 15);
+        assertTapped("Mountain", true);
+    }
+
+    @Test
+    public void testRemoved() {
+        skipInitShuffling();
+        addCard(Zone.LIBRARY, playerB, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerB, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerB, "Molecule Man");
+        addCard(Zone.HAND, playerB, "Fell");
+        addCard(Zone.BATTLEFIELD, playerB, "Swamp", 2);
+
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Fell");
+        addTarget(playerB, "Molecule Man");
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
+        assertHandCount(playerB, "Grizzly Bears", 1);
+    }
+
+    @Test
+    public void testControlChange() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerB, "Molecule Man");
+        addCard(Zone.LIBRARY, playerB, "Bear Cub");
+        addCard(Zone.LIBRARY, playerB, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerB, "Balduvian Bears");
+        addCard(Zone.LIBRARY, playerA, "Bear Cub");
+        addCard(Zone.LIBRARY, playerA, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerA, "Balduvian Bears");
+        addCard(Zone.HAND, playerA, "Entrancing Melody");
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 8);
+        addCard(Zone.HAND, playerA, "Ephemerate");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains");
+
+        // can successfully cast the bears when we draw our first card, turn 2
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        // turn 3, take control
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Entrancing Melody");
+        setChoice(playerA, "X=6");
+        addTarget(playerA, "Molecule Man");
+
+        // turn 4, playerB does not get miracle
+        // turn 5, playerA does get miracle
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+
+        // flicker, then turn 6 playerB should get miracle again
+        castSpell(5, PhaseStep.POSTCOMBAT_MAIN, playerA, "Ephemerate");
+        addTarget(playerA, "Molecule Man");
+
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        setStrictChooseMode(true);
+        setStopAt(6, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Balduvian Bears", 1);
+        assertPermanentCount(playerA, "Grizzly Bears", 1);
+        assertPermanentCount(playerB, "Bear Cub", 1);
+        assertHandCount(playerB, "Grizzly Bears", 1);
+        assertHandCount(playerA, "Balduvian Bears", 1);
+    }
+
+    @Test
+    public void testNoGrantedMiracleSecondCard() {
+        skipInitShuffling();
+        addCard(Zone.HAND, playerB, "Molecule Man");
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 7);
+        addCard(Zone.HAND, playerB, "Reach Through Mists");
+        addCard(Zone.LIBRARY, playerB, "Grizzly Bears");
+        addCard(Zone.LIBRARY, playerB, "Balduvian Bears");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Molecule Man");
+        castSpell(2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Reach Through Mists");
+        waitStackResolved(2, PhaseStep.POSTCOMBAT_MAIN);
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        checkPlayableAbility("can't cast bears", 2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Cast Balduvian Bears", false);
+        checkPlayableAbility("can't cast grizzlies", 2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Cast Grizzly Bears", false);
+        assertHandCount(playerB, "Balduvian Bears", 1);
+        assertHandCount(playerB, "Grizzly Bears", 1);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MiracleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MiracleTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.abilities.keywords;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -254,5 +255,45 @@ public class MiracleTest extends CardTestPlayerBase {
         checkPlayableAbility("can't cast grizzlies", 2, PhaseStep.POSTCOMBAT_MAIN, playerB, "Cast Grizzly Bears", false);
         assertHandCount(playerB, "Balduvian Bears", 1);
         assertHandCount(playerB, "Grizzly Bears", 1);
+    }
+
+    @Test
+    public void testDynamicMiracleCost() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerB, "Aminatou, Veil Piercer");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes");
+        addCard(Zone.LIBRARY, playerB, "Faceless One", 2);
+
+        addTarget(playerB, "Faceless One");
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Faceless One", 1);
+        assertTapped("Wastes", true);
+    }
+
+    @Test
+    public void testDynamicMiracleWithX() {
+        skipInitShuffling();
+        addCard(Zone.BATTLEFIELD, playerB, "Aminatou, Veil Piercer");
+        addCard(Zone.BATTLEFIELD, playerB, "Plains");
+        addCard(Zone.LIBRARY, playerB, "Defenders of Humanity", 2);
+
+        addTarget(playerB, "Defenders of Humanity");
+        setChoice(playerB, true);
+        setChoice(playerB, true);
+        setChoice(playerB, "X=2");
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerB, "Defenders of Humanity", 1);
+        assertPermanentCount(playerB, "Astartes Warrior Token", 2);
+        assertTapped("Plains", true);
     }
 }

--- a/Mage/src/main/java/mage/abilities/common/MiracleGrantedAbility.java
+++ b/Mage/src/main/java/mage/abilities/common/MiracleGrantedAbility.java
@@ -1,0 +1,61 @@
+package mage.abilities.common;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousEffectImpl;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.constants.Duration;
+import mage.constants.Layer;
+import mage.constants.Outcome;
+import mage.constants.SubLayer;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.util.functions.MiracleCostModifierCreator;
+import mage.watchers.common.MiracleGrantedWatcher;
+
+public class MiracleGrantedAbility extends SimpleStaticAbility {
+
+    private static final String staticRule = " <i>(You may cast that card for its miracle cost when you draw it if it's the first card you drew this turn.)</i>";
+    private final String ruleText;
+
+    public MiracleGrantedAbility(FilterCard filter, MiracleCostModifierCreator miracleCostModifierCreator, String costText) {
+        super(new MiracleGrantedEffect());
+        this.ruleText = filter.getMessage() + " in your hand have miracle. Its miracle cost is equal to " + costText + staticRule;
+        this.addWatcher(new MiracleGrantedWatcher(this.zone, filter, miracleCostModifierCreator, costText));
+    }
+
+    private MiracleGrantedAbility(final MiracleGrantedAbility ability) {
+        super(ability);
+        this.ruleText = ability.ruleText;
+    }
+
+    @Override
+    public MiracleGrantedAbility copy() {
+        return new MiracleGrantedAbility(this);
+    }
+
+    @Override
+    public String getRule() {
+        return this.ruleText;
+    }
+}
+
+class MiracleGrantedEffect extends ContinuousEffectImpl {
+
+    public MiracleGrantedEffect() {
+        super(Duration.WhileOnBattlefield, Layer.AbilityAddingRemovingEffects_6, SubLayer.NA, Outcome.AddAbility);
+    }
+
+    private MiracleGrantedEffect(final MiracleGrantedEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public MiracleGrantedEffect copy() {
+        return new MiracleGrantedEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        return true;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/cost/MiracleCostModifier.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/cost/MiracleCostModifier.java
@@ -1,0 +1,32 @@
+package mage.abilities.effects.common.cost;
+
+import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
+import mage.constants.CostModificationType;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.game.Game;
+
+public abstract class MiracleCostModifier extends CostModificationEffectImpl {
+
+    private SpellAbility castToModify;
+
+    public MiracleCostModifier(Outcome outcome, CostModificationType type) {
+        super(Duration.Custom, outcome, type);
+    }
+
+    protected MiracleCostModifier(MiracleCostModifier effect) {
+        super(effect);
+        this.castToModify = effect.castToModify;
+    }
+
+    public MiracleCostModifier setCastToModify(SpellAbility castToModify) {
+        this.castToModify = castToModify;
+        return this;
+    }
+
+    @Override
+    public boolean applies(Ability abilityToModify, Ability source, Game game) {
+        return abilityToModify != null && abilityToModify.getId().equals(this.castToModify.getId());
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/cost/MiracleCostModifierFlat.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/cost/MiracleCostModifierFlat.java
@@ -1,0 +1,38 @@
+package mage.abilities.effects.common.cost;
+
+import mage.abilities.Ability;
+import mage.abilities.costs.mana.ManaCost;
+import mage.abilities.costs.mana.ManaCosts;
+import mage.abilities.costs.mana.ManaCostsImpl;
+import mage.constants.CostModificationType;
+import mage.constants.Outcome;
+import mage.game.Game;
+
+public class MiracleCostModifierFlat extends MiracleCostModifier {
+
+    final private String costs;
+
+    public MiracleCostModifierFlat(String costs) {
+        super(Outcome.Benefit, CostModificationType.SET_COST);
+        this.costs = costs;
+    }
+
+    private MiracleCostModifierFlat(MiracleCostModifierFlat effect) {
+        super(effect);
+        this.costs = effect.costs;
+    }
+
+    @Override
+    public MiracleCostModifierFlat copy() {
+        return new MiracleCostModifierFlat(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, Ability abilityToModify) {
+        final ManaCosts<ManaCost> costRef = abilityToModify.getManaCostsToPay();
+        // replace with the new cost
+        costRef.clear();
+        costRef.add(new ManaCostsImpl<>(this.costs));
+        return true;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/keyword/MiracleAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/MiracleAbility.java
@@ -4,10 +4,9 @@ import mage.ApprovingObject;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.TriggeredAbilityImpl;
-import mage.abilities.costs.mana.ManaCost;
-import mage.abilities.costs.mana.ManaCosts;
-import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.cost.MiracleCostModifier;
+import mage.abilities.effects.common.cost.MiracleCostModifierFlat;
 import mage.cards.Card;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -15,6 +14,7 @@ import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTarget;
+import mage.util.functions.MiracleCostModifierCreator;
 import mage.watchers.common.MiracleWatcher;
 
 /**
@@ -75,16 +75,23 @@ public class MiracleAbility extends TriggeredAbilityImpl {
 
     private static final String staticRule = " <i>(You may cast this card for its miracle cost when you draw it if it's the first card you drew this turn.)</i>";
     private final String ruleText;
+    private final MiracleCostModifierCreator miracleCostModifierCreator;
+
+    public MiracleAbility(MiracleCostModifierCreator miracleCostModifierCreator, String costText) {
+        super(Zone.HAND, new MiracleEffect(miracleCostModifierCreator), true);
+        this.addWatcher(new MiracleWatcher());
+        this.ruleText = "Miracle " + costText + staticRule;
+        this.miracleCostModifierCreator = miracleCostModifierCreator;
+    }
 
     public MiracleAbility(String miracleCosts) {
-        super(Zone.HAND, new MiracleEffect(miracleCosts), true);
-        addWatcher(new MiracleWatcher());
-        ruleText = "Miracle " + miracleCosts + staticRule;
+        this(() -> new MiracleCostModifierFlat(miracleCosts), miracleCosts);
     }
 
     private MiracleAbility(final MiracleAbility ability) {
         super(ability);
         this.ruleText = ability.ruleText;
+        this.miracleCostModifierCreator = ability.miracleCostModifierCreator;
     }
 
     @Override
@@ -115,17 +122,16 @@ public class MiracleAbility extends TriggeredAbilityImpl {
 
 class MiracleEffect extends OneShotEffect {
 
-    private final ManaCosts<ManaCost> miracleCosts;
+    private final MiracleCostModifierCreator miracleCostModifierCreator;
 
-    public MiracleEffect(String miracleCosts) {
+    public MiracleEffect(MiracleCostModifierCreator miracleCostModifierCreator) {
         super(Outcome.Benefit);
-        this.staticText = "cast this card for its miracle cost";
-        this.miracleCosts = new ManaCostsImpl<>(miracleCosts);
+        this.miracleCostModifierCreator = miracleCostModifierCreator;
     }
 
     protected MiracleEffect(final MiracleEffect effect) {
         super(effect);
-        this.miracleCosts = effect.miracleCosts;
+        this.miracleCostModifierCreator = effect.miracleCostModifierCreator;
     }
 
     @Override
@@ -140,11 +146,10 @@ class MiracleEffect extends OneShotEffect {
         Card card = game.getCard(getTargetPointer().getFirst(game, source));
         if (controller != null && card != null) {
             SpellAbility abilityToCast = card.getSpellAbility().copy();
-            ManaCosts<ManaCost> costRef = abilityToCast.getManaCostsToPay();
-            // replace with the new cost
-            costRef.clear();
-            costRef.add(miracleCosts);
+            final MiracleCostModifier effect = this.miracleCostModifierCreator.get().setCastToModify(abilityToCast);
+            game.getState().getContinuousEffects().addEffect(effect, source);
             controller.cast(abilityToCast, game, false, new ApprovingObject(source, game));
+            effect.discard();
             return true;
         }
         return false;

--- a/Mage/src/main/java/mage/game/permanent/PermanentCard.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentCard.java
@@ -168,6 +168,10 @@ public class PermanentCard extends PermanentImpl {
         }
         this.abilities.setControllerId(this.controllerId);
         this.abilities.setSourceId(objectId);
+        this.abilities.stream().flatMap(ability -> ability.getWatchers().stream().map(watcher -> watcher.getKey())).map(game.getState()::getWatcher).distinct().forEach(watcher -> {
+            watcher.setControllerId(this.controllerId);
+            watcher.setSourceId(objectId);
+        });
         this.cardType.clear();
         this.cardType.addAll(card.getCardType());
         if (!isReset) {

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -43,7 +43,6 @@ import org.apache.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -963,6 +962,10 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
         // must change abilities controller too
         this.controllerId = newControllerId;
         this.getAbilities().setControllerId(newControllerId);
+
+        // and watchers
+        this.getAbilities().stream().flatMap(ability -> ability.getWatchers().stream().map(watcher -> watcher.getKey())).map(game.getState()::getWatcher).distinct().forEach(watcher -> watcher.setControllerId(newControllerId));
+
         return true;
     }
 

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -52,6 +52,14 @@ import mage.target.targetpointer.FixedTarget;
 import mage.watchers.Watcher;
 import org.apache.log4j.Logger;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -2041,6 +2049,20 @@ public final class CardUtil {
         } else if (value instanceof AbstractMap.SimpleImmutableEntry) { //Used by Leonin Arbiter, Vessel Of The All Consuming Wanderer as a generic Pair class
             AbstractMap.SimpleImmutableEntry entryValue = (AbstractMap.SimpleImmutableEntry) value;
             return (T) new AbstractMap.SimpleImmutableEntry(deepCopyObject(entryValue.getKey()), deepCopyObject(entryValue.getValue()));
+        } else if (value instanceof Serializable) {
+            try {
+                final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                try (final ObjectOutput out = new ObjectOutputStream(bos)) {
+                    out.writeObject(value);
+                    out.flush();
+                }
+                try (final ObjectInput in = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray().clone()))) {
+                    return (T)in.readObject();
+                }
+            }
+            catch (ClassNotFoundException|IOException ex) {
+                throw new IllegalStateException("Failed copying serializable object " + value.getClass().getSimpleName() + " during deep copy", ex);
+            }
         } else {
             // warning, do not add unnecessarily new data types and structures to game engine, try to use only standard types (see above)
             throw new IllegalStateException("Unhandled object " + value.getClass().getSimpleName() + " during deep copy, must add explicit handling of all Object types");

--- a/Mage/src/main/java/mage/util/functions/MiracleCostModifierCreator.java
+++ b/Mage/src/main/java/mage/util/functions/MiracleCostModifierCreator.java
@@ -1,0 +1,8 @@
+package mage.util.functions;
+
+import mage.abilities.effects.common.cost.MiracleCostModifier;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+public interface MiracleCostModifierCreator extends Supplier<MiracleCostModifier>, Serializable { }

--- a/Mage/src/main/java/mage/watchers/Watcher.java
+++ b/Mage/src/main/java/mage/watchers/Watcher.java
@@ -24,8 +24,18 @@ public abstract class Watcher implements Serializable {
     protected boolean condition;
     protected final WatcherScope scope;
 
+    // if a watcher can dynamically add other watchers to the game state, set this flag.
+    // this will protect it from modifying the watchers map inside its own watch(),
+    // which would cause a ConcurrentModificationException.
+    protected final boolean isolated;
+
     public Watcher(WatcherScope scope) {
+        this(scope, false);
+    }
+
+    public Watcher(WatcherScope scope, boolean isolated) {
         this.scope = scope;
+        this.isolated = isolated;
     }
 
     protected Watcher(final Watcher watcher) {
@@ -33,6 +43,7 @@ public abstract class Watcher implements Serializable {
         this.controllerId = watcher.controllerId;
         this.sourceId = watcher.sourceId;
         this.scope = watcher.scope;
+        this.isolated = watcher.isolated;
     }
 
     public UUID getControllerId() {
@@ -124,5 +135,9 @@ public abstract class Watcher implements Serializable {
 
     public WatcherScope getScope() {
         return scope;
+    }
+
+    public boolean isolated() {
+        return this.isolated;
     }
 }

--- a/Mage/src/main/java/mage/watchers/Watchers.java
+++ b/Mage/src/main/java/mage/watchers/Watchers.java
@@ -6,6 +6,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.stream.Stream;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -33,9 +34,13 @@ public class Watchers extends HashMap<String, Watcher> {
     }
 
     public void watch(GameEvent event, Game game) {
-        for (Watcher watcher : this.values()) {
-            watcher.watch(event, game);
-        }
+        final Watchers isolated = new Watchers();
+        this.values().stream().filter(Watcher::isolated).forEach(isolated::add);
+        Stream.concat(
+            this.values().stream().filter(watcher -> !watcher.isolated()),
+            isolated.values().stream()
+        ).forEach(watcher -> watcher.watch(event, game));
+        isolated.entrySet().stream().forEach(entry -> this.put(entry.getKey(), entry.getValue()));
     }
 
     public void reset() {

--- a/Mage/src/main/java/mage/watchers/common/MiracleGrantedWatcher.java
+++ b/Mage/src/main/java/mage/watchers/common/MiracleGrantedWatcher.java
@@ -1,0 +1,62 @@
+package mage.watchers.common;
+
+import mage.abilities.Ability;
+import mage.abilities.keyword.MiracleAbility;
+import mage.cards.Card;
+import mage.cards.Cards;
+import mage.cards.CardsImpl;
+import mage.constants.Outcome;
+import mage.constants.WatcherScope;
+import mage.constants.Zone;
+import mage.filter.FilterCard;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.players.Player;
+import mage.watchers.Watcher;
+import mage.watchers.common.CardsDrawnThisTurnWatcher;
+import mage.util.functions.MiracleCostModifierCreator;
+
+import java.util.UUID;
+
+public class MiracleGrantedWatcher extends Watcher {
+
+    final private Zone zone;
+    final private FilterCard filter;
+    final private MiracleCostModifierCreator miracleCostModifierCreator;
+    final private String costText;
+
+    public MiracleGrantedWatcher(Zone zone, FilterCard filter, MiracleCostModifierCreator miracleCostModifierCreator, String costText) {
+        super(WatcherScope.CARD, true);
+        this.zone = zone;
+        this.filter = filter;
+        this.miracleCostModifierCreator = miracleCostModifierCreator;
+        this.costText = costText;
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (event.getType() == GameEvent.EventType.UNTAP_STEP_PRE) {
+            this.reset();
+            return;
+        }
+
+        // inital card draws do not trigger miracle so check that phase != null
+        if (game.getPhase() != null && event.getType() == GameEvent.EventType.DREW_CARD && this.zone.match(game.getState().getZone(this.getSourceId()))) {
+            final UUID playerId = event.getPlayerId();
+            final Card card = game.getCard(event.getTargetId());
+            if (playerId != null && card != null && playerId.equals(this.getControllerId()) && game.getState().getWatcher(CardsDrawnThisTurnWatcher.class).getCardsDrawnThisTurn(playerId) == 1 && this.filter.match(card, game)) {
+                final Player controller = game.getPlayer(playerId);
+                if (controller != null) {
+                    final Cards cards = new CardsImpl(card);
+                    controller.lookAtCards("Miracle", cards, game);
+                    final Ability ability = new MiracleAbility(this.miracleCostModifierCreator, this.costText);
+                    if (controller.chooseUse(Outcome.Benefit, "Reveal " + card.getLogName() + " to be able to use Miracle?", ability, game)) {
+                        game.getState().addOtherAbility(card, ability);
+                        controller.revealCards("Miracle", cards, game);
+                        game.fireEvent(GameEvent.getEvent(GameEvent.EventType.MIRACLE_CARD_REVEALED, card.getId(), ability, controller.getId()));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements engine support for, and the individual cards of, the subset of 3 cards that dynamically grant miracle to other cards in hand.

My first draft of this was relatively straightforward, but the hardest problem was specifically the interaction between Aminatou and X-cost spells.  We can't apply our cost modifications prior to calling `controller.cast()`, as we don't yet know the value of X.  So they must be applied in the form of a continuous effect.  But that cost reduction effect must return `true` for `applies()` only for the specific card that has been drawn.  Thus we have to dynamically create the effect, insert it into the effects list, cast the spell, and then remove the effect.

This watcher is unique in that it adds a `MiracleAbility` inside of its `watch()` function, which is a class which adds a watcher to the global list when instantiated.  Since `watch()` is called while iterating over each watcher, dynamically adding a new `Watcher` triggers a `ConcurrentModificationException`.

To work around this, I've introduced a new `isolated` flag to watchers. When this flag is set, a copy of the watcher is made, `watch()` called on that, and the resulting changes merged back to the `Watchers` map. This flag defaults to unset, in which case the old behavior is retained. It should only be necessary to grant this flag for watchers which may possible add additonal watchers to the global map inside their `watch()` code.

The second major change is that when control of a permanent is changed, it also updates the `controllerId` (and `sourceId`, when that control change is due to the card becoming a new permanent e.g. blinking) of all associated watchers in the global map.  This is necessary because the watchers associated with an ability (via `Ability.getWatchers()`) are only used for instantiating new watchers, and it doesn't apply to watchers which were created by old instances of the permanent.

This should help improve some possible bugs with control-changing effects on watchers, especially CARD-scoped watchers (see https://github.com/magefree/mage/issues/13774)

The third change is that object-copying code now supports copying arbitrary serializable objects by serializing them to a byte array and back.  It is possible to serialize lambdas, which is why this was necessary since we need to instantiate a new instance of an effect on the fly.