### PR TITLE
fix: phase out multiple permanents together

### DIFF
--- a/Mage.Sets/src/mage/cards/c/ChangeOfPlans.java
+++ b/Mage.Sets/src/mage/cards/c/ChangeOfPlans.java
@@ -2,6 +2,7 @@ package mage.cards.c;
 
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.PhaseOutAllEffect;
 import mage.abilities.effects.keyword.ConniveTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -16,6 +17,8 @@ import mage.target.TargetPermanent;
 import mage.target.common.TargetControlledCreaturePermanent;
 import mage.target.targetadjustment.XTargetsCountAdjuster;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -82,12 +85,14 @@ class ChangeOfPlansEffect extends OneShotEffect {
         filter.add(new PermanentReferenceInCollectionPredicate(permanents, game));
         TargetPermanent target = new TargetPermanent(0, Integer.MAX_VALUE, filter, true);
         player.choose(outcome, target.withChooseHint("to phase out"), source, game);
+        List<UUID> idsToPhaseOut = new ArrayList<>();
         for (UUID targetId : target.getTargets()) {
             Permanent permanent = game.getPermanent(targetId);
             if (permanent != null) {
-                permanent.phaseOut(game);
+                idsToPhaseOut.add(permanent.getId());
             }
         }
+        new PhaseOutAllEffect(idsToPhaseOut).apply(game, source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DiscipleOfCaelusNin.java
+++ b/Mage.Sets/src/mage/cards/d/DiscipleOfCaelusNin.java
@@ -6,6 +6,7 @@ import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.PhaseOutAllEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -19,7 +20,9 @@ import mage.game.permanent.Permanent;
 import mage.players.Player;
 import mage.target.TargetPermanent;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -85,11 +88,13 @@ class DiscipleOfCaelusNinFirstEffect extends OneShotEffect {
             player.choose(outcome, target, source, game);
             toKeep.addAll(target.getTargets());
         }
+        List<UUID> idsToPhaseOut = new ArrayList<>();
         for (Permanent permanent : game.getBattlefield().getActivePermanents(source.getControllerId(), game)) {
             if (!toKeep.contains(permanent.getId())) {
-                permanent.phaseOut(game);
+                idsToPhaseOut.add(permanent.getId());
             }
         }
+        new PhaseOutAllEffect(idsToPhaseOut).apply(game, source);
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/p/PerchProtection.java
+++ b/Mage.Sets/src/mage/cards/p/PerchProtection.java
@@ -5,6 +5,7 @@ import mage.abilities.condition.common.GiftWasPromisedCondition;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.ExileSpellEffect;
+import mage.abilities.effects.common.PhaseOutAllEffect;
 import mage.abilities.effects.common.continuous.GainAbilityControllerEffect;
 import mage.abilities.effects.common.continuous.LifeTotalCantChangeControllerEffect;
 import mage.abilities.keyword.GiftAbility;
@@ -20,6 +21,8 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 import mage.game.permanent.token.SwanSongBirdToken;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -73,11 +76,13 @@ class PerchProtectionEffect extends OneShotEffect {
         if (GiftWasPromisedCondition.FALSE.apply(game, source)) {
             return false;
         }
+        List<UUID> idsToPhaseOut = new ArrayList<>();
         for (Permanent permanent : game.getBattlefield().getActivePermanents(
                 StaticFilters.FILTER_CONTROLLED_PERMANENT, source.getControllerId(), source, game
         )) {
-            permanent.phaseOut(game);
+            idsToPhaseOut.add(permanent.getId());
         }
+        new PhaseOutAllEffect(idsToPhaseOut).apply(game, source);
         game.addEffect(new LifeTotalCantChangeControllerEffect(Duration.UntilYourNextTurn), source);
         game.addEffect(new GainAbilityControllerEffect(
                 new ProtectionFromEverythingAbility(), Duration.UntilYourNextTurn

--- a/Mage.Sets/src/mage/cards/r/RipplesOfPotential.java
+++ b/Mage.Sets/src/mage/cards/r/RipplesOfPotential.java
@@ -1,6 +1,8 @@
 package mage.cards.r;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -9,6 +11,7 @@ import java.util.stream.Collectors;
 import mage.MageObjectReference;
 import mage.abilities.Ability;
 import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.PhaseOutAllEffect;
 import mage.abilities.effects.common.counter.ProliferateEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -98,12 +101,14 @@ class RipplesOfPotentialEffect extends OneShotEffect {
         ));
         TargetPermanent target = new TargetPermanent(0, Integer.MAX_VALUE, filter, true);
         controller.choose(outcome, target.withChooseHint("to phase out"), source, game);
+        List<UUID> idsToPhaseOut = new ArrayList<>();
         for (UUID targetId : target.getTargets()) {
             Permanent permanent = game.getPermanent(targetId);
             if (permanent != null) {
-                permanent.phaseOut(game);
+                idsToPhaseOut.add(permanent.getId());
             }
         }
+        new PhaseOutAllEffect(idsToPhaseOut).apply(game, source);
         watcher.reset();
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TeferiTimelessVoyager.java
+++ b/Mage.Sets/src/mage/cards/t/TeferiTimelessVoyager.java
@@ -6,6 +6,7 @@ import mage.abilities.LoyaltyAbility;
 import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.effects.common.PhaseOutAllEffect;
 import mage.abilities.effects.common.PutOnLibraryTargetEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -17,6 +18,8 @@ import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
 import mage.target.common.TargetOpponent;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -74,15 +77,17 @@ class TeferiTimelessVoyagerEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
+        List<UUID> idsToPhaseOut = new ArrayList<>();
         for (Permanent permanent : game
                 .getBattlefield()
                 .getAllActivePermanents(
                         StaticFilters.FILTER_PERMANENT_CREATURE, source.getFirstTarget(), game
                 )) {
             MageObjectReference mor = new MageObjectReference(permanent, game);
-            permanent.phaseOut(game);
+            idsToPhaseOut.add(permanent.getId());
             game.addEffect(new TeferiTimelessVoyagerPhaseEffect(mor), source);
         }
+        new PhaseOutAllEffect(idsToPhaseOut).apply(game, source);
         return true;
     }
 }


### PR DESCRIPTION
## What changed

- route multi-permanent phase-out effects through `PhaseOutAllEffect`
- preserve the existing single-permanent calls for cards such as Divine Smite and Oubliette
- cover Change of Plans, Disciple of Caelus Nin, Perch Protection, Ripples of Potential, and Teferi, Timeless Voyager

Closes #15797

## Why

`PhaseOutAllEffect` phases unattached permanents first and then directly phases out attached permanents. Collecting the selected IDs before applying the effect keeps attachments consistent when several permanents phase out together.

## Validation

- `git diff --check` passes
- Audited all `phaseOut(game)` call sites in `Mage.Sets`; remaining calls are single-permanent effects
- Maven tests were not run because Maven is not installed in this environment

This is an AI-assisted contribution prepared after maintainer confirmation. The diff is limited to the five multi-permanent card effects named above.