### PR TITLE
[don't merge] Consider rule modifying effects for valid targeting

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/targets/TargetRestrictionsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/targets/TargetRestrictionsTest.java
@@ -3,6 +3,7 @@ package org.mage.test.cards.targets;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
 
 /**
@@ -76,5 +77,22 @@ public class TargetRestrictionsTest extends CardTestPlayerBase {
         
         assertLife(playerA, 20);
         assertLife(playerB, 20);
+    }
+
+    // https://github.com/magefree/mage/issues/15756
+    @Test
+    public void testCantTargetCardsInGraveyards() {
+        addCard(Zone.BATTLEFIELD, playerA, "Dennick, Pious Apprentice");
+        addCard(Zone.GRAVEYARD, playerA, "Balduvian Bears");
+        addCard(Zone.BATTLEFIELD, playerA, "Scrabbling Claws");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}: Target player exiles a card from their graveyard");
+        addTarget(playerA, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertGraveyardCount(playerA, "Balduvian Bears", 1);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2621,9 +2621,9 @@ public class TestPlayer implements Player {
 
         // wrong target settings by addTarget
         // how to fix: implement target class processing above (if it a permanent target then check "filter instanceof" code too)
+        Set<UUID> possibleTargets = target.possibleTargets(abilityControllerId, source, game);
         if (!targets.isEmpty()) {
             String message;
-            Set<UUID> possibleTargets = target.possibleTargets(abilityControllerId, source, game);
 
             if (source != null) {
                 message = this.getName() + " - Targets list was setup by addTarget with " + targets + ", but not used"
@@ -2639,6 +2639,10 @@ public class TestPlayer implements Player {
                         + "\nYou must implement target class support in TestPlayer, \"filter instanceof\", or setup good targets";
             }
             Assert.fail(message);
+        }
+
+        if (possibleTargets.isEmpty()) {
+            return false;
         }
 
         this.chooseStrictModeFailed("target", game, getInfo(source, game) + "\n" + getInfo(target, source, game, null));

--- a/Mage/src/main/java/mage/target/Target.java
+++ b/Mage/src/main/java/mage/target/Target.java
@@ -2,6 +2,7 @@ package mage.target;
 
 import mage.MageObject;
 import mage.abilities.Ability;
+import mage.cards.Card;
 import mage.cards.Cards;
 import mage.constants.Outcome;
 import mage.constants.Zone;
@@ -151,6 +152,10 @@ public interface Target extends Copyable<Target>, Serializable {
                     if (targetPermanent != null) {
                         return canTarget(sourceControllerId, targetId, source, game)
                                 && targetPermanent.canBeTargetedBy(sourceObject, sourceControllerId, source, game);
+                    }
+                    Card targetCard = game.getCard(targetId);
+                    if (targetCard != null) {
+                        return canTarget(sourceControllerId, targetId, source, game);
                     }
                     return true;
                 })

--- a/Mage/src/main/java/mage/target/TargetCard.java
+++ b/Mage/src/main/java/mage/target/TargetCard.java
@@ -194,7 +194,7 @@ public class TargetCard extends TargetObject {
     public boolean canTarget(UUID id, Ability source, Game game) {
         // copy-pasted from super but with card instead object
         Card card = game.getCard(id);
-        return card != null
+        return super.canTarget(id, source, game) && card != null
                 && zone != null && zone.match(game.getState().getZone(id))
                 && getFilter() != null && getFilter().match(card, game);
     }
@@ -202,7 +202,7 @@ public class TargetCard extends TargetObject {
     @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Card card = game.getCard(id);
-        return card != null
+        return super.canTarget(id, source, game) && card != null
                 && zone != null && zone.match(game.getState().getZone(id))
                 && getFilter() != null && getFilter().match(card, playerId, source, game);
     }

--- a/Mage/src/main/java/mage/target/TargetObject.java
+++ b/Mage/src/main/java/mage/target/TargetObject.java
@@ -4,6 +4,7 @@ import mage.MageObject;
 import mage.abilities.Ability;
 import mage.constants.Zone;
 import mage.game.Game;
+import mage.game.events.TargetEvent;
 
 import java.util.UUID;
 
@@ -56,7 +57,8 @@ public abstract class TargetObject extends TargetImpl {
         MageObject object = game.getObject(id);
         return object != null
                 && zone != null && zone.match(game.getState().getZone(id))
-                && getFilter() != null && getFilter().match(object, game);
+                && getFilter() != null && getFilter().match(object, game)
+                && !game.getContinuousEffects().preventedByRuleModification(new TargetEvent(id, source), source, game, true);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInCommandZone.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInCommandZone.java
@@ -39,7 +39,8 @@ public class TargetCardInCommandZone extends TargetCard {
     @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
         Card card = game.getCard(id);
-        return game.getState().getZone(id) == Zone.COMMAND
+        return super.canTarget(playerId, id, source, game)
+                && game.getState().getZone(id) == Zone.COMMAND
                 && game.getState().getPlayersInRange(getTargetController() == null ? playerId : getTargetController(), game).contains(game.getOwnerId(id))
                 && filter.match(card, game);
     }

--- a/Mage/src/main/java/mage/target/common/TargetCardInGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInGraveyard.java
@@ -49,7 +49,7 @@ public class TargetCardInGraveyard extends TargetCard {
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
         Card card = game.getCard(id);
-        return card != null && game.getState().getZone(card.getId()) == Zone.GRAVEYARD && filter.match(card, game);
+        return super.canTarget(id, source, game) && card != null && game.getState().getZone(card.getId()) == Zone.GRAVEYARD && filter.match(card, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInHand.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInHand.java
@@ -48,7 +48,8 @@ public class TargetCardInHand extends TargetCard {
         // Has to be a card in the hand of a player in range. We don't know here, from which player's hand so we have to check all possible players
         // And because a card in hand is never targeted we can omitt specific targeting related checks
         Card card = game.getCard(id);
-        return game.getState().getZone(id) == Zone.HAND
+        return super.canTarget(playerId, id, source, game)
+                && game.getState().getZone(id) == Zone.HAND
                 && game.getState().getPlayersInRange(getTargetController() == null ? playerId : getTargetController(), game).contains(game.getOwnerId(id))
                 && filter.match(card, game);
     }

--- a/Mage/src/main/java/mage/target/common/TargetCardInLibrary.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInLibrary.java
@@ -116,7 +116,7 @@ public class TargetCardInLibrary extends TargetCard {
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
         Card card = game.getPlayer(source.getControllerId()).getLibrary().getCard(id, game);
-        return filter.match(card, source.getControllerId(), source, game);
+        return super.canTarget(id, source, game) && filter.match(card, source.getControllerId(), source, game);
     }
 
     @Override

--- a/Mage/src/main/java/mage/target/common/TargetCardInOpponentsGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInOpponentsGraveyard.java
@@ -38,6 +38,9 @@ public class TargetCardInOpponentsGraveyard extends TargetCard {
 
     @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
+            return false;
+        }
         Card card = game.getCard(id);
         if (card != null && zone.match(game.getState().getZone(id))) {
             if (game.getPlayer(source.getControllerId()).hasOpponent(card.getOwnerId(), game)) {
@@ -55,6 +58,9 @@ public class TargetCardInOpponentsGraveyard extends TargetCard {
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
+        if (!super.canTarget(id, source, game)) {
+            return false;
+        }
         Card card = game.getCard(id);
         if (card != null && game.getState().getZone(card.getId()) == Zone.GRAVEYARD) {
             if (game.getPlayer(source.getControllerId()).hasOpponent(card.getOwnerId(), game)) {

--- a/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyard.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyard.java
@@ -55,6 +55,9 @@ public class TargetCardInYourGraveyard extends TargetCard {
 
     @Override
     public boolean canTarget(UUID id, Ability source, Game game) {
+        if (!super.canTarget(id, source, game)) {
+            return false;
+        }
         Card card = game.getCard(id);
         if (card != null && game.getState().getZone(card.getId()) == Zone.GRAVEYARD) {
             if (game.getPlayer(source.getControllerId()).getGraveyard().contains(id)) {
@@ -66,6 +69,9 @@ public class TargetCardInYourGraveyard extends TargetCard {
 
     @Override
     public boolean canTarget(UUID playerId, UUID id, Ability ability, Game game) {
+        if (!super.canTarget(playerId, id, ability, game)) {
+            return false;
+        }
         Card card = game.getCard(id);
         if (card != null && game.getState().getZone(card.getId()) == Zone.GRAVEYARD) {
             if (game.getPlayer(playerId).getGraveyard().contains(id)) {

--- a/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyardOrExile.java
+++ b/Mage/src/main/java/mage/target/common/TargetCardInYourGraveyardOrExile.java
@@ -4,6 +4,7 @@ import mage.abilities.Ability;
 import mage.cards.Card;
 import mage.constants.Zone;
 import mage.filter.FilterCard;
+import mage.filter.StaticFilters;
 import mage.game.Game;
 import mage.players.Player;
 import mage.target.TargetCard;
@@ -21,7 +22,7 @@ public class TargetCardInYourGraveyardOrExile extends TargetCard {
     private final FilterCard filterExile;
 
     public TargetCardInYourGraveyardOrExile(FilterCard filterGraveyard, FilterCard filterExile) {
-        super(1, 1, Zone.GRAVEYARD, filterGraveyard); // we do not actually use those, as all is overwritten
+        super(1, 1, Zone.ALL, StaticFilters.FILTER_CARD); // we do not actually use those, as all is overwritten
         this.filterGraveyard = filterGraveyard;
         this.filterExile = filterExile;
         this.targetName = filterGraveyard.getMessage() + " or " + filterExile.getMessage();
@@ -57,6 +58,9 @@ public class TargetCardInYourGraveyardOrExile extends TargetCard {
 
     @Override
     public boolean canTarget(UUID playerId, UUID id, Ability source, Game game) {
+        if (!super.canTarget(playerId, id, source, game)) {
+            return false;
+        }
         Card card = game.getCard(id);
         if (card == null) {
             return false;


### PR DESCRIPTION
This unfortunately requires a series of changes to makework.  As the reported issue says, in its current state rule-modifying effects which affect target legality aren't checked when considering whether to show an object as targetable, rather they reject the attempt to target when the user tries to.  This indeed causes a game lockup.

The first thing I did was try to take this into account in `TargetObject.canTarget()`.  That worked, but only for permanents, it didn't work for the stated test case where a *card* was an illegal target.  Following that, I saw that we don't check card target legality generally at all.  I applied this in `TargetCard` to call up to the parent, and had to do the same for most of its subclasses.

This fixed the issue interactively (when there are no valid legal targets you are allowed to click the cancel button) but I also had to make some changes to the test framework in order to get `TestPlayer` to allow this possible state.  Now if there are no legal targets it allows omitting the `addTarget()` call.

This *might* be a regression in c7a485b as it removed a log of calls to `game.replaceEvent`, but not sure.

Fixes https://github.com/magefree/mage/issues/15756