### PR TITLE
[tests] Compare ascii name to normalised full name

### DIFF
--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -421,16 +421,16 @@ public class VerifyCardDataTest {
             for (MtgJsonCard refCard : refSet.cards) {
                 String cleanNumber = refCard.number.replaceAll("[\\D]", "");
                 if (cleanNumber.isEmpty()) {
-                    System.out.println("Found non-digit card number: " 
-                        + refSet.code + " - " 
-                        + refCard.getNameAsASCII() + " - " 
+                    System.out.println("Found non-digit card number: "
+                        + refSet.code + " - "
+                        + refCard.getNameAsASCII() + " - "
                         + refCard.number
                     );
                 }
                 if (cleanNumber.equals("0")) {
-                    System.out.println("Found zero card number: " 
-                        + refSet.code + " - " 
-                        + refCard.getNameAsASCII() + " - " 
+                    System.out.println("Found zero card number: "
+                        + refSet.code + " - "
+                        + refCard.getNameAsASCII() + " - "
                         + refCard.number
                     );
                 }
@@ -1972,7 +1972,7 @@ public class VerifyCardDataTest {
 
     // "copy" fails means that the copy constructor are not correct inside a card.
     // To fix those, try to find the class that did trigger the copy failure, and check
-    // that copy() exists, a copy constructor exists, and the copy constructor is right. 
+    // that copy() exists, a copy constructor exists, and the copy constructor is right.
     private void checkCardCanBeCopied(Card card1) {
         Card card2;
         try {
@@ -3575,7 +3575,7 @@ public class VerifyCardDataTest {
                 if (jsonCard.isUseUnicodeName()) {
                     String inName = jsonCard.getNameAsUnicode();
                     String outName = CardNameUtil.normalizeCardName(inName);
-                    String needOutName = jsonCard.getNameAsFace();
+                    String needOutName = jsonCard.getNameAsASCII();
                     if (!outName.equals(needOutName)) {
                         // how-to fix: add new unicode symbol in CardNameUtil.normalizeCardName
                         errorsList.add(String.format("error, found unsupported unicode symbol in %s - %s", inName, jsonSet.code));


### PR DESCRIPTION
Fixes #15740 

It's not wholly clear to me the intentions of the test but inferring from what it's doing, we're effectively exercising specifically that for all the unicode card names in the MTGJson set we can normalise them correctly in `CardNameUtil` and that there aren't unhandled characters we need to add. 

If this is the case, it doesn't matter necessarily that we pull and match the subset of the face name. We just need to be sure that given the full card name that all unicode characters are mapped correctly.

MTGJson doesn't give ASCII face name fields, and it would be tautological to both generate the reference data in code ourselves to compare our own generated values match.