### PR TITLE
[dev] Cleanup and minimise usage of mtg-sets-data.txt

### DIFF
--- a/Utils/gen-existing-cards-by-set-author.pl
+++ b/Utils/gen-existing-cards-by-set-author.pl
@@ -9,9 +9,7 @@ use strict;
 my $dataFile = "mtg-cards-data.txt";
 my $setsFile = "mtg-sets-data.txt";
 
-
 my %cards;
-my %sets;
 my %knownSets;
 
 my @setCards;
@@ -117,14 +115,6 @@ if ($cardsFound == 0) {
     $setName = <STDIN>;
     exit;
 }
-
-open (DATA, $setsFile) || die "can't open $setsFile";
-
-while(my $line = <DATA>) {
-    my @data = split('\\|', $line);
-    $sets{$data[0]}= $data[1];
-}
-close(DATA);
 
 open (DATA, $setsFile) || die "can't open $setsFile";
 while(my $line = <DATA>) {

--- a/Utils/gen-list-implemented-cards-for-set.pl
+++ b/Utils/gen-list-implemented-cards-for-set.pl
@@ -9,7 +9,6 @@ my $dataFile = "mtg-cards-data.txt";
 my $setsFile = "mtg-sets-data.txt";
 
 my %sets;
-my %knownSets;
 
 my @setCards;
 
@@ -28,13 +27,6 @@ while(my $line = <DATA>) {
     if ($data[1] eq $setName) {
         push(@setCards, \@data);
     }
-}
-close(DATA);
-
-open (DATA, $setsFile) || die "can't open $setsFile";
-while(my $line = <DATA>) {
-    my @data = split('\\|', $line);
-    $knownSets{$data[0]}= $data[2];
 }
 close(DATA);
 

--- a/Utils/gen_all_files_in_dck.pl
+++ b/Utils/gen_all_files_in_dck.pl
@@ -8,15 +8,8 @@
 
 use strict;
 use Scalar::Util qw(looks_like_number);
-
-my $dataFile = "mtg-cards-data.txt";
-my $setsFile = "mtg-sets-data.txt";
-
-my %sets;
-
-my @setCards;
-my %nameSetNumber;
-my %setNumber;
+use File::Find;
+use File::Spec;
 
 sub toCamelCase
 {
@@ -27,25 +20,30 @@ sub toCamelCase
 }
 
 my $option = $ARGV[0];
-
-open (DATA, $setsFile) || die "can't open $setsFile";
-while(my $line = <DATA>)
+if (!defined $option || $option eq "")
 {
-    my @data = split('\\|', $line);
-    $sets{$data[0]} = $data[1];
-    $sets{toCamelCase($data[0])} = $data[1];
+    die "Usage: $0 <pattern>\n";
 }
-close(DATA);
 
-my $dir_listing = "dir \/a \/b \/s ..\\Mage.Sets\\src\\mage\\sets | find \".java\" |";
-open (DIR_LISTING, "$dir_listing");
+my $sets_dir = File::Spec->catdir('..', 'Mage.Sets', 'src', 'mage', 'sets');
+my @java_files;
+find(
+    {
+        no_chdir => 1,
+        wanted   => sub {
+            return unless -f $_;
+            return unless /\.java\z/;
+            push @java_files, $File::Find::name;
+        },
+    },
+    $sets_dir
+);
+
 my %setsForJavafile;
 my $totalCards = 0;
 
-while (<DIR_LISTING>)
+foreach my $file (@java_files)
 {
-    chomp;
-    my $file = $_;
     my $name = "";
     my $cardNum = "";
 

--- a/Utils/gen_list_duplicate_collector_ids.pl
+++ b/Utils/gen_list_duplicate_collector_ids.pl
@@ -10,22 +10,9 @@ use strict;
 use Scalar::Util qw(looks_like_number);
 
 my $dataFile = "mtg-cards-data.txt";
-my $setsFile = "mtg-sets-data.txt";
 
-my %sets;
-
-my @setCards;
 my %nameSetNumber;
 my %setNumber;
-
-open (DATA, $setsFile) || die "can't open $setsFile";
-
-while(my $line = <DATA>)
-{
-    my @data = split('\\|', $line);
-    $sets{$data[0]}= $data[1];
-}
-close(DATA);
 
 
 sub toCamelCase

--- a/Utils/print-card-info.pl
+++ b/Utils/print-card-info.pl
@@ -8,11 +8,10 @@ use utf8;
 use open ':std', ':encoding(UTF-8)';
 
 my $dataFile = 'mtg-cards-data.txt';
-my $setsFile = 'mtg-sets-data.txt';
 my $cardInfoTemplate = 'cardInfo.tmpl';
 
 my %cards;
-my %sets;
+
 
 sub toCamelCase {
     my $string = $_[0];
@@ -44,15 +43,12 @@ sub printCardInfo {
 
     # Combine power and toughness if they exist
     my $powerToughness = "";
-    if ($card[6] && $card[7] && $card[6] ne "" && $card[7] ne "") {
+    if (defined $card[6] && defined $card[7] && $card[6] ne "" && $card[7] ne "") {
         $powerToughness = "$card[6]/$card[7]";
     }
     $vars{'powerToughness'} = $powerToughness;
 
-    my $cardAbilities = $card[8];
-    my @abilities = split(/\$/, $cardAbilities);
-    my $abilitiesFormatted = join("\n    ", @abilities);
-    $vars{'abilities'} = $abilitiesFormatted;
+    $vars{'abilities'} = join("\n    ", split(/\$/, $card[8]));
 
     my $result = $infoTemplate->fill_in(HASH => \%vars);
     print "$result\n\n";
@@ -66,12 +62,6 @@ while (my $line = <DATA>) {
 }
 close(DATA);
 
-open(DATA, $setsFile) || die "can't open $setsFile : $!";
-while (my $line = <DATA>) {
-    my @data = split('\\|', $line);
-    $sets{$data[0]} = $data[1];
-}
-close(DATA);
 
 # Get card names from arguments
 my @cardNames = @ARGV;


### PR DESCRIPTION
I've got this file on my shitlist because it's smells weird to be tracking this information like this. 

To make it easier to make sense of what's safe to do with this file or not I did an audit of where it's being used in Util scripts and found there's a large pattern of codeblocks having had been copy and pasted between scripts, but for no functional purpose.

In many cases it would read and parse this file, store it in variables, and then never actually ever use said variables. So let's just clean it all up. The code is not serving any purpose other than consuming memory needlessly when the scripts are run.