### PR TITLE
[don't merge] GUI: close orphaned choice and exile windows

### DIFF
--- a/Mage.Client/src/main/java/mage/client/dialog/CardInfoWindowDialog.java
+++ b/Mage.Client/src/main/java/mage/client/dialog/CardInfoWindowDialog.java
@@ -85,6 +85,14 @@ public class CardInfoWindowDialog extends MageDialog implements MageDesktopIconi
                 break;
             case EXILE:
                 this.setFrameIcon(new ImageIcon(ImageManagerImpl.instance.getExileImage()));
+                this.setClosable(true);
+                this.setDefaultCloseOperation(HIDE_ON_CLOSE);
+                this.addInternalFrameListener(new InternalFrameAdapter() {
+                    @Override
+                    public void internalFrameClosing(InternalFrameEvent e) {
+                        CardInfoWindowDialog.this.hideDialog();
+                    }
+                });
                 break;
             case COMPANION:
                 this.setFrameIcon(new ImageIcon(ImageManagerImpl.instance.getTokenIconImage()));
@@ -120,7 +128,9 @@ public class CardInfoWindowDialog extends MageDialog implements MageDesktopIconi
         setTitle(titel);
         this.setTitelBarToolTip(titel);
         if (!exile.isEmpty()) {
-            show();
+            if (!positioned || changed) {
+                show();
+            }
             if (changed) {
                 try {
                     this.setIcon(false);

--- a/Mage.Client/src/main/java/mage/client/game/GamePanel.java
+++ b/Mage.Client/src/main/java/mage/client/game/GamePanel.java
@@ -114,6 +114,7 @@ public final class GamePanel extends javax.swing.JPanel {
     private ReplayTask replayTask;
     private final PickNumberDialog pickNumber;
     private final PickMultiNumberDialog pickMultiNumber;
+    private PickChoiceDialog pickChoice;
     private JLayeredPane jLayeredPane;
     private String chosenHandKey = "You";
     private final skipButtonsList skipButtons = new skipButtonsList();
@@ -415,6 +416,7 @@ public final class GamePanel extends javax.swing.JPanel {
         if (pickMultiNumber != null) {
             pickMultiNumber.removeDialog();
         }
+        clearPickChoiceDialog();
         for (CardInfoWindowDialog windowDialog : exiles.values()) {
             windowDialog.cleanUp();
             windowDialog.removeDialog();
@@ -469,6 +471,15 @@ public final class GamePanel extends javax.swing.JPanel {
         // remove dialogs forever on clean or full update
         clearPickTargetDialogs();
         clearPickPileDialogs();
+    }
+
+    private void clearPickChoiceDialog() {
+        if (this.pickChoice != null) {
+            PickChoiceDialog oldPickChoice = this.pickChoice;
+            this.pickChoice = null;
+            oldPickChoice.hideDialog();
+            oldPickChoice.removeDialog();
+        }
     }
 
     private void clearPickTargetDialogs() {
@@ -2234,8 +2245,16 @@ public final class GamePanel extends javax.swing.JPanel {
         DialogManager.getManager(gameId).fadeOut();
 
         // TODO: remember last choices and search incremental for same events?
-        PickChoiceDialog pickChoice = new PickChoiceDialog();
-        pickChoice.showDialog(choice, null, objectId, choiceWindowState, bigCard, () -> {
+        clearPickChoiceDialog();
+        PickChoiceDialog newPickChoice = new PickChoiceDialog();
+        this.pickChoice = newPickChoice;
+        newPickChoice.showDialog(choice, null, objectId, choiceWindowState, bigCard, () -> {
+            if (this.pickChoice != newPickChoice) {
+                newPickChoice.removeDialog();
+                return;
+            }
+            this.pickChoice = null;
+
             // special mode adds # to the answer (server side code must process that prefix, see replacementEffectChoice)
             String specialPrefix = choice.isChosenSpecial() ? "#" : "";
 
@@ -2248,9 +2267,9 @@ public final class GamePanel extends javax.swing.JPanel {
             SessionHandler.sendPlayerString(gameId, valueToSend == null ? null : specialPrefix + valueToSend);
 
             // keep dialog position
-            choiceWindowState = new MageDialogState(pickChoice);
+            choiceWindowState = new MageDialogState(newPickChoice);
 
-            pickChoice.removeDialog();
+            newPickChoice.removeDialog();
         });
     }
 


### PR DESCRIPTION
## Summary

Fix two game-window lifecycle cases that can leave dialogs stuck after they are no longer useful.

### Changes

- Track the active `PickChoiceDialog` so replacement and game teardown remove it without sending stale choices or leaving card hints visible.
- Make exile card windows closable and keep user-hidden windows closed until their contents change.

### Scope

This handles the close/hide behavior discussed in #1115 and #4155. It does not change when exile windows first appear, group exiled cards by player, or add global dialog visibility controls.

Related to the non-blocking dialog ownership introduced in #12825.

### Testing

- Full Maven reactor test suite with JDK 17
- 6,989 tests run, 0 failures, 0 errors, 143 skipped
