### PR TITLE
[minor] Update ability hints to match Oracle printings

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CaptainAmericaWingsOfFreedom.java
+++ b/Mage.Sets/src/mage/cards/c/CaptainAmericaWingsOfFreedom.java
@@ -42,7 +42,7 @@ public final class CaptainAmericaWingsOfFreedom extends CardImpl {
         this.addAbility(FirstStrikeAbility.getInstance());
 
         // Ward {1}
-        this.addAbility(new WardAbility(new ManaCostsImpl<>("{1}")));
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{1}"), false));
 
         // Whenever Captain America attacks, each other Hero you control gets +X/+X until end of turn, where X is Captain America's toughness.
         this.addAbility(new AttacksTriggeredAbility(new BoostControlledEffect(

--- a/Mage.Sets/src/mage/cards/f/FalconsWingHarness.java
+++ b/Mage.Sets/src/mage/cards/f/FalconsWingHarness.java
@@ -43,7 +43,7 @@ public final class FalconsWingHarness extends CardImpl {
         this.addAbility(ability);
 
         // Equip {2}{U}
-        this.addAbility(new EquipAbility(Outcome.BoostCreature, new ManaCostsImpl<>("{2}{U}"), false));
+        this.addAbility(new EquipAbility(Outcome.BoostCreature, new ManaCostsImpl<>("{2}{U}")));
     }
 
     private FalconsWingHarness(final FalconsWingHarness card) {

--- a/Mage.Sets/src/mage/cards/h/HulkbusterArmor.java
+++ b/Mage.Sets/src/mage/cards/h/HulkbusterArmor.java
@@ -48,11 +48,12 @@ public final class HulkbusterArmor extends CardImpl {
         this.addAbility(new EquipAbility(
             Outcome.AddAbility,
             new GenericManaCost(3),
-            new TargetPermanent(filter)
+            new TargetPermanent(filter),
+            false
         ));
 
         // Equip {6}
-        this.addAbility(new EquipAbility(6));
+        this.addAbility(new EquipAbility(6, false));
     }
 
     private HulkbusterArmor(final HulkbusterArmor card) {

--- a/Mage.Sets/src/mage/cards/m/MidnightAngelArmor.java
+++ b/Mage.Sets/src/mage/cards/m/MidnightAngelArmor.java
@@ -42,7 +42,7 @@ public final class MidnightAngelArmor extends CardImpl {
         this.addAbility(ability);
 
         // Equip {3}
-        this.addAbility(new EquipAbility(3));
+        this.addAbility(new EquipAbility(3, false));
     }
 
     private MidnightAngelArmor(final MidnightAngelArmor card) {

--- a/Mage.Sets/src/mage/cards/m/MikeyAndDonPartyPlanners.java
+++ b/Mage.Sets/src/mage/cards/m/MikeyAndDonPartyPlanners.java
@@ -54,7 +54,7 @@ public final class MikeyAndDonPartyPlanners extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Ward {2}
-        this.addAbility(new WardAbility(new ManaCostsImpl<>("{2}")));
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{2}"), false));
 
         // You may look at the top card of your library any time.
         this.addAbility(new SimpleStaticAbility(new LookAtTopCardOfLibraryAnyTimeEffect()));

--- a/Mage.Sets/src/mage/cards/m/MyPrecious.java
+++ b/Mage.Sets/src/mage/cards/m/MyPrecious.java
@@ -40,7 +40,7 @@ public final class MyPrecious extends AdventureCard {
         this.addAbility(ability);
 
         // Equip - {2}, Pay 2 life.
-        ability = new EquipAbility(2);
+        ability = new EquipAbility(2, false);
         ability.addCost(new PayLifeCost(2));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/r/RedGhostIntangibleGenius.java
+++ b/Mage.Sets/src/mage/cards/r/RedGhostIntangibleGenius.java
@@ -32,7 +32,7 @@ public final class RedGhostIntangibleGenius extends CardImpl {
         this.toughness = new MageInt(3);
 
         // Ward {2}
-        this.addAbility(new WardAbility(new ManaCostsImpl<>("{2}")));
+        this.addAbility(new WardAbility(new ManaCostsImpl<>("{2}"), false));
 
         // Red Ghost can't be blocked.
         this.addAbility(new SimpleStaticAbility(new CantBeBlockedSourceEffect()));

--- a/Mage.Sets/src/mage/cards/s/SwordsmansSteel.java
+++ b/Mage.Sets/src/mage/cards/s/SwordsmansSteel.java
@@ -42,7 +42,7 @@ public final class SwordsmansSteel extends CardImpl {
         ).addHint(hint));
 
         // Equip {3}
-        this.addAbility(new EquipAbility(3));
+        this.addAbility(new EquipAbility(3, false));
     }
 
     private SwordsmansSteel(final SwordsmansSteel card) {

--- a/Mage.Sets/src/mage/cards/u/UnstableMoleculeSuit.java
+++ b/Mage.Sets/src/mage/cards/u/UnstableMoleculeSuit.java
@@ -49,7 +49,7 @@ public final class UnstableMoleculeSuit extends CardImpl {
         ));
 
         // Equip {4}
-        this.addAbility(new EquipAbility(4));
+        this.addAbility(new EquipAbility(4, false));
     }
 
     private UnstableMoleculeSuit(final UnstableMoleculeSuit card) {

--- a/Mage.Sets/src/mage/cards/v/VibraniumStrikeGauntlets.java
+++ b/Mage.Sets/src/mage/cards/v/VibraniumStrikeGauntlets.java
@@ -47,7 +47,7 @@ public final class VibraniumStrikeGauntlets extends CardImpl {
         this.addAbility(ability);
 
         // Equip {3}
-        this.addAbility(new EquipAbility(3));
+        this.addAbility(new EquipAbility(3, false));
     }
 
     private VibraniumStrikeGauntlets(final VibraniumStrikeGauntlets card) {

--- a/Mage.Sets/src/mage/cards/w/WakandanTusker.java
+++ b/Mage.Sets/src/mage/cards/w/WakandanTusker.java
@@ -26,7 +26,7 @@ public final class WakandanTusker extends CardImpl {
 
         // Whenever this creature becomes tapped, you gain 1 life and scry 1.
         Ability ability = new BecomesTappedSourceTriggeredAbility(new GainLifeEffect(1));
-        ability.addEffect(new ScryEffect(1, false).concatBy("and"));
+        ability.addEffect(new ScryEffect(1).concatBy("and"));
         this.addAbility(ability);
     }
 


### PR DESCRIPTION
Spotted while peering into the abyss of doing full ability text verification comparison. Minor fixes that just depend on ensuring that we're passing the appropriate boolean to existing methods. 