### PR TITLE
fix: skip 303.4g aura ETB check for face-down permanents

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MorphTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/MorphTest.java
@@ -1,5 +1,7 @@
 package org.mage.test.cards.abilities.keywords;
 
+import mage.abilities.keyword.DeathtouchAbility;
+import mage.abilities.keyword.IndestructibleAbility;
 import mage.cards.Card;
 import mage.constants.*;
 import mage.filter.Filter;
@@ -61,6 +63,86 @@ public class MorphTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 1);
         assertPowerToughness(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 2, 2);
 
+    }
+
+    @Test
+    public void testGiftOfDoomCastFaceDown() {
+        addCard(Zone.HAND, playerA, "Gift of Doom");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gift of Doom using Morph");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 1);
+        assertPowerToughness(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 2, 2);
+    }
+
+    @Test
+    public void testGiftOfDoomTurnFaceUp() {
+        addCard(Zone.HAND, playerA, "Gift of Doom");
+        addCard(Zone.BATTLEFIELD, playerA, "Memnite");
+        addCard(Zone.BATTLEFIELD, playerA, "Runeclaw Bear");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gift of Doom using Morph");
+        waitStackResolved(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Turn this face-down permanent face up");
+        setChoice(playerA, "Memnite"); // Sacrifice another creature
+        setChoice(playerA, true); // Attach Gift of Doom
+        addTarget(playerA, "Runeclaw Bear");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerA, "Memnite", 1);
+        assertPermanentCount(playerA, EmptyNames.FACE_DOWN_CREATURE.getTestCommand(), 0);
+        assertPermanentCount(playerA, "Gift of Doom", 1);
+        assertAttachedTo(playerA, "Gift of Doom", "Runeclaw Bear", true);
+        assertAbility(playerA, "Runeclaw Bear", DeathtouchAbility.getInstance(), true);
+        assertAbility(playerA, "Runeclaw Bear", IndestructibleAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testGiftOfDoomCastNormally() {
+        addCard(Zone.HAND, playerA, "Gift of Doom");
+        addCard(Zone.BATTLEFIELD, playerA, "Runeclaw Bear");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gift of Doom", "Runeclaw Bear");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Gift of Doom", 1);
+        assertAttachedTo(playerA, "Gift of Doom", "Runeclaw Bear", true);
+        assertAbility(playerA, "Runeclaw Bear", DeathtouchAbility.getInstance(), true);
+        assertAbility(playerA, "Runeclaw Bear", IndestructibleAbility.getInstance(), true);
+    }
+
+    @Test
+    public void testGiftOfDoomCastWithIllegalTarget() {
+        addCard(Zone.HAND, playerA, "Gift of Doom");
+        addCard(Zone.HAND, playerA, "One with the Stars");
+        addCard(Zone.BATTLEFIELD, playerA, "Runeclaw Bear");
+        addCard(Zone.BATTLEFIELD, playerA, "Vedalken Orrery");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Gift of Doom", "Runeclaw Bear");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "One with the Stars", "Runeclaw Bear");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, "Gift of Doom", 1);
+        assertPermanentCount(playerA, "Gift of Doom", 0);
     }
 
     /**

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -5009,7 +5009,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                     // 303.4g. If an Aura is entering the battlefield and there is no legal object or player for it to enchant,
                     // the Aura remains in its current zone, unless that zone is the stack. In that case, the Aura is put into
                     // its owner's graveyard instead of entering the battlefield. If the Aura is a token, it isn't created.
-                    if (card.hasSubtype(SubType.AURA, game) && !(source instanceof BestowAbility)) {
+                    if (!faceDown && card.hasSubtype(SubType.AURA, game) && !(source instanceof BestowAbility)) {
                         SpellAbility auraSpellAbility;
                         if (source instanceof SpellAbility && card.getAbilities(game).contains(source)) {
                             // cast aura - use source ability


### PR DESCRIPTION
## Summary

Casting Gift of Doom face down with Morph no longer crashes the server. The CR 303.4g guard in `PlayerImpl.moveCards` ("Aura entering the battlefield with no legal object to enchant") fired for face-down casts because it read the printed card's Aura subtype, then found the morph cast's SpellAbility with an empty target list and threw `IllegalArgumentException: Something wrong, found etb aura with empty spell ability or without any targets`. Per CR 708.2, a face-down spell resolves as a 2/2 face-down creature with no name, types, or subtypes, so the Aura ETB check must not apply when the permanent enters face down — the guard is now skipped for `faceDown` entries.

## Why this matters

The reporter in #15580 hit a full game crash from a legal line of play with any morph Aura (Gift of Doom being the canonical example). The change is one condition on the existing guard; face-up Aura entries keep the exact 303.4g handling they have today.

## Testing

Added `MorphTest` cases: casting Gift of Doom face down resolves as a nameless 2/2 face-down creature, and turning it face up (sacrificing a creature for its own trigger, then attaching to a target) works end to end, including the deathtouch/indestructible grants on the enchanted creature. Tests run under `Mage.Tests` in CI.

Fixes #15580
