### PR TITLE
fix(rooms): cast half enters unlocked, card art, no duplicate triggers

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/images/ImageCache.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/images/ImageCache.java
@@ -94,6 +94,21 @@ public final class ImageCache {
             } else {
                 // CARD
                 path = CardImageUtils.buildImagePathToCardOrToken(info);
+                // Some image sources (pre-built packs, Scryfall) include the collector
+                // ID in the filename even when usesVariousArt is false. Try without it
+                // first, then with collector ID as fallback.
+                TFile cardFile = getTFile(path);
+                if ((cardFile == null || !cardFile.exists())
+                        && !usesVariousArt
+                        && !collectorId.isEmpty()
+                        && !"0".equals(collectorId)) {
+                    CardDownloadData altInfo = new CardDownloadData(name, setCode, collectorId, true, imageNumber);
+                    String altPath = CardImageUtils.buildImagePathToCardOrToken(altInfo);
+                    TFile altFile = getTFile(altPath);
+                    if (altFile != null && altFile.exists()) {
+                        path = altPath;
+                    }
+                }
             }
 
             TFile file = getTFile(path);

--- a/Mage.Common/src/main/java/mage/view/CardView.java
+++ b/Mage.Common/src/main/java/mage/view/CardView.java
@@ -464,6 +464,17 @@ public class CardView extends SimpleCardView {
                 fullCardName = card.getName();
                 this.manaCostLeftStr = card.getManaCostSymbols();
                 this.manaCostRightStr = new ArrayList<>();
+
+                // Room cards on battlefield: permanent's name is modified
+                // to show only unlocked halves, but card image and display
+                // name must use the full split card name.
+                Card mainCard = sourceCard.getMainCard();
+                if (mainCard instanceof SplitCard) {
+                    fullCardName = mainCard.getName();
+                    if (this.imageFileName.isEmpty()) {
+                        this.imageFileName = fullCardName;
+                    }
+                }
             }
 
             this.name = card.getName();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/cost/splitcards/RoomCardTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/cost/splitcards/RoomCardTest.java
@@ -1075,4 +1075,44 @@ public class RoomCardTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, sakashimaTheImpostor, 0);
         assertGraveyardCount(playerA, sakashimaTheImpostor, 1);
     }
+
+    /**
+     * Verify that room half triggered abilities are not duplicated in the
+     * triggers map by dormant init-time registrations.  Before the fix in
+     * {@code RoomCardHalfImpl.getInitAbilities()}, each triggered ability
+     * appeared twice — once keyed to the half card (from
+     * {@code GameState.addCard}) and once keyed to the permanent (from
+     * {@code addRoomCharacteristics}).  The half-card entries are dormant
+     * but pollute the map.
+     */
+    @Test
+    public void testNoDuplicateTriggerRegistrations() {
+        skipInitShuffling();
+        addCard(Zone.HAND, playerA, bottomlessPoolLockerRoom);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 5);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, bottomlessPool);
+        addTarget(playerA, TestPlayer.TARGET_SKIP);
+
+        runCode("verify no duplicate triggers", 1, PhaseStep.PRECOMBAT_MAIN, playerA, (info, player, game) -> {
+            // After the room enters and the left door unlocks, check that
+            // the right (locked) half's triggered ability is registered at
+            // most once in the triggers map.  Pre-fix, each half ability got
+            // two entries — one init-time (keyed to the half card) and one
+            // runtime (keyed to the permanent).  Post-fix, getInitAbilities()
+            // returns empty so only the runtime entry exists.
+            String rightHalfRule = "Whenever one or more creatures you control"
+                    + " deal combat damage to a player, draw a card.";
+            long count = game.getState().getTriggers().values().stream()
+                    .filter(t -> rightHalfRule.equals(t.getRule()))
+                    .count();
+
+            assertEquals(0, count,
+                    "Right-half trigger must have no dormant registrations"
+                            + " (init-time duplicates from getInitAbilities())");
+        });
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+    }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/RoomCharacteristicsEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RoomCharacteristicsEffect.java
@@ -201,10 +201,11 @@ public class RoomCharacteristicsEffect extends ContinuousEffectImpl {
             }
         }
         // restore removed abilities
-        // copies need abilities to be added back to game state for triggers
         SplitCard roomCard = (SplitCard) findRoomCard(permanent);
         UUID sourceId = permanent.isCopy() ? permanent.getId() : null;
