### PR TITLE
AI: improved modal abilities support

### DIFF
--- a/Mage.Server.Plugins/Mage.Player.AI.MAD/src/mage/player/ai/ComputerPlayer6.java
+++ b/Mage.Server.Plugins/Mage.Player.AI.MAD/src/mage/player/ai/ComputerPlayer6.java
@@ -754,13 +754,19 @@ public class ComputerPlayer6 extends ComputerPlayer {
 
     protected String getAbilityAndSourceInfo(Game game, Ability ability, boolean showTargets) {
         // ability
-        // TODO: add modal info
-        // + (action.isModal() ? " Mode = " + action.getModes().getMode().toString() : "")
-        if (ability.isModal()) {
-            //throw new IllegalStateException("TODO: need implement");
-        }
         MageObject sourceObject = ability.getSourceObject(game);
         String abilityInfo = (sourceObject == null ? "" : sourceObject.getIdName() + ": ") + CardUtil.substring(ability.toString(), 30, "...");
+
+        // modes
+        List<String> modesInfo = new ArrayList<>();
+        String modesInfoStr = "";
+        if (ability.isModal()) {
+            ability.getModes().getSelectedModes().forEach(mode -> {
+                modesInfo.add(String.format("mode: %s", CardUtil.substring(ability.getModes().get(mode).toString(), 20, "...")));
+            });
+            modesInfoStr = "modes " + ability.getModes().getSelectedModes().size() + ": " + String.join(", ", modesInfo);
+        }
+
         // targets
         String targetsInfo = "";
         if (showTargets) {
@@ -797,7 +803,7 @@ public class ComputerPlayer6 extends ComputerPlayer {
             });
             targetsInfo = String.join(" + ", allTargetsInfo);
         }
-        return abilityInfo + (targetsInfo.isEmpty() ? "" : " -> " + targetsInfo);
+        return abilityInfo + (targetsInfo.isEmpty() ? "" : " -> " + targetsInfo) + (modesInfoStr.isEmpty() ? "" : " (" + modesInfoStr + ")");
     }
 
     private String printDiffScore(int score) {

--- a/Mage.Server.Plugins/Mage.Player.AI/src/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/mage/player/ai/ComputerPlayer.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * AI: basic server side bot with simple actions support (game, draft, construction/sideboarding).
@@ -924,18 +925,30 @@ public class ComputerPlayer extends PlayerImpl {
     @Override
     public Mode chooseMode(Modes modes, Ability source, Game game) {
         if (modes.getMode() != null && modes.getMaxModes(game, source) == modes.getSelectedModes().size()) {
-            // mode was already set by the AI
+            // normal use case with cast/activate on priority like simulated games
+            logger.debug("AI, found already selected modes on " + game);
             return modes.getMode();
         }
 
-        // spell modes simulated by AI, see addModeOptions
-        // trigger modes chooses here
-        // TODO: add AI support to select best modes, current code uses first valid mode
-        return modes.getAvailableModes(source, game).stream()
+        // normal use cases for forced selection (e.g. cast by effect instead priority)
+        // bad use cases for cast/activate on priority
+        logger.debug("AI, fallback to modes selection on " + game);
+        logger.debug("  - available modes order: " + modes.getAvailableModes(source, game).stream()
+                .map(m -> m.getId() + " [" + m.getEffects().getText(m) + "]")
+                .collect(Collectors.joining(" | ")));
+
+        Mode result = modes.getAvailableModes(source, game).stream()
                 .filter(mode -> !modes.getSelectedModes().contains(mode.getId()))
                 .filter(mode -> mode.getTargets().canChoose(source.getControllerId(), source, game))
                 .findFirst()
                 .orElse(null);
+
+        logger.debug("  - fallback picked: " + (result == null ? "null" : result.getId() + " [" + result.getEffects().getText(result) + "]"));
+        logger.debug("  - canChoose per mode: " + modes.getAvailableModes(source, game).stream()
+            .map(m -> m.getId() + "=" + m.getTargets().canChoose(source.getControllerId(), source, game))
+            .collect(Collectors.joining(" | ")));
+
+        return result;
     }
 
     @Override

--- a/Mage.Server.Plugins/Mage.Player.AI/src/mage/player/ai/ComputerPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.AI/src/mage/player/ai/ComputerPlayer.java
@@ -938,7 +938,7 @@ public class ComputerPlayer extends PlayerImpl {
                 .collect(Collectors.joining(" | ")));
 
         Mode result = modes.getAvailableModes(source, game).stream()
-                .filter(mode -> !modes.getSelectedModes().contains(mode.getId()))
+                .filter(mode -> modes.isMayChooseSameModeMoreThanOnce() || !modes.getSelectedModes().contains(mode.getId()))
                 .filter(mode -> mode.getTargets().canChoose(source.getControllerId(), source, game))
                 .findFirst()
                 .orElse(null);

--- a/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/SimulatedPlayerMCTS.java
+++ b/Mage.Server.Plugins/Mage.Player.AIMCTS/src/mage/player/ai/SimulatedPlayerMCTS.java
@@ -23,6 +23,7 @@ import org.apache.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * AI: helper class to simulate games with MCTS AI (each player replaced by simulated)
@@ -370,12 +371,16 @@ public final class SimulatedPlayerMCTS extends MCTSPlayer {
     @Override
     public Mode chooseMode(Modes modes, Ability source, Game game) {
         if (this.isHuman()) {
-            Iterator<Mode> it = modes.getAvailableModes(source, game).iterator();
+            List<Mode> availableModes = modes.getAvailableModes(source, game).stream()
+                    .filter(mode -> modes.isMayChooseSameModeMoreThanOnce() || !modes.getSelectedModes().contains(mode.getId()))
+                    .filter(mode -> mode.getTargets().canChoose(source.getControllerId(), source, game))
+                    .collect(Collectors.toList());
+            Iterator<Mode> it = availableModes.iterator();
             Mode mode = it.next();
-            if (modes.size() == 1) {
+            if (availableModes.size() == 1) {
                 return mode;
             }
-            int modeNum = RandomUtil.nextInt(modes.getAvailableModes(source, game).size());
+            int modeNum = RandomUtil.nextInt(availableModes.size());
             for (int i = 0; i < modeNum; i++) {
                 mode = it.next();
             }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2564,9 +2564,11 @@ public class HumanPlayer extends PlayerImpl {
             }
 
             // done button for "for up" choices only
-            boolean canEndChoice = (modes.getSelectedModes().size() >= modes.getMinModes() && modes.getMaxPawPrints() == 0) ||
-                    (modes.getSelectedPawPrints() >= modes.getMaxPawPrints() && modes.getMaxPawPrints() > 0) ||
-                    modes.isMayChooseNone();
+            boolean isValidSelection = 
+                (modes.getMaxPawPrints() == 0 && modes.getSelectedModes().size() >= modes.getMinModes())
+                || (modes.getMaxPawPrints() > 0 && modes.getSelectedPawPrints() <= modes.getMaxPawPrints())
+                || (modes.isMayChooseNone() && modes.getSelectedModes().isEmpty());
+            boolean canEndChoice = isValidSelection;
             if (canEndChoice) {
                 modeMap.put(Modes.CHOOSE_OPTION_DONE_ID, "Done");
             }

--- a/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
+++ b/Mage.Server.Plugins/Mage.Player.Human/src/mage/player/human/HumanPlayer.java
@@ -2595,11 +2595,14 @@ public class HumanPlayer extends PlayerImpl {
             // process choice
             UUID responseId = getFixedResponseUUID(game);
             if (responseId != null) {
-                for (Mode mode : modes.getAvailableModes(source, game)) {
-                    if (mode.getId().equals(responseId)) {
+                for (Mode responseMode : modes.getAvailableModes(source, game).stream()
+                        .filter(mode -> modes.isMayChooseSameModeMoreThanOnce() || !modes.getSelectedModes().contains(mode.getId()))
+                        .filter(mode -> mode.getTargets().canChoose(source.getControllerId(), source, game))
+                        .collect(Collectors.toList())) {
+                    if (responseMode.getId().equals(responseId)) {
                         // TODO: add checks on 2x selects (cheaters can rewrite client side code and select same mode multiple times)
                         // reason: wrong setup eachModeMoreThanOnce and eachModeOnlyOnce in many cards
-                        return mode;
+                        return responseMode;
                     }
                 }
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
@@ -1,5 +1,11 @@
 package org.mage.test.AI.basic;
 
+import mage.abilities.Ability;
+import mage.abilities.Mode;
+import mage.abilities.common.SimpleActivatedAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.common.LoseLifeOpponentsEffect;
+import mage.abilities.effects.common.LoseLifeSourceControllerEffect;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 
@@ -151,5 +157,64 @@ public class ChooseModalAbilityAITest extends CardTestPlayerBaseWithAIHelps {
         execute();
 
         assertGraveyardCount(playerA, "Kolaghan's Command", 1);
+    }
+
+    @Test
+    public void test_LimitedUsageModes_AndNoModes_AI() {
+        addCustomCardWithAbility(ACTIVATE_ABILITY, playerA, null);
+        // make sure no errors on addModeOptions
+
+        // Galadriel, Light of Valinor - Alliance 
+        // Whenever another creature you control enters, choose
+        // one that hasn't been chosen this turn -"
+        // * Add {G}{G}{G}.
+        // * Put a +1/+1 counter on each creature you control.
+        // * Scry 2, then draw a card.
+        addCard(Zone.BATTLEFIELD, playerA, "Galadriel, Light of Valinor", 1);
+
+        // x3 triggers to exec all x3 modes
+        // x1 trigger to exec 0 modes due limited usage of modes (all x3 modes already used)
+        addCard(Zone.HAND, playerA, "Ornithopter", 4); // {0} artifact creature
+
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertPermanentCount(playerA, "Galadriel, Light of Valinor", 1);
+    }
+
+
+    @Test
+    public void test_PartialPawPrintSelection_AI() {
+        // make sure paw prints allow to select only part of the budget and AI will use it for better score
+
+        // there aren't any real cards (like Season of the Bold) so use custom ability
+        // with 2 modes and {P} cost budget = 5, minModes = 0
+        // * {P} -- You lose 3 life.                     (always legal, no target, always bad)
+        // * {P}{P}{P}{P} -- Each opponent loses 4 life.  (always legal, no target, always good)
+        Ability ability = new SimpleActivatedAbility(new LoseLifeSourceControllerEffect(3), new TapSourceCost());
+        ability.getModes().setMinModes(0);
+        ability.getModes().setMaxModes(5);
+        ability.getModes().setMaxPawPrints(5);
+        ability.getModes().setMayChooseSameModeMoreThanOnce(true);
+        ability.getModes().getMode().withPawPrintValue(1);
+ 
+        Mode mode2 = new Mode(new LoseLifeOpponentsEffect(4));
+        mode2.withPawPrintValue(4);
+        ability.addMode(mode2);
+ 
+        addCustomCardWithAbility("War Totem", playerA, ability);
+ 
+        // AI must use non-full budget and ignore damage to self (mode 1)
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+ 
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+ 
+        assertLife(playerA, 20);
+        assertLife(playerB, 20 - 4);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
@@ -105,4 +105,51 @@ public class ChooseModalAbilityAITest extends CardTestPlayerBaseWithAIHelps {
         assertGraveyardCount(playerA, "Fiery Confluence", 1);
         assertLife(playerB, 20 - 2 * 3);
     }
+
+    private void setupChooseTwoMode() {
+        // Kolaghan's Command {1}{B}{R} - Choose two -
+        // * Return target creature card from your graveyard to your hand;
+        // * Target player discards a card;
+        // * Destroy target artifact;
+        // * Kolaghan's Command deals 2 damage to any target.
+        addCard(Zone.HAND, playerA, "Kolaghan's Command", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 1);
+
+        // only 2 modes valid here: mode 2 (discard) and mode 4 (damage any target)
+    }
+
+    @Test
+    public void test_ChooseTwoModal_Manual() {
+        setupChooseTwoMode();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Kolaghan's Command");
+        setModeChoice(playerA, "2"); // Target player discards a card
+        addTarget(playerA, playerB);
+        setModeChoice(playerA, "4"); // deals 2 damage to any target
+        addTarget(playerA, playerB);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerA, "Kolaghan's Command", 1);
+        assertLife(playerB, 20 - 2);
+    }
+
+    @Test
+    public void test_ChooseTwoModal_AI() {
+        setupChooseTwoMode();
+
+        // test case for AI's getAvailableModes - make sure selected modes processing is correct
+        // if not then will be error like "Wrong call of addSelectedMode: mode already selected, you can't select it again"
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertGraveyardCount(playerA, "Kolaghan's Command", 1);
+    }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
@@ -3,7 +3,6 @@ package org.mage.test.AI.basic;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
 
@@ -93,7 +92,6 @@ public class ChooseModalAbilityAITest extends CardTestPlayerBaseWithAIHelps {
     }
 
     @Test
-    @Ignore // TODO: add support of You may choose the same mode more than once, see addModeOptions
     public void test_MultiModal_AI() {
         setupMultiMode();
 

--- a/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/AI/basic/ChooseModalAbilityAITest.java
@@ -1,0 +1,110 @@
+package org.mage.test.AI.basic;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBaseWithAIHelps;
+
+/**
+ *
+ * @author JayDi85
+ */
+public class ChooseModalAbilityAITest extends CardTestPlayerBaseWithAIHelps {
+
+    private void setupSingleMode() {
+        // Choose one --
+        // * Target creature you control deals damage equal to its power to target creature an opponent controls.
+        // * Destroy target artifact or enchantment.
+        addCard(Zone.HAND, playerA, "It's Clobberin' Time!", 1); // {2}{G}
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+
+        // possible mode 1 target: own creature - negative score
+        addCard(Zone.BATTLEFIELD, playerA, "Raging Goblin", 1); // 1/1
+
+        // possible mode 1 target: opponent creature, survive, nothing to score
+        addCard(Zone.BATTLEFIELD, playerB, "Balduvian Bears", 1); // 2/2
+
+        // possible mode 2 target: opponent artifact, destroy, gives ~500 score
+        addCard(Zone.BATTLEFIELD, playerB, "Manalith", 1);
+    }
+
+    @Test
+    public void test_SingleModal_Manual() {
+        setupSingleMode();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "It's Clobberin' Time!");
+        setModeChoice(playerA, "2"); // 2: Destroy target artifact or enchantment
+        addTarget(playerA, "Manalith");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertExileCount(playerA, "It's Clobberin' Time!", 1);
+        assertPermanentCount(playerB, "Manalith", 0);
+    }
+
+    @Test
+    public void test_SingleModal_AI() {
+        setupSingleMode();
+
+        // ai must choose mode 2 due useless mode 1 (1 damage to 2/2 bear is worthless)
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertExileCount(playerA, "It's Clobberin' Time!", 1); // exile due to Rebound
+        assertPermanentCount(playerB, "Manalith", 0);
+    }
+
+    private void setupMultiMode() {
+        // Fiery Confluence {2}{R}{R} - Choose three. You may choose the same mode more than once.
+        // * Fiery Confluence deals 1 damage to each creature.
+        // * Fiery Confluence deals 2 damage to each opponent.
+        // * Destroy target artifact.
+        addCard(Zone.HAND, playerA, "Fiery Confluence", 1);
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 4);
+
+        // no targets on mode 1 = it's useless
+        // has targets on mode 2 = so AI must use it
+        // no targets on mode 3 = it's useless
+    }
+
+    @Test
+    public void test_MultiModal_Manual() {
+        setupMultiMode();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Fiery Confluence");
+        // 2: {this} deals 2 damage to each opponent
+        setModeChoice(playerA, "2");
+        setModeChoice(playerA, "2");
+        setModeChoice(playerA, "2");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertGraveyardCount(playerA, "Fiery Confluence", 1);
+        assertLife(playerB, 20 - 2 * 3);
+    }
+
+    @Test
+    @Ignore // TODO: add support of You may choose the same mode more than once, see addModeOptions
+    public void test_MultiModal_AI() {
+        setupMultiMode();
+
+        // ai must choose x3 mode 2 due useless mode 1 and 3 (no targets)
+        aiPlayPriority(1, PhaseStep.PRECOMBAT_MAIN, playerA);
+
+        setStopAt(1, PhaseStep.END_TURN);
+        setStrictChooseMode(true);
+        execute();
+
+        assertGraveyardCount(playerA, "Fiery Confluence", 1);
+        assertLife(playerB, 20 - 2 * 3);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
+++ b/Mage.Tests/src/test/java/org/mage/test/player/TestPlayer.java
@@ -2208,11 +2208,6 @@ public class TestPlayer implements Player {
 
     @Override
     public Mode chooseMode(Modes modes, Ability source, Game game) {
-        if (modes.getSelectedModes().size() >= modes.getMaxModes(game, source)) {
-            // TODO: no needs here cause min/max mode must be checked by parent code? try to remove it from here
-            return null;
-        }
-
         StringBuilder modesInfo = new StringBuilder();
         modesInfo.append("\nAvailable modes:");
         int i = 1;

--- a/Mage/src/main/java/mage/abilities/AbilityImpl.java
+++ b/Mage/src/main/java/mage/abilities/AbilityImpl.java
@@ -213,9 +213,20 @@ public abstract class AbilityImpl implements Ability {
             if (this instanceof TriggeredAbility) {
                 for (UUID modeId : this.getModes().getSelectedModes()) {
                     this.getModes().setActiveMode(modeId);
+                    logger.debug("AbilityImpl.resolve as triggered ability: " + this.getModes().getMode());
+                    result = resolveMode(game);
+                }
+            } else if (this instanceof ActivatedAbility && !(this instanceof SpellAbility)) {
+                // 2026-08-09
+                // there aren't any cards with multiple modes in activated ability (except spells)
+                // but support added for future releases, see ChooseModalAbilityAITest
+                for (UUID modeId : this.getModes().getSelectedModes()) {
+                    this.getModes().setActiveMode(modeId);
+                    logger.debug("AbilityImpl.resolve as activated and non-spell ability: " + this.getModes().getMode());
                     result = resolveMode(game);
                 }
             } else {
+                logger.debug("AbilityImpl.resolve as other ability: " + this.getModes().getMode());
                 result = resolveMode(game);
             }
         }

--- a/Mage/src/main/java/mage/abilities/Modes.java
+++ b/Mage/src/main/java/mage/abilities/Modes.java
@@ -28,7 +28,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
     private static final Logger logger = Logger.getLogger(Modes.class);
 
     // TODO: add performance tests for infinite modes and make sure limit works fine, see ChooseModalAbilityAITest
-    private static final int MAX_MODES_TO_SELECT = 10; // limit human and AI choices, cause some modes allow to select infinite amount of times
+    private static final int MAX_MODES_TO_SELECT = 5; // limit human and AI choices, cause some modes allow to select infinite amount of times
 
     // choose ID for options in ability/mode picker dialogs
     public static final UUID CHOOSE_OPTION_DONE_ID = UUID.fromString("33e72ad6-17ae-4bfb-a097-6e7aa06b49e9");
@@ -510,7 +510,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
 
         if (selectedModes.contains(modeId)) {
             if (!mayChooseSameModeMoreThanOnce) {
-                // how-to fix: make sure AI code clean and setup modes and targets correctly
+                // how-to fix: make sure AI code clean, filter and setup modes and targets correctly
                 throw new IllegalArgumentException("Wrong call of addSelectedMode: mode already selected, you can't select it again");
             }
             Mode duplicateMode = mode.copy();
@@ -584,6 +584,8 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
 
     /**
      * Returns all (still) available modes of the ability
+     * 
+     * Warning, you must filter out already selected modes by yourself due diff usages (for AI, for real game cycle, for logs, etc)
      *
      * @param source
      * @param game

--- a/Mage/src/main/java/mage/abilities/Modes.java
+++ b/Mage/src/main/java/mage/abilities/Modes.java
@@ -27,6 +27,9 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
 
     private static final Logger logger = Logger.getLogger(Modes.class);
 
+    // TODO: add performance tests for infinite modes and make sure limit works fine, see ChooseModalAbilityAITest
+    private static final int MAX_MODES_TO_SELECT = 10; // limit human and AI choices, cause some modes allow to select infinite amount of times
+
     // choose ID for options in ability/mode picker dialogs
     public static final UUID CHOOSE_OPTION_DONE_ID = UUID.fromString("33e72ad6-17ae-4bfb-a097-6e7aa06b49e9");
     public static final UUID CHOOSE_OPTION_CANCEL_ID = UUID.fromString("0125bd0c-5610-4eba-bc80-fc6d0a7b9de6");
@@ -347,9 +350,10 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
         int selectedTargetsCount = this.values().stream().mapToInt(
                 m -> m.getTargets().stream().mapToInt(t -> t.getTargets().size()).sum()
         ).sum();
-        if (selectedTargetsCount > 0) {
+        int selectedModesCount = this.selectedModes.size();
+        if (selectedTargetsCount > 0 || selectedModesCount > 1) {
             // keep
-            logger.debug("modes choose, keep predefined modes and targets " + selectedTargetsCount);
+            logger.debug("modes choose, keep predefined modes " + selectedModesCount + " and targets " + selectedTargetsCount);
         } else {
             // clear
             if (isAlreadySelectedModesOutdated(game, source)) {
@@ -587,6 +591,18 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
      */
     public List<Mode> getAvailableModes(Ability source, Game game) {
         List<Mode> availableModes = new ArrayList<>();
+
+        // limit by max selected
+        if (this.getSelectedModes().size() >= this.getMaxModes(game, source)) {
+            return availableModes;
+        }
+
+        // limit by max allowed by game engine
+        if (this.getSelectedModes().size() >= MAX_MODES_TO_SELECT) {
+            logger.warn("reach max modes limit for " + source + " in " + game);
+            return availableModes;
+        }
+
         Set<UUID> nonAvailableModes;
         if (isMayChooseSameModeMoreThanOnce()) {
             nonAvailableModes = new HashSet<>();

--- a/Mage/src/main/java/mage/abilities/Modes.java
+++ b/Mage/src/main/java/mage/abilities/Modes.java
@@ -1,5 +1,10 @@
 package mage.abilities;
 
+import java.util.*;
+import java.util.stream.Stream;
+
+import org.apache.log4j.Logger;
+
 import mage.abilities.condition.Condition;
 import mage.abilities.costs.OptionalAdditionalModeSourceCosts;
 import mage.abilities.effects.Effect;
@@ -15,13 +20,12 @@ import mage.util.CardUtil;
 import mage.util.Copyable;
 import mage.util.RandomUtil;
 
-import java.util.*;
-import java.util.stream.Stream;
-
 /**
  * @author BetaSteward_at_googlemail.com
  */
 public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> {
+
+    private static final Logger logger = Logger.getLogger(Modes.class);
 
     // choose ID for options in ability/mode picker dialogs
     public static final UUID CHOOSE_OPTION_DONE_ID = UUID.fromString("33e72ad6-17ae-4bfb-a097-6e7aa06b49e9");
@@ -171,6 +175,22 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
         this.selectedModes.clear();
         this.selectedDuplicateModes.clear();
         this.selectedDuplicateToOriginalModeRefs.clear();
+
+        // clean predefined targets lists too to make sure it's really new selection 
+        // (it helps to find bad AI code, e.g. in addModeOptions)
+        int selectedTargetsCount = this.values().stream()
+                .mapToInt(m -> m.getTargets().stream()
+                        .mapToInt(t -> t.getTargets().size())
+                        .sum()
+                )
+                .sum();
+        if (selectedTargetsCount > 0) {
+            logger.debug("found predefined targets to clean: " + selectedTargetsCount);
+            this.values().forEach(
+                mode -> logger.debug(" - targets count " + mode.getTargets().stream().mapToInt(t -> t.getTargets().size()).sum() + ", " + mode)
+            );
+        }
+        this.values().forEach(mode -> mode.getTargets().clearChosen());
     }
 
     public int getSelectedStats(UUID modeId) {
@@ -322,10 +342,21 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
     }
 
     public boolean choose(Game game, Ability source) {
-        if (isAlreadySelectedModesOutdated(game, source)) {
-            this.clearAlreadySelectedModes(source, game);
+        // in multi-modal abilities it must keep already selected modes and targets
+        // to make sure AI simulations will keep predefined setup (modes + targets)
+        int selectedTargetsCount = this.values().stream().mapToInt(
+                m -> m.getTargets().stream().mapToInt(t -> t.getTargets().size()).sum()
+        ).sum();
+        if (selectedTargetsCount > 0) {
+            // keep
+            logger.debug("modes choose, keep predefined modes and targets " + selectedTargetsCount);
+        } else {
+            // clear
+            if (isAlreadySelectedModesOutdated(game, source)) {
+                this.clearAlreadySelectedModes(source, game);
+            }
+            this.clearSelectedModes();
         }
-        this.clearSelectedModes();
 
         // runtime check
         if (this.isRandom && limitUsageByOnce) {
@@ -345,7 +376,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
 
         // modal spells must show choose dialog even for 1 option, so check this.size instead availableModes.size here
         if (this.size() > 1) {
-            // multiple modes
+            // MULTI MODAL ability
 
             // modes modifications, e.g. choose max modes instead single
             Card card = game.getCard(source.getSourceId());
@@ -398,11 +429,14 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
             }
 
             // player chooses modes manually
+            logger.debug("modes choose, before clear, currentMode = " + currentMode + " " + game);
             this.currentMode = null;
             int currentMaxModes = this.getMaxModes(game, source);
 
+            logger.debug("modes choose, start " + game);
             while ((this.selectedModes.size() < currentMaxModes && maxPawPrints == 0) ||
                     (this.getSelectedPawPrints() < maxPawPrints && maxPawPrints > 0)) {
+                logger.debug("modes choose, single choose step " + game);
                 Mode choice = player.chooseMode(this, source, game);
                 if (choice == null) {
                     // user press cancel/stop in choose dialog or nothing to choose
@@ -413,6 +447,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
                     currentMode = choice;
                 }
             }
+            logger.debug("modes choose, end " + game);
             // effects helper (keep real choosing player)
             if (chooseController == TargetController.OPPONENT) {
                 selectedModes
@@ -422,10 +457,13 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
                         .forEach(effects -> effects.setValue("choosingPlayer", playerId));
             }
         } else {
-            // only one mode
+            // SINGLE MODAL ability
+            // make sure it selected by default (e.g. for AI simulations)
             Mode mode = this.values().iterator().next();
-            this.addSelectedMode(mode.getId());
-            this.setActiveMode(mode);
+            if (this.getSelectedModes().isEmpty()) {
+                this.addSelectedMode(mode.getId());
+                this.setActiveMode(mode);
+            }
         }
 
         return isSelectedValid(source, game);
@@ -466,7 +504,11 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
 
         Mode mode = get(modeId);
 
-        if (selectedModes.contains(modeId) && mayChooseSameModeMoreThanOnce) {
+        if (selectedModes.contains(modeId)) {
+            if (!mayChooseSameModeMoreThanOnce) {
+                // how-to fix: make sure AI code clean and setup modes and targets correctly
+                throw new IllegalArgumentException("Wrong call of addSelectedMode: mode already selected, you can't select it again");
+            }
             Mode duplicateMode = mode.copy();
             UUID originalId = modeId;
             duplicateMode.setRandomId();
@@ -474,7 +516,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
             selectedDuplicateModes.put(modeId, duplicateMode);
             selectedDuplicateToOriginalModeRefs.put(duplicateMode.getId(), originalId);
         }
-        // TODO: bugged and allows to choose same mode multiple times without mayChooseSameModeMoreThanOnce?
+
         this.selectedModes.add(modeId);
     }
 

--- a/Mage/src/main/java/mage/abilities/Modes.java
+++ b/Mage/src/main/java/mage/abilities/Modes.java
@@ -36,6 +36,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
 
     private Mode currentMode; // current active mode for resolving
 
+    private boolean isPreselected = false; // true after filled by AI auto-select, e.g. hide choose call on good options
     private final List<UUID> selectedModes = new ArrayList<>(); // all selected modes (this + duplicate), use getSelectedModes all the time to keep modes order
     private final Map<UUID, Mode> selectedDuplicateModes = new LinkedHashMap<>(); // for 2x selects: additional selected modes
     private final Map<UUID, UUID> selectedDuplicateToOriginalModeRefs = new LinkedHashMap<>(); // for 2x selects: stores ref from duplicate to original mode
@@ -71,6 +72,7 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
         for (Map.Entry<UUID, Mode> entry : modes.entrySet()) {
             this.put(entry.getKey(), entry.getValue().copy());
         }
+        this.isPreselected = modes.isPreselected;
         for (Map.Entry<UUID, Mode> entry : modes.selectedDuplicateModes.entrySet()) {
             selectedDuplicateModes.put(entry.getKey(), entry.getValue().copy());
         }
@@ -156,6 +158,17 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
     }
 
     /**
+     * Returns true if the mode was preselected by AI auto-select.
+     */
+    public boolean isPreselected() {
+        return isPreselected;
+    }
+
+    public void setPreselected(boolean isPreselected) {
+        this.isPreselected = isPreselected;
+    }
+
+    /**
      * Return full list of selected modes in default/rules order (without multi selects)
      */
     public List<UUID> getSelectedModes() {
@@ -175,25 +188,10 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
     }
 
     public void clearSelectedModes() {
+        this.setPreselected(false);
         this.selectedModes.clear();
         this.selectedDuplicateModes.clear();
         this.selectedDuplicateToOriginalModeRefs.clear();
-
-        // clean predefined targets lists too to make sure it's really new selection 
-        // (it helps to find bad AI code, e.g. in addModeOptions)
-        int selectedTargetsCount = this.values().stream()
-                .mapToInt(m -> m.getTargets().stream()
-                        .mapToInt(t -> t.getTargets().size())
-                        .sum()
-                )
-                .sum();
-        if (selectedTargetsCount > 0) {
-            logger.debug("found predefined targets to clean: " + selectedTargetsCount);
-            this.values().forEach(
-                mode -> logger.debug(" - targets count " + mode.getTargets().stream().mapToInt(t -> t.getTargets().size()).sum() + ", " + mode)
-            );
-        }
-        this.values().forEach(mode -> mode.getTargets().clearChosen());
     }
 
     public int getSelectedStats(UUID modeId) {
@@ -347,20 +345,25 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
     public boolean choose(Game game, Ability source) {
         // in multi-modal abilities it must keep already selected modes and targets
         // to make sure AI simulations will keep predefined setup (modes + targets)
-        int selectedTargetsCount = this.values().stream().mapToInt(
-                m -> m.getTargets().stream().mapToInt(t -> t.getTargets().size()).sum()
-        ).sum();
-        int selectedModesCount = this.selectedModes.size();
-        if (selectedTargetsCount > 0 || selectedModesCount > 1) {
-            // keep
-            logger.debug("modes choose, keep predefined modes " + selectedModesCount + " and targets " + selectedTargetsCount);
-        } else {
-            // clear
-            if (isAlreadySelectedModesOutdated(game, source)) {
-                this.clearAlreadySelectedModes(source, game);
+        if (this.isPreselected()) {
+            int selectedTargetsCount = this.values().stream()
+                    .mapToInt(m -> m.getTargets().stream()
+                            .mapToInt(t -> t.getTargets().size())
+                            .sum()
+                    )
+                    .sum();
+            logger.debug("modes choose, keep predefined modes " + this.selectedModes.size() + " and targets " + selectedTargetsCount);
+            if (isSelectedValid(source, game)) {
+                return true;
             }
-            this.clearSelectedModes();
+            logger.warn("modes choose, not valid - need fallback to manual select (something wrong with AI targets generation?)");
         }
+
+        // fallback to manual select, full cleanup from prev selections or wrong preselections
+        if (isAlreadySelectedModesOutdated(game, source)) {
+            this.clearAlreadySelectedModes(source, game);
+        }
+        this.clearSelectedModes();
 
         // runtime check
         if (this.isRandom && limitUsageByOnce) {
@@ -436,6 +439,22 @@ public class Modes extends LinkedHashMap<UUID, Mode> implements Copyable<Modes> 
             logger.debug("modes choose, before clear, currentMode = " + currentMode + " " + game);
             this.currentMode = null;
             int currentMaxModes = this.getMaxModes(game, source);
+
+            // clean predefined targets lists too to make sure it's really new selection 
+            // (it helps to find bad AI code, e.g. in addModeOptions)
+            int selectedTargetsCount = this.values().stream()
+                    .mapToInt(m -> m.getTargets().stream()
+                            .mapToInt(t -> t.getTargets().size())
+                            .sum()
+                    )
+                    .sum();
+            if (selectedTargetsCount > 0) {
+                logger.debug("found predefined targets to clean: " + selectedTargetsCount);
+                this.values().forEach(
+                    mode -> logger.debug(" - targets count " + mode.getTargets().stream().mapToInt(t -> t.getTargets().size()).sum() + ", " + mode)
+                );
+            }
+            this.values().forEach(mode -> mode.getTargets().clearChosen());
 
             logger.debug("modes choose, start " + game);
             while ((this.selectedModes.size() < currentMaxModes && maxPawPrints == 0) ||

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -1,6 +1,14 @@
 package mage.players;
 
+import java.io.Serializable;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.apache.log4j.Logger;
+
 import com.google.common.collect.ImmutableMap;
+
 import mage.*;
 import mage.abilities.*;
 import mage.abilities.ActivatedAbility.ActivationStatus;
@@ -60,12 +68,6 @@ import mage.target.common.TargetDiscard;
 import mage.util.CardUtil;
 import mage.util.GameLog;
 import mage.util.RandomUtil;
-import org.apache.log4j.Logger;
-
-import java.io.Serializable;
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 /**
  * Server: basic player implementation, shared for human and AI
@@ -4592,20 +4594,28 @@ public abstract class PlayerImpl implements Player, Serializable {
         // there are possible ifinite modes to select due isMayChooseSameModeMoreThanOnce
         // so used protection logic:
         // - fill modes one by one until reach required conditionals or game engine limit
+        // - also must put any valid up to options
 
-        List<Mode> availableModes = option.getModes().getAvailableModes(option, game).stream()
+        Modes modes = option.getModes();
+        boolean isValidSelection =
+            (modes.getMaxPawPrints() == 0 && modes.getSelectedModes().size() >= modes.getMinModes())
+            || (modes.getMaxPawPrints() > 0 && modes.getSelectedPawPrints() <= modes.getMaxPawPrints())
+            || (modes.isMayChooseNone() && modes.getSelectedModes().isEmpty());
+        if (isValidSelection) {
+            // add valid option and continue to generate new ones (it already prepared targets in parent call)
+            // see tests paw prints like Galadriel, Light of Valinor, etc.
+            // it can be 0 of 5, 3 of 5, etc
+            Ability finalizedOption = option.copy();
+            finalizedOption.getModes().setPreselected(true);
+            options.add(finalizedOption);
+        }
+
+        List<Mode> availableModes = modes.getAvailableModes(option, game).stream()
                 .filter(mode -> !option.getModes().getSelectedModes().contains(mode.getId()) || option.getModes().isMayChooseSameModeMoreThanOnce())
                 .filter(mode -> mode.getTargets().canChoose(option.getControllerId(), option, game))
                 .collect(Collectors.toList());
-
-        // no more modes to add - finish it on good valid
         if (availableModes.isEmpty()) {
-            if (option.getModes().getSelectedModes().isEmpty() && !option.getModes().isMayChooseNone()) {
-                throw new IllegalStateException("AI, addModeOptions catch ability without modes, report to github (possible reason - require to select too much modes?): " + option);
-            }
-            if (option.getModes().getSelectedModes().size() >= option.getModes().getMinModes()) {
-                options.add(option);
-            }
+            // all modes selected, nothing to do here
             return;
         }
 
@@ -4689,6 +4699,7 @@ public abstract class PlayerImpl implements Player, Serializable {
                 addCostTargetOptions(options, newOption, 0, game);
             } else {
                 // all filled, ability ready with all targets and costs
+                newOption.getModes().setPreselected(true);
                 options.add(newOption);
             }
         }
@@ -4704,6 +4715,7 @@ public abstract class PlayerImpl implements Player, Serializable {
             if (targetNum < option.getCosts().getTargets().size() - 1) {
                 addCostTargetOptions(options, newOption, targetNum + 1, game);
             } else {
+                newOption.getModes().setPreselected(true);
                 options.add(newOption);
             }
         }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -4593,7 +4593,10 @@ public abstract class PlayerImpl implements Player, Serializable {
         // so used protection logic:
         // - fill modes one by one until reach required conditionals or game engine limit
 
-        List<Mode> availableModes = option.getModes().getAvailableModes(option, game);
+        List<Mode> availableModes = option.getModes().getAvailableModes(option, game).stream()
+                .filter(mode -> !option.getModes().getSelectedModes().contains(mode.getId()) || option.getModes().isMayChooseSameModeMoreThanOnce())
+                .filter(mode -> mode.getTargets().canChoose(option.getControllerId(), option, game))
+                .collect(Collectors.toList());
 
         // no more modes to add - finish it on good valid
         if (availableModes.isEmpty()) {

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -4570,6 +4570,7 @@ public abstract class PlayerImpl implements Player, Serializable {
     public List<Ability> getPlayableOptions(Ability ability, Game game) {
         List<Ability> options = new ArrayList<>();
         if (ability.isModal()) {
+            ability.getModes().clearSelectedModes(); // clear default first mode too
             addModeOptions(options, ability, game);
         } else if (ability.getTargets().getNextUnchosen(game) != null) {
             // TODO: Handle other variable costs than mana costs
@@ -4588,23 +4589,52 @@ public abstract class PlayerImpl implements Player, Serializable {
      * AI related code
      */
     private void addModeOptions(List<Ability> options, Ability option, Game game) {
-        // TODO: support modal spells with more than one selectable mode (also must use max modes filter)
-        for (Mode mode : option.getModes().values()) {
+        // there are possible ifinite modes to select due isMayChooseSameModeMoreThanOnce
+        // so used protection logic:
+        // - fill modes one by one until reach required conditionals or game engine limit
+
+        List<Mode> availableModes = option.getModes().getAvailableModes(option, game);
+
+        // no more modes to add - finish it on good valid
+        if (availableModes.isEmpty()) {
+            if (option.getModes().getSelectedModes().isEmpty()) {
+                throw new IllegalStateException("AI, addModeOptions catch ability without modes, report to github (possible reason - require to select too much modes?): " + option);
+            }
+            if (option.getModes().getSelectedModes().size() >= option.getModes().getMinModes()) {
+                options.add(option);
+            }
+            return;
+        }
+
+        // continue to adding more modes
+        for (Mode mode : availableModes) {
             Ability newOption = option.copy();
-            // TODO: bugged? Research option.getModes().isMayChooseSameModeMoreThanOnce() - is it affected here
-            newOption.getModes().clearSelectedModes();
             newOption.getModes().addSelectedMode(mode.getId());
             newOption.getModes().setActiveMode(mode);
+
+            // fill each mode with completed targets
+            List<Ability> withTargetsFilled = new ArrayList<>();
             if (newOption.getTargets().getNextUnchosen(game) != null) {
+                // 1
                 if (!newOption.getManaCosts().getVariableCosts().isEmpty()) {
-                    addVariableXOptions(options, newOption, 0, game);
+                    // 1.1
+                    addVariableXOptions(withTargetsFilled, newOption, 0, game);
                 } else {
-                    addTargetOptions(options, newOption, 0, game);
+                    // 1.2
+                    addTargetOptions(withTargetsFilled, newOption, 0, game);
                 }
             } else if (newOption.getCosts().getTargets().getNextUnchosen(game) != null) {
-                addCostTargetOptions(options, newOption, 0, game);
+                // 2
+                addCostTargetOptions(withTargetsFilled, newOption, 0, game);
             } else {
-                options.add(newOption);
+                // 3
+                withTargetsFilled.add(newOption);
+            }
+
+            // now we have added mode with combination of filled targets
+            // add it recursively with additional modes
+            for (Ability filled : withTargetsFilled) {
+                addModeOptions(options, filled, game);
             }
         }
     }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -4597,7 +4597,7 @@ public abstract class PlayerImpl implements Player, Serializable {
 
         // no more modes to add - finish it on good valid
         if (availableModes.isEmpty()) {
-            if (option.getModes().getSelectedModes().isEmpty()) {
+            if (option.getModes().getSelectedModes().isEmpty() && !option.getModes().isMayChooseNone()) {
                 throw new IllegalStateException("AI, addModeOptions catch ability without modes, report to github (possible reason - require to select too much modes?): " + option);
             }
             if (option.getModes().getSelectedModes().size() >= option.getModes().getMinModes()) {


### PR DESCRIPTION
Old AI support only single modal abilities and doesn't work in many use cases, e.g. choose bad actions.

New AI fully support modal abilities including multi-modal, same option choose multiple times, paw parts budget calculation and other things. Also new AI brings more possible actions and some cards like Season of the Burrow can generate too much options to calculate, see todo and main topic in #9539

What's new:
- engine: added modes support to activated abilities (like triggers does, used for tests and for future cards);
- game: added max modes selection limit to 5 due performance optimization (can be increased in next releases);
- AI: added support of multi-modal abilities (computer can simulate and activate ability with multiple modes);
- AI: added support of multi modal abilities with paw prints budget;
- AI: added support of multi modal abilities with "may choose same mode more than once" ;
- AI: fixed that computer was able to activate bad options on modal abilities (due wrong usage of game sims);
- AI: improved game logs, added selected modes info in possible actions;

TODO for multi modal:
* add performance tests with Season of the Burrow card and targets;
* add modes optimizations (combinations instead permutations, max possible options cap to 1500-2000);

TODO for other:
* research and add options estimate and child sorting by it in mimax simulations, incremental bestChild inside node (for workable result on AI timeout);

P.S. The new AI was tested on over 1000 random games/decks on the most badly modal usage sets like BLB,C15,SNC,DSK,WHO -- in order to detect errors and potential stability issues.