### PR TITLE
Add a hint to cards that refer to players to left/right

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AminatouTheFateshifter.java
+++ b/Mage.Sets/src/mage/cards/a/AminatouTheFateshifter.java
@@ -7,6 +7,7 @@ import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.ExileThenReturnTargetEffect;
 import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.abilities.hint.common.PlayersLeftRightHint;
 import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -57,7 +58,7 @@ public class AminatouTheFateshifter extends CardImpl {
 
         // -6: Choose left or right. Each player gains control of all nonland permanents other than Aminatou, the
         // Fateshifter controlled by the next player in the chosen direction.
-        ability = new LoyaltyAbility(new AminatouUltimateEffect(), -6);
+        ability = new LoyaltyAbility(new AminatouUltimateEffect(), -6).addHint(PlayersLeftRightHint.instance);
         this.addAbility(ability);
 
         // Aminatou, the Fateshifter can be your commander.

--- a/Mage.Sets/src/mage/cards/m/MysticBarrier.java
+++ b/Mage.Sets/src/mage/cards/m/MysticBarrier.java
@@ -4,6 +4,7 @@ import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.continuous.PlayerCanOnlyAttackInDirectionRestrictionEffect;
+import mage.abilities.hint.common.PlayersLeftRightHint;
 import mage.abilities.meta.OrTriggeredAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
@@ -32,7 +33,7 @@ public final class MysticBarrier extends CardImpl {
                         Duration.WhileOnBattlefield,
                         "the last chosen direction"
                 )
-        ));
+        ).addHint(PlayersLeftRightHint.instance));
     }
 
     private MysticBarrier(final MysticBarrier card) {

--- a/Mage.Sets/src/mage/cards/o/OrderOfSuccession.java
+++ b/Mage.Sets/src/mage/cards/o/OrderOfSuccession.java
@@ -7,6 +7,7 @@ import mage.abilities.Ability;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.GainControlTargetEffect;
+import mage.abilities.hint.common.PlayersLeftRightHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.choices.Choice;
@@ -35,7 +36,7 @@ public final class OrderOfSuccession extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{3}{U}");
 
         // Choose left or right. Starting with you and proceeding in the chosen direction, each player chooses a creature controlled by the next player in that direction. Each player gains control of the creature they chose.
-        this.getSpellAbility().addEffect(new OrderOfSuccessionEffect());
+        this.getSpellAbility().addHint(PlayersLeftRightHint.instance).addEffect(new OrderOfSuccessionEffect());
     }
 
     private OrderOfSuccession(final OrderOfSuccession card) {

--- a/Mage.Sets/src/mage/cards/p/PramikonSkyRampart.java
+++ b/Mage.Sets/src/mage/cards/p/PramikonSkyRampart.java
@@ -4,6 +4,7 @@ import mage.MageInt;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.continuous.PlayerCanOnlyAttackInDirectionRestrictionEffect;
+import mage.abilities.hint.common.PlayersLeftRightHint;
 import mage.abilities.keyword.DefenderAbility;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
@@ -43,7 +44,7 @@ public final class PramikonSkyRampart extends CardImpl {
                         Duration.WhileOnBattlefield,
                         "the chosen direction"
                 )
-        ));
+        ).addHint(PlayersLeftRightHint.instance));
     }
 
     private PramikonSkyRampart(final PramikonSkyRampart card) {

--- a/Mage.Sets/src/mage/cards/t/TeyoGeometricTactician.java
+++ b/Mage.Sets/src/mage/cards/t/TeyoGeometricTactician.java
@@ -7,6 +7,7 @@ import mage.abilities.effects.common.CreateTokenEffect;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
 import mage.abilities.effects.common.DrawCardTargetEffect;
 import mage.abilities.effects.common.continuous.PlayerCanOnlyAttackInDirectionRestrictionEffect;
+import mage.abilities.hint.common.PlayersLeftRightHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -51,7 +52,7 @@ public final class TeyoGeometricTactician extends CardImpl {
         ability = new LoyaltyAbility(
                 PlayerCanOnlyAttackInDirectionRestrictionEffect.choiceEffect(),
                 -2
-        );
+        ).addHint(PlayersLeftRightHint.instance);
         ability.addEffect(new PlayerCanOnlyAttackInDirectionRestrictionEffect(
                 Duration.UntilYourNextTurn,
                 "the last chosen direction"

--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -21,6 +21,7 @@ import mage.abilities.hint.common.CitysBlessingHint;
 import mage.abilities.hint.common.CurrentDungeonHint;
 import mage.abilities.hint.common.InitiativeHint;
 import mage.abilities.hint.common.MonarchHint;
+import mage.abilities.hint.common.PlayersLeftRightHint;
 import mage.abilities.keyword.*;
 import mage.cards.*;
 import mage.cards.decks.CardNameUtil;
@@ -58,6 +59,7 @@ import mage.verify.mtgjson.MtgJsonSet;
 import mage.verify.mtgjson.SpellBookCardsPage;
 import mage.watchers.Watcher;
 import net.java.truevfs.access.TFile;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -2602,9 +2604,10 @@ public class VerifyCardDataTest {
         cardHints.put(InitiativeHint.class, "the initiative");
         cardHints.put(CurrentDungeonHint.class, "venture into");
         cardHints.put(ColorsOfManaSpentToCastCount.getHint().getClass(), "Converge —");
+        cardHints.put(PlayersLeftRightHint.class, "choose left or right");
         for (Class hintClass : cardHints.keySet()) {
             String lookupText = cardHints.get(hintClass);
-            boolean needHint = ref.text.contains(lookupText);
+            boolean needHint = StringUtils.containsIgnoreCase(ref.text, lookupText);
             if (needHint) {
                 boolean haveHint = card.getAbilities()
                         .stream()

--- a/Mage/src/main/java/mage/abilities/hint/common/PlayersLeftRightHint.java
+++ b/Mage/src/main/java/mage/abilities/hint/common/PlayersLeftRightHint.java
@@ -1,0 +1,33 @@
+package mage.abilities.hint.common;
+
+import mage.abilities.Ability;
+import mage.abilities.hint.Hint;
+import mage.game.Game;
+import mage.players.Player;
+
+public enum PlayersLeftRightHint implements Hint {
+    instance;
+ 
+    @Override
+    public String getText(Game game, Ability ability) {
+        final Player controller = game.getPlayer(ability.getControllerId());
+        if (controller == null) {
+            return null;
+        }
+        final StringBuilder ret = new StringBuilder();
+        final Player left = game.getState().getPlayerList(ability.getControllerId()).getNext(game, false);
+        if (left != null) {
+            ret.append("Player to left: " + left.getName() + "<br>");
+        }
+        final Player right = game.getState().getPlayerList(ability.getControllerId()).getPrevious(game);
+        if (right != null) {
+            ret.append("Player to right: " + right.getName() + "<br>");
+        }
+        return ret.toString();
+    }
+ 
+    @Override
+    public Hint copy() {
+        return instance;
+    }
+}

--- a/Mage/src/main/java/mage/abilities/hint/common/PlayersLeftRightHint.java
+++ b/Mage/src/main/java/mage/abilities/hint/common/PlayersLeftRightHint.java
@@ -1,31 +1,43 @@
 package mage.abilities.hint.common;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import mage.abilities.Ability;
 import mage.abilities.hint.Hint;
 import mage.game.Game;
 import mage.players.Player;
+import mage.players.PlayerList;
 
 public enum PlayersLeftRightHint implements Hint {
     instance;
- 
+
     @Override
     public String getText(Game game, Ability ability) {
         final Player controller = game.getPlayer(ability.getControllerId());
         if (controller == null) {
             return null;
         }
-        final StringBuilder ret = new StringBuilder();
-        final Player left = game.getState().getPlayerList(ability.getControllerId()).getNext(game, false);
-        if (left != null) {
-            ret.append("Player to left: " + left.getName() + "<br>");
+
+        PlayerList players = game.getState().getPlayersInRange(ability.getControllerId(), game, true);
+
+        List<String> info = new ArrayList<>();
+        String leftInfo = "Player to left (next after you): %s";
+        Player leftPlayer = players.copy().getNext(game, false);
+        String rightInfo = "Player to right: %s";
+        Player rightPlayer = players.copy().getPrevious(game);
+        if (game.isTurnOrderReversed()) {
+            info.add("Turn order reversed by effects");
+            leftInfo = "Player to left: %s";
+            leftPlayer = players.copy().getPrevious(game);
+            rightInfo = "Player to right (next after you): %s";
+            rightPlayer = players.copy().getNext(game, false);
         }
-        final Player right = game.getState().getPlayerList(ability.getControllerId()).getPrevious(game);
-        if (right != null) {
-            ret.append("Player to right: " + right.getName() + "<br>");
-        }
-        return ret.toString();
+        info.add(String.format(leftInfo, leftPlayer == null ? "-" : leftPlayer.getLogName()));
+        info.add(String.format(rightInfo, rightPlayer == null ? "-" : rightPlayer.getLogName()));
+        return String.join("<br>", info);
     }
- 
+
     @Override
     public Hint copy() {
         return instance;


### PR DESCRIPTION
This is relevant to range of influence, but also because I've had a couple players report to me that these effects were not working correctly, but I haven't been able to reproduce it myself.  Just add this little hint indicating which players is to the controller's left/right for relevant abilities.