### PR TITLE
Also restrict initial equip targets for equipment with restrictions

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GateSmasher.java
+++ b/Mage.Sets/src/mage/cards/g/GateSmasher.java
@@ -3,6 +3,7 @@ package mage.cards.g;
 import mage.abilities.Ability;
 import mage.abilities.common.AttachableToRestrictedAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
@@ -11,10 +12,8 @@ import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
-import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.ToughnessPredicate;
-import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -45,7 +44,7 @@ public final class GateSmasher extends CardImpl {
         this.addAbility(ability);
 
         // Equip {3}
-        this.addAbility(new EquipAbility(3, false));
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(3), new TargetPermanent(filter.copy().add(TargetController.YOU.getControllerPredicate())), false));
     }
 
     private GateSmasher(final GateSmasher card) {

--- a/Mage.Sets/src/mage/cards/k/KondasBanner.java
+++ b/Mage.Sets/src/mage/cards/k/KondasBanner.java
@@ -3,6 +3,7 @@ package mage.cards.k;
 import mage.abilities.Ability;
 import mage.abilities.common.AttachableToRestrictedAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.continuous.BoostAllEffect;
 import mage.abilities.keyword.EquipAbility;
 import mage.cards.CardImpl;
@@ -10,11 +11,9 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
 import mage.filter.StaticFilters;
-import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -45,7 +44,7 @@ public final class KondasBanner extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new KondasBannerTypeBoostEffect()));
 
         // Equip {2}
-        this.addAbility(new EquipAbility(2, false));
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2), new TargetPermanent(legendaryFilter.copy().add(TargetController.YOU.getControllerPredicate())), false));
     }
 
     private KondasBanner(final KondasBanner card) {

--- a/Mage.Sets/src/mage/cards/o/ONaginata.java
+++ b/Mage.Sets/src/mage/cards/o/ONaginata.java
@@ -3,6 +3,7 @@ package mage.cards.o;
 import mage.abilities.Ability;
 import mage.abilities.common.AttachableToRestrictedAbility;
 import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.continuous.BoostEquippedEffect;
 import mage.abilities.effects.common.continuous.GainAbilityAttachedEffect;
 import mage.abilities.keyword.EquipAbility;
@@ -10,11 +11,8 @@ import mage.abilities.keyword.TrampleAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.common.FilterControlledCreaturePermanent;
-import mage.filter.common.FilterCreatureCard;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
-import mage.target.TargetCard;
 import mage.target.TargetPermanent;
 
 import java.util.UUID;
@@ -45,7 +43,7 @@ public final class ONaginata extends CardImpl {
         this.addAbility(ability);
 
         // Equip {2}
-        this.addAbility(new EquipAbility(2));
+        this.addAbility(new EquipAbility(Outcome.AddAbility, new GenericManaCost(2), new TargetPermanent(filter.copy().add(TargetController.YOU.getControllerPredicate()))));
     }
 
     private ONaginata(final ONaginata card) {

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/EquipAbilityTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/activated/EquipAbilityTest.java
@@ -103,4 +103,35 @@ public class EquipAbilityTest extends CardTestPlayerBase {
         assertPermanentCount(playerA, "Elvish Mystic", 0);
     }
 
+    @Test
+    public void testEquipRequirements() {
+        addCard(Zone.BATTLEFIELD, playerA, "O-Naginata");
+        addCard(Zone.BATTLEFIELD, playerA, "Benevolent Bodyguard");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+        checkPlayableAbility("should not be able to equip", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip", false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+    }
+
+    @Test
+    public void testEquipFallsOff() {
+        addCard(Zone.BATTLEFIELD, playerA, "O-Naginata");
+        addCard(Zone.BATTLEFIELD, playerA, "Barbarian Horde");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Island", 3);
+        addCard(Zone.HAND, playerB, "Befuddle");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip", "Barbarian Horde");
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Befuddle", "Barbarian Horde");
+
+        setStrictChooseMode(true);
+        setStopAt(2, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Barbarian Horde", -1, 3);
+        Assert.assertTrue(getPermanent("Barbarian Horde", playerA).getAttachments().isEmpty());
+    }
 }

--- a/Mage/src/main/java/mage/filter/FilterPermanent.java
+++ b/Mage/src/main/java/mage/filter/FilterPermanent.java
@@ -64,7 +64,7 @@ public class FilterPermanent extends FilterObject<Permanent> implements FilterIn
         return extraPredicates.stream().allMatch(p -> p.apply(osp, game));
     }
 
-    public final void add(ObjectSourcePlayerPredicate predicate) {
+    public final FilterPermanent add(ObjectSourcePlayerPredicate predicate) {
         if (isLockedFilter()) {
             throw new UnsupportedOperationException("You may not modify a locked filter");
         }
@@ -73,6 +73,7 @@ public class FilterPermanent extends FilterObject<Permanent> implements FilterIn
         Predicates.makeSurePredicateCompatibleWithFilter(predicate, Permanent.class);
 
         extraPredicates.add(predicate);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
Equipment with restrictions doesn't seem to be enforcing those restrictions when it is equipped, only during the state-based actions check.  This affects cards like [[O-Naginata]] because its effect precludes the equip restriction from failing (unless the creature has its power reduced via another effect).

Make sure to pass this filter to the equip ability in addition to the static restriction effect.