### PR TITLE
[tests] Disable checking/enforcing booster info for OM1

### DIFF
--- a/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
+++ b/Mage.Verify/src/test/java/mage/verify/VerifyCardDataTest.java
@@ -1023,8 +1023,6 @@ public class VerifyCardDataTest {
         ignoreBoosterSets.add("Zendikar Rising Expeditions"); // box toppers
         ignoreBoosterSets.add("March of the Machine: The Aftermath"); // epilogue boosters aren't for draft
         ignoreBoosterSets.add("Mystery Booster"); // temporary
-        // TEMPORARY: Pending MTGJson updates
-        ignoreBoosterSets.add("The Hobbit");
     }
 
     @Test
@@ -1214,6 +1212,11 @@ public class VerifyCardDataTest {
             if (jsonSet.booster != null && !jsonSet.booster.isEmpty() && !implementedSets.contains(jsonSet.code)) {
                 if (jsonSet.code.equals("HBG")) {
                     // TODO: remove after implement dozens A-cards, see HBG - Alchemy Horizons: Baldur's Gate
+                    return;
+                }
+                if (jsonSet.code.equals("OM1")) {
+                    // TODO: Determine how to model this set, if at all.
+                    // Wizards released this in lieu of SPM due to licensing issues. Almost mechannically identical, but with unique card names/art.
                     return;
                 }
                 // how-to fix: it's miss promo sets with boosters, so just add/generate it in most use cases


### PR DESCRIPTION
```
Error: missing set implementation (important for draft format) - OM1 - Through the Omenpaths - boosters: [arena]
```

Originally released to sidestep what looks like licensing issues from Wizards; https://magic.wizards.com/en/news/announcements/through-the-omenpaths-and-digital-universes-beyond-updates

But then walked back later with MSH being released; https://magic.wizards.com/en/news/mtg-arena/marvel-super-heroes#:~:text=Magic:%20The%20Gathering%20|%20Marvel's%20Spider%2DMan%20Comes%20to%20MTG%20Arena

Unsure of how we want to model this pseudo-set, if at all, but for now, don't have it fail CI runs and potentially mask other failures