### PR TITLE
Fix Torpor Orb etc logic on batch events

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/replacement/TorporOrbTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/replacement/TorporOrbTest.java
@@ -84,4 +84,23 @@ public class TorporOrbTest extends CardTestPlayerBase {
         assertGraveyardCount(playerA, "Highland Game", 1);
     }
 
+    @Test
+    public void testMoonshadow() {
+        addCard(Zone.HAND, playerA, "Torpor Orb");
+        addCard(Zone.HAND, playerA, "Moonshadow");
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp");
+        addCard(Zone.BATTLEFIELD, playerA, "Mogg Fanatic");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Moonshadow");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Torpor Orb");
+        activateAbility(3, PhaseStep.POSTCOMBAT_MAIN, playerA, "Sacrifice");
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Moonshadow", 2, 2);
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/DontCauseTriggerEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/DontCauseTriggerEffect.java
@@ -109,19 +109,20 @@ public class DontCauseTriggerEffect extends ContinuousRuleModifyingEffectImpl {
                 return false;
             case ZONE_CHANGE_BATCH:
                 ZoneChangeBatchEvent zoneChangeBatch = ((ZoneChangeBatchEvent) sourceEvent);
-                boolean all_match = true;
                 for (ZoneChangeEvent zoneChangeEvent : zoneChangeBatch.getEvents()) {
                     if (zoneChangeEvent.getToZone() == Zone.BATTLEFIELD ||
                             (orDying && zoneChangeEvent.isDiesEvent())) {
                         Permanent permanent = zoneChangeEvent.getTarget();
                         // This is technically undefined behavior under CR, but I'm assuming "Can't beats can" principle.
                         if (permanent != null && !filterEntering.match(permanent, source.getControllerId(), source, game)) {
-                            all_match = false;
-                            break;
+                            return false;
                         }
                     }
+                    else {
+                        return false;
+                    }
                 }
-                return all_match;
+                return true;
             default:
                 return false;
         }


### PR DESCRIPTION
The logic for Torpor Orb & friends that was supposed to look at batch zone change events doesn't seem correct.

Fixes 49d292a
Fixes https://github.com/magefree/mage/issues/15654