### PR TITLE
[minor] Rename UtvaraHellkiteDragonToken to generic Dragon66Token

### DIFF
--- a/Mage.Sets/src/mage/cards/m/MegaFlare.java
+++ b/Mage.Sets/src/mage/cards/m/MegaFlare.java
@@ -9,7 +9,7 @@ import mage.abilities.keyword.KickerAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.game.permanent.token.UtvaraHellkiteDragonToken;
+import mage.game.permanent.token.Dragon66Token;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.targetadjustment.ForEachPlayerTargetsAdjuster;
 import mage.target.targetpointer.EachTargetPointer;
@@ -29,7 +29,7 @@ public final class MegaFlare extends CardImpl {
 
         // If this spell was kicked, create a 6/6 red Dragon creature token with flying.
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new CreateTokenEffect(new UtvaraHellkiteDragonToken()), KickedCondition.ONCE,
+                new CreateTokenEffect(new Dragon66Token()), KickedCondition.ONCE,
                 "if this spell was kicked, create a 6/6 red Dragon creature token with flying"
         ));
 

--- a/Mage.Sets/src/mage/cards/u/UtvaraHellkite.java
+++ b/Mage.Sets/src/mage/cards/u/UtvaraHellkite.java
@@ -11,7 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.game.permanent.token.UtvaraHellkiteDragonToken;
+import mage.game.permanent.token.Dragon66Token;
 
 /**
  *
@@ -36,7 +36,7 @@ public final class UtvaraHellkite extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Whenever a Dragon you control attacks, create a 6/6 red Dragon creature token with flying.
-        this.addAbility(new AttacksCreatureYouControlTriggeredAbility(new CreateTokenEffect(new UtvaraHellkiteDragonToken()), false, filter));
+        this.addAbility(new AttacksCreatureYouControlTriggeredAbility(new CreateTokenEffect(new Dragon66Token()), false, filter));
     }
 
     private UtvaraHellkite(final UtvaraHellkite card) {

--- a/Mage/src/main/java/mage/game/permanent/token/Dragon66Token.java
+++ b/Mage/src/main/java/mage/game/permanent/token/Dragon66Token.java
@@ -8,9 +8,9 @@ import mage.constants.SubType;
 /**
  * @author spjspj
  */
-public final class UtvaraHellkiteDragonToken extends TokenImpl {
+public final class Dragon66Token extends TokenImpl {
 
-    public UtvaraHellkiteDragonToken() {
+    public Dragon66Token() {
         super("Dragon Token", "6/6 red Dragon creature token with flying");
         cardType.add(CardType.CREATURE);
         color.setRed(true);
@@ -20,11 +20,11 @@ public final class UtvaraHellkiteDragonToken extends TokenImpl {
         addAbility(FlyingAbility.getInstance());
     }
 
-    private UtvaraHellkiteDragonToken(final UtvaraHellkiteDragonToken token) {
+    private Dragon66Token(final Dragon66Token token) {
         super(token);
     }
 
-    public UtvaraHellkiteDragonToken copy() {
-        return new UtvaraHellkiteDragonToken(this);
+    public Dragon66Token copy() {
+        return new Dragon66Token(this);
     }
 }

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -370,7 +370,7 @@
 |TOK:C17|Cat Dragon||WasitoraCatDragonToken|
 |TOK:C17|Cat Warrior||CatWarriorToken|
 |TOK:C17|Dragon|1|DragonToken|
-|TOK:C17|Dragon|2|UtvaraHellkiteDragonToken|
+|TOK:C17|Dragon|2|Dragon66Token|
 |TOK:C17|Eldrazi Spawn||EldraziSpawnToken|
 |TOK:C17|Gold||GoldToken|
 |TOK:C17|Rat||DeathtouchRatToken|
@@ -917,7 +917,7 @@
 |TOK:RTR|Assassin||AssassinToken|
 |TOK:RTR|Bird||BirdToken|
 |TOK:RTR|Centaur||CentaurToken|
-|TOK:RTR|Dragon||UtvaraHellkiteDragonToken|
+|TOK:RTR|Dragon||Dragon66Token|
 |TOK:RTR|Elemental||GreenAndWhiteElementalToken|
 |TOK:RTR|Goblin||GoblinToken|
 |TOK:RTR|Knight||KnightToken|
@@ -1799,7 +1799,7 @@
 |TOK:GK2|Bat||BatToken|
 |TOK:GK2|Bird||WhiteBlueBirdToken|
 |TOK:GK2|Cleric||DeathpactAngelToken|
-|TOK:GK2|Dragon||UtvaraHellkiteDragonToken|
+|TOK:GK2|Dragon||Dragon66Token|
 |TOK:GK2|Goblin||RakdosGuildmageGoblinToken|
 |TOK:GK2|Ooze||OozeToken|
 |TOK:GK2|Saproling||SaprolingToken|
@@ -2362,7 +2362,7 @@
 |TOK:RVR|Bird||BirdToken|
 |TOK:RVR|Bird Illusion||BirdIllusionToken|
 |TOK:RVR|Centaur||CentaurToken|
-|TOK:RVR|Dragon||UtvaraHellkiteDragonToken|
+|TOK:RVR|Dragon||Dragon66Token|
 |TOK:RVR|Elf Knight||ElfKnightToken|
 |TOK:RVR|Goblin|1|GoblinToken|
 |TOK:RVR|Goblin|2|RakdosGuildmageGoblinToken|
@@ -3074,7 +3074,7 @@
 |TOK:HOB|Bear||BearToken|
 |TOK:HOB|Bird Soldier||BirdSoldierToken|
 |TOK:HOB|Human Soldier||HumanSoldierToken|
-|TOK:HOB|Dragon||UtvaraHellkiteDragonToken|
+|TOK:HOB|Dragon||Dragon66Token|
 |TOK:HOB|Dwarf||Dwarf22Token|
 |TOK:HOB|Elf||GreenElfToken|
 |TOK:HOB|Goblin Army|1|GoblinArmyToken|


### PR DESCRIPTION
This token is not exclusive to Utvara Hellkite anymore (hasn't been since Final Fantasy). Rename it to a generic name to make it easier to find in the codebase and align with the other generic Dragon55Token. 

I very almost created a new token for The Hobbit before finding this one hiding under this name