### PR TITLE
[HOB] Implement rules change for Hone counters + Equipment for Sting, Bilbo's Sword

### DIFF
--- a/Mage.Sets/src/mage/cards/s/StingBilbosSword.java
+++ b/Mage.Sets/src/mage/cards/s/StingBilbosSword.java
@@ -1,19 +1,34 @@
 package mage.cards.s;
 
 import java.util.UUID;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.dynamicvalue.common.PermanentsTargetOpponentControlsCount;
 import mage.constants.SubType;
 import mage.constants.SuperType;
+import mage.counters.CounterType;
+import mage.filter.StaticFilters;
+import mage.target.common.TargetControlledCreaturePermanent;
+import mage.target.common.TargetOpponent;
 import mage.abilities.keyword.FlashAbility;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldTriggeredAbility;
+import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.counter.AddCountersSourceEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.target.targetpointer.SecondTargetPointer;
 
 /**
  *
  * @author muz
  */
 public final class StingBilbosSword extends CardImpl {
+
+    private static final DynamicValue xValue =
+            new PermanentsTargetOpponentControlsCount(StaticFilters.FILTER_PERMANENT_CREATURES);
 
     public StingBilbosSword(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
@@ -25,6 +40,17 @@ public final class StingBilbosSword extends CardImpl {
         this.addAbility(FlashAbility.getInstance());
 
         // When Sting enters, put a hone counter on Sting for each creature target opponent controls. Attach Sting to up to one target creature you control.
+        Ability ability = new EntersBattlefieldTriggeredAbility(
+            new AddCountersSourceEffect(CounterType.HONE.createInstance(), xValue)
+                .setText("put a hone counter on {this} for each creature target opponent controls")
+        );
+        ability.addTarget(new TargetOpponent());
+        ability.addEffect(
+            new AttachEffect(Outcome.BoostCreature, "attach {this} to up to one target creature you control")
+                .setTargetPointer(new SecondTargetPointer())
+        );
+        ability.addTarget(new TargetControlledCreaturePermanent(0, 1));
+        this.addAbility(ability);
 
         // Equip {3}
         this.addAbility(new EquipAbility(3));

--- a/Mage.Sets/src/mage/cards/s/StingBilbosSword.java
+++ b/Mage.Sets/src/mage/cards/s/StingBilbosSword.java
@@ -1,0 +1,42 @@
+package mage.cards.s;
+
+import java.util.UUID;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.abilities.keyword.FlashAbility;
+import mage.abilities.keyword.EquipAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+
+/**
+ *
+ * @author muz
+ */
+public final class StingBilbosSword extends CardImpl {
+
+    public StingBilbosSword(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.EQUIPMENT);
+
+        // Flash
+        this.addAbility(FlashAbility.getInstance());
+
+        // When Sting enters, put a hone counter on Sting for each creature target opponent controls. Attach Sting to up to one target creature you control.
+
+        // Equip {3}
+        this.addAbility(new EquipAbility(3));
+
+    }
+
+    private StingBilbosSword(final StingBilbosSword card) {
+        super(card);
+    }
+
+    @Override
+    public StingBilbosSword copy() {
+        return new StingBilbosSword(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/TheHobbit.java
+++ b/Mage.Sets/src/mage/sets/TheHobbit.java
@@ -55,6 +55,9 @@ public final class TheHobbit extends ExpansionSet {
         cards.add(new SetCardInfo("Smaug the Magnificent", 229, Rarity.MYTHIC, mage.cards.s.SmaugTheMagnificent.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Smaug the Magnificent", 249, Rarity.MYTHIC, mage.cards.s.SmaugTheMagnificent.class, FULL_ART_USE_VARIOUS));
         cards.add(new SetCardInfo("Smaug the Magnificent", 265, Rarity.MYTHIC, mage.cards.s.SmaugTheMagnificent.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sting, Bilbo's Sword", 178, Rarity.RARE, mage.cards.s.StingBilbosSword.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sting, Bilbo's Sword", 237, Rarity.RARE, mage.cards.s.StingBilbosSword.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Sting, Bilbo's Sword", 273, Rarity.RARE, mage.cards.s.StingBilbosSword.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Swamp", 196, Rarity.LAND, mage.cards.basiclands.Swamp.class, FULL_ART));
         cards.add(new SetCardInfo("The Arkenstone", 170, Rarity.MYTHIC, mage.cards.t.TheArkenstone.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("The Arkenstone", 234, Rarity.MYTHIC, mage.cards.t.TheArkenstone.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/rules/HoneCounterRuleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/rules/HoneCounterRuleTest.java
@@ -1,0 +1,42 @@
+package org.mage.test.cards.rules;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class HoneCounterRuleTest extends CardTestPlayerBase {
+
+    private static final String LION = "Silvercoat Lion";
+    private static final String SHIELD = "Accorder's Shield";
+
+    @Test
+    public void testHoneCountersBoostEquippedCreature() {
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 4);
+        addCard(Zone.BATTLEFIELD, playerA, SHIELD);
+        addCard(Zone.BATTLEFIELD, playerA, LION);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip {3}", LION);
+        addCounters(1, PhaseStep.PRECOMBAT_MAIN, playerA, SHIELD, CounterType.HONE, 2);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // 2/2 plus +0/+3 from Accorder's Shield plus +2/+0 from two hone counters.
+        assertPowerToughness(playerA, LION, 4, 5);
+    }
+
+    @Test
+    public void testHoneCountersDoNothingIfNotEquipped() {
+        addCard(Zone.BATTLEFIELD, playerA, SHIELD);
+        addCard(Zone.BATTLEFIELD, playerA, LION);
+
+        addCounters(1, PhaseStep.PRECOMBAT_MAIN, playerA, SHIELD, CounterType.HONE, 3);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerA, LION, 2, 2);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/rules/HoneCounterRuleTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/rules/HoneCounterRuleTest.java
@@ -8,7 +8,16 @@ import org.mage.test.serverside.base.CardTestPlayerBase;
 
 public class HoneCounterRuleTest extends CardTestPlayerBase {
 
+    /**
+    * Silvercoat Lion
+    * 2/2
+    */
     private static final String LION = "Silvercoat Lion";
+
+    /**
+    * Accorder's Shield
+    * Equipped creature gets +0/+3 and has vigilance.
+    */
     private static final String SHIELD = "Accorder's Shield";
 
     @Test
@@ -21,6 +30,7 @@ public class HoneCounterRuleTest extends CardTestPlayerBase {
         addCounters(1, PhaseStep.PRECOMBAT_MAIN, playerA, SHIELD, CounterType.HONE, 2);
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
         execute();
 
         // 2/2 plus +0/+3 from Accorder's Shield plus +2/+0 from two hone counters.
@@ -35,6 +45,7 @@ public class HoneCounterRuleTest extends CardTestPlayerBase {
         addCounters(1, PhaseStep.PRECOMBAT_MAIN, playerA, SHIELD, CounterType.HONE, 3);
 
         setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        setStrictChooseMode(true);
         execute();
 
         assertPowerToughness(playerA, LION, 2, 2);

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/hob/StingBilbosSwordTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/hob/StingBilbosSwordTest.java
@@ -1,0 +1,48 @@
+package org.mage.test.cards.single.hob;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class StingBilbosSwordTest extends CardTestPlayerBase {
+
+    private static final String STING = "Sting, Bilbo's Sword";
+    private static final String LION = "Silvercoat Lion";
+    private static final String BEARS = "Grizzly Bears";
+
+    @Test
+    public void testEtbAddsHoneByOppCreaturesAndAttaches() {
+        addCard(Zone.HAND, playerA, STING);
+        addCard(Zone.BATTLEFIELD, playerA, LION);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+
+        addCard(Zone.BATTLEFIELD, playerB, BEARS, 2);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, STING);
+        addTarget(playerA, LION);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertCounterCount(STING, CounterType.HONE, 2);
+        assertAttachedTo(playerA, STING, LION, true);
+        assertPowerToughness(playerA, LION, 4, 2);
+    }
+
+    @Test
+    public void testEtbAddsHoneEvenIfNoAttachTarget() {
+        addCard(Zone.HAND, playerA, STING);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
+
+        addCard(Zone.BATTLEFIELD, playerB, BEARS, 3);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, STING);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertCounterCount(STING, CounterType.HONE, 3);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/ApplyStatusEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/ApplyStatusEffect.java
@@ -5,6 +5,7 @@ import mage.abilities.keyword.MenaceAbility;
 import mage.constants.*;
 import mage.counters.AbilityCounter;
 import mage.counters.BoostCounter;
+import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -37,6 +38,23 @@ public class ApplyStatusEffect extends ContinuousEffectImpl {
                 }
                 if (permanent.isSuspected()) {
                     permanent.addAbility(new MenaceAbility(false), source == null ? permanent.getId() : source.getSourceId(), game);
+                }
+            }
+        }
+        if (layer == Layer.PTChangingEffects_7 && sublayer == SubLayer.ModifyPT_7c) {
+            for (Permanent equipment : game.getBattlefield().getAllActivePermanents()) {
+                if (!equipment.hasSubtype(SubType.EQUIPMENT, game)) {
+                    continue;
+                }
+
+                int honeCounters = equipment.getCounters(game).getCount(CounterType.HONE);
+                if (honeCounters <= 0) {
+                    continue;
+                }
+
+                Permanent equippedCreature = game.getPermanent(equipment.getAttachedTo());
+                if (equippedCreature != null && equippedCreature.isCreature(game)) {
+                    equippedCreature.addPower(honeCounters);
                 }
             }
         }

--- a/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
+++ b/Mage/src/main/java/mage/abilities/effects/ContinuousEffects.java
@@ -1133,6 +1133,8 @@ public class ContinuousEffects implements Serializable {
             }
         }
 
+        applyStatus.apply(Layer.PTChangingEffects_7, SubLayer.ModifyPT_7c, null, game);
+
         applyStatus.apply(Layer.PTChangingEffects_7, SubLayer.Counters_7d, null, game);
 
         for (ContinuousEffect effect : layer) {


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/issues/14857

> Various cards in this set put hone counters on Equipment, including Sting, Bilbo's Sword, which does so for itself. Every hone counter on an Equipment gives +1/+0 to the equipped creature. Notably, this isn't an ability given to the Equipment. It's just true because of rules associated with the counter. 

- [ref](https://magic.wizards.com/en/news/feature/the-hobbit-mechanics)