### PR TITLE
Add card hint to cards with ControlYourCommanderCondition

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AncestralCommunion.java
+++ b/Mage.Sets/src/mage/cards/a/AncestralCommunion.java
@@ -6,6 +6,7 @@ import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.common.CastSourceTriggeredAbility;
 import mage.abilities.effects.common.CopySourceSpellEffect;
 import mage.abilities.effects.common.ReturnFromGraveyardToHandTargetEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -27,7 +28,8 @@ public final class AncestralCommunion extends CardImpl {
         // When you cast this spell while you control your commander, copy this spell. You may choose a new target for the copy.
         this.addAbility(new CastSourceTriggeredAbility(
             new CopySourceSpellEffect().setText("copy this spell. You may choose a new target for the copy")
-        ).withTriggerCondition(ControlYourCommanderCondition.instance));
+        ).withTriggerCondition(ControlYourCommanderCondition.instance)
+                .addHint(ControlYourCommanderHint.instance));
 
         // Return target permanent card from your graveyard to your hand.
         this.getSpellAbility().addEffect(new ReturnFromGraveyardToHandTargetEffect());

--- a/Mage.Sets/src/mage/cards/c/ConvergenceOfDominion.java
+++ b/Mage.Sets/src/mage/cards/c/ConvergenceOfDominion.java
@@ -8,6 +8,7 @@ import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.MillCardsControllerEffect;
 import mage.abilities.effects.common.cost.CostModificationEffectImpl;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
@@ -26,7 +27,9 @@ public final class ConvergenceOfDominion extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{3}");
 
         // Dynastic Command Node -- As long as you control your commander, activated abilities of cards in your graveyard cost {2} less to activate. This effect can't reduce the mana in that ability's activation cost to less than one mana.
-        this.addAbility(new SimpleStaticAbility(new ConvergenceOfDominionEffect()).withFlavorWord("Dynastic Command Node"));
+        this.addAbility(new SimpleStaticAbility(new ConvergenceOfDominionEffect())
+                .withFlavorWord("Dynastic Command Node")
+                .addHint(ControlYourCommanderHint.instance));
 
         // Translocation Protocols -- {3}, {T}: Mill three cards.
         Ability ability = new SimpleActivatedAbility(new MillCardsControllerEffect(3), new GenericManaCost(3));

--- a/Mage.Sets/src/mage/cards/i/IronwillForger.java
+++ b/Mage.Sets/src/mage/cards/i/IronwillForger.java
@@ -4,6 +4,7 @@ import mage.MageInt;
 import mage.abilities.Ability;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.MyriadAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -43,6 +44,7 @@ public final class IronwillForger extends CardImpl {
                 new GainAbilityTargetEffect(new MyriadAbility(false))
         ).withInterveningIf(ControlYourCommanderCondition.instance);
         ability.addTarget(new TargetPermanent(filter));
+        ability.addHint(ControlYourCommanderHint.instance);
         this.addAbility(ability.setAbilityWord(AbilityWord.LIEUTENANT));
     }
 

