### PR TITLE
[codex] Add opt-in Simplified Chinese UI overlay

### DIFF
--- a/Mage.Client/src/main/java/mage/client/MageFrame.java
+++ b/Mage.Client/src/main/java/mage/client/MageFrame.java
@@ -224,6 +224,7 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
         // apply current theme
         GUISizeHelper.calculateGUISizes();
         GuiDisplayUtil.refreshThemeSettings();
+        ChineseUi.install();
 
         // workaround to stop JSplitPane from eating F6 and F8 or any other function keys
         Object value = UIManager.get("SplitPane.ancestorInputMap");
@@ -265,6 +266,7 @@ public class MageFrame extends javax.swing.JFrame implements MageClient {
         }
 
         initComponents();
+        ChineseUi.translateTree(this);
 
         // auto-update switch panels button with actual stats
         desktopPane.addContainerListener(new ContainerAdapter() {

--- a/Mage.Client/src/main/java/mage/client/table/TablesButtonColumn.java
+++ b/Mage.Client/src/main/java/mage/client/table/TablesButtonColumn.java
@@ -1,6 +1,7 @@
 package mage.client.table;
 
 import mage.client.util.GUISizeHelper;
+import mage.client.util.ChineseUi;
 
 import javax.swing.*;
 import javax.swing.table.TableCellEditor;
@@ -68,14 +69,14 @@ public class TablesButtonColumn extends AbstractCellEditor implements TableCellR
             renderButton.setBackground(UIManager.getColor("Button.background"));
         }
 
-        renderButton.setText((value == null) ? "" : value.toString());
+        renderButton.setText(ChineseUi.tr((value == null) ? "" : value.toString()));
         return renderButton;
     }
 
     @Override
     public Component getTableCellEditorComponent(JTable table, Object value, boolean isSelected, int row, int column) {
         text = (value == null) ? "" : value.toString();
-        editButton.setText(text);
+        editButton.setText(ChineseUi.tr(text));
         return editButton;
     }
 

