### PR TITLE
[dev] Generate link to Scryfall for unimplmented cards by collector number

### DIFF
--- a/Utils/gen-list-unimplemented-cards-for-set.pl
+++ b/Utils/gen-list-unimplemented-cards-for-set.pl
@@ -138,29 +138,27 @@ foreach my $card (sort cardSort @setCards) {
 
     if(-e $currentFileName) {
         # Card is implemented
-        $cardNames{$cardName} = 1;
+        $cardNames{$cardName} = 0;
         my $implementedEntry = "- [x] [$cardName](https://scryfall.com/search?q=!$cardNameForUrl%20e:$setAbbr)";
         push(@implementedCards, $implementedEntry);
     } else {
         # Card is not implemented
-        $cardNames{$cardName} = 0;
+        $cardNames{$cardName} = $collectorNumber;
         push(@unimplementedCards, $cardEntry);
     }
 }
 
 # Build the unimplemented URL for Scryfall
-my $unimplementedUrl = "https://scryfall.com/search?q=";
-my @unimplementedNames;
+my $unimplementedUrl = "https://scryfall.com/search?q=s:$setAbbr%20%28";
+my @unimplementedNumbers;
 foreach my $cardName (sort keys %cardNames) {
-    if ($cardNames{$cardName} == 0) {
-        my $urlCardName = $cardName;
-        $urlCardName =~ s/ //g;
-        $urlCardName =~ s/"/\\"/g;  # Escape quotes
-        $urlCardName =~ s/\&/%26/g; # URL encode ampersands
-        push(@unimplementedNames, "!\"$urlCardName\"");
+    if ($cardNames{$cardName} != 0) {
+        push(@unimplementedNumbers, "cn:$cardNames{$cardName}");
     }
 }
-$unimplementedUrl .= join("or", @unimplementedNames) . "&unique=cards";
+# Scryfall's UI has a 1024 chracter limit for search queries, which realistically limits us to 100 card numbers for the search query
+$unimplementedUrl .= join("%20or%20", @unimplementedNumbers[0 .. List::Util::min(99, $#unimplementedNumbers)] );
+$unimplementedUrl .= "%29";
 
 # Read template file
 my $template = Text::Template->new(TYPE => 'FILE', SOURCE => $templateFile, DELIMITERS => [ '[=', '=]' ]);

--- a/Utils/issue_tracker.tmpl
+++ b/Utils/issue_tracker.tmpl
@@ -16,7 +16,7 @@ Note that this represents all printings/faces of cards in a set, and does not re
 
 [=$unimplemented=]
 
-[Scryfall gallery of everything currently unimplemented]([=$unimplementedUrl=])
+[Scryfall gallery of cards currently unimplemented]([=$unimplementedUrl=])
 # Implemented Cards
 <details><summary>Click to expand</summary>
 


### PR DESCRIPTION
Currently the set tracking issue makes a link for "all unimplemented cards" in a given set; which is not possible to guarantee.

Scryfall has a 1024 character limit on the web interface, and truncates anything beyond that for one. We currently use the exact card name search, but if the card names are long, well, we exhaust that limit quickly enough.

Case in point is currently for The Hobbit, you only get 47 cards from the generated link due to the truncation;
```
https://scryfall.com/search?q=!%22AlongtheCrookedWay%22or!%22Attercop%22or!%22Azog,Moria%27sRuin%22or!%22Balin,Loremaster%22or!%22BardtheBowman%22or!%22Bard,KingofDale%22or!%22BejeweledWarg%22or!%22BelladonnaTook%22or!%22BeorntheFierce%22or!%22Beorn%27sHospitality%22or!%22Beorn,ReluctantHost%22or!%22Bifur,MelodicRider%22or!%22BilboBaggins,Burglar%22or!%22Bilbo%27sDeadlySlice%22or!%22Bilbo%27sGambit%22or!%22Bofur,ReliableGuardian%22or!%22BolgoftheNorth%22or!%22Bolg%27sCompany%22or!%22Bombur,GentleDreamer%22or!%22BoughsideWanderers%22or!%22CantankerousKeepers%22or!%22CelebratetheMountain-king%22or!%22ChiefWarg%27sCompany%22or!%22ConfusticateandBebother%22or!%22CrudeBentBlade%22or!%22DainIronfoot%22or!%22Dain%27sCompany%22or!%22Dain,LordoftheIronHills%22or!%22DancingfromDarktoDawn%22or!%22DesertWere-Worm%22or!%22Dori,BearerofFriends%22or!%22DownintheValley%22or!%22Down,DowntoGoblin-town%22or!%22DreadedBat-Cloud%22or!%22DuskwatchHunter%22or!%22Dwalin,Weaponmaster%22or!%22DwarvenMattock%22or!%22DwarvenMauler%22or!%22DwarvenProvisioner%22or!%22DwarvenShortsword%22or!%22EagleoftheGreatShelf%22or!%22Eagle%27sRescue%22or!%22Elrond,Moon-Reader%22or!%22ElvenPassage%22or!%22ElvenRaft-Steerer%22or!%22Elvenking%27sHalls%22or!%22Elvenking%27sHarper%22or!%22EnchantedRiver%27sGrasp%22or!%22EsgarothGarrison%22or!%22FatefulDiscovery%22or!%22FilithePathfinder%22or!%22FrontPorchSentries%22or!%22Galion,Elvenking%27sButler%22or!%22Gandalf,Goblins%27Bane%22or!%22Gandalf,SparkStarter%22or!%22Gandalf,WanderingWizard%22or!%22GetawayBarrel%22or!%22Giant%27sBoulder%22or!%22Glamdring,Foe-hammer%22or!%22GleamingSplendor%22or!%22GlointheMighty%22or!%22GnashingofTeeth%22or!%22GoblinPlateMail%22or!%22Goblin-town%22or!%22Goblin-townFlunkies%22or!%22GollumtheAbandoned%22or!%22Gollum,RiddleMaster%22or!%22Gollum,SilentSlinker%22or!%22GreatFierceBee%22or!%22GreatUgly-LookingGoblin%22or!%22GuardianoftheHalls%22or!%22GundabadOpportunist%22or!%22HeadoftheHunt%22or!%22HobbitHole%22or!%22InsideInformation%22or!%22IronHills%22or!%22IronHillsBlacksmith%22or!%22IronHillsStalwart%22or!%22KeytotheSide-Door%22or!%22KilitheResourceful%22or!%22Lake-town%22or!%22Lake-townLookout%22or!%22Lake-townMariners%22or!%22Lake-townToymaker%22or!%22LakeshoreApothecary%22or!%22LastLightofDurin%27sDay%22or!%22LittleBear%22or!%22LongLakeNuisance%22or!%22Long-BodiedGreyDog%22or!%22MagnificentEnd%22or!%22Master%27sCouncillors%22or!%22Mirkwood%22or!%22MirkwoodMeditator%22or!%22MirkwoodNurturer%22or!%22MomentofGlory%22or!%22MostDecrepitOldBird%22or!%22NastyLittleRabbit%22or!%22NighthowlPursuer%22or!%22Nori,TellerofTales%22or!%22OintheBrave%22or!%22OldFatSpider%22or!%22OldFatSpiderCan%27tSeeMe%22or!%22OldThrush%22or!%22Orcrist,Goblin-cleaver%22or!%22Ori,KeeperofSongs%22or!%22PartinFriendship%22or!%22PatientInstructor%22or!%22PineconeStrike%22or!%22PlundertheTrollshaws%22or!%22Quarrel%22or!%22RadagastofRhosgobel%22or!%22RageintotheValley%22or!%22RaggedShortSpear%22or!%22RaveningWarg%22or!%22ReverentHowl%22or!%22RhovanionRampager%22or!%22RoadsGoEver,EverOn%22or!%22Roll-Roll-Roll-Roll%22or!%22SilvanReveler%22or!%22Smaug%27sFury%22or!%22Smaug,WickedWorm%22or!%22Smaug,theGreatCalamity%22or!%22SnowslopeHunter%22or!%22SoundtheTrumpets%22or!%22StirUpTrouble%22or!%22StonebySunlight%22or!%22Stone-GiantofHighPass%22or!%22Stony-VoicedGoblins%22or!%22SupperforSpiders%22or!%22TheBlackArrow%22or!%22TheEaglesAreComing!%22or!%22TheGreatGoblin%22or!%22TheLordoftheEagles%22or!%22TheMasterofLake-town%22or!%22TheMistyMountainsCold%22or!%22TheMountain-king%27sReturn%22or!%22TheNotaryHobbits%22or!%22TheSackville-Bagginses%22or!%22Thorin%27sLastStand%22or!%22Thranduil%27sCompany%22or!%22Thranduil%27sDecree%22or!%22Thranduil,SindarinLiege%22or!%22Thranduil,theElvenking%22or!%22Thror%27sMap%22or!%22ThroughtheForestGate%22or!%22TidingsofWar%22or!%22TrollNegotiations%22or!%22TroopofPonies%22or!%22UncovertheMoon-Letters%22or!%22UneasyPartings%22or!%22VelvetwingButterflies%22or!%22VowtoErebor%22or!%22WargTactics%22or!%22Wargling%22or!%22Well-WornSpatula%22or!%22WilderlandScrounger%22or!%22Wizard%27sStaff%22or!%22WoodlandWeavemaster%22&unique=cards
```

By switching to collector numbers, we can cram more into that limit; e.g `s:SET (cn:1 OR cn:2 OR cn:123 ...)`

Realistically, declaring the set and paranthesis uses 8 characters, and each declared card uses anything between 8-10 characters. Erring on the side of caution, with the 1016 characters left to spare, we could fit 101 cards in. 100's a nice number, so I just went with that. 

We can never guarantee that it'll all fit so let's make the best of it for something that'll only likely benefit like 2 or 3 people, and yes, I know this is more ugly Perl, but this is a quicker fix than migrating it to something more palatable like Python. 