--- a/Mage.Sets/src/mage/cards/l/LoyalApprentice.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalApprentice.java
@@ -5,6 +5,7 @@ import mage.abilities.Ability;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -36,7 +37,8 @@ public final class LoyalApprentice extends CardImpl {
         // Lieutenant — At the beginning of combat on your turn, if you control your commander, create a 1/1 colorless Thopter artifact creature token with flying. That token gains haste until end of turn.
         this.addAbility(new BeginningOfCombatTriggeredAbility(new LoyalApprenticeEffect())
                 .withInterveningIf(ControlYourCommanderCondition.instance)
-                .setAbilityWord(AbilityWord.LIEUTENANT));
+                .setAbilityWord(AbilityWord.LIEUTENANT)
+                .addHint(ControlYourCommanderHint.instance));
     }
 
     private LoyalApprentice(final LoyalApprentice card) {

--- a/Mage.Sets/src/mage/cards/l/LoyalDrake.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalDrake.java
@@ -3,6 +3,7 @@ package mage.cards.l;
 import mage.MageInt;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -31,7 +32,8 @@ public final class LoyalDrake extends CardImpl {
         // Lieutenant — At the beginning of combat on your turn, if you control your commander, draw a card.
         this.addAbility(new BeginningOfCombatTriggeredAbility(new DrawCardSourceControllerEffect(1))
                 .withInterveningIf(ControlYourCommanderCondition.instance)
-                .setAbilityWord(AbilityWord.LIEUTENANT));
+                .setAbilityWord(AbilityWord.LIEUTENANT)
+                .addHint(ControlYourCommanderHint.instance));
     }
 
     private LoyalDrake(final LoyalDrake card) {

--- a/Mage.Sets/src/mage/cards/l/LoyalGuardian.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalGuardian.java
@@ -3,6 +3,7 @@ package mage.cards.l;
 import mage.MageInt;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.common.counter.AddCountersAllEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.TrampleAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -33,7 +34,9 @@ public final class LoyalGuardian extends CardImpl {
         // Lieutenant — At the beginning of combat on your turn, if you control your commander, put a +1/+1 counter on each creature you control.
         this.addAbility(new BeginningOfCombatTriggeredAbility(new AddCountersAllEffect(
                 CounterType.P1P1.createInstance(), StaticFilters.FILTER_CONTROLLED_CREATURE
-        )).withInterveningIf(ControlYourCommanderCondition.instance).setAbilityWord(AbilityWord.LIEUTENANT));
+        )).withInterveningIf(ControlYourCommanderCondition.instance)
+                .setAbilityWord(AbilityWord.LIEUTENANT)
+                .addHint(ControlYourCommanderHint.instance));
     }
 
     private LoyalGuardian(final LoyalGuardian card) {

--- a/Mage.Sets/src/mage/cards/l/LoyalSubordinate.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalSubordinate.java
@@ -3,6 +3,7 @@ package mage.cards.l;
 import mage.MageInt;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.common.LoseLifeOpponentsEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.MenaceAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -31,7 +32,8 @@ public final class LoyalSubordinate extends CardImpl {
         // Lieutenant — At the beginning of combat on your turn, if you control your commander, each opponent loses 3 life.
         this.addAbility(new BeginningOfCombatTriggeredAbility(new LoseLifeOpponentsEffect(3))
                 .withInterveningIf(ControlYourCommanderCondition.instance)
-                .setAbilityWord(AbilityWord.LIEUTENANT));
+                .setAbilityWord(AbilityWord.LIEUTENANT)
+                .addHint(ControlYourCommanderHint.instance));
     }
 
     private LoyalSubordinate(final LoyalSubordinate card) {

--- a/Mage.Sets/src/mage/cards/l/LoyalUnicorn.java
+++ b/Mage.Sets/src/mage/cards/l/LoyalUnicorn.java
@@ -5,6 +5,7 @@ import mage.abilities.Ability;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.effects.common.PreventAllDamageToAllEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAllEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.VigilanceAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -40,6 +41,7 @@ public final class LoyalUnicorn extends CardImpl {
                 VigilanceAbility.getInstance(), Duration.EndOfTurn,
                 StaticFilters.FILTER_CONTROLLED_CREATURES, true
         ));
+        ability.addHint(ControlYourCommanderHint.instance);
         this.addAbility(ability.setAbilityWord(AbilityWord.LIEUTENANT));
     }
 

--- a/Mage.Sets/src/mage/cards/s/SiegeGangLieutenant.java
+++ b/Mage.Sets/src/mage/cards/s/SiegeGangLieutenant.java
@@ -9,6 +9,7 @@ import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.OneShotEffect;
 import mage.abilities.effects.common.DamageTargetEffect;
 import mage.abilities.effects.common.continuous.GainAbilityTargetEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.HasteAbility;
 import mage.abilities.triggers.BeginningOfCombatTriggeredAbility;
 import mage.cards.CardImpl;
@@ -44,7 +45,8 @@ public final class SiegeGangLieutenant extends CardImpl {
         // Lieutenant -- At the beginning of combat on your turn, if you control your commander, create two 1/1 red Goblin creature tokens. Those tokens gain haste until end of turn.
         this.addAbility(new BeginningOfCombatTriggeredAbility(new SiegeGangLieutenantEffect())
                 .withInterveningIf(ControlYourCommanderCondition.instance)
-                .setAbilityWord(AbilityWord.LIEUTENANT));
+                .setAbilityWord(AbilityWord.LIEUTENANT)
+                .addHint(ControlYourCommanderHint.instance));
 
         // {2}, Sacrifice a Goblin: Siege-Gang Lieutenant deals 1 damage to any target.
         Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(1), new GenericManaCost(2));

