### PR TITLE
[minor] Clean up Mode registration on cards

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AbunasChant.java
+++ b/Mage.Sets/src/mage/cards/a/AbunasChant.java
@@ -22,15 +22,15 @@ public final class AbunasChant extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{W}");
 
 
-        // Choose one - 
+        // Choose one -
         this.getSpellAbility().getModes().setMinModes(1);
         this.getSpellAbility().getModes().setMaxModes(1);
-        //You gain 5 life; 
+        //You gain 5 life;
         this.getSpellAbility().addEffect(new GainLifeEffect(5));
         //or prevent the next 5 damage that would be dealt to target creature this turn.
         Mode mode = new Mode(new PreventDamageToTargetEffect(Duration.EndOfTurn, 5));
         mode.addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // Entwine {2}
         this.addAbility(new EntwineAbility("{2}"));
     }

--- a/Mage.Sets/src/mage/cards/a/AmazingAcrobatics.java
+++ b/Mage.Sets/src/mage/cards/a/AmazingAcrobatics.java
@@ -20,7 +20,7 @@ public final class AmazingAcrobatics extends CardImpl {
 
     public AmazingAcrobatics(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{U}{U}");
-        
+
 
         // Choose one or both --
         this.getSpellAbility().getModes().setMinModes(1);
@@ -33,7 +33,7 @@ public final class AmazingAcrobatics extends CardImpl {
         // * Tap one or two target creatures.
         Mode mode = new Mode(new TapTargetEffect());
         mode.addTarget(new TargetPermanent(1, 2, StaticFilters.FILTER_PERMANENT_CREATURES));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private AmazingAcrobatics(final AmazingAcrobatics card) {

--- a/Mage.Sets/src/mage/cards/a/AustereCommand.java
+++ b/Mage.Sets/src/mage/cards/a/AustereCommand.java
@@ -37,13 +37,13 @@ public final class AustereCommand extends CardImpl {
         this.getSpellAbility().addEffect(new DestroyAllEffect(new FilterArtifactPermanent("artifacts")));
         // or destroy all enchantments;
         Mode mode = new Mode(new DestroyAllEffect(new FilterEnchantmentPermanent("enchantments")));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // or destroy all creatures with converted mana cost 3 or less;
         mode = new Mode(new DestroyAllEffect(filter3orLess));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // or destroy all creatures with converted mana cost 4 or greater.
         mode = new Mode(new DestroyAllEffect(filter4orMore));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private AustereCommand(final AustereCommand card) {

--- a/Mage.Sets/src/mage/cards/b/BarbedLightning.java
+++ b/Mage.Sets/src/mage/cards/b/BarbedLightning.java
@@ -27,7 +27,7 @@ public final class BarbedLightning extends CardImpl {
         // or Barbed Lightning deals 3 damage to target player.
         Mode mode = new Mode(new DamageTargetEffect(3));
         mode.addTarget(new TargetPlayerOrPlaneswalker());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}
         this.addAbility(new EntwineAbility("{2}"));

--- a/Mage.Sets/src/mage/cards/b/BetrayalOfFlesh.java
+++ b/Mage.Sets/src/mage/cards/b/BetrayalOfFlesh.java
@@ -11,9 +11,7 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledLandPermanent;
 import mage.target.common.TargetCardInYourGraveyard;
-import mage.target.common.TargetControlledPermanent;
 import mage.target.common.TargetCreaturePermanent;
 
 /**
@@ -35,7 +33,7 @@ public final class BetrayalOfFlesh extends CardImpl {
         // or return target creature card from your graveyard to the battlefield.
         Mode mode = new Mode(new ReturnFromGraveyardToBattlefieldTargetEffect());
         mode.addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // Entwine-Sacrifice three lands.
         this.addAbility(new EntwineAbility(new SacrificeTargetCost(3, StaticFilters.FILTER_LANDS)));
     }

--- a/Mage.Sets/src/mage/cards/b/BlindingBeam.java
+++ b/Mage.Sets/src/mage/cards/b/BlindingBeam.java
@@ -17,7 +17,6 @@ import mage.constants.PhaseStep;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.game.turn.Step;
 import mage.players.Player;
@@ -43,7 +42,7 @@ public final class BlindingBeam extends CardImpl {
         // or creatures don't untap during target player's next untap step.
         Mode mode = new Mode(new BlindingBeamEffect());
         mode.addTarget(new TargetPlayer());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {1}
         this.addAbility(new EntwineAbility("{1}"));
@@ -73,7 +72,7 @@ class BlindingBeamEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player player = game.getPlayer(getTargetPointer().getFirst(game, source));
-        if (player != null) {                
+        if (player != null) {
             game.addEffect(new BlindingBeamEffect2(player.getId()), source);
             return true;
         }
@@ -123,7 +122,7 @@ class BlindingBeamEffect2 extends ContinuousRuleModifyingEffectImpl {
     public boolean checksEventType(GameEvent event, Game game) {
         return event.getType() == GameEvent.EventType.UNTAP;
     }
-    
+
     @Override
     public boolean applies(GameEvent event, Ability source, Game game) {
         // prevent untap event of creatures of target player

--- a/Mage.Sets/src/mage/cards/c/ChoreographedSparks.java
+++ b/Mage.Sets/src/mage/cards/c/ChoreographedSparks.java
@@ -62,7 +62,7 @@ public final class ChoreographedSparks extends CardImpl {
                     + "the end step, sacrifice this token.\"")
         );
         mode.addTarget(new TargetSpell(filter2));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private ChoreographedSparks(final ChoreographedSparks card) {

--- a/Mage.Sets/src/mage/cards/c/CleansingNova.java
+++ b/Mage.Sets/src/mage/cards/c/CleansingNova.java
@@ -23,7 +23,7 @@ public final class CleansingNova extends CardImpl {
 
         // • Destroy all artifacts and enchantments.
         Mode mode = new Mode(new DestroyAllEffect(StaticFilters.FILTER_PERMANENT_ARTIFACTS_AND_ENCHANTMENTS));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private CleansingNova(final CleansingNova card) {

--- a/Mage.Sets/src/mage/cards/c/CrypticCommand.java
+++ b/Mage.Sets/src/mage/cards/c/CrypticCommand.java
@@ -33,15 +33,15 @@ public final class CrypticCommand extends CardImpl {
         // or return target permanent to its owner's hand;
         Mode mode = new Mode(new ReturnToHandTargetEffect());
         mode.addTarget(new TargetPermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // or tap all creatures your opponents control;
         mode = new Mode(new TapAllEffect(StaticFilters.FILTER_OPPONENTS_PERMANENT_CREATURES));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // or draw a card.
         mode = new Mode(new DrawCardSourceControllerEffect(1));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private CrypticCommand(final CrypticCommand card) {

--- a/Mage.Sets/src/mage/cards/d/DisplayOfDominance.java
+++ b/Mage.Sets/src/mage/cards/d/DisplayOfDominance.java
@@ -18,7 +18,6 @@ import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.ColorPredicate;
 import mage.game.Game;
 import mage.game.events.GameEvent;
-import mage.game.events.GameEvent.EventType;
 import mage.game.permanent.Permanent;
 import mage.game.stack.Spell;
 import mage.target.TargetPermanent;
@@ -28,7 +27,7 @@ import mage.target.TargetPermanent;
  * @author LevelX2
  */
 public final class DisplayOfDominance extends CardImpl {
-    
+
     private static final FilterPermanent filter = new FilterPermanent("blue or black noncreature permanent");
 
     static {
@@ -51,7 +50,7 @@ public final class DisplayOfDominance extends CardImpl {
 
         // or Permanents you control can't be the targets of blue or black spells your opponents control this turn
         Mode mode = new Mode(new DisplayOfDominanceEffect());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private DisplayOfDominance(final DisplayOfDominance card) {

--- a/Mage.Sets/src/mage/cards/d/DromokasCommand.java
+++ b/Mage.Sets/src/mage/cards/d/DromokasCommand.java
@@ -11,7 +11,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
 import mage.counters.CounterType;
-import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.common.FilterEnchantmentPermanent;
 import mage.filter.common.FilterInstantOrSorcerySpell;
@@ -19,8 +18,6 @@ import mage.target.TargetPermanent;
 import mage.target.TargetPlayer;
 import mage.target.TargetSpell;
 import mage.target.common.TargetControlledCreaturePermanent;
-import mage.target.common.TargetCreaturePermanent;
-
 import java.util.UUID;
 
 import static mage.filter.StaticFilters.FILTER_CREATURE_YOU_DONT_CONTROL;
@@ -50,14 +47,14 @@ public final class DromokasCommand extends CardImpl {
         effect.setText("Target player sacrifices an enchantment");
         Mode mode = new Mode(effect);
         mode.addTarget(new TargetPlayer());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Put a +1/+1 counter on target creature;
         effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance());
         effect.setText("Put a +1/+1 counter on target creature");
         mode = new Mode(effect);
         mode.addTarget(new TargetPermanent(filterCreature));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // or Target creature you control fights target creature you don't control.
         effect = new FightTargetsEffect();
@@ -65,7 +62,7 @@ public final class DromokasCommand extends CardImpl {
         mode = new Mode(effect);
         mode.addTarget(new TargetControlledCreaturePermanent());
         mode.addTarget(new TargetPermanent(FILTER_CREATURE_YOU_DONT_CONTROL));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
     }
 

--- a/Mage.Sets/src/mage/cards/f/FieryConfluence.java
+++ b/Mage.Sets/src/mage/cards/f/FieryConfluence.java
@@ -26,18 +26,18 @@ public final class FieryConfluence extends CardImpl {
         this.getSpellAbility().getModes().setMinModes(3);
         this.getSpellAbility().getModes().setMaxModes(3);
         this.getSpellAbility().getModes().setMayChooseSameModeMoreThanOnce(true);
-        
+
         // - Fiery Confluence deals 1 damage to each creature;
         this.getSpellAbility().addEffect(new DamageAllEffect(1, new FilterCreaturePermanent()));
-        
+
         // Fiery Confluence deals 2 damage to each opponent;
         Mode mode = new Mode(new DamagePlayersEffect(2, TargetController.OPPONENT));
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
         // Destroy target artifact.
         mode = new Mode(new DestroyTargetEffect());
         mode.addTarget(new TargetArtifactPermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private FieryConfluence(final FieryConfluence card) {

--- a/Mage.Sets/src/mage/cards/f/FuryCharm.java
+++ b/Mage.Sets/src/mage/cards/f/FuryCharm.java
@@ -55,11 +55,11 @@ public final class FuryCharm extends CardImpl {
         effect.setText("and gains trample until end of turn");
         mode.addEffect(effect);
         mode.addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // or remove two time counters from target permanent or suspended card.
         mode = new Mode(new FuryCharmRemoveCounterEffect());
         mode.addTarget(new TargetPermanentOrSuspendedCard());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private FuryCharm(final FuryCharm card) {

--- a/Mage.Sets/src/mage/cards/g/GrabTheReins.java
+++ b/Mage.Sets/src/mage/cards/g/GrabTheReins.java
@@ -50,7 +50,7 @@ public final class GrabTheReins extends CardImpl {
         TargetAnyTarget target2 = new TargetAnyTarget();
         target2.withTargetName("a creature or player to damage");
         mode.addTarget(target2);
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}{R}
         this.addAbility(new EntwineAbility("{2}{R}"));

--- a/Mage.Sets/src/mage/cards/i/IncendiaryCommand.java
+++ b/Mage.Sets/src/mage/cards/i/IncendiaryCommand.java
@@ -37,14 +37,14 @@ public final class IncendiaryCommand extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayerOrPlaneswalker());
         // or Incendiary Command deals 2 damage to each creature;
         Mode mode = new Mode(new DamageAllEffect(2, new FilterCreaturePermanent()));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // or destroy target nonbasic land;
         mode = new Mode(new DestroyTargetEffect());
         mode.addTarget(new TargetNonBasicLandPermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // or each player discards all the cards in their hand, then draws that many cards.
         mode = new Mode(new IncendiaryCommandDrawEffect());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
     }
 

--- a/Mage.Sets/src/mage/cards/i/InciteWar.java
+++ b/Mage.Sets/src/mage/cards/i/InciteWar.java
@@ -20,7 +20,6 @@ import mage.filter.predicate.permanent.ControllerIdPredicate;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetPlayer;
-import mage.watchers.common.AttackedThisTurnWatcher;
 
 /**
  *
@@ -37,7 +36,7 @@ public final class InciteWar extends CardImpl {
 
         // or creatures you control gain first strike until end of turn.
         Mode mode = new Mode(new GainAbilityControlledEffect(FirstStrikeAbility.getInstance(), Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURES));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}
         this.addAbility(new EntwineAbility("{2}"));

--- a/Mage.Sets/src/mage/cards/i/InsidiousWill.java
+++ b/Mage.Sets/src/mage/cards/i/InsidiousWill.java
@@ -37,7 +37,7 @@ public final class InsidiousWill extends CardImpl {
         // Copy target instant or sorcery spell. You may choose new targets for the copy.
         mode = new Mode(new CopyTargetStackObjectEffect());
         mode.addTarget(new TargetSpell(StaticFilters.FILTER_SPELL_INSTANT_OR_SORCERY));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private InsidiousWill(final InsidiousWill card) {

--- a/Mage.Sets/src/mage/cards/j/JourneyOfDiscovery.java
+++ b/Mage.Sets/src/mage/cards/j/JourneyOfDiscovery.java
@@ -23,13 +23,13 @@ public final class JourneyOfDiscovery extends CardImpl {
     public JourneyOfDiscovery(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{2}{G}");
 
-        // Choose one - Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library; 
+        // Choose one - Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle your library;
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_BASIC_LANDS), true));
-        
+
         // or you may play up to two additional lands this turn.
         Mode mode = new Mode(new PlayAdditionalLandsControllerEffect(2, Duration.EndOfTurn));
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
         // Entwine {2}{G}
         this.addAbility(new EntwineAbility("{2}{G}"));
     }

--- a/Mage.Sets/src/mage/cards/k/KolaghansCommand.java
+++ b/Mage.Sets/src/mage/cards/k/KolaghansCommand.java
@@ -43,17 +43,17 @@ public final class KolaghansCommand extends CardImpl {
         // or Target player discards a card;
         Mode mode = new Mode(new DiscardTargetEffect(1));
         mode.addTarget(new TargetPlayer());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // or Destroy target artifact;
         mode = new Mode(new DestroyTargetEffect());
         mode.addTarget(new TargetPermanent(filter));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // or Kolaghan's Command deals 2 damage to any target.
         mode = new Mode(new DamageTargetEffect(2));
         mode.addTarget(new TargetAnyTarget());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private KolaghansCommand(final KolaghansCommand card) {

--- a/Mage.Sets/src/mage/cards/m/MirageMockery.java
+++ b/Mage.Sets/src/mage/cards/m/MirageMockery.java
@@ -36,7 +36,7 @@ public final class MirageMockery extends CardImpl {
         // • Create a token that's a copy of target nonartifact creature you control.
         Mode mode = new Mode(new CreateTokenCopyTargetEffect());
         mode.addTarget(new TargetPermanent(filter2));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}{U}
         this.addAbility(new EntwineAbility("{2}{U}"));

--- a/Mage.Sets/src/mage/cards/m/MysticConfluence.java
+++ b/Mage.Sets/src/mage/cards/m/MysticConfluence.java
@@ -22,23 +22,23 @@ public final class MysticConfluence extends CardImpl {
     public MysticConfluence(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{U}{U}");
 
-        // Choose three. You may choose the same mode more than once. 
+        // Choose three. You may choose the same mode more than once.
         this.getSpellAbility().getModes().setMinModes(3);
         this.getSpellAbility().getModes().setMaxModes(3);
         this.getSpellAbility().getModes().setMayChooseSameModeMoreThanOnce(true);
-        
+
         // - Counter target spell unless its controller pays {3};
         this.getSpellAbility().addEffect(new CounterUnlessPaysEffect(new GenericManaCost(3)));
         this.getSpellAbility().addTarget(new TargetSpell());
-        
+
         //  Return target creature to its owner's hand;
         Mode mode = new Mode(new ReturnToHandTargetEffect());
         mode.addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
          // Draw a card.
         mode = new Mode(new DrawCardSourceControllerEffect(1));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private MysticConfluence(final MysticConfluence card) {

--- a/Mage.Sets/src/mage/cards/o/OjutaisCommand.java
+++ b/Mage.Sets/src/mage/cards/o/OjutaisCommand.java
@@ -41,15 +41,15 @@ public final class OjutaisCommand extends CardImpl {
         this.getSpellAbility().getTargets().add(new TargetCardInYourGraveyard(filter));
 
         // or You gain 4 life;
-        this.getSpellAbility().getModes().addMode(new Mode(new GainLifeEffect(4)));
+        this.getSpellAbility().addMode(new Mode(new GainLifeEffect(4)));
 
         // or Counter target creature spell;
         Mode mode = new Mode(new CounterTargetEffect());
         mode.addTarget(new TargetSpell(StaticFilters.FILTER_SPELL_CREATURE));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // or Draw a card
-        this.getSpellAbility().getModes().addMode(new Mode(new DrawCardSourceControllerEffect(1)));
+        this.getSpellAbility().addMode(new Mode(new DrawCardSourceControllerEffect(1)));
     }
 
     private OjutaisCommand(final OjutaisCommand card) {

--- a/Mage.Sets/src/mage/cards/p/PlungeIntoDarkness.java
+++ b/Mage.Sets/src/mage/cards/p/PlungeIntoDarkness.java
@@ -18,13 +18,11 @@ import mage.constants.Outcome;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.Target;
 import mage.target.TargetCard;
-import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.common.TargetSacrifice;
 
 /**
@@ -43,7 +41,7 @@ public final class PlungeIntoDarkness extends CardImpl {
         this.getSpellAbility().addEffect(new PlungeIntoDarknessLifeEffect());
         // or pay X life, then look at the top X cards of your library, put one of those cards into your hand, and exile the rest.
         Mode mode = new Mode(new PlungeIntoDarknessSearchEffect());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {B}
         this.addAbility(new EntwineAbility("{B}"));

--- a/Mage.Sets/src/mage/cards/p/PrimalCommand.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalCommand.java
@@ -36,15 +36,15 @@ public final class PrimalCommand extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
 
         // or put target noncreature permanent on top of its owner's library;
-        this.getSpellAbility().getModes().addMode(new Mode(new PutOnLibraryTargetEffect(true))
+        this.getSpellAbility().addMode(new Mode(new PutOnLibraryTargetEffect(true))
                 .addTarget(new TargetPermanent(StaticFilters.FILTER_PERMANENT_NON_CREATURE)));
 
         // or target player shuffles their graveyard into their library;
-        this.getSpellAbility().getModes().addMode(new Mode(new PrimalCommandShuffleGraveyardEffect())
+        this.getSpellAbility().addMode(new Mode(new PrimalCommandShuffleGraveyardEffect())
                 .addTarget(new TargetPlayer()));
 
         // or search your library for a creature card, reveal it, put it into your hand, then shuffle your library.
-        this.getSpellAbility().getModes().addMode(new Mode(new SearchLibraryPutInHandEffect(
+        this.getSpellAbility().addMode(new Mode(new SearchLibraryPutInHandEffect(
                 new TargetCardInLibrary(StaticFilters.FILTER_CARD_CREATURE), true
         )));
     }

--- a/Mage.Sets/src/mage/cards/p/PromiseOfPower.java
+++ b/Mage.Sets/src/mage/cards/p/PromiseOfPower.java
@@ -33,7 +33,7 @@ public final class PromiseOfPower extends CardImpl {
         this.getSpellAbility().addEffect(new LoseLifeSourceControllerEffect(5).concatBy("and"));
 
         // - Create an X/X black Demon creature token with flying, where X is the number of cards in your hand.
-        this.getSpellAbility().getModes().addMode(new Mode(new PromiseOfPowerEffect()));
+        this.getSpellAbility().addMode(new Mode(new PromiseOfPowerEffect()));
 
         // Entwine {4}
         this.addAbility(new EntwineAbility("{4}"));

--- a/Mage.Sets/src/mage/cards/r/RainOfRust.java
+++ b/Mage.Sets/src/mage/cards/r/RainOfRust.java
@@ -27,7 +27,7 @@ public final class RainOfRust extends CardImpl {
         //or destroy target land.
         Mode mode = new Mode(new DestroyTargetEffect());
         mode.addTarget(new TargetLandPermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
         // Entwine {3}{R}
         this.addAbility(new EntwineAbility("{3}{R}"));
     }

--- a/Mage.Sets/src/mage/cards/r/RallyTheMonastery.java
+++ b/Mage.Sets/src/mage/cards/r/RallyTheMonastery.java
@@ -48,11 +48,11 @@ public final class RallyTheMonastery extends CardImpl {
         this.getSpellAbility().addEffect(new CreateTokenEffect(new MonasteryMentorToken(), 2));
 
         // • Up to two target creatures you control each get +2/+2 until end of turn.
-        this.getSpellAbility().getModes().addMode(new Mode(new BoostTargetEffect(2, 2))
+        this.getSpellAbility().addMode(new Mode(new BoostTargetEffect(2, 2))
                 .addTarget(new TargetControlledCreaturePermanent(0, 2)));
 
         // • Destroy target creature with power 4 or greater.
-        this.getSpellAbility().getModes().addMode(new Mode(new DestroyTargetEffect()).addTarget(new TargetPermanent(filter)));
+        this.getSpellAbility().addMode(new Mode(new DestroyTargetEffect()).addTarget(new TargetPermanent(filter)));
     }
 
     private RallyTheMonastery(final RallyTheMonastery card) {

--- a/Mage.Sets/src/mage/cards/r/ReapAndSow.java
+++ b/Mage.Sets/src/mage/cards/r/ReapAndSow.java
@@ -23,15 +23,15 @@ public final class ReapAndSow extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.SORCERY},"{3}{G}");
 
 
-        // Choose one - 
+        // Choose one -
         this.getSpellAbility().getModes().setMinModes(1);
         this.getSpellAbility().getModes().setMaxModes(1);
-        //Destroy target land; 
+        //Destroy target land;
         this.getSpellAbility().addEffect(new DestroyTargetEffect());
         this.getSpellAbility().addTarget(new TargetLandPermanent());
         //or search your library for a land card, put that card onto the battlefield, then shuffle your library.
         Mode mode = new Mode(new SearchLibraryPutInPlayEffect(new TargetCardInLibrary(new FilterLandCard()), false, true));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {1}{G}
         this.addAbility(new EntwineAbility("{1}{G}"));

--- a/Mage.Sets/src/mage/cards/r/RighteousConfluence.java
+++ b/Mage.Sets/src/mage/cards/r/RighteousConfluence.java
@@ -32,11 +32,11 @@ public final class RighteousConfluence extends CardImpl {
         //  - Exile target enchantment;
         Mode mode = new Mode(new ExileTargetEffect());
         mode.addTarget(new TargetEnchantmentPermanent());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // You gain 5 life;
         mode = new Mode(new GainLifeEffect(5));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private RighteousConfluence(final RighteousConfluence card) {

--- a/Mage.Sets/src/mage/cards/r/RoarOfTheKha.java
+++ b/Mage.Sets/src/mage/cards/r/RoarOfTheKha.java
@@ -16,7 +16,7 @@ import mage.filter.StaticFilters;
  * @author fireshoes
  */
 public final class RoarOfTheKha extends CardImpl {
-    
+
     private static final String rule = "untap all creatures you control";
 
     public RoarOfTheKha(UUID ownerId, CardSetInfo setInfo) {
@@ -24,11 +24,11 @@ public final class RoarOfTheKha extends CardImpl {
 
         // Choose one - Creatures you control get +1/+1 until end of turn;
         this.getSpellAbility().addEffect(new BoostControlledEffect(1, 1, Duration.EndOfTurn));
-        
+
         // or untap all creatures you control.
         Mode mode = new Mode(new UntapAllControllerEffect(StaticFilters.FILTER_CONTROLLED_CREATURES, rule));
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
         // Entwine {1}{W}
         this.addAbility(new EntwineAbility("{1}{W}"));
     }

--- a/Mage.Sets/src/mage/cards/r/RudeAwakening.java
+++ b/Mage.Sets/src/mage/cards/r/RudeAwakening.java
@@ -30,7 +30,7 @@ public final class RudeAwakening extends CardImpl {
         Mode mode = new Mode(new BecomesCreatureAllEffect(
                 new CreatureToken(2, 2, "2/2 creatures"),
                 "lands", new FilterControlledLandPermanent("lands you control"), Duration.EndOfTurn, false));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}{G}
         this.addAbility(new EntwineAbility("{2}{G}"));

--- a/Mage.Sets/src/mage/cards/s/SavageBeating.java
+++ b/Mage.Sets/src/mage/cards/s/SavageBeating.java
@@ -36,7 +36,7 @@ public final class SavageBeating extends CardImpl {
         // or untap all creatures you control and after this phase, there is an additional combat phase.
         Mode mode = new Mode(new UntapAllControllerEffect(new FilterControlledCreaturePermanent(), "untap all creatures you control"));
         mode.addEffect(new AdditionalCombatPhaseEffect());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {1}{R}
         this.addAbility(new EntwineAbility("{1}{R}"));

--- a/Mage.Sets/src/mage/cards/s/SecondSight.java
+++ b/Mage.Sets/src/mage/cards/s/SecondSight.java
@@ -35,7 +35,7 @@ public final class SecondSight extends CardImpl {
         this.getSpellAbility().addTarget(new TargetOpponent());
 
         //or look at the top five cards of your library, then put them back in any order.
-        this.getSpellAbility().getModes().addMode(new Mode(new LookLibraryControllerEffect(5)));
+        this.getSpellAbility().addMode(new Mode(new LookLibraryControllerEffect(5)));
 
         // Entwine {U}
         this.addAbility(new EntwineAbility("{U}"));

--- a/Mage.Sets/src/mage/cards/s/ShivanSandMage.java
+++ b/Mage.Sets/src/mage/cards/s/ShivanSandMage.java
@@ -49,7 +49,6 @@ public final class ShivanSandMage extends CardImpl {
         Mode mode = new Mode(new ShivanSandMageEffect(true));
         mode.addTarget(new TargetPermanentOrSuspendedCard(filter, false));
         ability.addMode(mode);
-        ability.getModes().addMode(mode);
         this.addAbility(ability);
 
         // Suspend 4-{R}

--- a/Mage.Sets/src/mage/cards/s/ShrivelingRot.java
+++ b/Mage.Sets/src/mage/cards/s/ShrivelingRot.java
@@ -38,7 +38,7 @@ public final class ShrivelingRot extends CardImpl {
 
         // Until end of turn, whenever a creature dies, that creature's controller loses life equal to its toughness.
         Mode mode = new Mode(new CreateDelayedTriggeredAbilityEffect(new ShrivelingRotLoseLifeTriggeredAbility()));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}{B}
         this.addAbility(new EntwineAbility("{2}{B}"));

--- a/Mage.Sets/src/mage/cards/s/SilumgarsCommand.java
+++ b/Mage.Sets/src/mage/cards/s/SilumgarsCommand.java
@@ -31,28 +31,28 @@ public final class SilumgarsCommand extends CardImpl {
     public SilumgarsCommand(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId,setInfo,new CardType[]{CardType.INSTANT},"{3}{U}{B}");
 
-        // Choose two - 
+        // Choose two -
         this.getSpellAbility().getModes().setMinModes(2);
         this.getSpellAbility().getModes().setMaxModes(2);
-        
+
         // Counter target noncreature spell;
         this.getSpellAbility().getEffects().add(new CounterTargetEffect());
         this.getSpellAbility().getTargets().add(new TargetSpell(StaticFilters.FILTER_SPELL_NON_CREATURE));
-        
-        // or Return target permanent to its owner's hand; 
+
+        // or Return target permanent to its owner's hand;
         Mode mode = new Mode(new ReturnToHandTargetEffect());
         mode.addTarget(new TargetPermanent());
-        this.getSpellAbility().getModes().addMode(mode);        
-     
+        this.getSpellAbility().addMode(mode);
+
         // or Target creature gets -3/-3 until end of turn;
         mode = new Mode(new BoostTargetEffect(-3, -3, Duration.EndOfTurn));
         mode.addTarget(new TargetCreaturePermanent());
-        this.getSpellAbility().getModes().addMode(mode);        
+        this.getSpellAbility().addMode(mode);
 
         // or Destroy target planeswalker.
         mode = new Mode(new DestroyTargetEffect());
         mode.addTarget(new TargetPermanent(filter2));
-        this.getSpellAbility().getModes().addMode(mode);        
+        this.getSpellAbility().addMode(mode);
     }
 
     private SilumgarsCommand(final SilumgarsCommand card) {

--- a/Mage.Sets/src/mage/cards/s/SolarTide.java
+++ b/Mage.Sets/src/mage/cards/s/SolarTide.java
@@ -11,20 +11,18 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.ComparisonType;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterControlledLandPermanent;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
-import mage.target.common.TargetControlledPermanent;
 
 /**
  *
  * @author fireshoes
  */
 public final class SolarTide extends CardImpl {
-    
+
     private static final FilterCreaturePermanent filter1 = new FilterCreaturePermanent("creatures with power 2 or less");
     private static final FilterCreaturePermanent filter2 = new FilterCreaturePermanent("creatures with power 3 or greater");
-    
+
     static {
         filter1.add(new PowerPredicate(ComparisonType.FEWER_THAN, 3));
         filter2.add(new PowerPredicate(ComparisonType.MORE_THAN, 2));
@@ -35,11 +33,11 @@ public final class SolarTide extends CardImpl {
 
         // Choose one - Destroy all creatures with power 2 or less;
         this.getSpellAbility().addEffect(new DestroyAllEffect(filter1));
-        
+
         // or destroy all creatures with power 3 or greater.
         Mode mode = new Mode(new DestroyAllEffect(filter2));
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
         // Entwine-Sacrifice two lands.
         this.addAbility(new EntwineAbility(new SacrificeTargetCost(2, StaticFilters.FILTER_LANDS)));
     }

--- a/Mage.Sets/src/mage/cards/s/StirThePride.java
+++ b/Mage.Sets/src/mage/cards/s/StirThePride.java
@@ -24,7 +24,7 @@ public final class StirThePride extends CardImpl {
     public StirThePride(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{4}{W}");
 
-        // Choose one - 
+        // Choose one -
         this.getSpellAbility().getModes().setMinModes(1);
         this.getSpellAbility().getModes().setMaxModes(1);
         // Creatures you control get +2/+2 until end of turn;
@@ -33,7 +33,7 @@ public final class StirThePride extends CardImpl {
         Effect effect = new GainAbilityControlledEffect(new DealsDamageSourceTriggeredAbility(new GainLifeEffect(SavedDamageValue.MUCH)), Duration.EndOfTurn, StaticFilters.FILTER_PERMANENT_CREATURES);
         effect.setText("until end of turn, creatures you control gain \"Whenever this creature deals damage, you gain that much life.\"");
         Mode mode = new Mode(effect);
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {1}{W}
         this.addAbility(new EntwineAbility("{1}{W}"));

--- a/Mage.Sets/src/mage/cards/t/TemporalCascade.java
+++ b/Mage.Sets/src/mage/cards/t/TemporalCascade.java
@@ -28,7 +28,7 @@ public final class TemporalCascade extends CardImpl {
 
         // or each player draws seven cards.
         Mode mode = new Mode(new TemporalCascadeDrawEffect());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}
         this.addAbility(new EntwineAbility("{2}"));
@@ -58,7 +58,7 @@ class TemporalCascadeDrawEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player sourcePlayer = game.getPlayer(source.getControllerId());
-        game.getState().handleSimultaneousEvent(game); // needed here so state based triggered effects 
+        game.getState().handleSimultaneousEvent(game); // needed here so state based triggered effects
         for (UUID playerId : game.getState().getPlayersInRange(sourcePlayer.getId(), game)) {
             Player player = game.getPlayer(playerId);
             if (player != null) {

--- a/Mage.Sets/src/mage/cards/t/Timebender.java
+++ b/Mage.Sets/src/mage/cards/t/Timebender.java
@@ -43,7 +43,7 @@ public final class Timebender extends CardImpl {
         // Morph {U}
         this.addAbility(new MorphAbility(this, new ManaCostsImpl<>("{U}")));
 
-        // When Timebender is turned face up, choose one — 
+        // When Timebender is turned face up, choose one —
         // Remove two time counters from target permanent or suspended card.
         Ability ability = new TurnedFaceUpSourceTriggeredAbility(new TimebenderEffect(false));
         ability.addTarget(new TargetPermanentOrSuspendedCard());
@@ -52,7 +52,6 @@ public final class Timebender extends CardImpl {
         Mode mode = new Mode(new TimebenderEffect(true));
         mode.addTarget(new TargetPermanentOrSuspendedCard(filter, false));
         ability.addMode(mode);
-        ability.getModes().addMode(mode);
         this.addAbility(ability);
 
     }

--- a/Mage.Sets/src/mage/cards/t/ToothAndNail.java
+++ b/Mage.Sets/src/mage/cards/t/ToothAndNail.java
@@ -32,7 +32,7 @@ public final class ToothAndNail extends CardImpl {
         this.getSpellAbility().addEffect(new SearchLibraryPutInHandEffect(new TargetCardInLibrary(0, 2, StaticFilters.FILTER_CARD_CREATURES), true));
         // or put up to two creature cards from your hand onto the battlefield.
         Mode mode = new Mode(new ToothAndNailPutCreatureOnBattlefieldEffect());
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Entwine {2}
         this.addAbility(new EntwineAbility("{2}"));

--- a/Mage.Sets/src/mage/cards/v/VerdantConfluence.java
+++ b/Mage.Sets/src/mage/cards/v/VerdantConfluence.java
@@ -30,20 +30,20 @@ public final class VerdantConfluence extends CardImpl {
         this.getSpellAbility().getModes().setMinModes(3);
         this.getSpellAbility().getModes().setMaxModes(3);
         this.getSpellAbility().getModes().setMayChooseSameModeMoreThanOnce(true);
-        
+
         // - Put two +1/+1 counters on target creature;
         this.getSpellAbility().addEffect(new AddCountersTargetEffect(CounterType.P1P1.createInstance(2)));
         this.getSpellAbility().addTarget(new TargetCreaturePermanent());
-        
+
         // Return target permanent card from your graveyard to your hand;
         Mode mode = new Mode(new ReturnFromGraveyardToHandTargetEffect());
         mode.addTarget(new TargetCardInYourGraveyard(new FilterPermanentCard()));
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
         // Search your library for a basic land card, put it onto the battlefield tapped, then shuffle your library.
         TargetCardInLibrary target = new TargetCardInLibrary(StaticFilters.FILTER_CARD_BASIC_LAND);
         mode = new Mode(new SearchLibraryPutInPlayEffect(target, true));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private VerdantConfluence(final VerdantConfluence card) {

--- a/Mage.Sets/src/mage/cards/v/VeryCrypticCommandD.java
+++ b/Mage.Sets/src/mage/cards/v/VeryCrypticCommandD.java
@@ -26,8 +26,6 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
 import mage.target.TargetStackObject;
-import mage.target.common.TargetCreaturePermanent;
-
 import java.util.UUID;
 
 /**
@@ -47,7 +45,7 @@ public final class VeryCrypticCommandD extends CardImpl {
     public VeryCrypticCommandD(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{1}{U}{U}{U}");
 
-        // Choose two - 
+        // Choose two -
         this.getSpellAbility().getModes().setMinModes(2);
         this.getSpellAbility().getModes().setMaxModes(2);
 
@@ -60,17 +58,17 @@ public final class VeryCrypticCommandD extends CardImpl {
         Effect effect = new DiscardControllerEffect(1);
         effect.setText(", then discard a card");
         mode.addEffect(effect);
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Change the target of target spell with a single target.
         mode = new Mode(new ChooseNewTargetsTargetEffect(true, true));
         mode.addTarget(new TargetStackObject(filter));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
 
         // Turn over target nontoken creature.
         mode = new Mode(new TurnOverEffect());
         mode.addTarget(new TargetPermanent(filter2));
-        this.getSpellAbility().getModes().addMode(mode);
+        this.getSpellAbility().addMode(mode);
     }
 
     private VeryCrypticCommandD(final VeryCrypticCommandD card) {

--- a/Mage.Sets/src/mage/cards/w/WailOfTheNim.java
+++ b/Mage.Sets/src/mage/cards/w/WailOfTheNim.java
@@ -21,11 +21,11 @@ public final class WailOfTheNim extends CardImpl {
 
         // Choose one - Regenerate each creature you control;
         this.getSpellAbility().addEffect(new RegenerateAllEffect(StaticFilters.FILTER_CONTROLLED_CREATURE));
-        
+
         // or Wail of the Nim deals 1 damage to each creature and each player.
         Mode mode = new Mode(new DamageEverythingEffect(1));
-        this.getSpellAbility().getModes().addMode(mode);
-        
+        this.getSpellAbility().addMode(mode);
+
         // Entwine {B}
         this.addAbility(new EntwineAbility("{B}"));
     }

--- a/Mage.Sets/src/mage/cards/w/WretchedConfluence.java
+++ b/Mage.Sets/src/mage/cards/w/WretchedConfluence.java
@@ -34,11 +34,11 @@ public final class WretchedConfluence extends CardImpl {
         this.getSpellAbility().addTarget(new TargetPlayer());
 
         // Target creature gets -2/-2 until end of turn;
-        this.getSpellAbility().getModes().addMode(new Mode(new BoostTargetEffect(-2, -2))
+        this.getSpellAbility().addMode(new Mode(new BoostTargetEffect(-2, -2))
                 .addTarget(new TargetCreaturePermanent()));
 
         // Return target creature card from your graveyard to your hand.
-        this.getSpellAbility().getModes().addMode(new Mode(new ReturnFromGraveyardToHandTargetEffect())
+        this.getSpellAbility().addMode(new Mode(new ReturnFromGraveyardToHandTargetEffect())
                 .addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD)));
     }
 


### PR DESCRIPTION
* 2 cards were calling `.getModes().addMode()` and then `.addMode()`. They both do the same thing as under the hood `.addMode()` on the Ability calls `.getModes()` to add the mode to it.
* Clean up cards that were calling `.getModes.addMode()` to call `.addMode()` directly for consistency across the codebase and to leave a clearer hint to the next person 
* For the files touched, remove any flagged unused imports as we're under the hood for these files anyway
* Purely cosmetic, but my IDE has also cleaned up lines where there was whitespace indentation that was unnecessary 