### PR TITLE
Update City's Blessing hint to be more informative

### DIFF
--- a/Mage/src/main/java/mage/abilities/hint/common/CitysBlessingHint.java
+++ b/Mage/src/main/java/mage/abilities/hint/common/CitysBlessingHint.java
@@ -2,9 +2,10 @@ package mage.abilities.hint.common;
 
 import mage.abilities.Ability;
 import mage.abilities.condition.common.CitysBlessingCondition;
-import mage.abilities.hint.ConditionHint;
 import mage.abilities.hint.Hint;
+import mage.filter.StaticFilters;
 import mage.game.Game;
+import mage.players.Player;
 
 /**
  * @author JayDi85
@@ -12,11 +13,16 @@ import mage.game.Game;
 public enum CitysBlessingHint implements Hint {
 
     instance;
-    private static final ConditionHint hint = new ConditionHint(CitysBlessingCondition.instance, "You have city's blessing");
 
     @Override
     public String getText(Game game, Ability ability) {
-        return hint.getText(game, ability);
+        Player controller = game.getPlayer(ability.getControllerId());
+        if (CitysBlessingCondition.instance.apply(game, ability)) {
+            return "You have the city's blessing";
+        }
+
+        int count = controller == null ? 0 : game.getBattlefield().countAll(StaticFilters.FILTER_PERMANENT, controller.getId(), game);
+        return "You don't have the city's blessing (controlled permanents: " + count + " of 10)";
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/hint/common/CitysBlessingHint.java
+++ b/Mage/src/main/java/mage/abilities/hint/common/CitysBlessingHint.java
@@ -3,6 +3,7 @@ package mage.abilities.hint.common;
 import mage.abilities.Ability;
 import mage.abilities.condition.common.CitysBlessingCondition;
 import mage.abilities.hint.Hint;
+import mage.abilities.hint.HintUtils;
 import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
@@ -17,12 +18,16 @@ public enum CitysBlessingHint implements Hint {
     @Override
     public String getText(Game game, Ability ability) {
         Player controller = game.getPlayer(ability.getControllerId());
-        if (CitysBlessingCondition.instance.apply(game, ability)) {
-            return "You have the city's blessing";
+        boolean hasCitysBlessing = CitysBlessingCondition.instance.apply(game, ability);
+        if (hasCitysBlessing) {
+            return HintUtils.prepareText("You have the city's blessing", null, HintUtils.HINT_ICON_GOOD);
         }
 
         int count = controller == null ? 0 : game.getBattlefield().countAll(StaticFilters.FILTER_PERMANENT, controller.getId(), game);
-        return "You don't have the city's blessing (controlled permanents: " + count + " of 10)";
+        return HintUtils.prepareText(
+                "You don't have the city's blessing (controlled permanents: " + count + " of 10)",
+                null, HintUtils.HINT_ICON_BAD
+        );
     }
 
     @Override

--- a/Mage/src/main/java/mage/abilities/hint/common/CitysBlessingHint.java
+++ b/Mage/src/main/java/mage/abilities/hint/common/CitysBlessingHint.java
@@ -17,13 +17,13 @@ public enum CitysBlessingHint implements Hint {
 
     @Override
     public String getText(Game game, Ability ability) {
-        Player controller = game.getPlayer(ability.getControllerId());
         boolean hasCitysBlessing = CitysBlessingCondition.instance.apply(game, ability);
         if (hasCitysBlessing) {
             return HintUtils.prepareText("You have the city's blessing", null, HintUtils.HINT_ICON_GOOD);
         }
 
-        int count = controller == null ? 0 : game.getBattlefield().countAll(StaticFilters.FILTER_PERMANENT, controller.getId(), game);
+        Player controller = game.getPlayer(ability.getControllerId());
+        int count = controller == null ? 0 : game.getBattlefield().countAll(StaticFilters.FILTER_PERMANENT, ability.getControllerId(), game);
         return HintUtils.prepareText(
                 "You don't have the city's blessing (controlled permanents: " + count + " of 10)",
                 null, HintUtils.HINT_ICON_BAD


### PR DESCRIPTION
Following feedback on implementation of the Storied/Enduring Story in HOB there was a comment about making the hint there more user friendly https://github.com/magefree/mage/pull/15670#discussion_r3608845786. The same is probably true for the City's Blessing