### PR TITLE
[FRA] Text fixes and alignment with Oracle

### DIFF
--- a/Mage.Sets/src/mage/cards/l/LilianaTheFaultless.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaTheFaultless.java
@@ -30,7 +30,7 @@ import mage.constants.Duration;
 public final class LilianaTheFaultless extends CardImpl {
 
     private static final FilterPermanent filter
-        = new FilterCreatureOrPlaneswalkerPermanent("another creature or planeswalker you control");
+        = new FilterCreatureOrPlaneswalkerPermanent("another creature or planeswalker");
 
     static {
         filter.add(AnotherPredicate.instance);

--- a/Mage.Sets/src/mage/cards/l/LilianaTheRepentant.java
+++ b/Mage.Sets/src/mage/cards/l/LilianaTheRepentant.java
@@ -30,7 +30,7 @@ import mage.constants.CardType;
 public final class LilianaTheRepentant extends CardImpl {
 
     private static final FilterPermanent filter
-        = new FilterCreatureOrPlaneswalkerPermanent("another creature or planeswalker you control");
+        = new FilterCreatureOrPlaneswalkerPermanent("another creature or planeswalker");
     private static final FilterCard filterCard
         = new FilterCard("creature or planeswalker card from your graveyard");
 

--- a/Mage/src/main/java/mage/game/permanent/token/AjanisPridemateToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/AjanisPridemateToken.java
@@ -13,7 +13,7 @@ import mage.counters.CounterType;
 public final class AjanisPridemateToken extends TokenImpl {
 
     public AjanisPridemateToken() {
-        super("Ajani's Pridemate", "2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on Ajani's Pridemate.\"");
+        super("Ajani's Pridemate", "2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on this token\"");
         cardType.add(CardType.CREATURE);
         color.setWhite(true);
         subtype.add(SubType.CAT);


### PR DESCRIPTION
* Redundant text in filters leading to duplication of "you control" on ability text
* Token has been updated to state "on this token" and not refer to it by name (even in older cards that also reference the same token and mechanic; https://scryfall.com/card/j22/141/ajani-strength-of-the-pride)