### PR TITLE
[minor] Cleanup redundant calls to extending ManaCondition implementing Condition

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AdarkarUnicorn.java
+++ b/Mage.Sets/src/mage/cards/a/AdarkarUnicorn.java
@@ -4,7 +4,6 @@ import mage.ConditionalMana;
 import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.keyword.CumulativeUpkeepAbility;
 import mage.abilities.mana.ConditionalColoredManaAbility;
@@ -69,7 +68,7 @@ class AdarkarUnicornConditionalMana extends ConditionalMana {
     }
 }
 
-class AdarkarUnicornManaCondition extends ManaCondition implements Condition {
+class AdarkarUnicornManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/c/CultivatorDrone.java
+++ b/Mage.Sets/src/mage/cards/c/CultivatorDrone.java
@@ -7,7 +7,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCost;
@@ -74,7 +73,7 @@ class CultivatorDroneConditionalMana extends ConditionalMana {
     }
 }
 
-class CultivatorDroneManaCondition extends ManaCondition implements Condition {
+class CultivatorDroneManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costToPay) {

--- a/Mage.Sets/src/mage/cards/g/GreatHallOfTheCitadel.java
+++ b/Mage.Sets/src/mage/cards/g/GreatHallOfTheCitadel.java
@@ -5,7 +5,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
@@ -71,7 +70,7 @@ class GreatHallOfTheCitadelConditionalMana extends ConditionalMana {
     }
 }
 
