### PR TITLE
Refactor: combine attacking alone predicate

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CrowdOfTrueBelievers.java
+++ b/Mage.Sets/src/mage/cards/c/CrowdOfTrueBelievers.java
@@ -11,9 +11,7 @@ import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.predicate.Predicate;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
+import mage.filter.predicate.permanent.AttackingAlonePredicate;
 import mage.target.common.TargetControlledPermanent;
 
 import java.util.UUID;
@@ -54,21 +52,5 @@ public final class CrowdOfTrueBelievers extends CardImpl {
     @Override
     public CrowdOfTrueBelievers copy() {
         return new CrowdOfTrueBelievers(this);
-    }
-}
-
-enum AttackingAlonePredicate implements Predicate<Permanent> {
-    instance;
-
-    @Override
-    public boolean apply(Permanent input, Game game) {
-        return input.isAttacking()
-            && game.getCombat().attacksAlone()
-            && game.getCombat().getAttackers().contains(input.getId());
-    }
-
-    @Override
-    public String toString() {
-        return "Attacking alone";
     }
 }

--- a/Mage.Sets/src/mage/cards/v/ViperCruelConspirator.java
+++ b/Mage.Sets/src/mage/cards/v/ViperCruelConspirator.java
@@ -17,9 +17,7 @@ import mage.constants.Duration;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.filter.common.FilterCreaturePermanent;
-import mage.filter.predicate.Predicate;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
+import mage.filter.predicate.permanent.AttackingAlonePredicate;
 import mage.target.TargetPermanent;
 
 /**
@@ -71,21 +69,5 @@ public final class ViperCruelConspirator extends CardImpl {
     @Override
     public ViperCruelConspirator copy() {
         return new ViperCruelConspirator(this);
-    }
-}
-
-enum AttackingAlonePredicate implements Predicate<Permanent> {
-    instance;
-
-    @Override
-    public boolean apply(Permanent input, Game game) {
-        return input.isAttacking()
-            && game.getCombat().attacksAlone()
-            && game.getCombat().getAttackers().contains(input.getId());
-    }
-
-    @Override
-    public String toString() {
-        return "Attacking alone";
     }
 }

--- a/Mage/src/main/java/mage/filter/predicate/permanent/AttackingAlonePredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/AttackingAlonePredicate.java
@@ -1,4 +1,3 @@
-
 package mage.filter.predicate.permanent;
 
 import mage.filter.predicate.Predicate;

--- a/Mage/src/main/java/mage/filter/predicate/permanent/AttackingAlonePredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/AttackingAlonePredicate.java
@@ -1,0 +1,25 @@
+
+package mage.filter.predicate.permanent;
+
+import mage.filter.predicate.Predicate;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+/**
+ * @author muz
+ */
+public enum AttackingAlonePredicate implements Predicate<Permanent> {
+    instance;
+
+    @Override
+    public boolean apply(Permanent input, Game game) {
+        return input.isAttacking()
+                && game.getCombat().attacksAlone()
+                && game.getCombat().getAttackers().contains(input.getId());
+    }
+
+    @Override
+    public String toString() {
+        return "Attacking alone";
+    }
+}

--- a/Mage/src/main/java/mage/filter/predicate/permanent/AttackingAlonePredicate.java
+++ b/Mage/src/main/java/mage/filter/predicate/permanent/AttackingAlonePredicate.java
@@ -6,7 +6,7 @@ import mage.game.Game;
 import mage.game.permanent.Permanent;
 
 /**
- * @author muz
+ * @author anishtilekar
  */
 public enum AttackingAlonePredicate implements Predicate<Permanent> {
     instance;


### PR DESCRIPTION
## Summary
- `Crowd of True Believers` and `Viper, Cruel Conspirator` each declared an identical local `AttackingAlonePredicate` enum.
- Extracted the shared logic into `mage.filter.predicate.permanent.AttackingAlonePredicate`, following the existing naming/placement convention used by `AttackingPredicate` and friends in the same package.
- Both cards now import and use the shared predicate; no behavior change.

Closes #15906

## Test plan
- `mvn -pl Mage,Mage.Sets -am compile` succeeds with no errors.
- No prior unit tests existed for either card; this is a behavior-preserving refactor (identical predicate logic), so no test changes are included.