### PR TITLE
Fix Vastlands Scavenger: missing EntersPreparedAbility

### DIFF
--- a/Mage.Sets/src/mage/cards/v/VastlandsScavenger.java
+++ b/Mage.Sets/src/mage/cards/v/VastlandsScavenger.java
@@ -2,6 +2,7 @@ package mage.cards.v;
 
 import mage.MageInt;
 import mage.abilities.Ability;
+import mage.abilities.common.EntersPreparedAbility;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.DeathtouchAbility;
 import mage.cards.Card;
@@ -38,6 +39,8 @@ public final class VastlandsScavenger extends PrepareCard {
         this.addAbility(DeathtouchAbility.getInstance());
 
         // This creature enters prepared.
+        this.addAbility(new EntersPreparedAbility());
+
         // Bind to Life
         // Instant {4}{G}
         // Mill seven cards. Then put a creature card from among them onto the battlefield.


### PR DESCRIPTION
One-card fix: **Vastlands Scavenger** says *"This creature enters prepared."* but `EntersPreparedAbility` was never added, so it entered the battlefield without the prepared designation.

This surfaced during review of #15599 (thanks @muz for confirming it there — "Good catch"). Re-submitting it standalone since the mechanic implementation is now being handled in #15601 and this fix is independent of it: it only uses the existing `EntersPreparedAbility` / prepared-designation machinery already on master.

Ref #14329.
