### PR TITLE
[dev] Util folder cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,6 @@ Mage.Verify/*.json
 
 # Utils
 __pycache__
-Utils/*-scryfall.json
-Utils/author.txt
-
-# TODO: remove with outdated perl scripts
-Utils/*_tracker.txt
-Utils/*implemented.txt
 
 # dev environments, IDE and OS
 # IntelliJ IDEA

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Mage.Verify/*.json
 
 # Utils
 __pycache__
+Utils/data
 
 # dev environments, IDE and OS
 # IntelliJ IDEA

--- a/Utils/data/.gitkeep
+++ b/Utils/data/.gitkeep
@@ -1,0 +1,1 @@
+# Contents of this folder should be persisted across Util script runs but never tracked in git

--- a/Utils/de-dup-cards-data.py
+++ b/Utils/de-dup-cards-data.py
@@ -38,6 +38,6 @@ with open(orig_txt_filename) as orig_txt_file:
 			new_contents += line
 
 # generate new file with the de-duped contents
-new_txt_filename = 'unduped-cards-data.txt'
+new_txt_filename = 'tmp/unduped-cards-data.txt'
 with open(new_txt_filename, "w") as new_txt_file:
 	new_txt_file.write(new_contents)

--- a/Utils/de-dup-cards-data.py
+++ b/Utils/de-dup-cards-data.py
@@ -38,6 +38,6 @@ with open(orig_txt_filename) as orig_txt_file:
 			new_contents += line
 
 # generate new file with the de-duped contents
-new_txt_filename = 'tmp/unduped-cards-data.txt'
+new_txt_filename = 'data/unduped-cards-data.txt'
 with open(new_txt_filename, "w") as new_txt_file:
 	new_txt_file.write(new_contents)

--- a/Utils/extract_in_wiki_format.pl
+++ b/Utils/extract_in_wiki_format.pl
@@ -41,7 +41,7 @@ while(my $line = <DATA>) {
 close(DATA);
 
 
-open CARDS, "< added_cards.txt" or die;
+open CARDS, "< tmp/added_cards.txt" or die;
 while (<CARDS>) {
     my $line = $_;
     if ( $line =~/(\w.*)\/(\w.*)\.java/ ) {
@@ -58,7 +58,7 @@ while (<CARDS>) {
     }
 }
 
-open REPORT, "> added_cards_in_wiki_format.txt";
+open REPORT, "> tmp/added_cards_in_wiki_format.txt";
 print REPORT "* Added cards ($cards_count):\n";
 foreach my $set (keys(%cards)) {
     if ($set ne "tokens") {

--- a/Utils/extract_in_wiki_format.pl
+++ b/Utils/extract_in_wiki_format.pl
@@ -41,7 +41,7 @@ while(my $line = <DATA>) {
 close(DATA);
 
 
-open CARDS, "< tmp/added_cards.txt" or die;
+open CARDS, "< data/added_cards.txt" or die;
 while (<CARDS>) {
     my $line = $_;
     if ( $line =~/(\w.*)\/(\w.*)\.java/ ) {
@@ -58,7 +58,7 @@ while (<CARDS>) {
     }
 }
 
-open REPORT, "> tmp/added_cards_in_wiki_format.txt";
+open REPORT, "> data/added_cards_in_wiki_format.txt";
 print REPORT "* Added cards ($cards_count):\n";
 foreach my $set (keys(%cards)) {
     if ($set ne "tokens") {

--- a/Utils/gen-card-test.pl
+++ b/Utils/gen-card-test.pl
@@ -15,7 +15,7 @@ use Text::Template;
 use strict;
 use File::Path qw(make_path);
 
-my $authorFile = 'author.txt';
+my $authorFile = 'tmp/author.txt';
 my $dataFile = 'mtg-cards-data.txt';
 my $setsFile = 'mtg-sets-data.txt';
 my $keywordsFile = 'keywords.txt';

--- a/Utils/gen-card-test.pl
+++ b/Utils/gen-card-test.pl
@@ -15,7 +15,7 @@ use Text::Template;
 use strict;
 use File::Path qw(make_path);
 
-my $authorFile = 'tmp/author.txt';
+my $authorFile = 'data/author.txt';
 my $dataFile = 'mtg-cards-data.txt';
 my $setsFile = 'mtg-sets-data.txt';
 my $keywordsFile = 'keywords.txt';

--- a/Utils/gen-card.pl
+++ b/Utils/gen-card.pl
@@ -5,7 +5,7 @@
 use Text::Template;
 use strict;
 
-my $authorFile = 'author.txt';
+my $authorFile = 'tmp/author.txt';
 my $dataFile = 'mtg-cards-data.txt';
 my $setsFile = 'mtg-sets-data.txt';
 my $keywordsFile = 'keywords.txt';

--- a/Utils/gen-card.pl
+++ b/Utils/gen-card.pl
@@ -5,7 +5,7 @@
 use Text::Template;
 use strict;
 
-my $authorFile = 'tmp/author.txt';
+my $authorFile = 'data/author.txt';
 my $dataFile = 'mtg-cards-data.txt';
 my $setsFile = 'mtg-sets-data.txt';
 my $keywordsFile = 'keywords.txt';

--- a/Utils/gen-existing-cards-by-set.pl
+++ b/Utils/gen-existing-cards-by-set.pl
@@ -157,12 +157,6 @@ sub getRarity
 
 # Generate the cards
 
-my $landForest = 0;
-my $landMountain = 0;
-my $landSwamp = 0;
-my $landPlains = 0;
-my $landIsland = 0;
-
 print ("Reading in existing cards in set\n");
 open (SET_FILE, "../../mage/Mage.Sets/src/mage/sets/$knownSets{$setName}.java") || die "can't open $dataFile";
 my %alreadyIn;
@@ -192,22 +186,6 @@ foreach $name_collectorid (sort @setCards)
     $cardNr = $2;
     {
         if($cardName eq "Forest" || $cardName eq "Island" || $cardName eq "Plains" || $cardName eq "Swamp" || $cardName eq "Mountain") {
-            my $found = 0;
-            if ($cardName eq "Forest") {
-                $landForest++;
-            }
-            if ($cardName eq "Mountain") {
-                $landMountain++;
-            }
-            if ($cardName eq "Swamp") {
-                $landSwamp++;
-            }
-            if ($cardName eq "Plains") {
-                $landPlains++;
-            }
-            if ($cardName eq "Island") {
-                $landIsland++;
-            }
             if (!exists ($alreadyIn{$cardNr})) {
                 print ("        cards.add(new SetCardInfo(\"$cardName\", $cardNr, Rarity.LAND, mage.cards.basiclands.$cardName.class, USE_RANDOM_ART));\n");
             }

--- a/Utils/gen-existing-cards-by-set.pl
+++ b/Utils/gen-existing-cards-by-set.pl
@@ -2,11 +2,10 @@
 
 #author: North
 
-use Text::Template;
 use strict;
 
 
-my $authorFile = 'author.txt';
+my $authorFile = 'tmp/author.txt';
 my $dataFile = "mtg-cards-data.txt";
 my $setsFile = "mtg-sets-data.txt";
 
@@ -25,23 +24,11 @@ if(!$setName) {
     chomp $setName;
 }
 
-my $template = Text::Template->new(TYPE => 'FILE', SOURCE => 'cardExtendedClass.tmpl', DELIMITERS => [ '[=', '=]' ]);
-my $templateBasicLand = Text::Template->new(TYPE => 'FILE', SOURCE => 'cardExtendedLandClass.tmpl', DELIMITERS => [ '[=', '=]' ]);
-
 sub toCamelCase {
     my $string = $_[0];
     $string =~ s/\b([\w']+)\b/ucfirst($1)/ge;
     $string =~ s/[-,\s\'\/]//g;
     $string;
-}
-
-my $author;
-if (-e $authorFile) {
-    open (DATA, $authorFile);
-    $author = <DATA>;
-    close(DATA);
-} else {
-    $author = 'anonymous';
 }
 
 my $cardsFound = 0;
@@ -169,11 +156,6 @@ sub getRarity
 }
 
 # Generate the cards
-
-my %vars;
-$vars{'author'} = $author;
-$vars{'set'} = $knownSets{$setName};
-$vars{'expansionSetCode'} = $sets{$setName};
 
 my $landForest = 0;
 my $landMountain = 0;

--- a/Utils/gen-existing-cards-by-set.pl
+++ b/Utils/gen-existing-cards-by-set.pl
@@ -5,7 +5,6 @@
 use strict;
 
 
-my $authorFile = 'tmp/author.txt';
 my $dataFile = "mtg-cards-data.txt";
 my $setsFile = "mtg-sets-data.txt";
 

--- a/Utils/gen-list-cards-for-set.pl
+++ b/Utils/gen-list-cards-for-set.pl
@@ -52,6 +52,6 @@ foreach my $card (sort cardSort @setCards) {
     }   
     $toPrint .= "@{$card}[2]|@{$card}[0]"; 
 }
-open CARD, "> " . lc($sets{$setName}) . ".txt";
+open CARD, "> tmp/" . lc($sets{$setName}) . ".txt";
 print CARD $toPrint;
 close CARD;

--- a/Utils/gen-list-cards-for-set.pl
+++ b/Utils/gen-list-cards-for-set.pl
@@ -52,6 +52,6 @@ foreach my $card (sort cardSort @setCards) {
     }   
     $toPrint .= "@{$card}[2]|@{$card}[0]"; 
 }
-open CARD, "> tmp/" . lc($sets{$setName}) . ".txt";
+open CARD, "> data/" . lc($sets{$setName}) . ".txt";
 print CARD $toPrint;
 close CARD;

--- a/Utils/gen-list-implemented-cards-for-set.pl
+++ b/Utils/gen-list-implemented-cards-for-set.pl
@@ -72,6 +72,6 @@ foreach my $card (sort cardSort @setCards) {
 print "Number of cards found for set " . $setName . ": " . $cardsFound . "\n";
 print "Number of implemented cards:  " . $cardsImplemented . "\n";
 
-open CARD, "> " . lc($sets{$setName}) . "_implemented.txt";
+open CARD, "> tmp/" . lc($sets{$setName}) . "_implemented.txt";
 print CARD $toPrint;
 close CARD;

--- a/Utils/gen-list-implemented-cards-for-set.pl
+++ b/Utils/gen-list-implemented-cards-for-set.pl
@@ -72,6 +72,6 @@ foreach my $card (sort cardSort @setCards) {
 print "Number of cards found for set " . $setName . ": " . $cardsFound . "\n";
 print "Number of implemented cards:  " . $cardsImplemented . "\n";
 
-open CARD, "> tmp/" . lc($sets{$setName}) . "_implemented.txt";
+open CARD, "> data/" . lc($sets{$setName}) . "_implemented.txt";
 print CARD $toPrint;
 close CARD;

--- a/Utils/gen-list-unimplemented-cards-for-set.pl
+++ b/Utils/gen-list-unimplemented-cards-for-set.pl
@@ -175,7 +175,7 @@ $vars{'setName'} = $setName;
 $vars{'unimplementedUrl'} = $unimplementedUrl;
 my $result = $template->fill_in(HASH => \%vars);
 # Write the final issue tracker file
-my $outputFile = lc($sets{$setName}) . "_issue_tracker.txt";
+my $outputFile = "tmp/" . lc($sets{$setName}) . "_issue_tracker.txt";
 open(OUTPUT, "> $outputFile") || die "can't open $outputFile for writing";
 print OUTPUT $result;
 close(OUTPUT);

--- a/Utils/gen-list-unimplemented-cards-for-set.pl
+++ b/Utils/gen-list-unimplemented-cards-for-set.pl
@@ -175,7 +175,7 @@ $vars{'setName'} = $setName;
 $vars{'unimplementedUrl'} = $unimplementedUrl;
 my $result = $template->fill_in(HASH => \%vars);
 # Write the final issue tracker file
-my $outputFile = "tmp/" . lc($sets{$setName}) . "_issue_tracker.txt";
+my $outputFile = "data/" . lc($sets{$setName}) . "_issue_tracker.txt";
 open(OUTPUT, "> $outputFile") || die "can't open $outputFile for writing";
 print OUTPUT $result;
 close(OUTPUT);

--- a/Utils/gen_list_duplicate_collector_ids.pl
+++ b/Utils/gen_list_duplicate_collector_ids.pl
@@ -25,7 +25,7 @@ sub toCamelCase
 
 
 open (DATA, $dataFile) || die "can't open $dataFile";
-open (FILES_TO_CHECK, ">files_to_check.bat");
+open (FILES_TO_CHECK, ">tmp/files_to_check.bat");
 print FILES_TO_CHECK "\@echo  off\n";
 print FILES_TO_CHECK "find \"super(ownerId\" ";
 print ("Looking at data in $dataFile\n");

--- a/Utils/gen_list_duplicate_collector_ids.pl
+++ b/Utils/gen_list_duplicate_collector_ids.pl
@@ -25,7 +25,7 @@ sub toCamelCase
 
 
 open (DATA, $dataFile) || die "can't open $dataFile";
-open (FILES_TO_CHECK, ">tmp/files_to_check.bat");
+open (FILES_TO_CHECK, ">data/files_to_check.bat");
 print FILES_TO_CHECK "\@echo  off\n";
 print FILES_TO_CHECK "find \"super(ownerId\" ";
 print ("Looking at data in $dataFile\n");

--- a/Utils/mtg-cards-data-scryfall.py
+++ b/Utils/mtg-cards-data-scryfall.py
@@ -121,9 +121,10 @@ def parse_set_codes(argv):
     return set_codes
 
 # Loop through each set
+tmp_dir = os.path.join(os.path.dirname(__file__), "tmp")
 sets_data = parse_set_codes(sys.argv)
 for set_code in sets_data:
-    file_path = set_code.upper() + "-scryfall.json"
+    file_path = os.path.join(tmp_dir, set_code.upper() + "-scryfall.json")
 
     # Check if file doesn't exist or is stale (older than 24 hours)
     if is_file_stale(file_path, 24):

--- a/Utils/mtg-cards-data-scryfall.py
+++ b/Utils/mtg-cards-data-scryfall.py
@@ -121,10 +121,10 @@ def parse_set_codes(argv):
     return set_codes
 
 # Loop through each set
-tmp_dir = os.path.join(os.path.dirname(__file__), "tmp")
+data_dir = os.path.join(os.path.dirname(__file__), "data")
 sets_data = parse_set_codes(sys.argv)
 for set_code in sets_data:
-    file_path = os.path.join(tmp_dir, set_code.upper() + "-scryfall.json")
+    file_path = os.path.join(data_dir, set_code.upper() + "-scryfall.json")
 
     # Check if file doesn't exist or is stale (older than 24 hours)
     if is_file_stale(file_path, 24):

--- a/Utils/readme.txt
+++ b/Utils/readme.txt
@@ -4,14 +4,16 @@ gen-existing-cards-by-set.pl - generates the java clases for the cards from the 
 gen-simple-cards-by-set.pl - generates the java clases for the cards from the set of your choice that can be completly generated
 update-list-implemented-cards.pl
  - generates
-  - oldList.txt: list of cards implemented at the time the script is ran
-  - newList.txt: list of cards implemented since the last time the script was ran
-gen-list-cards-for-set.pl - generates the file for cards for a set
-gen-list-unimplemented-cards-for-set.pl - generates the file for unimplemented cards for a set
+  - tmp/oldList.txt: list of cards implemented at the time the script is ran
+  - tmp/newList.txt: list of cards implemented since the last time the script was ran
+gen-list-cards-for-set.pl - generates the file for cards for a set in tmp/
+gen-list-unimplemented-cards-for-set.pl - generates the file for unimplemented cards for a set in tmp/
 mtg-cards-data-scryfall.py - generates mtg-cards-data.txt based on Scryfall
 
 Files used:
- - author.txt - one line file that contains the author name you want to appear in the generated java files
  - keywords.txt - list of keywords that have an implementation and are automatically added to the card implementation
  - mtg-cards-data.txt - MTG cards data, used for card implementation trackers and generating release notes
  - mtg-sets-data.txt - list of sets in MTG, the 3 letters code, and mage class name if available
+ - tmp/author.txt - one line file that contains the author name you want to appear in the generated java files
+
+Temporary output and local configuration belong in tmp/. Its contents are ignored by Git.

--- a/Utils/readme.txt
+++ b/Utils/readme.txt
@@ -4,16 +4,18 @@ gen-existing-cards-by-set.pl - generates the java clases for the cards from the 
 gen-simple-cards-by-set.pl - generates the java clases for the cards from the set of your choice that can be completly generated
 update-list-implemented-cards.pl
  - generates
-  - tmp/oldList.txt: list of cards implemented at the time the script is ran
-  - tmp/newList.txt: list of cards implemented since the last time the script was ran
-gen-list-cards-for-set.pl - generates the file for cards for a set in tmp/
-gen-list-unimplemented-cards-for-set.pl - generates the file for unimplemented cards for a set in tmp/
+  - data/oldList.txt: list of cards implemented at the time the script is ran
+  - data/newList.txt: list of cards implemented since the last time the script was ran
+gen-list-cards-for-set.pl - generates the file for cards for a set in data/
+gen-list-unimplemented-cards-for-set.pl - generates the file for unimplemented cards for a set in data/
 mtg-cards-data-scryfall.py - generates mtg-cards-data.txt based on Scryfall
 
 Files used:
  - keywords.txt - list of keywords that have an implementation and are automatically added to the card implementation
  - mtg-cards-data.txt - MTG cards data, used for card implementation trackers and generating release notes
  - mtg-sets-data.txt - list of sets in MTG, the 3 letters code, and mage class name if available
- - tmp/author.txt - one line file that contains the author name you want to appear in the generated java files
+ - data/author.txt - one line file that contains the author name you want to appear in the generated java files
 
-Temporary output and local configuration belong in tmp/. Its contents are ignored by Git.
+Some scripts fetch or generate files needed after the script finishes. Store those files in Utils/data, which is ignored by Git.
+
+If files are only needed during a single run, keep them in memory or write them to the OS temporary directory so they are cleaned up and do not pollute the repository.

--- a/Utils/tmp/.gitignore
+++ b/Utils/tmp/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/Utils/tmp/.gitignore
+++ b/Utils/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/Utils/update-list-implemented-cards.pl
+++ b/Utils/update-list-implemented-cards.pl
@@ -6,8 +6,8 @@ use strict;
 
 my $dataFile = "mtg-cards-data.txt";
 my $setsFile = "mtg-sets-data.txt";
-my $oldListFile = "oldList.txt";
-my $newListFile = "newList.txt";
+my $oldListFile = "tmp/oldList.txt";
+my $newListFile = "tmp/newList.txt";
 
 
 my %cardsBySet;
@@ -60,7 +60,7 @@ foreach my $setName (keys %knownSets) {
 }
 
 open (OLD, "> $oldListFile");
-open (NEW, "> newList.txt");
+open (NEW, "> $newListFile");
 foreach my $cardName (sort (keys %implementedCards)) {
     print OLD $cardName . "\n";
     if (!exists $oldList{$cardName}) {

--- a/Utils/update-list-implemented-cards.pl
+++ b/Utils/update-list-implemented-cards.pl
@@ -6,8 +6,8 @@ use strict;
 
 my $dataFile = "mtg-cards-data.txt";
 my $setsFile = "mtg-sets-data.txt";
-my $oldListFile = "tmp/oldList.txt";
-my $newListFile = "tmp/newList.txt";
+my $oldListFile = "data/oldList.txt";
+my $newListFile = "data/newList.txt";
 
 
 my %cardsBySet;


### PR DESCRIPTION
Super minor but in my ongoing efforts to make that Utils folder more usable (I'm gearing up towards wanting to get rid of Perl entirely and move to modernised Python scripts wherever applicable), a convention I want to establish is that any files that we create and don't want in the git tree just go into an appropriate directory that is not tracked.

Eventually, what I'm thinking is that we can have MtgJSON/Scryfall downloads locally staged and never version control. Also, just having the scripts cleaned up make it easier to reason with what they're doing and to ascertain if they're even needed still - but that comes later.

Anyhow, rather than get too stuck in the weeds:
 * Move existing temp file usage in existing scripts to this new folder for both reads and writes
 * Clean up `Utils/gen-existing-cards-by-set.pl` because it was doing a couple of things it didn't need to
 
 This should be functionally equivalent but cleans up the top level `.gitignore` and establishes a norm that'll be easier to work with down the line. 