--- a/Mage.Client/src/main/java/mage/client/util/ChineseUi.java
+++ b/Mage.Client/src/main/java/mage/client/util/ChineseUi.java
@@ -1,0 +1,674 @@
+package mage.client.util;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.table.TableColumn;
+import java.awt.*;
+import java.awt.event.AWTEventListener;
+import java.awt.event.ContainerEvent;
+import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Optional Simplified Chinese display layer for XMage's Swing user interface.
+ *
+ * It deliberately translates only known UI labels. Card names, rules text,
+ * game logs and values received from the server are left untouched.
+ * Enable with: -Dxmage.ui.lang=zh_CN
+ */
+public final class ChineseUi {
+
+    private static final String LANGUAGE_PROPERTY = "xmage.ui.lang";
+    private static final String FONT_SAMPLE = "汉化设置下载套牌编辑器连接服务器反馈关于";
+    private static final String CHINESE_FONT_FAMILY = findChineseFontFamily();
+    private static final Map<String, String> TEXT = new LinkedHashMap<>();
+    private static final Set<Component> LISTENING = Collections.newSetFromMap(new WeakHashMap<Component, Boolean>());
+    private static final Pattern PLAYER_YOU = Pattern.compile("Player (\\d+) \\(You\\)");
+    private static final Pattern PLAYER_NUMBER = Pattern.compile("Player (\\d+)");
+    private static final Pattern PACK_NUMBER = Pattern.compile("Pack (\\d+):");
+    private static final Pattern STEP_NUMBER = Pattern.compile("Step (\\d+):");
+    private static boolean installed;
+
+    static {
+        // Main window
+        put("Switch panels", "切换面板");
+        put("Preferences", "设置");
+        put("CONNECT TO SERVER", "连接服务器");
+        put("Deck Editor", "套牌编辑器");
+        put("Card Viewer", "卡牌查看器");
+        put("Feedback", "反馈");
+        put("Download", "下载");
+        put("About", "关于");
+        put("Debug", "调试");
+        put("Download card images", "下载卡牌图片");
+        put("Download mana symbols", "下载法术力符号");
+        put("Run custom code", "运行自定义代码");
+        put("Test Card Render Modes", "测试卡牌渲染模式");
+        put("Test Modal Dialogs", "测试模态窗口");
+        put("100% Free mem", "内存完全空闲");
+
+        // Generic buttons and dialogs
+        put("OK", "确定");
+        put("Cancel", "取消");
+        put("Apply", "应用");
+        put("Close", "关闭");
+        put("Close Window", "关闭窗口");
+        put("Create", "创建");
+        put("Start", "开始");
+        put("Stop", "停止");
+        put("Done", "完成");
+        put("Done (enough)", "完成（足够）");
+        put("Choose", "选择");
+        put("Browse...", "浏览…");
+        put("Load...", "加载…");
+        put("Save...", "保存…");
+        put("Search", "搜索");
+        put("Search:", "搜索：");
+        put("Clear", "清除");
+        put("Refresh", "刷新");
+        put("Copy", "复制");
+        put("Send", "发送");
+        put("Reset to default", "恢复默认");
+        put("set to default", "设为默认");
+        put("Select all", "全选");
+        put("Select none", "全不选");
+        put("Move Up", "上移");
+        put("Move Down", "下移");
+        put("Yes", "是");
+        put("No", "否");
+        put("None", "无");
+        put("Other...", "其他…");
+        put("Other", "其他");
+        put("Settings", "设置");
+        put("General Options", "常规选项");
+        put("Custom Options...", "自定义选项…");
+        put("Load settings", "加载设置");
+        put("Save settings", "保存设置");
+        put("Load default settings", "加载默认设置");
+        put("Load from last time", "加载上次设置");
+        put("Load from config 1", "加载配置 1");
+        put("Load from config 2", "加载配置 2");
+        put("Save to config 1", "保存到配置 1");
+        put("Save to config 2", "保存到配置 2");
+
+        // Server connection
+        put("Connect to server", "连接服务器");
+        put("Connect to:", "连接到：");
+        put("Server name:", "服务器地址：");
+        put("Server:", "服务器：");
+        put("Port:", "端口：");
+        put("Username:", "用户名：");
+        put("Password:", "密码：");
+        put("User's flag:", "用户旗帜：");
+        put("Check online status", "检查在线状态");
+        put("Automatically connect to this server next time", "下次自动连接此服务器");
+        put("Proxy Settings...", "代理设置…");
+        put("Show what's new", "查看更新内容");
+        put("Register new user...", "注册新用户…");
+        put("Forgot password...", "忘记密码…");
+        put("Register", "注册");
+        put("Connecting...", "正在连接…");
+        put("Connected", "已连接");
+        put("Connect was canceled", "连接已取消");
+        put("LOCAL, AI", "本地 / AI");
+        put("BETA", "测试服");
+        put("EU", "欧洲服");
+        put("US", "美国服");
+        put("(use empty password for servers without registration)", "（无需注册的服务器请将密码留空）");
+
+        // Lobby and filters
+        put("New Match", "新建比赛");
+        put("New Tourney", "新建赛事");
+        put("Matches", "比赛");
+        put("Constructed tourney", "构筑赛事");
+        put("Limited tourney", "限制赛事");
+        put("Beginner", "新手");
+        put("Casual", "休闲");
+        put("Serious", "竞技");
+        put("Rated", "计分");
+        put("Unrated", "不计分");
+        put("Block", "环境构筑");
+        put("Standard", "标准");
+        put("Modern", "现代");
+        put("Pioneer", "先驱");
+        put("Legacy", "薪传");
+        put("Vintage", "特选");
+        put("Premodern", "前现代");
+        put("Commander", "指挥官");
+        put("Oathbreaker", "破誓者");
+        put("Tiny Leader", "小小领袖");
+        put("Limited", "限制赛");
+        put("Open", "公开");
+        put("PW", "有密码");
+        put("Quick 2 player", "快速双人");
+        put("Quick 4 player", "快速四人");
+        put("Show open games", "显示公开游戏");
+        put("Show passworded games", "显示有密码的游戏");
+        put("Message of the Day:", "每日消息：");
+        put("Next message", "下一条消息");
+        put("Server's lobby", "服务器大厅");
+        put("Connected players", "在线玩家");
+        put("Talk", "聊天");
+        put("System", "系统");
+
+        // Table headers and actions (display only)
+        put("Deck Type", "套牌类型");
+        put("Name", "名称");
+        put("Name:", "名称：");
+        put("Seats", "席位");
+        put("Owner / Players", "房主 / 玩家");
+        put("Players", "玩家");
+        put("Players:", "玩家：");
+        put("Game Type", "游戏类型");
+        put("Game Type:", "游戏类型：");
+        put("Info", "信息");
+        put("Status", "状态");
+        put("Password", "密码");
+        put("Created / Started", "创建 / 开始");
+        put("Skill Level", "水平");
+        put("Skill Level:", "水平：");
+        put("Rating", "积分");
+        put("Result", "结果");
+        put("Duration", "时长");
+        put("Start Time", "开始时间");
+        put("End Time", "结束时间");
+        put("Action", "操作");
+        put("Quit %", "退出率");
+        put("Min Rating", "最低积分");
+        put("Minimum rating:", "最低积分：");
+        put("Join", "加入");
+        put("Show", "查看");
+        put("Watch", "观战");
+        put("Replay", "回放");
+        put("Round Number", "轮次");
+        put("State", "状态");
+        put("State:", "状态：");
+
+        // Create match / tournament
+        put("New Tournament", "新建赛事");
+        put("Tournament", "赛事");
+        put("Tournament Type:", "赛事类型：");
+        put("Deck Type:", "套牌类型：");
+        put("Time Limit:", "时间限制：");
+        put("Buffer Time:", "缓冲时间：");
+        put("Rollbacks", "允许回滚");
+        put("Spectators allowed", "允许观战");
+        put("Allow spectators", "允许观战");
+        put("Rated game", "计分比赛");
+        put("Wins:", "获胜局数：");
+        put("Other Players", "其他玩家");
+        put("Allowed quit %", "允许退出率：");
+        put("EDH power level:", "EDH 强度等级：");
+        put("Range of Influence:", "影响范围：");
+        put("Attack Option:", "攻击选项：");
+        put("Player 1 (You)", "玩家 1（你）");
+        put("Player", "玩家");
+        put("Player #", "玩家编号");
+        put("Player Num:", "玩家编号：");
+        put("Computer", "电脑 AI");
+        put("Human", "真人玩家");
+        put("Draft Cube:", "轮抽方块：");
+        put("Packs", "卡包");
+        put("Number of Swiss Rounds:", "瑞士轮轮数：");
+        put("Construction Time (Minutes):", "构筑时间（分钟）：");
+        put("play as single game", "作为单局游戏进行");
+
+        // Deck editor
+        put("Deck Name:", "套牌名称：");
+        put("NEW", "新建");
+        put("Generate", "生成");
+        put("LOAD", "加载");
+        put("Import", "导入");
+        put("SAVE", "保存");
+        put("Export", "导出");
+        put("SUBMIT", "提交");
+        put("Lands", "地牌");
+        put("Validate", "检查合法性");
+        put("Exit", "退出");
+        put("Suggest lands", "推荐地牌");
+        put("Add lands", "添加地牌");
+        put("Open Booster", "打开补充包");
+        put("Sort", "排序");
+        put("Piles", "分堆");
+        put("Legal", "合法");
+        put("Not Legal", "不合法");
+        put("Library", "牌库");
+        put("Hand", "手牌");
+        put("Graveyard", "坟墓场");
+        put("Exile", "放逐区");
+        put("Command zone", "指挥区");
+        put("Deck:", "套牌：");
+        put("Card count:", "卡牌数量：");
+        put("Deck size:", "套牌数量：");
+        put("Choose deck format:", "选择套牌格式：");
+
+        // Game controls and zones
+        put("Turn", "回合");
+        put("Turn:", "回合：");
+        put("Phase", "阶段");
+        put("Phase:", "阶段：");
+        put("Step", "步骤");
+        put("Step:", "步骤：");
+        put("Active Player", "当前回合玩家");
+        put("Active Player:", "当前回合玩家：");
+        put("Priority Player", "优先权玩家");
+        put("Priority Player:", "优先权玩家：");
+        put("Hold", "保留优先权");
+        put("CANCEL all skips", "取消所有跳过");
+        put("CONCEDE current game", "认输本局");
+        put("Undo", "撤销");
+        put("Special", "特殊操作");
+        put("Main 1:", "第一主阶段：");
+        put("Main 2:", "第二主阶段：");
+        put("Before combat:", "战斗前：");
+        put("End of combat:", "战斗结束：");
+        put("End of turn:", "回合结束：");
+        put("End Step:", "结束步骤：");
+        put("Opponent(s) turn", "对手回合");
+        put("Other Players", "其他玩家");
+        put("Life", "生命");
+        put("Energy", "能量");
+        put("Command Zone (Commanders, Emblems, and Planes)", "指挥区（指挥官、徽记与时空）");
+
+        // Download window
+        put("Download card images", "下载卡牌图片");
+        put("Images source to download:", "图片来源：");
+        put("Language:", "语言：");
+        put("Download threads:", "下载线程数：");
+        put("Sets to download:", "要下载的系列：");
+        put("Start download", "开始下载");
+        put("Initializing image download...", "正在初始化图片下载…");
+        put("Store images in zip files", "将图片保存在 ZIP 文件中");
+        put("Default images language:", "默认图片语言：");
+
+        // Preferences
+        put("Theme:", "主题：");
+        put("GUI color style:", "界面配色：");
+        put("Render mode:", "渲染模式：");
+        put("Card size:", "卡牌大小：");
+        put("App's elements:", "应用界面元素：");
+        put("Game's elements:", "游戏界面元素：");
+        put("Enable game sounds", "启用游戏音效");
+        put("Enable draft sounds", "启用轮抽音效");
+        put("Enable other sounds", "启用其他音效");
+        put("Play music during match", "比赛中播放音乐");
+        put("Show card name on card panel", "在卡牌面板上显示卡名");
+        put("Show player names on avatar permanently", "始终在头像上显示玩家名称");
+        put("Display life on avatar image", "在头像上显示生命值");
+        put("Small mode", "紧凑模式");
+        put("Reset all defined automatic answers for Yes/No usage requests (with two buttons).", "清除所有已保存的是/否自动回答。");
+
+        // Miscellaneous windows
+        put("About app", "关于程序");
+        put("ERROR", "错误");
+        put("Error", "错误");
+        put("Hints", "提示");
+        put("Rules", "规则");
+        put("Category", "类别");
+        put("Type:", "类型：");
+        put("Types", "类型");
+        put("Order:", "顺序：");
+        put("Confirm:", "确认：");
+        put("Remember choose", "记住选择");
+        put("Remember Password", "记住密码");
+        put("Email:", "邮箱：");
+        put("New password:", "新密码：");
+        put("Submit a new password", "提交新密码");
+        put("Register", "注册");
+        put("Open github and create bug report", "打开 GitHub 创建错误报告");
+        put("Copy error to clipboard", "复制错误到剪贴板");
+    }
+
+    private ChineseUi() {
+    }
+
+    private static void put(String english, String chinese) {
+        TEXT.put(english, chinese);
+    }
+
+    public static boolean isEnabled() {
+        String language = System.getProperty(LANGUAGE_PROPERTY, "");
+        return "zh_CN".equalsIgnoreCase(language) || "zh-CN".equalsIgnoreCase(language) || "zh".equalsIgnoreCase(language);
+    }
+
+    public static synchronized void install() {
+        if (installed || !isEnabled()) {
+            return;
+        }
+        installed = true;
+        installChineseFonts();
+        installStandardDialogText();
+
+        AWTEventListener listener = event -> {
+            if (event instanceof ContainerEvent && event.getID() == ContainerEvent.COMPONENT_ADDED) {
+                Component child = ((ContainerEvent) event).getChild();
+                SwingUtilities.invokeLater(() -> translateTree(child));
+            } else if (event instanceof WindowEvent
+                    && (event.getID() == WindowEvent.WINDOW_OPENED || event.getID() == WindowEvent.WINDOW_ACTIVATED)) {
+                SwingUtilities.invokeLater(() -> translateTree(((WindowEvent) event).getWindow()));
+            }
+        };
+        Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.CONTAINER_EVENT_MASK | AWTEvent.WINDOW_EVENT_MASK);
+    }
+
+    private static void installStandardDialogText() {
+        UIManager.put("OptionPane.okButtonText", "确定");
+        UIManager.put("OptionPane.cancelButtonText", "取消");
+        UIManager.put("OptionPane.yesButtonText", "是");
+        UIManager.put("OptionPane.noButtonText", "否");
+        UIManager.put("FileChooser.openButtonText", "打开");
+        UIManager.put("FileChooser.saveButtonText", "保存");
+        UIManager.put("FileChooser.cancelButtonText", "取消");
+        UIManager.put("FileChooser.lookInLabelText", "查找位置：");
+        UIManager.put("FileChooser.fileNameLabelText", "文件名：");
+        UIManager.put("FileChooser.filesOfTypeLabelText", "文件类型：");
+        UIManager.put("FileChooser.openDialogTitleText", "打开");
+        UIManager.put("FileChooser.saveDialogTitleText", "保存");
+        UIManager.put("ColorChooser.okText", "确定");
+        UIManager.put("ColorChooser.cancelText", "取消");
+        UIManager.put("ColorChooser.resetText", "重置");
+    }
+
+    private static String findChineseFontFamily() {
+        String[] preferred = new String[]{"Microsoft YaHei UI", "Microsoft YaHei", "SimHei", "SimSun", Font.DIALOG};
+        String[] available = GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames();
+        for (String candidate : preferred) {
+            for (String fontName : available) {
+                if (candidate.equalsIgnoreCase(fontName)) {
+                    Font font = new Font(fontName, Font.PLAIN, 12);
+                    if (font.canDisplayUpTo(FONT_SAMPLE) == -1) {
+                        return fontName;
+                    }
+                }
+            }
+        }
+        return Font.DIALOG;
+    }
+
+    private static void installChineseFonts() {
+        UIDefaults defaults = UIManager.getDefaults();
+        java.util.List<Object> fontKeys = new java.util.ArrayList<>();
+        Enumeration<Object> keys = defaults.keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            Object value = defaults.get(key);
+            if (value instanceof Font) {
+                fontKeys.add(key);
+            }
+        }
+        for (Object key : fontKeys) {
+            Font current = defaults.getFont(key);
+            if (current != null) {
+                defaults.put(key, new FontUIResource(CHINESE_FONT_FAMILY, current.getStyle(), current.getSize()));
+            }
+        }
+    }
+
+    public static void translateTree(Component root) {
+        if (!isEnabled() || root == null) {
+            return;
+        }
+        translateComponent(root);
+        if (root instanceof JMenu) {
+            for (Component child : ((JMenu) root).getMenuComponents()) {
+                translateTree(child);
+            }
+        }
+        if (root instanceof Container) {
+            for (Component child : ((Container) root).getComponents()) {
+                translateTree(child);
+            }
+        }
+    }
+
+    private static void translateComponent(Component component) {
+        installPropertyListener(component);
+
+        if (component instanceof AbstractButton) {
+            AbstractButton button = (AbstractButton) component;
+            String original = button.getText();
+            String translated = tr(original);
+            if (!same(original, translated)) {
+                String actionCommand = button.getActionCommand();
+                if (actionCommand == null || actionCommand.equals(original)) {
+                    button.setActionCommand(original);
+                }
+                button.setText(translated);
+            }
+            if (containsChinese(button.getText())) {
+                ensureChineseFont(button);
+            }
+        } else if (component instanceof JLabel) {
+            JLabel label = (JLabel) component;
+            String original = label.getText();
+            String translated = tr(original);
+            if (!same(original, translated)) {
+                label.setText(translated);
+            }
+            if (containsChinese(label.getText())) {
+                ensureChineseFont(label);
+            }
+        }
+
+        if (component instanceof JComponent) {
+            JComponent swingComponent = (JComponent) component;
+            String tooltip = swingComponent.getToolTipText();
+            String translatedTooltip = tr(tooltip);
+            if (!same(tooltip, translatedTooltip)) {
+                swingComponent.setToolTipText(translatedTooltip);
+            }
+            Border border = swingComponent.getBorder();
+            if (border instanceof TitledBorder) {
+                TitledBorder titledBorder = (TitledBorder) border;
+                String title = titledBorder.getTitle();
+                String translatedTitle = tr(title);
+                if (!same(title, translatedTitle)) {
+                    titledBorder.setTitle(translatedTitle);
+                }
+                if (containsChinese(titledBorder.getTitle())) {
+                    Font titleFont = titledBorder.getTitleFont();
+                    if (titleFont == null) {
+                        titleFont = swingComponent.getFont();
+                    }
+                    if (titleFont != null) {
+                        titledBorder.setTitleFont(toChineseFont(titleFont));
+                    }
+                }
+            }
+        }
+
+        if (component instanceof JFrame) {
+            JFrame frame = (JFrame) component;
+            frame.setTitle(tr(frame.getTitle()));
+        } else if (component instanceof JDialog) {
+            JDialog dialog = (JDialog) component;
+            dialog.setTitle(tr(dialog.getTitle()));
+        } else if (component instanceof JInternalFrame) {
+            JInternalFrame frame = (JInternalFrame) component;
+            frame.setTitle(tr(frame.getTitle()));
+        } else if (component instanceof JTabbedPane) {
+            JTabbedPane tabs = (JTabbedPane) component;
+            for (int i = 0; i < tabs.getTabCount(); i++) {
+                tabs.setTitleAt(i, tr(tabs.getTitleAt(i)));
+            }
+            ensureChineseFont(tabs);
+        } else if (component instanceof JTable) {
+            JTable table = (JTable) component;
+            for (int i = 0; i < table.getColumnModel().getColumnCount(); i++) {
+                TableColumn column = table.getColumnModel().getColumn(i);
+                Object header = column.getHeaderValue();
+                if (header instanceof String) {
+                    column.setHeaderValue(tr((String) header));
+                }
+            }
+            if (table.getTableHeader() != null) {
+                ensureChineseFont(table.getTableHeader());
+                table.getTableHeader().repaint();
+            }
+        } else if (component instanceof JComboBox) {
+            installComboRenderer((JComboBox) component);
+        } else if (component instanceof JList) {
+            installListRenderer((JList) component);
+        }
+    }
+
+    private static void installPropertyListener(Component component) {
+        synchronized (LISTENING) {
+            if (LISTENING.contains(component)) {
+                return;
+            }
+            LISTENING.add(component);
+        }
+        PropertyChangeListener listener = (PropertyChangeEvent event) -> {
+            String property = event.getPropertyName();
+            if ("text".equals(property) || "title".equals(property) || "toolTipText".equals(property)
+                    || "model".equals(property) || "columnModel".equals(property) || "font".equals(property)) {
+                SwingUtilities.invokeLater(() -> translateComponent(component));
+            }
+        };
+        component.addPropertyChangeListener(listener);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void installComboRenderer(JComboBox comboBox) {
+        if (Boolean.TRUE.equals(comboBox.getClientProperty("xmage.zh.renderer"))) {
+            return;
+        }
+        comboBox.putClientProperty("xmage.zh.renderer", Boolean.TRUE);
+        ListCellRenderer delegate = comboBox.getRenderer();
+        if (delegate == null) {
+            delegate = new DefaultListCellRenderer();
+        }
+        final ListCellRenderer original = delegate;
+        comboBox.setRenderer((list, value, index, isSelected, cellHasFocus) -> {
+            Component rendered = original.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            translateRendererText(rendered, value);
+            return rendered;
+        });
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void installListRenderer(JList list) {
+        if (Boolean.TRUE.equals(list.getClientProperty("xmage.zh.renderer"))) {
+            return;
+        }
+        list.putClientProperty("xmage.zh.renderer", Boolean.TRUE);
+        ListCellRenderer delegate = list.getCellRenderer();
+        if (delegate == null) {
+            delegate = new DefaultListCellRenderer();
+        }
+        final ListCellRenderer original = delegate;
+        list.setCellRenderer((renderList, value, index, isSelected, cellHasFocus) -> {
+            Component rendered = original.getListCellRendererComponent(renderList, value, index, isSelected, cellHasFocus);
+            translateRendererText(rendered, value);
+            return rendered;
+        });
+    }
+
+    private static void translateRendererText(Component rendered, Object value) {
+        if (rendered instanceof JLabel && value instanceof String) {
+            JLabel label = (JLabel) rendered;
+            String translated = tr((String) value);
+            label.setText(translated);
+            ensureChineseFont(label);
+        }
+    }
+
+    private static boolean same(String first, String second) {
+        return first == null ? second == null : first.equals(second);
+    }
+
+    private static boolean containsChinese(String text) {
+        if (text == null) {
+            return false;
+        }
+        for (int i = 0; i < text.length(); i++) {
+            Character.UnicodeBlock block = Character.UnicodeBlock.of(text.charAt(i));
+            if (block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS
+                    || block == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS
+                    || block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String tr(String text) {
+        if (!isEnabled() || text == null || text.isEmpty()) {
+            return text;
+        }
+        String translated = TEXT.get(text);
+        if (translated != null) {
+            return translated;
+        }
+
+        Matcher matcher = PLAYER_YOU.matcher(text);
+        if (matcher.matches()) {
+            return "玩家 " + matcher.group(1) + "（你）";
+        }
+        matcher = PLAYER_NUMBER.matcher(text);
+        if (matcher.matches()) {
+            return "玩家 " + matcher.group(1);
+        }
+        matcher = PACK_NUMBER.matcher(text);
+        if (matcher.matches()) {
+            return "卡包 " + matcher.group(1) + "：";
+        }
+        matcher = STEP_NUMBER.matcher(text);
+        if (matcher.matches()) {
+            return "步骤 " + matcher.group(1) + "：";
+        }
+
+        if (text.startsWith("Switch panels (")) {
+            return text.replaceFirst("Switch panels", "切换面板");
+        }
+        if (text.startsWith("Memory used:")) {
+            return text.replaceFirst("Memory used:", "内存使用：");
+        }
+        if (text.startsWith("Message of the Day:")) {
+            return text.replaceFirst("Message of the Day:", "每日消息：");
+        }
+        if (text.startsWith("XMage Client:")) {
+            text = text.replaceFirst("XMage Client:", "XMage 客户端：");
+        }
+        if (text.contains("Server: <not connected>")) {
+            text = text.replace("Server: <not connected>", "服务器：<未连接>");
+        } else if (text.contains("Server:")) {
+            text = text.replace("Server:", "服务器：");
+        }
+        return text;
+    }
+
+    private static void ensureChineseFont(Component component) {
+        Font current = component.getFont();
+        if (current == null) {
+            return;
+        }
+        Font chineseFont = toChineseFont(current);
+        if (current.getFamily().equalsIgnoreCase(chineseFont.getFamily())
+                && current.getStyle() == chineseFont.getStyle()
+                && current.getSize() == chineseFont.getSize()) {
+            return;
+        }
+        component.setFont(chineseFont);
+    }
+
+    private static Font toChineseFont(Font current) {
+        Font chineseFont = new Font(CHINESE_FONT_FAMILY, current.getStyle(), current.getSize());
+        if (chineseFont.canDisplayUpTo(FONT_SAMPLE) != -1) {
+            chineseFont = new Font(Font.DIALOG, current.getStyle(), current.getSize());
+        }
+        return chineseFont;
+    }
+}

--- a/Mage.Client/src/test/java/mage/client/util/ChineseUiTest.java
+++ b/Mage.Client/src/test/java/mage/client/util/ChineseUiTest.java
@@ -1,0 +1,67 @@
+package mage.client.util;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ChineseUiTest {
+
+    private static final String LANGUAGE_PROPERTY = "xmage.ui.lang";
+
+    private String originalLanguage;
+
+    @Before
+    public void rememberLanguage() {
+        originalLanguage = System.getProperty(LANGUAGE_PROPERTY);
+    }
+
+    @After
+    public void restoreLanguage() {
+        if (originalLanguage == null) {
+            System.clearProperty(LANGUAGE_PROPERTY);
+        } else {
+            System.setProperty(LANGUAGE_PROPERTY, originalLanguage);
+        }
+    }
+
+    @Test
+    public void keepsEnglishUiUnchangedByDefault() {
+        System.clearProperty(LANGUAGE_PROPERTY);
+
+        assertFalse(ChineseUi.isEnabled());
+        assertEquals("Deck Editor", ChineseUi.tr("Deck Editor"));
+    }
+
+    @Test
+    public void recognizesSupportedChineseLanguageCodes() {
+        System.setProperty(LANGUAGE_PROPERTY, "zh_CN");
+        assertTrue(ChineseUi.isEnabled());
+
+        System.setProperty(LANGUAGE_PROPERTY, "zh-CN");
+        assertTrue(ChineseUi.isEnabled());
+
+        System.setProperty(LANGUAGE_PROPERTY, "zh");
+        assertTrue(ChineseUi.isEnabled());
+    }
+
+    @Test
+    public void translatesKnownAndDynamicUiText() {
+        System.setProperty(LANGUAGE_PROPERTY, "zh_CN");
+
+        assertEquals("套牌编辑器", ChineseUi.tr("Deck Editor"));
+        assertEquals("玩家 2（你）", ChineseUi.tr("Player 2 (You)"));
+        assertEquals("内存使用： 42%", ChineseUi.tr("Memory used: 42%"));
+    }
+
+    @Test
+    public void doesNotTranslateCardNamesOrUnknownServerText() {
+        System.setProperty(LANGUAGE_PROPERTY, "zh_CN");
+
+        assertEquals("Lightning Bolt", ChineseUi.tr("Lightning Bolt"));
+        assertEquals("Doctor Doom, Unrivaled", ChineseUi.tr("Doctor Doom, Unrivaled"));
+    }
+}


### PR DESCRIPTION
## What changed

- Add an opt-in Simplified Chinese display layer for known Swing UI labels, buttons, dialog titles, tooltips, table headers, and list/combo renderers.
- Preserve original action commands and untranslated values so server data and control flow remain unchanged.
- Leave card names, rules text, game logs, and unknown server-provided strings in their original language.
- Select an installed CJK-capable font at runtime, with logical-font fallback, instead of requiring a Windows-only font.
- Translate dynamically created table action buttons and newly added Swing components.

Enable the overlay with:

```text
-Dxmage.ui.lang=zh_CN
```

English remains the default and follows the existing code path when the property is absent.

## Why this approach

XMage's Swing forms were designed around one language. The earlier i18n experiment in #6323 required changes across many generated `.form` and `.java` files. This draft explores a smaller runtime overlay instead: two integration points plus one self-contained translation class, without modifying NetBeans-generated forms.

This is intentionally a draft to ask whether maintainers consider this architecture acceptable before expanding translation coverage or adding a preferences selector.

## Scope and limitations

- Initial Simplified Chinese UI coverage only; it is not a complete generic i18n framework yet.
- Language selection currently requires a JVM property and application restart.
- Card content is deliberately outside the scope.
- The runtime overlay translates only exact known UI strings and a few bounded dynamic patterns.

## Validation

```text
mvn -pl Mage.Client -am -Dtest=ChineseUiTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 4 tests passed; reactor build succeeded on the current `master` branch.

The tests verify that English stays unchanged by default, supported Chinese language codes enable the overlay, dynamic UI text is translated, and card names remain untouched.