-class GreatHallOfTheCitadelManaCondition extends ManaCondition implements Condition {
+class GreatHallOfTheCitadelManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
+++ b/Mage.Sets/src/mage/cards/g/GuidelightOptimizer.java
@@ -7,7 +7,6 @@ import mage.MageInt;
 import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
 import mage.abilities.mana.ConditionalColoredManaAbility;
 import mage.abilities.mana.builder.ConditionalManaBuilder;
 import mage.abilities.mana.conditional.ManaCondition;
@@ -25,7 +24,7 @@ public final class GuidelightOptimizer extends CardImpl {
 
     public GuidelightOptimizer(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{1}{U}");
-        
+
         this.subtype.add(SubType.ROBOT);
         this.power = new MageInt(2);
         this.toughness = new MageInt(1);
@@ -66,7 +65,7 @@ class ArtifactOrActivatedConditionalMana extends ConditionalMana {
     }
 }
 
-class ArtifactOrActivatedManaCondition extends ManaCondition implements Condition {
+class ArtifactOrActivatedManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/j/JamesWanderingDad.java
+++ b/Mage.Sets/src/mage/cards/j/JamesWanderingDad.java
@@ -4,7 +4,6 @@ import mage.ConditionalMana;
 import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.dynamicvalue.common.GetXValue;
@@ -85,7 +84,7 @@ class JamesWanderingDadConditionalMana extends ConditionalMana {
     }
 }
 
-class JamesWanderingDadManaCondition extends ManaCondition implements Condition {
+class JamesWanderingDadManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {
@@ -99,4 +98,3 @@ class JamesWanderingDadManaCondition extends ManaCondition implements Condition 
         return apply(game, source);
     }
 }
-

--- a/Mage.Sets/src/mage/cards/k/KarfellHarbinger.java
+++ b/Mage.Sets/src/mage/cards/k/KarfellHarbinger.java
@@ -6,7 +6,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.keyword.ForetellAbility;
 import mage.abilities.mana.ConditionalColoredManaAbility;
@@ -70,7 +69,7 @@ class KarfellHarbingerConditionalMana extends ConditionalMana {
     }
 }
 
-class KarfellHarbingerManaCondition extends ManaCondition implements Condition {
+class KarfellHarbingerManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/k/KlauthUnrivaledAncient.java
+++ b/Mage.Sets/src/mage/cards/k/KlauthUnrivaledAncient.java
@@ -7,7 +7,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.AttacksTriggeredAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.keyword.FlyingAbility;
@@ -118,7 +117,7 @@ class KlauthUnrivaledAncientConditionalMana extends ConditionalMana {
     }
 }
 
-class KlauthUnrivaledAncientManaCondition extends ManaCondition implements Condition {
+class KlauthUnrivaledAncientManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/l/LaForgePerceptiveEngineer.java
+++ b/Mage.Sets/src/mage/cards/l/LaForgePerceptiveEngineer.java
@@ -11,7 +11,6 @@ import mage.constants.SuperType;
 import mage.game.Game;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.abilities.mana.ConditionalColoredManaAbility;
@@ -75,7 +74,7 @@ class LaForgeSpellConditionalMana extends ConditionalMana {
     }
 }
 
-class LaForgeSpellManaCondition extends ManaCondition implements Condition {
+class LaForgeSpellManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/m/MeetingOfTheFive.java
+++ b/Mage.Sets/src/mage/cards/m/MeetingOfTheFive.java
@@ -5,7 +5,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.asthought.CanPlayCardControllerEffect;
@@ -126,7 +125,7 @@ class MeetingOfTheFiveConditionalMana extends ConditionalMana {
     }
 }
 
-class MeetingOfTheFiveManaCondition extends ManaCondition implements Condition {
+class MeetingOfTheFiveManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/n/NarsetOfTheAncientWay.java
+++ b/Mage.Sets/src/mage/cards/n/NarsetOfTheAncientWay.java
@@ -6,7 +6,6 @@ import mage.abilities.Ability;
 import mage.abilities.LoyaltyAbility;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.delayed.ReflexiveTriggeredAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
@@ -93,7 +92,7 @@ class NarsetOfTheAncientWayManaEffect extends OneShotEffect {
     }
 }
 
-class NarsetOfTheAncientWayManaCondition extends ManaCondition implements Condition {
+class NarsetOfTheAncientWayManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/n/NikoDefiesDestiny.java
+++ b/Mage.Sets/src/mage/cards/n/NikoDefiesDestiny.java
@@ -6,7 +6,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.SagaAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.dynamicvalue.DynamicValue;
 import mage.abilities.effects.Effect;
@@ -162,7 +161,7 @@ class NikoDefiesDestinyConditionalMana extends ConditionalMana {
     }
 }
 
-class NikoDefiesDestinyManaCondition extends ManaCondition implements Condition {
+class NikoDefiesDestinyManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/o/OpenTheOmenpaths.java
+++ b/Mage.Sets/src/mage/cards/o/OpenTheOmenpaths.java
@@ -6,7 +6,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.Mode;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.BoostControlledEffect;
@@ -80,7 +79,7 @@ class OpenTheOmenpathsEffect extends OneShotEffect {
     }
 }
 
-class OpenTheOmenpathsCondition extends ManaCondition implements Condition {
+class OpenTheOmenpathsCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/p/PlazaOfHeroes.java
+++ b/Mage.Sets/src/mage/cards/p/PlazaOfHeroes.java
@@ -6,7 +6,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.ExileSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
@@ -103,7 +102,7 @@ class PlazaOfHeroesConditionalMana extends ConditionalMana {
     }
 }
 
-class PlazaOfHeroesManaCondition extends ManaCondition implements Condition {
+class PlazaOfHeroesManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/q/QuinjetTechnician.java
+++ b/Mage.Sets/src/mage/cards/q/QuinjetTechnician.java
@@ -6,7 +6,6 @@ import mage.ConditionalMana;
 import mage.MageInt;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.keyword.PowerUpAbility;
@@ -75,7 +74,7 @@ class QuinjetTechnicianConditionalMana extends ConditionalMana {
     }
 }
 
-class QuinjetTechnicianManaCondition extends ManaCondition implements Condition {
+class QuinjetTechnicianManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/s/SageOfTheUnknowable.java
+++ b/Mage.Sets/src/mage/cards/s/SageOfTheUnknowable.java
@@ -6,7 +6,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.mana.ConditionalColorlessManaAbility;
@@ -69,7 +68,7 @@ class SageOfTheUnknowableConditionalMana extends ConditionalMana {
     }
 }
 
-class SageOfTheUnknowableManaCondition extends ManaCondition implements Condition {
+class SageOfTheUnknowableManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costToPay) {

--- a/Mage.Sets/src/mage/cards/s/ShangChiMasterOfKungFu.java
+++ b/Mage.Sets/src/mage/cards/s/ShangChiMasterOfKungFu.java
@@ -6,7 +6,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.effects.AsThoughEffectImpl;
@@ -110,7 +109,7 @@ class ShangChiMasterOfKungFuConditionalMana extends ConditionalMana {
     }
 }
 
-class ShangChiMasterOfKungFuManaCondition extends ManaCondition implements Condition {
+class ShangChiMasterOfKungFuManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/s/Snowfall.java
+++ b/Mage.Sets/src/mage/cards/s/Snowfall.java
@@ -6,7 +6,6 @@ import mage.ConditionalMana;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.common.TapForManaAllTriggeredManaAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.mana.ManaEffect;
@@ -153,7 +152,7 @@ class SnowfallConditionalMana extends ConditionalMana {
     }
 }
 
-class SnowfallManaCondition extends ManaCondition implements Condition {
+class SnowfallManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/s/SoldeviMachinist.java
+++ b/Mage.Sets/src/mage/cards/s/SoldeviMachinist.java
@@ -5,7 +5,6 @@ import mage.MageInt;
 import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.mana.ConditionalColorlessManaAbility;
@@ -68,7 +67,7 @@ class ArtifactAbilityConditionalMana extends ConditionalMana {
     }
 }
 
-class ArtifactAbilityManaCondition extends ManaCondition implements Condition {
+class ArtifactAbilityManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/s/SorcererClass.java
+++ b/Mage.Sets/src/mage/cards/s/SorcererClass.java
@@ -8,7 +8,6 @@ import mage.abilities.SpellAbility;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.dynamicvalue.common.InstantAndSorceryCastThisTurn;
 import mage.abilities.effects.OneShotEffect;
@@ -107,7 +106,7 @@ class SorcererClassConditionalMana extends ConditionalMana {
     }
 }
 
-class SorcererClassManaCondition extends ManaCondition implements Condition {
+class SorcererClassManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/s/SteelswarmOperator.java
+++ b/Mage.Sets/src/mage/cards/s/SteelswarmOperator.java
@@ -6,7 +6,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.mana.ConditionalColoredManaAbility;
@@ -75,7 +74,7 @@ class SteelswarmOperatorSpellConditionalMana extends ConditionalMana {
     }
 }
 
-class SteelswarmOperatorSpellManaCondition extends ManaCondition implements Condition {
+class SteelswarmOperatorSpellManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {
@@ -114,7 +113,7 @@ class SteelswarmOperatorAbilitiesConditionalMana extends ConditionalMana {
     }
 }
 
-class SteelswarmOperatorAbilitiesManaCondition extends ManaCondition implements Condition {
+class SteelswarmOperatorAbilitiesManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
+++ b/Mage.Sets/src/mage/cards/t/TazriStalwartSurvivor.java
@@ -119,7 +119,7 @@ class TazriStalwartSurvivorManaEffect extends ManaEffect {
         }
     }
 
-    private static final class TazriStalwartSurvivorManaCondition extends ManaCondition implements Condition {
+    private static final class TazriStalwartSurvivorManaCondition extends ManaCondition {
 
         @Override
         public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/t/ThranTurbine.java
+++ b/Mage.Sets/src/mage/cards/t/ThranTurbine.java
@@ -5,7 +5,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.triggers.BeginningOfUpkeepTriggeredAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.mana.AddConditionalColorlessManaEffect;
@@ -95,7 +94,7 @@ class ThranTurbineConditionalMana extends ConditionalMana {
     }
 }
 
-class ThranTurbineManaCondition extends ManaCondition implements Condition {
+class ThranTurbineManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source, UUID originalId, Cost costToPay) {

--- a/Mage.Sets/src/mage/cards/u/UnblinkingObserver.java
+++ b/Mage.Sets/src/mage/cards/u/UnblinkingObserver.java
@@ -6,7 +6,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.keyword.DisturbAbility;
 import mage.abilities.mana.ConditionalColoredManaAbility;
@@ -71,7 +70,7 @@ class UnblinkingObserverConditionalMana extends ConditionalMana {
     }
 }
 
-class UnblinkingObserverManaCondition extends ManaCondition implements Condition {
+class UnblinkingObserverManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/u/UntaidakeTheCloudKeeper.java
+++ b/Mage.Sets/src/mage/cards/u/UntaidakeTheCloudKeeper.java
@@ -8,7 +8,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.PayLifeCost;
 import mage.abilities.costs.common.TapSourceCost;
@@ -72,7 +71,7 @@ class LegendaryCastConditionalMana extends ConditionalMana {
     }
 }
 
-class LegendaryCastManaCondition extends ManaCondition implements Condition {
+class LegendaryCastManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/v/VoldarenEstate.java
+++ b/Mage.Sets/src/mage/cards/v/VoldarenEstate.java
@@ -8,7 +8,6 @@ import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
 import mage.abilities.common.SimpleActivatedAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.CostAdjuster;
 import mage.abilities.costs.common.PayLifeCost;
@@ -103,7 +102,7 @@ class VoldarenEstateConditionalMana extends ConditionalMana {
     }
 }
 
-class VoldarenEstateManaCondition extends ManaCondition implements Condition {
+class VoldarenEstateManaCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage.Sets/src/mage/cards/v/VolsheTideturner.java
+++ b/Mage.Sets/src/mage/cards/v/VolsheTideturner.java
@@ -6,7 +6,6 @@ import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
 import mage.abilities.SpellAbility;
-import mage.abilities.condition.Condition;
 import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.TapSourceCost;
@@ -71,7 +70,7 @@ class VolsheTideturnerConditionalMana extends ConditionalMana {
     }
 }
 
-class VolsheTideturnerCondition extends ManaCondition implements Condition {
+class VolsheTideturnerCondition extends ManaCondition {
 
     @Override
     public boolean apply(Game game, Ability source) {


### PR DESCRIPTION
Saw this dotted about the codebase, figured it's due a cleanup to prevent it propagating further. 

There's no need for custom mana conditions to explicitly declare that they implement the Condition interface, when the ManaCondition class itself already does that. 

With removing it, the import is also then redundant in the majority of these classes; so clean that up too where safe. 