--- a/Mage.Sets/src/mage/cards/s/SkyhunterStrikeForce.java
+++ b/Mage.Sets/src/mage/cards/s/SkyhunterStrikeForce.java
@@ -5,6 +5,7 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
 import mage.abilities.effects.common.continuous.GainAbilityControlledEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.MeleeAbility;
 import mage.cards.CardImpl;
@@ -43,7 +44,8 @@ public final class SkyhunterStrikeForce extends CardImpl {
                         StaticFilters.FILTER_CONTROLLED_CREATURES, true
                 ), ControlYourCommanderCondition.instance, "as long as you control your commander, " +
                 "other creatures you control have melee"
-        )).setAbilityWord(AbilityWord.LIEUTENANT));
+        )).setAbilityWord(AbilityWord.LIEUTENANT)
+                .addHint(ControlYourCommanderHint.instance));
     }
 
     private SkyhunterStrikeForce(final SkyhunterStrikeForce card) {

--- a/Mage/src/main/java/mage/abilities/abilityword/LieutenantAbility.java
+++ b/Mage/src/main/java/mage/abilities/abilityword/LieutenantAbility.java
@@ -5,6 +5,7 @@ import mage.abilities.condition.common.ControlYourCommanderCondition;
 import mage.abilities.decorator.ConditionalContinuousEffect;
 import mage.abilities.effects.ContinuousEffect;
 import mage.abilities.effects.common.continuous.BoostSourceEffect;
+import mage.abilities.hint.common.ControlYourCommanderHint;
 import mage.constants.AbilityWord;
 import mage.constants.Duration;
 import mage.constants.Zone;
@@ -22,6 +23,7 @@ public class LieutenantAbility extends SimpleStaticAbility {
                 "as long as you control your commander, {this} gets +2/+2"
         ));
         this.setAbilityWord(AbilityWord.LIEUTENANT);
+        this.addHint(ControlYourCommanderHint.instance);
         this.addLieutenantEffect(effect, text);
     }
 

--- a/Mage/src/main/java/mage/abilities/hint/common/ControlYourCommanderHint.java
+++ b/Mage/src/main/java/mage/abilities/hint/common/ControlYourCommanderHint.java
@@ -1,0 +1,26 @@
+package mage.abilities.hint.common;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.common.ControlYourCommanderCondition;
+import mage.abilities.hint.ConditionHint;
+import mage.abilities.hint.Hint;
+import mage.game.Game;
+
+/**
+ * @author anishtilekar
+ */
+public enum ControlYourCommanderHint implements Hint {
+
+    instance;
+    private static final ConditionHint hint = new ConditionHint(ControlYourCommanderCondition.instance, "You control your commander");
+
+    @Override
+    public String getText(Game game, Ability ability) {
+        return hint.getText(game, ability);
+    }
+
+    @Override
+    public Hint copy() {
+        return instance;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `ControlYourCommanderHint` and attaches it to every card gated on `ControlYourCommanderCondition`, so players can see at a glance whether the condition is currently met.

The new hint follows `ControlACommanderHint`, its existing neighbour in `mage.abilities.hint.common`, rather than `MonarchHint` — `MonarchHint` overrides `getText` only to append the current monarch's name, which has no equivalent here.

Closes #15909

## Coverage

15 cards depend on the condition, in two groups:

- **10 use the condition directly** and get `.addHint(...)` individually: Ancestral Communion, Convergence of Dominion, Ironwill Forger, Loyal Apprentice, Loyal Drake, Loyal Guardian, Loyal Subordinate, Loyal Unicorn, Siege-Gang Lieutenant, Skyhunter Strike Force.
- **5 go through `LieutenantAbility`** — Angelic Field Marshal, Demon of Wailing Agonies, Stormsurge Kraken, Thunderfoot Baloth, Tyrant's Familiar. The hint is added once in that shared ability instead of in each card.

Cross-checked by grepping card sources for the oracle phrase "control your commander"; it returns exactly these 15 files, so nothing is missed.

## Test plan

- `mvn -pl Mage,Mage.Sets -am -DskipTests compile` passes.
- Display-only change — hints are surfaced separately from rules text and do not affect `getRule()` or game behavior, so no test changes are included.
