### PR TITLE
Refactor duplicated enchanted counter removal effect

### DIFF
--- a/Mage.Sets/src/mage/cards/e/EnchantedRiversGrasp.java
+++ b/Mage.Sets/src/mage/cards/e/EnchantedRiversGrasp.java
@@ -1,17 +1,14 @@
 package mage.cards.e;
 
-import java.util.Optional;
 import java.util.UUID;
 import mage.constants.SubType;
-import mage.game.Game;
-import mage.game.permanent.Permanent;
 import mage.target.common.TargetCreaturePermanent;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.AttachEffect;
 import mage.abilities.effects.common.DontUntapInControllersUntapStepEnchantedEffect;
+import mage.abilities.effects.common.RemoveAllCountersEnchantedEffect;
 import mage.abilities.effects.common.TapEnchantedEffect;
 import mage.abilities.effects.common.continuous.LoseAllAbilitiesAttachedEffect;
 import mage.constants.Outcome;
@@ -41,7 +38,7 @@ public final class EnchantedRiversGrasp extends CardImpl {
 
         // When this Aura enters, tap enchanted creature and remove all counters from it.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapEnchantedEffect());
-        ability.addEffect(new EnchantedRiversGraspEffect());
+        ability.addEffect(new RemoveAllCountersEnchantedEffect().setText("and remove all counters from it"));
         this.addAbility(ability);
 
         // Enchanted creature loses all abilities and doesn't untap during its controller's untap step.
@@ -57,32 +54,5 @@ public final class EnchantedRiversGrasp extends CardImpl {
     @Override
     public EnchantedRiversGrasp copy() {
         return new EnchantedRiversGrasp(this);
-    }
-}
-
-class EnchantedRiversGraspEffect extends OneShotEffect {
-
-    EnchantedRiversGraspEffect() {
-        super(Outcome.Benefit);
-        staticText = "and remove all counters from it";
-    }
-
-    private EnchantedRiversGraspEffect(final EnchantedRiversGraspEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public EnchantedRiversGraspEffect copy() {
-        return new EnchantedRiversGraspEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return Optional
-                .ofNullable((Permanent) getValue("permanentEnteredBattlefield"))
-                .map(Permanent::getAttachedTo)
-                .map(game::getPermanent)
-                .filter(permanent -> permanent.removeAllCounters(source, game) > 0)
-                .isPresent();
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EnchantedRiversGrasp.java
+++ b/Mage.Sets/src/mage/cards/e/EnchantedRiversGrasp.java
@@ -38,7 +38,7 @@ public final class EnchantedRiversGrasp extends CardImpl {
 
         // When this Aura enters, tap enchanted creature and remove all counters from it.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapEnchantedEffect());
-        ability.addEffect(new RemoveAllCountersEnchantedEffect().setText("and remove all counters from it"));
+        ability.addEffect(new RemoveAllCountersEnchantedEffect().concatBy("and"));
         this.addAbility(ability);
 
         // Enchanted creature loses all abilities and doesn't untap during its controller's untap step.

--- a/Mage.Sets/src/mage/cards/h/HonestWork.java
+++ b/Mage.Sets/src/mage/cards/h/HonestWork.java
@@ -38,7 +38,7 @@ public final class HonestWork extends CardImpl {
 
         // When this Aura enters, tap enchanted creature and remove all counters from it.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapEnchantedEffect());
-        ability.addEffect(new RemoveAllCountersEnchantedEffect().setText("and remove all counters from it"));
+        ability.addEffect(new RemoveAllCountersEnchantedEffect().concatBy("and"));
         this.addAbility(ability);
 
         // Enchanted creature loses all abilities and is a Citizen with base power and toughness 1/1 and "{T}: Add {C}" named Humble Merchant.

--- a/Mage.Sets/src/mage/cards/h/HonestWork.java
+++ b/Mage.Sets/src/mage/cards/h/HonestWork.java
@@ -4,8 +4,8 @@ import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.ContinuousEffectImpl;
-import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.AttachEffect;
+import mage.abilities.effects.common.RemoveAllCountersEnchantedEffect;
 import mage.abilities.effects.common.TapEnchantedEffect;
 import mage.abilities.keyword.EnchantAbility;
 import mage.abilities.mana.ColorlessManaAbility;
@@ -38,7 +38,7 @@ public final class HonestWork extends CardImpl {
 
         // When this Aura enters, tap enchanted creature and remove all counters from it.
         Ability ability = new EntersBattlefieldTriggeredAbility(new TapEnchantedEffect());
-        ability.addEffect(new HonestWorkCountersEffect());
+        ability.addEffect(new RemoveAllCountersEnchantedEffect().setText("and remove all counters from it"));
         this.addAbility(ability);
 
         // Enchanted creature loses all abilities and is a Citizen with base power and toughness 1/1 and "{T}: Add {C}" named Humble Merchant.
@@ -55,32 +55,6 @@ public final class HonestWork extends CardImpl {
     }
 }
 
-class HonestWorkCountersEffect extends OneShotEffect {
-
-    HonestWorkCountersEffect() {
-        super(Outcome.Benefit);
-        staticText = "and remove all counters from it";
-    }
-
-    private HonestWorkCountersEffect(final HonestWorkCountersEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public HonestWorkCountersEffect copy() {
-        return new HonestWorkCountersEffect(this);
-    }
-
-    @Override
-    public boolean apply(Game game, Ability source) {
-        return Optional
-                .ofNullable((Permanent) getValue("permanentEnteredBattlefield"))
-                .map(Permanent::getAttachedTo)
-                .map(game::getPermanent)
-                .filter(permanent -> permanent.removeAllCounters(source, game) > 0)
-                .isPresent();
-    }
-}
 
 class HonestWorkAbilityEffect extends ContinuousEffectImpl {
 

--- a/Mage/src/main/java/mage/abilities/effects/common/RemoveAllCountersEnchantedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RemoveAllCountersEnchantedEffect.java
@@ -1,0 +1,40 @@
+package mage.abilities.effects.common;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.constants.Outcome;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+
+import java.util.Optional;
+
+/**
+ * @author Karthikeyan010
+ */
+
+public class RemoveAllCountersEnchantedEffect extends OneShotEffect {
+    public RemoveAllCountersEnchantedEffect() {
+        super(Outcome.Benefit);
+        staticText ="remove all counters from it";
+    }
+
+    protected RemoveAllCountersEnchantedEffect(final RemoveAllCountersEnchantedEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public RemoveAllCountersEnchantedEffect copy() {
+        return new RemoveAllCountersEnchantedEffect(this);
+
+    }
+
+    @override
+    public boolean apply(Game game , Ability source) {
+        return Optional
+                .ofNullable((Permanent) getValue("permanentEnteredBattlefield"))
+                .map(Permanent::getAttachedTo)
+                .map(game::getPermanent)
+                .filter(permanent -> permanent.removeAllCounters(source, game) > 0)
+                .isPresent();
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/RemoveAllCountersEnchantedEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/RemoveAllCountersEnchantedEffect.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 public class RemoveAllCountersEnchantedEffect extends OneShotEffect {
     public RemoveAllCountersEnchantedEffect() {
         super(Outcome.Benefit);
-        staticText ="remove all counters from it";
+        staticText = "remove all counters from it";
     }
 
     protected RemoveAllCountersEnchantedEffect(final RemoveAllCountersEnchantedEffect effect) {
@@ -28,7 +28,7 @@ public class RemoveAllCountersEnchantedEffect extends OneShotEffect {
 
     }
 
-    @override
+    @Override
     public boolean apply(Game game , Ability source) {
         return Optional
                 .ofNullable((Permanent) getValue("permanentEnteredBattlefield"))


### PR DESCRIPTION
## Summary

Extracts the duplicated logic for removing all counters from an enchanted permanent into a reusable `RemoveAllCountersEnchantedEffect`.

Updates:
- `EnchantedRiversGrasp`
- `HonestWork`

Both cards now use the shared effect instead of maintaining separate `OneShotEffect` implementations.

Closes #15901

## Testing

- `mvn -pl Mage.Sets -am -DskipTests clean compile`
- Build completed successfully.
- `git diff --cached --check` completed without errors.