### PR TITLE
[MBC] Don't enable Acorn stamp reprints in Constructed by default

### DIFF
--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Brawl.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Brawl.java
@@ -43,6 +43,19 @@ public class Brawl extends Constructed {
         banned.add("Time Warp");
         banned.add("Ugin's Labyrinth");
         banned.add("Wash Away");
+
+        // These cards are banned by default in Constructed due to MBC acorn reprints.
+        // Brawl explicitly exempts them.
+        banned.remove("Case of the Lost Witness");
+        banned.remove("Emerald Collector");
+        banned.remove("Euru, Acorn Scrounger");
+        banned.remove("Jet Collector");
+        banned.remove("Oracle of the Alpha");
+        banned.remove("Overcooked");
+        banned.remove("Pearl Collector");
+        banned.remove("Perforator Crocodile");
+        banned.remove("Ruby Collector");
+        banned.remove("Sapphire Collector");
     }
 
     @Override

--- a/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Historic.java
+++ b/Mage.Server.Plugins/Mage.Deck.Constructed/src/mage/deck/Historic.java
@@ -113,5 +113,18 @@ public class Historic extends Constructed {
         banned.add("Fa'adiyah Seer");
         banned.add("Scrounging Bandar");
         banned.add("Time to Feed");
+
+        // These cards are banned by default in Constructed due to MBC acorn reprints.
+        // Historic explicitly exempts them.
+        banned.remove("Case of the Lost Witness");
+        banned.remove("Emerald Collector");
+        banned.remove("Euru, Acorn Scrounger");
+        banned.remove("Jet Collector");
+        banned.remove("Oracle of the Alpha");
+        banned.remove("Overcooked");
+        banned.remove("Pearl Collector");
+        banned.remove("Perforator Crocodile");
+        banned.remove("Ruby Collector");
+        banned.remove("Sapphire Collector");
     }
 }

--- a/Mage/src/main/java/mage/cards/decks/Constructed.java
+++ b/Mage/src/main/java/mage/cards/decks/Constructed.java
@@ -102,6 +102,7 @@ public class Constructed extends DeckValidator {
         banned.add("Blufferfish");
         banned.add("Busted!");
         banned.add("Carnival Barker");
+        banned.add("Case of the Lost Witness");
         banned.add("Centrifuge");
         banned.add("Claire D'Loon, Joy Sculptor");
         banned.add("Cover the Spot");
@@ -111,6 +112,8 @@ public class Constructed extends DeckValidator {
         banned.add("Devil K. Nevil");
         banned.add("Disemvowel");
         banned.add("Don't Try This at Home");
+        banned.add("Emerald Collector");
+        banned.add("Euru, Acorn Scrounger");
         banned.add("Exit Through the Grift Shop");
         banned.add("Far Out");
         banned.add("Fluros of Myra's Marvels");
@@ -137,6 +140,7 @@ public class Constructed extends DeckValidator {
         banned.add("It Came from Planet Glurg");
         banned.add("Jermane, Pride of the Circus");
         banned.add("Jetpack Janitor");
+        banned.add("Jet Collector");
         banned.add("Juggletron");
         banned.add("Katerina of Myra's Marvels");
         banned.add("Killer Cosplay");
@@ -155,9 +159,13 @@ public class Constructed extends DeckValidator {
         banned.add("Now You See Me . . .");
         banned.add("Octo Opus");
         banned.add("Omniclown Colossus");
+        banned.add("Oracle of the Alpha");
         banned.add("Opening Ceremony");
+        banned.add("Overcooked");
         banned.add("Park Map");
         banned.add("Park Re-Entry");
+        banned.add("Pearl Collector");
+        banned.add("Perforator Crocodile");
         banned.add("Phone a Friend");
         banned.add("Photo Op");
         banned.add("Pie-Eating Contest");
@@ -168,8 +176,10 @@ public class Constructed extends DeckValidator {
         banned.add("Questionable Cuisine");
         banned.add("Rat in the Hat");
         banned.add("Rock Star");
+        banned.add("Ruby Collector");
         banned.add("Scavenger Hunt");
         banned.add("Scooch");
+        banned.add("Sapphire Collector");
         banned.add("Solaflora, Intergalactic Icon");
         banned.add("Sole Performer");
         banned.add("Souvenir T-Shirt");


### PR DESCRIPTION
We can't rely on source set code alone to validate card legality, and these cards while reprinted in MBC, are all acorn stamped making them not Constructed format legal by default (exemptions for special events/sealed).

Although they are reprints and should be allowed in the formats that explicitly allow them; i.e Brawl and Historic