### PR TITLE
[fix] Revert Thriving lands effect chaining change to restore 'choose' functionality

### DIFF
--- a/Mage.Sets/src/mage/cards/t/ThrivingBluff.java
+++ b/Mage.Sets/src/mage/cards/t/ThrivingBluff.java
@@ -1,6 +1,5 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -24,14 +23,11 @@ public final class ThrivingBluff extends CardImpl {
     public ThrivingBluff(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
 
+        // Thriving Bluff enters the battlefield tapped.
+        this.addAbility(new EntersBattlefieldTappedAbility());
 
-        // This land enters tapped. As it enters, choose a color other than red.
-        Ability ability = new EntersBattlefieldTappedAbility();
-        ability.addEffect(
-            new ChooseColorEffect(Outcome.Neutral, "Red")
-                .setText("As it enters, choose a color other than red")
-        );
-        this.addAbility(ability);
+        // As Thriving Bluff enters the battlefield, choose a color other than red.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral, "Red")));
 
         // {T}: Add {R} or one mana of the chosen color.
         this.addAbility(new RedManaAbility());

--- a/Mage.Sets/src/mage/cards/t/ThrivingGrove.java
+++ b/Mage.Sets/src/mage/cards/t/ThrivingGrove.java
@@ -1,6 +1,5 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -24,14 +23,11 @@ public final class ThrivingGrove extends CardImpl {
     public ThrivingGrove(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
 
+        // Thriving Grove enters the battlefield tapped.
+        this.addAbility(new EntersBattlefieldTappedAbility());
 
-        // This land enters tapped. As it enters, choose a color other than green.
-        Ability ability = new EntersBattlefieldTappedAbility();
-        ability.addEffect(
-            new ChooseColorEffect(Outcome.Neutral, "Green")
-                .setText("As it enters, choose a color other than green")
-        );
-        this.addAbility(ability);
+        // As Thriving Grove enters the battlefield, choose a color other than green.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral, "Green")));
 
         // {T}: Add {G} or one mana of the chosen color.
         this.addAbility(new GreenManaAbility());

--- a/Mage.Sets/src/mage/cards/t/ThrivingHeath.java
+++ b/Mage.Sets/src/mage/cards/t/ThrivingHeath.java
@@ -1,6 +1,5 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -24,14 +23,11 @@ public final class ThrivingHeath extends CardImpl {
     public ThrivingHeath(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
 
+        // Thriving Heath enters the battlefield tapped.
+        this.addAbility(new EntersBattlefieldTappedAbility());
 
-        // This land enters tapped. As it enters, choose a color other than white.
-        Ability ability = new EntersBattlefieldTappedAbility();
-        ability.addEffect(
-            new ChooseColorEffect(Outcome.Neutral, "White")
-                .setText("As it enters, choose a color other than white")
-        );
-        this.addAbility(ability);
+        // As Thriving Heath enters the battlefield, choose a color other than white.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral, "White")));
 
         // {T}: Add {W} or one mana of the chosen color.
         this.addAbility(new WhiteManaAbility());

--- a/Mage.Sets/src/mage/cards/t/ThrivingIsle.java
+++ b/Mage.Sets/src/mage/cards/t/ThrivingIsle.java
@@ -1,6 +1,5 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -24,14 +23,11 @@ public final class ThrivingIsle extends CardImpl {
     public ThrivingIsle(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
 
+        // Thriving Isle enters the battlefield tapped.
+        this.addAbility(new EntersBattlefieldTappedAbility());
 
-        // This land enters tapped. As it enters, choose a color other than blue.
-        Ability ability = new EntersBattlefieldTappedAbility();
-        ability.addEffect(
-            new ChooseColorEffect(Outcome.Neutral, "Blue")
-                .setText("As it enters, choose a color other than blue")
-        );
-        this.addAbility(ability);
+        // As Thriving Isle enters the battlefield, choose a color other than blue.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral, "Blue")));
 
         // {T}: Add {U} or one mana of the chosen color.
         this.addAbility(new BlueManaAbility());

--- a/Mage.Sets/src/mage/cards/t/ThrivingMoor.java
+++ b/Mage.Sets/src/mage/cards/t/ThrivingMoor.java
@@ -1,6 +1,5 @@
 package mage.cards.t;
 
-import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.EntersBattlefieldTappedAbility;
 import mage.abilities.costs.common.TapSourceCost;
@@ -24,13 +23,11 @@ public final class ThrivingMoor extends CardImpl {
     public ThrivingMoor(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.LAND}, "");
 
-        // This land enters tapped. As it enters, choose a color other than black.
-        Ability ability = new EntersBattlefieldTappedAbility();
-        ability.addEffect(
-            new ChooseColorEffect(Outcome.Neutral, "Black")
-                .setText("As it enters, choose a color other than black")
-        );
-        this.addAbility(ability);
+        // Thriving Moor enters the battlefield tapped.
+        this.addAbility(new EntersBattlefieldTappedAbility());
+
+        // As Thriving Moor enters the battlefield, choose a color other than black.
+        this.addAbility(new AsEntersBattlefieldAbility(new ChooseColorEffect(Outcome.Neutral, "Black")));
 
         // {T}: Add {B} or one mana of the chosen color.
         this.addAbility(new BlackManaAbility());


### PR DESCRIPTION
Reported via Discord, looks like in trying to align the text with Oracle's new templating for these lands, it broke the application of the "choose" effect. 

Reverting this back for now, because incorrect text and functionally correct lands beats incorrect text and incorrect functionality.

<img width="623" height="328" alt="Screenshot 2026-08-12 at 21 12 19" src="https://github.com/user-attachments/assets/1ced449b-8171-4ca1-b8ea-6da294a1cd3f" />
