### PR TITLE
Refactor Daydream/Spaceshift to align with Lilysplash Mentor

### DIFF
--- a/Mage.Sets/src/mage/cards/d/Daydream.java
+++ b/Mage.Sets/src/mage/cards/d/Daydream.java
@@ -1,24 +1,15 @@
 package mage.cards.d;
 
-import mage.abilities.Ability;
-import java.util.UUID;
-
+import mage.abilities.effects.common.ExileThenReturnTargetEffect;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.FlashbackAbility;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.counters.Counters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.common.TargetControlledCreaturePermanent;
-import mage.util.CardUtil;
+
+import java.util.UUID;
 
 /**
  *
@@ -31,7 +22,9 @@ public final class Daydream extends CardImpl {
 
         // Exile target creature you control, then return that card to the battlefield under its owner's control with a +1/+1 counter on it.
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
-        this.getSpellAbility().addEffect(new DaydreamEffect());
+        this.getSpellAbility().addEffect(
+            new ExileThenReturnTargetEffect(false, false).withEnterWithCounters(CounterType.P1P1.createInstance())
+        );
 
         // Flashback {2}{W}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{2}{W}")));
@@ -44,43 +37,5 @@ public final class Daydream extends CardImpl {
     @Override
     public Daydream copy() {
         return new Daydream(this);
-    }
-}
-
-class DaydreamEffect extends OneShotEffect {
-
-    DaydreamEffect() {
-        super(Outcome.Benefit);
-        staticText = "Exile target creature you control, then return that card to the battlefield under its owner's control with a +1/+1 counter on it";
-    }
-
-    private DaydreamEffect(final DaydreamEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public DaydreamEffect copy() {
-        return new DaydreamEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getFirstTarget());
-        Player controller = game.getPlayer(source.getControllerId());
-        if (permanent != null && controller != null) {
-            UUID exileId = CardUtil.getExileZoneId("DaydreamEffectExile" + source.toString(), game);
-            if (controller.moveCardsToExile(permanent, source, game, true, exileId, "")) {
-                if (game.getExile().getExileZone(exileId) != null) {
-                    Card exiledCard = game.getExile().getExileZone(exileId).get(permanent.getId(), game);
-                    if (exiledCard != null) {
-                        Counters countersToAdd = new Counters();
-                        countersToAdd.addCounter(CounterType.P1P1.createInstance());
-                        game.setEnterWithCounters(exiledCard.getId(), countersToAdd);
-                        return controller.moveCards(exiledCard, Zone.BATTLEFIELD, source, game, false, false, true, null);
-                    }
-                }
-            }
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/Daydream.java
+++ b/Mage.Sets/src/mage/cards/d/Daydream.java
@@ -1,16 +1,24 @@
 package mage.cards.d;
 
+import mage.abilities.Ability;
 import java.util.UUID;
 
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.common.ExileThenReturnTargetEffect;
-import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.FlashbackAbility;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.counters.Counters;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
 import mage.target.common.TargetControlledCreaturePermanent;
+import mage.util.CardUtil;
 
 /**
  *
@@ -23,9 +31,7 @@ public final class Daydream extends CardImpl {
 
         // Exile target creature you control, then return that card to the battlefield under its owner's control with a +1/+1 counter on it.
         this.getSpellAbility().addTarget(new TargetControlledCreaturePermanent());
-        this.getSpellAbility().addEffect(new ExileThenReturnTargetEffect(false, true).withAfterEffect(
-            new AddCountersTargetEffect(CounterType.P1P1.createInstance()).setText("with a +1/+1 counter on it")
-        ));
+        this.getSpellAbility().addEffect(new DaydreamEffect());
 
         // Flashback {2}{W}
         this.addAbility(new FlashbackAbility(this, new ManaCostsImpl<>("{2}{W}")));
@@ -38,5 +44,43 @@ public final class Daydream extends CardImpl {
     @Override
     public Daydream copy() {
         return new Daydream(this);
+    }
+}
+
+class DaydreamEffect extends OneShotEffect {
+
+    DaydreamEffect() {
+        super(Outcome.Benefit);
+        staticText = "Exile target creature you control, then return that card to the battlefield under its owner's control with a +1/+1 counter on it";
+    }
+
+    private DaydreamEffect(final DaydreamEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public DaydreamEffect copy() {
+        return new DaydreamEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getFirstTarget());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent != null && controller != null) {
+            UUID exileId = CardUtil.getExileZoneId("DaydreamEffectExile" + source.toString(), game);
+            if (controller.moveCardsToExile(permanent, source, game, true, exileId, "")) {
+                if (game.getExile().getExileZone(exileId) != null) {
+                    Card exiledCard = game.getExile().getExileZone(exileId).get(permanent.getId(), game);
+                    if (exiledCard != null) {
+                        Counters countersToAdd = new Counters();
+                        countersToAdd.addCounter(CounterType.P1P1.createInstance());
+                        game.setEnterWithCounters(exiledCard.getId(), countersToAdd);
+                        return controller.moveCards(exiledCard, Zone.BATTLEFIELD, source, game, false, false, true, null);
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/l/LilysplashMentor.java
+++ b/Mage.Sets/src/mage/cards/l/LilysplashMentor.java
@@ -3,24 +3,16 @@ package mage.cards.l;
 import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.common.ActivateAsSorceryActivatedAbility;
+import mage.abilities.effects.common.ExileThenReturnTargetEffect;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.ReachAbility;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.counters.Counters;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -41,7 +33,9 @@ public final class LilysplashMentor extends CardImpl {
         this.addAbility(ReachAbility.getInstance());
 
         // {1}{G}{U}: Exile another target creature you control, then return it to the battlefield under its owner's control with a +1/+1 counter on it. Activate only as a sorcery.
-        Ability ability = new ActivateAsSorceryActivatedAbility(new LilysplashMentorEffect(), new ManaCostsImpl<>("{1}{G}{U}"));
+        Ability ability = new ActivateAsSorceryActivatedAbility(
+            new ExileThenReturnTargetEffect(false, false).withEnterWithCounters(CounterType.P1P1.createInstance()),
+            new ManaCostsImpl<>("{1}{G}{U}"));
         ability.addTarget(new TargetPermanent(StaticFilters.FILTER_ANOTHER_TARGET_CREATURE_YOU_CONTROL));
         this.addAbility(ability);
     }
@@ -53,45 +47,5 @@ public final class LilysplashMentor extends CardImpl {
     @Override
     public LilysplashMentor copy() {
         return new LilysplashMentor(this);
-    }
-}
-
-//Copied from Planar Incision
-class LilysplashMentorEffect extends OneShotEffect {
-
-    LilysplashMentorEffect() {
-        super(Outcome.Benefit);
-        staticText = "Exile another target creature you control, then return it to the battlefield under its owner's control with a +1/+1 counter on it";
-    }
-
-    private LilysplashMentorEffect(final LilysplashMentorEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public LilysplashMentorEffect copy() {
-        return new LilysplashMentorEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getFirstTarget());
-        Player controller = game.getPlayer(source.getControllerId());
-        if (permanent != null
-                && controller != null) {
-            UUID exileId = CardUtil.getExileZoneId("LilysplashMentorEffectExile" + source.toString(), game);
-            if (controller.moveCardsToExile(permanent, source, game, true, exileId, "")) {
-                if (game.getExile().getExileZone(exileId) != null) {
-                    Card exiledCard = game.getExile().getExileZone(exileId).get(permanent.getId(), game);
-                    if (exiledCard != null) {
-                        Counters countersToAdd = new Counters();
-                        countersToAdd.addCounter(CounterType.P1P1.createInstance());
-                        game.setEnterWithCounters(exiledCard.getId(), countersToAdd);
-                        return controller.moveCards(exiledCard, Zone.BATTLEFIELD, source, game, false, false, true, null);
-                    }
-                }
-            }
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PlanarIncision.java
+++ b/Mage.Sets/src/mage/cards/p/PlanarIncision.java
@@ -1,22 +1,13 @@
 package mage.cards.p;
 
 import java.util.UUID;
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
+import mage.abilities.effects.common.ExileThenReturnTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.counters.Counters;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.util.CardUtil;
 
 /**
  * @author jeffwadsworth
@@ -27,7 +18,9 @@ public final class PlanarIncision extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{U}");
 
         // Exile target artifact or creature, then return it to the battlefield under its owner’s control with a +1/+1 counter on it.
-        this.getSpellAbility().addEffect(new PlanarIncisionEffect());
+        this.getSpellAbility().addEffect(
+            new ExileThenReturnTargetEffect(false, false).withEnterWithCounters(CounterType.P1P1.createInstance())
+        );
         this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
     }
 
@@ -38,44 +31,5 @@ public final class PlanarIncision extends CardImpl {
     @Override
     public PlanarIncision copy() {
         return new PlanarIncision(this);
-    }
-}
-
-class PlanarIncisionEffect extends OneShotEffect {
-
-    PlanarIncisionEffect() {
-        super(Outcome.Benefit);
-        staticText = "Exile target artifact or creature, then return it to the battlefield under its owner's control with a +1/+1 counter on it";
-    }
-
-    private PlanarIncisionEffect(final PlanarIncisionEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public PlanarIncisionEffect copy() {
-        return new PlanarIncisionEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getFirstTarget());
-        Player controller = game.getPlayer(source.getControllerId());
-        if (permanent != null
-                && controller != null) {
-            UUID exileId = CardUtil.getExileZoneId("planarIncisionExile" + source.toString(), game);
-            if (controller.moveCardsToExile(permanent, source, game, true, exileId, "")) {
-                if (game.getExile().getExileZone(exileId) != null) {
-                    Card exiledCard = game.getExile().getExileZone(exileId).get(permanent.getId(), game);
-                    if (exiledCard != null) {
-                        Counters countersToAdd = new Counters();
-                        countersToAdd.addCounter(CounterType.P1P1.createInstance());
-                        game.setEnterWithCounters(exiledCard.getId(), countersToAdd);
-                        return controller.moveCards(exiledCard, Zone.BATTLEFIELD, source, game, false, false, true, null);
-                    }
-                }
-            }
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/s/Spaceshift.java
+++ b/Mage.Sets/src/mage/cards/s/Spaceshift.java
@@ -2,22 +2,13 @@ package mage.cards.s;
 
 import java.util.UUID;
 
-import mage.abilities.Ability;
-import mage.abilities.effects.OneShotEffect;
-import mage.cards.Card;
+import mage.abilities.effects.common.ExileThenReturnTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Outcome;
-import mage.constants.Zone;
 import mage.counters.CounterType;
-import mage.counters.Counters;
 import mage.filter.StaticFilters;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
-import mage.players.Player;
 import mage.target.TargetPermanent;
-import mage.util.CardUtil;
 
 /**
  *
@@ -30,7 +21,9 @@ public final class Spaceshift extends CardImpl {
 
         // Exile target artifact or creature, then return that card to the battlefield under its owner's control with a +1/+1 counter on it.
         this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
-        this.getSpellAbility().addEffect(new SpaceshiftEffect());
+        this.getSpellAbility().addEffect(
+            new ExileThenReturnTargetEffect(false, false).withEnterWithCounters(CounterType.P1P1.createInstance())
+        );
     }
 
     private Spaceshift(final Spaceshift card) {
@@ -40,43 +33,5 @@ public final class Spaceshift extends CardImpl {
     @Override
     public Spaceshift copy() {
         return new Spaceshift(this);
-    }
-}
-
-class SpaceshiftEffect extends OneShotEffect {
-
-    SpaceshiftEffect() {
-        super(Outcome.Benefit);
-        staticText = "Exile target artifact or creature, then return that card to the battlefield under its owner's control with a +1/+1 counter on it";
-    }
-
-    private SpaceshiftEffect(final SpaceshiftEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public SpaceshiftEffect copy() {
-        return new SpaceshiftEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getFirstTarget());
-        Player controller = game.getPlayer(source.getControllerId());
-        if (permanent != null && controller != null) {
-            UUID exileId = CardUtil.getExileZoneId("SpaceshiftEffectExile" + source.toString(), game);
-            if (controller.moveCardsToExile(permanent, source, game, true, exileId, "")) {
-                if (game.getExile().getExileZone(exileId) != null) {
-                    Card exiledCard = game.getExile().getExileZone(exileId).get(permanent.getId(), game);
-                    if (exiledCard != null) {
-                        Counters countersToAdd = new Counters();
-                        countersToAdd.addCounter(CounterType.P1P1.createInstance());
-                        game.setEnterWithCounters(exiledCard.getId(), countersToAdd);
-                        return controller.moveCards(exiledCard, Zone.BATTLEFIELD, source, game, false, false, true, null);
-                    }
-                }
-            }
-        }
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/s/Spaceshift.java
+++ b/Mage.Sets/src/mage/cards/s/Spaceshift.java
@@ -2,14 +2,22 @@ package mage.cards.s;
 
 import java.util.UUID;
 
-import mage.abilities.effects.common.ExileThenReturnTargetEffect;
-import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
+import mage.constants.Outcome;
+import mage.constants.Zone;
 import mage.counters.CounterType;
+import mage.counters.Counters;
 import mage.filter.StaticFilters;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
 import mage.target.TargetPermanent;
+import mage.util.CardUtil;
 
 /**
  *
@@ -22,9 +30,7 @@ public final class Spaceshift extends CardImpl {
 
         // Exile target artifact or creature, then return that card to the battlefield under its owner's control with a +1/+1 counter on it.
         this.getSpellAbility().addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_ARTIFACT_OR_CREATURE));
-        this.getSpellAbility().addEffect(new ExileThenReturnTargetEffect(false, true).withAfterEffect(
-            new AddCountersTargetEffect(CounterType.P1P1.createInstance()).setText("with a +1/+1 counter on it")
-        ));
+        this.getSpellAbility().addEffect(new SpaceshiftEffect());
     }
 
     private Spaceshift(final Spaceshift card) {
@@ -34,5 +40,43 @@ public final class Spaceshift extends CardImpl {
     @Override
     public Spaceshift copy() {
         return new Spaceshift(this);
+    }
+}
+
+class SpaceshiftEffect extends OneShotEffect {
+
+    SpaceshiftEffect() {
+        super(Outcome.Benefit);
+        staticText = "Exile target artifact or creature, then return that card to the battlefield under its owner's control with a +1/+1 counter on it";
+    }
+
+    private SpaceshiftEffect(final SpaceshiftEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SpaceshiftEffect copy() {
+        return new SpaceshiftEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Permanent permanent = game.getPermanent(source.getFirstTarget());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (permanent != null && controller != null) {
+            UUID exileId = CardUtil.getExileZoneId("SpaceshiftEffectExile" + source.toString(), game);
+            if (controller.moveCardsToExile(permanent, source, game, true, exileId, "")) {
+                if (game.getExile().getExileZone(exileId) != null) {
+                    Card exiledCard = game.getExile().getExileZone(exileId).get(permanent.getId(), game);
+                    if (exiledCard != null) {
+                        Counters countersToAdd = new Counters();
+                        countersToAdd.addCounter(CounterType.P1P1.createInstance());
+                        game.setEnterWithCounters(exiledCard.getId(), countersToAdd);
+                        return controller.moveCards(exiledCard, Zone.BATTLEFIELD, source, game, false, false, true, null);
+                    }
+                }
+            }
+        }
+        return false;
     }
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/ExileThenReturnTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ExileThenReturnTargetEffect.java
@@ -7,13 +7,17 @@ import mage.cards.Card;
 import mage.constants.Outcome;
 import mage.constants.PutCards;
 import mage.constants.Zone;
+import mage.counters.Counter;
+import mage.counters.Counters;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.targetpointer.FixedTargets;
 import mage.util.CardUtil;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,6 +30,8 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
     private final boolean yourControl;
     private final boolean textThatCard;
     private final PutCards putCards;
+    private Counters enterWithCounters = null;
+    private String enterWithCountersText = null;
     private OneShotEffect afterEffect = null;
 
     public ExileThenReturnTargetEffect(boolean yourControl, boolean textThatCard) {
@@ -44,6 +50,8 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
         this.putCards = effect.putCards;
         this.yourControl = effect.yourControl;
         this.textThatCard = effect.textThatCard;
+        this.enterWithCounters = effect.enterWithCounters == null ? null : effect.enterWithCounters.copy();
+        this.enterWithCountersText = effect.enterWithCountersText;
         this.afterEffect = effect.afterEffect == null ? null : effect.afterEffect.copy();
     }
 
@@ -54,6 +62,18 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
 
     public ExileThenReturnTargetEffect withAfterEffect(OneShotEffect afterEffect) {
         this.afterEffect = afterEffect;
+        return this;
+    }
+
+    public ExileThenReturnTargetEffect withEnterWithCounters(Counter... counters) {
+        if (counters == null || counters.length == 0) {
+            return this;
+        }
+        this.enterWithCounters = new Counters();
+        for (Counter counter : counters) {
+            this.enterWithCounters.addCounter(counter.copy());
+        }
+        this.enterWithCountersText = makeEnterWithCountersText(counters);
         return this;
     }
 
@@ -74,6 +94,9 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
         controller.moveCards(toFlicker, Zone.EXILED, source, game);
         game.processAction();
         for (Card card : CardUtil.getAllCardsFromPermanentsLeftBattlefield(toFlicker, game)) {
+            if (enterWithCounters != null) {
+                game.setEnterWithCounters(card.getId(), enterWithCounters.copy());
+            }
             putCards.moveCard(
                     yourControl ? controller : game.getPlayer(card.getOwnerId()),
                     card.getMainCard(), source, game, "card");
@@ -105,10 +128,22 @@ public class ExileThenReturnTargetEffect extends OneShotEffect {
             sb.append(this.yourControl ? "your" : "its owner's");
         }
         sb.append(" control");
+        if (enterWithCountersText != null) {
+            sb.append(enterWithCountersText);
+            sb.append(getTargetPointer().isPlural(mode.getTargets()) ? " on them" : " on it");
+        }
         if (afterEffect != null) {
             sb.append(". ").append(CardUtil.getTextWithFirstCharUpperCase(afterEffect.getText(mode)));
         }
         return sb.toString();
+    }
+
+    private static String makeEnterWithCountersText(Counter... counters) {
+        List<String> descriptions = new ArrayList<>();
+        for (Counter counter : counters) {
+            descriptions.add(counter.getDescription());
+        }
+        return " with " + CardUtil.concatWithAnd(descriptions);
     }
 
 }


### PR DESCRIPTION
Previous implementation wouldn't locate the re-entering permanent as a target correctly. Refactor to use a single one shot effect along the lines of how Lilysplash Mentor does it so that the object comes with the counters