### PR TITLE
Hide additional costs rules from Web-Slinging to prevent incorrectly …

### DIFF
--- a/Mage/src/main/java/mage/abilities/keyword/WebSlingingAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/WebSlingingAbility.java
@@ -38,6 +38,7 @@ public class WebSlingingAbility extends SpellAbility {
         this.clearManaCostsToPay();
         this.addCost(new ManaCostsImpl<>(manaString));
         this.addCost(new ReturnToHandChosenControlledPermanentCost(new TargetControlledPermanent(filter)));
+        this.setAdditionalCostsRuleVisible(false);
 
         this.setRuleAtTheTop(true);
     }


### PR DESCRIPTION
Fixes unexpected rules text appearing on cards with Web-Slinging during Mage.Verify ability text checks.

WebSlinging cards were showing an extra generated line:
"As an additional cost to cast this spell, return a tapped creature you control to its owner's hand."

<img width="645" height="353" alt="Screenshot 2026-08-05 at 22 37 32" src="https://github.com/user-attachments/assets/7ce0818d-7af4-46e7-bd66-f9457586f192" />

That line is engine-generated from spell costs, but Web-Slinging already provides its own keyword reminder text, so the extra line created a mismatch against reference Oracle-style text in verification.

Mechanically, the ability works as before, but we just correctly omit showing that superfluous rule now. This is in keeping a bit with how Blitz and Warp do it