-        Game gameParam = permanent.isCopy() ? game : null;
+        Game gameParam = game;
+        // Remove stale triggers from locked-half cleanup to prevent duplicates
+        game.getState().getTriggers().removeAbilitiesOfSource(permanent.getId());
         if (permanent.isLeftDoorUnlocked()) {
             for (Ability ability : roomCard.getLeftHalfCard().getAbilities()) {
                 permanent.addAbility(ability, sourceId, gameParam, true);

--- a/Mage/src/main/java/mage/cards/RoomCard.java
+++ b/Mage/src/main/java/mage/cards/RoomCard.java
@@ -78,13 +78,13 @@ public abstract class RoomCard extends SplitCard {
 
     public static void addRoomCharacteristics(Permanent permanent, RoomCard roomCard, Game game) {
         // 709.5.
-        // Some split cards are permanent cards with a single shared type line. A shared type line 
-        // on such an object represents two static abilities that function on the battlefield. These 
-        // are “As long as this permanent doesn’t have the ‘left half unlocked’ designation, it 
-        // doesn’t have the name, mana cost, or rules text of this object’s left half” and “As long 
-        // as this permanent doesn’t have the ‘right half unlocked’ designation, it doesn’t have the 
-        // name, mana cost, or rules text of this object’s right half.” These abilities, as well as 
-        // which half of that permanent a characteristic is in, are part of that object’s copiable 
+        // Some split cards are permanent cards with a single shared type line. A shared type line
+        // on such an object represents two static abilities that function on the battlefield. These
+        // are "As long as this permanent doesn't have the 'left half unlocked' designation, it
+        // doesn't have the name, mana cost, or rules text of this object's left half" and "As long
+        // as this permanent doesn't have the 'right half unlocked' designation, it doesn't have the
+        // name, mana cost, or rules text of this object's right half." These abilities, as well as
+        // which half of that permanent a characteristic is in, are part of that object's copiable
         // values.
 
         // add all rooms data, real rule apply by RoomCharacteristicsEffect
@@ -92,6 +92,9 @@ public abstract class RoomCard extends SplitCard {
 
         permanent.setName(roomCard.getName());
         permanent.setManaCost(roomCard.getManaCost());
+
+        // Clear stale triggers before re-adding (prevents duplicates on reset cycles)
+        game.getState().getTriggers().removeAbilitiesOfSource(permanent.getId());
 
         Abilities<Ability> leftAbilities = roomCard.getLeftHalfCard().getAbilities();
         for (Ability ability : leftAbilities) {

--- a/Mage/src/main/java/mage/cards/RoomCard.java
+++ b/Mage/src/main/java/mage/cards/RoomCard.java
@@ -146,8 +146,7 @@ class RoomEnterUnlockEffect extends OneShotEffect {
         // TODO: possible buggy with AI -- find spell mode by spell ability and do not store it in card's data due game states isolation?!
         SpellAbilityType lastCastHalf = roomCardBlueprint.getLastCastHalf();
         if (lastCastHalf == SpellAbilityType.SPLIT_LEFT || lastCastHalf == SpellAbilityType.SPLIT_RIGHT) {
-            roomCardBlueprint.setLastCastHalf(null);
-            return permanent.unlockDoor(game, source, lastCastHalf == SpellAbilityType.SPLIT_LEFT);
+            permanent.unlockDoor(game, source, lastCastHalf == SpellAbilityType.SPLIT_LEFT);
         }
 
         return true;

--- a/Mage/src/main/java/mage/cards/RoomCard.java
+++ b/Mage/src/main/java/mage/cards/RoomCard.java
@@ -143,9 +143,17 @@ class RoomEnterUnlockEffect extends OneShotEffect {
             return true;
         }
 
-        // TODO: possible buggy with AI -- find spell mode by spell ability and do not store it in card's data due game states isolation?!
+        // Find which half was cast from the shared blueprint. After reading,
+        // we MUST clear it: the blueprint is a server-singleton and stale
+        // lastCastHalf would leak into copy permanents (Clever Impersonator,
+        // Sakashima) that use the same RoomCard blueprint. Zone transitions
+        // through non-battlefield/stack zones (hand, graveyard, exile, library)
+        // also clear it via ZonesHandler.moveCard(), so the only window where
+        // it can leak is during this ETB. Game-state copies of already-unlocked
+        // permanents are guarded by wasRoomUnlockedOnCast() above.
         SpellAbilityType lastCastHalf = roomCardBlueprint.getLastCastHalf();
         if (lastCastHalf == SpellAbilityType.SPLIT_LEFT || lastCastHalf == SpellAbilityType.SPLIT_RIGHT) {
+            roomCardBlueprint.setLastCastHalf(null);
             permanent.unlockDoor(game, source, lastCastHalf == SpellAbilityType.SPLIT_LEFT);
         }
 

--- a/Mage/src/main/java/mage/cards/RoomCardHalfImpl.java
+++ b/Mage/src/main/java/mage/cards/RoomCardHalfImpl.java
@@ -1,5 +1,8 @@
 package mage.cards;
 
+import mage.abilities.Abilities;
+import mage.abilities.AbilitiesImpl;
+import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.constants.CardType;
 import mage.constants.SpellAbilityType;
@@ -26,6 +29,19 @@ public class RoomCardHalfImpl extends SplitCardHalfImpl implements RoomCardHalf 
     @Override
     public RoomCardHalfImpl copy() {
         return new RoomCardHalfImpl(this);
+    }
+
+    /**
+     * Room halves never exist on the battlefield independently — only the
+     * parent RoomCard does. Half abilities are added to the permanent by
+     * {@link RoomCard#addRoomCharacteristics} during permanent creation.
+     * Returning empty here prevents double-registration in the triggers map
+     * (once from game init via {@code GameImpl.loadCards} and once from
+     * {@code addRoomCharacteristics}).
+     */
+    @Override
+    public Abilities<Ability> getInitAbilities() {
+        return new AbilitiesImpl<>();
     }
 
     @Override


### PR DESCRIPTION
- Casting a Room half now auto-unlocks that door on ETB as the rules require. Previously the permanent entered fully locked, neither half active, forcing manual re-unlock.

- Card art now renders on the battlefield. The permanent's name is modified by RoomCharacteristicsEffect (showing only unlocked halves), but the client looked up card images by that modified name. Now uses the full split-card name from the blueprint. Additionally falls back to collector-ID-inclusive filenames for image sets that include them.

- Fixed compounding trigger registrations. Room halves would fire 2× after first unlock, 3× after both unlocked. Three interacting bugs: restoreUnlockedStats() skipped game-state trigger registration for non-copy permanents; half-card triggered abilities leaked into the trigger map during game init; addRoomCharacteristics() re-registered all half abilities on every game-state reset cycle, duplicating the entries restoreUnlockedStats() had already re-added.

Tested in-game with [Unholy Annex // Ritual Chamber](https://gatherer.wizards.com/Pages/Card/Details.aspx?name=Unholy+Annex) and confirmed it is working. No other obvious splash damage introduced with these changes.