### PR TITLE
[don't merge] fix: abort convoke mana payment on invalid or missing color choice

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-12T12:40:55.042835+00:00",
+  "commits_behind_before_sync": 0,
+  "action_taken": "noop"
+}

--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,5 +1,0 @@
-{
-  "fork_synced_at": "2026-07-12T12:40:55.042835+00:00",
-  "commits_behind_before_sync": 0,
-  "action_taken": "noop"
-}

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -666,8 +666,10 @@ public class HumanPlayer extends PlayerImpl {
                 } else {
                     choice.setChoice(val);
                 }
-                choice.onChooseEnd(game, playerId, val);
-                return true;
+                if (choice.isChosen()) {
+                    choice.onChooseEnd(game, playerId, val);
+                    return true;
+                }
             } else if (!choice.isRequired()) {
                 // cancel
                 choice.onChooseEnd(game, playerId, null);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ConvokeTest.java
@@ -1,16 +1,87 @@
 package org.mage.test.cards.abilities.keywords;
 
+import mage.choices.Choice;
+import mage.choices.ChoiceColor;
+import mage.constants.Outcome;
 import mage.constants.PhaseStep;
+import mage.constants.RangeOfInfluence;
 import mage.constants.Zone;
+import mage.game.Game;
+import mage.player.human.HumanPlayer;
+import mage.player.human.PlayerResponse;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
 
 /**
  * @author JayDi85
  */
 
 public class ConvokeTest extends CardTestPlayerBaseWithAIHelps {
+
+    private static class QueuedHumanPlayer extends HumanPlayer {
+
+        private final PlayerResponse response;
+        private final Queue<String> responses;
+        private int responseCount;
+
+        private QueuedHumanPlayer(PlayerResponse response, String... responses) {
+            super(new HumanPlayer("Test Player", RangeOfInfluence.ALL, 1), response);
+            this.response = response;
+            this.responses = new ArrayDeque<>(Arrays.asList(responses));
+        }
+
+        @Override
+        public boolean canRespond() {
+            return !responses.isEmpty();
+        }
+
+        @Override
+        protected boolean isExecutingMacro() {
+            return true;
+        }
+
+        @Override
+        protected void prepareForResponse(Game game) {
+        }
+
+        @Override
+        protected void waitForResponse(Game game) {
+            response.clear();
+            response.setString(responses.remove());
+            responseCount++;
+        }
+    }
+
+    @Test
+    public void test_HumanPlayer_InvalidChoiceRePrompts() {
+        PlayerResponse response = new PlayerResponse();
+        QueuedHumanPlayer player = new QueuedHumanPlayer(response, "Unknown", "Black");
+        Choice choice = new ChoiceColor();
+
+        Assert.assertTrue(player.choose(Outcome.Benefit, choice, currentGame));
+        Assert.assertTrue(choice.isChosen());
+        Assert.assertEquals("Black", choice.getChoice());
+        Assert.assertEquals(2, player.responseCount);
+    }
+
+    @Test
+    public void test_HumanPlayer_CancelChoice() {
+        PlayerResponse response = new PlayerResponse();
+        QueuedHumanPlayer player = new QueuedHumanPlayer(response, "");
+        Choice choice = new ChoiceColor();
+
+        Assert.assertFalse(player.choose(Outcome.Benefit, choice, currentGame));
+        Assert.assertFalse(choice.isChosen());
+        Assert.assertNull(choice.getChoice());
+        Assert.assertFalse(currentGame.hasEnded());
+    }
 
     @Test
     public void test_Playable_NoMana_NoConvoke() {
@@ -279,6 +350,50 @@ public class ConvokeTest extends CardTestPlayerBaseWithAIHelps {
         setStrictChooseMode(true);
         setStopAt(1, PhaseStep.END_TURN);
         execute();
+    }
+
+    @Test
+    public void test_Other_MulticolorCreatureConvokeChoice() {
+        // {5}{B/G}{B/G}
+        // You can't spend mana to cast this spell.
+        // Convoke, delve
+        addCard(Zone.GRAVEYARD, playerA, "Hogaak, Arisen Necropolis", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Lluwen, Imperfect Naturalist", 1); // black and green convoke pay
+        addCard(Zone.BATTLEFIELD, playerA, "Grizzly Bears", 1); // green convoke pay
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears", 5); // generic convoke pay
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Hogaak, Arisen Necropolis");
+        addTarget(playerA, "Lluwen, Imperfect Naturalist");
+        setChoice(playerA, "Black");
+        addTarget(playerA, "Grizzly Bears");
+        addTarget(playerA, "Balduvian Bears", 5);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPermanentCount(playerA, "Hogaak, Arisen Necropolis", 1);
+        assertTapped("Lluwen, Imperfect Naturalist", true);
+    }
+
+    @Test
+    public void test_Other_CancelMulticolorCreatureConvokeChoice() {
+        addCard(Zone.GRAVEYARD, playerA, "Hogaak, Arisen Necropolis", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Lluwen, Imperfect Naturalist", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Balduvian Bears", 6);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Hogaak, Arisen Necropolis");
+        addTarget(playerA, "Lluwen, Imperfect Naturalist");
+        setChoice(playerA, TestPlayer.CHOICE_SKIP);
+        setChoice(playerA, TestPlayer.SKIP_FAILED_COMMAND);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, "Hogaak, Arisen Necropolis", 1);
+        assertTapped("Lluwen, Imperfect Naturalist", false);
+        Assert.assertFalse(currentGame.hasEnded());
     }
 
     @Test

--- a/Mage/src/main/java/mage/abilities/keyword/ConvokeAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ConvokeAbility.java
@@ -232,31 +232,35 @@ class ConvokeEffect extends OneShotEffect {
                         } else {
                             chooseManaType.setChoice(chooseManaType.getChoices().iterator().next());
                         }
-                        if (chooseManaType.getChoice().equals("Black")) {
+                        String choiceValue = chooseManaType.getChoice();
+                        if (!chooseManaType.isChosen() || choiceValue == null) {
+                            return false;
+                        }
+                        if (choiceValue.equals("Black")) {
                             manaPool.addMana(Mana.BlackMana(1), game, source);
                             manaPool.unlockManaType(ManaType.BLACK);
                         }
-                        if (chooseManaType.getChoice().equals("Blue")) {
+                        if (choiceValue.equals("Blue")) {
                             manaPool.addMana(Mana.BlueMana(1), game, source);
                             manaPool.unlockManaType(ManaType.BLUE);
                         }
-                        if (chooseManaType.getChoice().equals("Green")) {
+                        if (choiceValue.equals("Green")) {
                             manaPool.addMana(Mana.GreenMana(1), game, source);
                             manaPool.unlockManaType(ManaType.GREEN);
                         }
-                        if (chooseManaType.getChoice().equals("White")) {
+                        if (choiceValue.equals("White")) {
                             manaPool.addMana(Mana.WhiteMana(1), game, source);
                             manaPool.unlockManaType(ManaType.WHITE);
                         }
-                        if (chooseManaType.getChoice().equals("Red")) {
+                        if (choiceValue.equals("Red")) {
                             manaPool.addMana(Mana.RedMana(1), game, source);
                             manaPool.unlockManaType(ManaType.RED);
                         }
-                        if (chooseManaType.getChoice().equals("Colorless")) {
+                        if (choiceValue.equals("Colorless")) {
                             manaPool.addMana(Mana.ColorlessMana(1), game, source);
                             manaPool.unlockManaType(ManaType.COLORLESS);
                         }
-                        manaName = chooseManaType.getChoice().toLowerCase(Locale.ENGLISH);
+                        manaName = choiceValue.toLowerCase(Locale.ENGLISH);
                     } else {
                         manaPool.addMana(Mana.ColorlessMana(1), game, source);
                         manaPool.unlockManaType(ManaType.COLORLESS);


### PR DESCRIPTION
## Summary

Convoke no longer throws a NullPointerException when the mana-color choice comes back empty. `ConvokeEffect` in `Mage/src/main/java/mage/abilities/keyword/ConvokeAbility.java` read `chooseManaType.getChoice()` and compared it against color names without checking the choice was actually made; a null response (disconnect, canceled dialog, invalid response) crashed the game. The choice value is now read once, validated (`isChosen()` and non-null), and the convoke payment aborts cleanly when no valid color was selected. `HumanPlayer.choose` also stops accepting an invalid empty response as a completed choice, which is the path that produced the null in the first place.

## Why this matters

The reporter in #15579 hit a server-side NPE crash mid-cast when convoking with a multicolor creature — a game-ending failure from a UI hiccup. Aborting the single mana payment (rather than crashing the game) matches how other choice-driven payments handle an unmade choice.

## Testing

Added regression cases to `ConvokeTest` covering the multicolor-creature choice path and the abort-on-no-choice behavior. The targeted `ConvokeTest` suite passes: 23 tests including the new cases.

Fixes #15579
