### PR TITLE
[HOB] Implement Glamdring, Foe-hammer

### DIFF
--- a/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
+++ b/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
@@ -61,11 +61,11 @@ public final class GlamdringFoeHammer extends AdventureCard {
 class GlamdringFoeHammerEffect extends CostModificationEffectImpl {
 
     private static final DynamicValue xValue = new EquippedCreaturesPowerDynamicValue();
-    private static final Hint hint = new ValueHint("equipped creature’s power", xValue);
+    private static final Hint hint = new ValueHint("equipped creature's power", xValue);
 
     GlamdringFoeHammerEffect() {
         super(Duration.WhileOnStack, Outcome.Benefit, CostModificationType.REDUCE_COST);
-        staticText = "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature’s power";
+        staticText = "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature's power";
     }
 
     private GlamdringFoeHammerEffect(final GlamdringFoeHammerEffect effect) {
@@ -127,7 +127,7 @@ class EquippedCreaturesPowerDynamicValue implements DynamicValue {
 
     @Override
     public String getMessage() {
-        return "equipped creature’s power";
+        return "equipped creature's power";
     }
 }
 
@@ -156,7 +156,7 @@ class GleamofDeathEffect extends OneShotEffect {
         Cards cards = player.millCards(6, source, game);
         cards.retainZone(Zone.GRAVEYARD, game);
         for (Card card : cards.getCards(game)) {
-            //Keep all instants and sorcerys
+            //Keep all instants and sorceries
             if (!card.isInstantOrSorcery()) {
                 cards.remove(card);
             }

--- a/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
+++ b/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
@@ -1,0 +1,169 @@
+package mage.cards.g;
+
+import mage.abilities.Ability;
+import mage.abilities.SpellAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.dynamicvalue.DynamicValue;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.cost.CostModificationEffectImpl;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.ValueHint;
+import mage.abilities.keyword.EquipAbility;
+import mage.cards.AdventureCard;
+import mage.cards.Card;
+import mage.cards.CardSetInfo;
+import mage.cards.Cards;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.players.Player;
+import mage.util.CardUtil;
+
+import java.util.UUID;
+
+/**
+ *
+ * @author miesma
+ */
+public final class GlamdringFoeHammer extends AdventureCard {
+
+    public GlamdringFoeHammer(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, new CardType[]{CardType.SORCERY}, "{2}" , "Gleam of Death", "{3}{U}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.EQUIPMENT);
+
+        // Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature’s power.
+        this.addAbility(new SimpleStaticAbility(new GlamdringFoeHammerEffect())
+                .addHint(GlamdringFoeHammerEffect.getHint()));
+
+
+        // Equip {2}
+        this.addAbility(new EquipAbility(2, false));
+
+        // Gleam of Death
+        // Mill six cards, then put all instant and sorcery cards from among them into your hand.
+        this.getSpellCard().getSpellAbility().addEffect(new GleamofDdeathEffect());
+
+        this.finalizeAdventure();
+    }
+
+    private GlamdringFoeHammer(final GlamdringFoeHammer card) {
+        super(card);
+    }
+
+    @Override
+    public GlamdringFoeHammer copy() { return new GlamdringFoeHammer(this); }
+
+}
+
+class GlamdringFoeHammerEffect extends CostModificationEffectImpl {
+
+    private static final DynamicValue xValue = new EquippedCreaturesPowerDynamicValue();
+    private static final Hint hint = new ValueHint("equipped creature’s power", xValue);
+
+    GlamdringFoeHammerEffect() {
+        super(Duration.WhileOnStack, Outcome.Benefit, CostModificationType.REDUCE_COST);
+        staticText = "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature’s power";
+    }
+
+    private GlamdringFoeHammerEffect(final mage.cards.g.GlamdringFoeHammerEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source, Ability abilityToModify) {
+        CardUtil.reduceCost(abilityToModify, xValue.calculate(game, source, this));
+        return true;
+    }
+
+    @Override
+    public boolean applies(Ability abilityToModify, Ability source, Game game) {
+        return abilityToModify instanceof SpellAbility
+                && abilityToModify.isControlledBy(source.getControllerId())
+                && ((SpellAbility) abilityToModify).getCharacteristics(game).isInstantOrSorcery(game)
+                && game.getCard(abilityToModify.getSourceId()) != null;
+    }
+
+    @Override
+    public mage.cards.g.GlamdringFoeHammerEffect copy() {
+        return new mage.cards.g.GlamdringFoeHammerEffect(this);
+    }
+
+    public static Hint getHint() {
+        return hint;
+    }
+}
+
+class EquippedCreaturesPowerDynamicValue implements DynamicValue {
+
+    @Override
+    public int calculate(Game game, Ability sourceAbility, Effect effect) {
+        Permanent equipment = game.getPermanent(sourceAbility.getSourceId());
+        int xValue = 0;
+        if (equipment != null && equipment.getAttachedTo() != null) {
+            Permanent equipedCreature = game.getPermanent(equipment.getAttachedTo());
+            if (equipedCreature != null) {
+                //107.1b If a calculation that would determine the result of an effect yields a negative number, zero is used instead
+                xValue = equipedCreature.getPower().getValue();
+                if (xValue < 0) {
+                    return 0;
+                }
+            }
+        }
+        return xValue;
+    }
+
+    @Override
+    public mage.cards.g.EquippedCreaturesPowerDynamicValue copy() {
+        return new mage.cards.g.EquippedCreaturesPowerDynamicValue();
+    }
+
+    @Override
+    public String toString() {
+        return "X";
+    }
+
+    @Override
+    public String getMessage() {
+        return "equipped creature’s power";
+    }
+}
+
+class GleamofDdeathEffect extends OneShotEffect {
+
+    GleamofDdeathEffect() {
+        super(Outcome.DrawCard);
+        staticText = "Mill six cards, then put all instant and sorcery cards from among them into your hand";
+    }
+
+    private GleamofDdeathEffect(final mage.cards.g.GleamofDdeathEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public mage.cards.g.GleamofDdeathEffect copy() {
+        return new mage.cards.g.GleamofDdeathEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        if (player == null) {
+            return false;
+        }
+        Cards cards = player.millCards(6, source, game);
+        cards.retainZone(Zone.GRAVEYARD, game);
+        for (Card card : cards.getCards(game)) {
+            //Keep all instants and sorcerys
+            if (!card.isInstantOrSorcery()) {
+                cards.remove(card);
+            }
+        }
+        player.moveCardsToHandWithInfo(cards, source, game, true);
+        return true;
+    }
+}
+
+

--- a/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
+++ b/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
@@ -44,7 +44,7 @@ public final class GlamdringFoeHammer extends AdventureCard {
 
         // Gleam of Death
         // Mill six cards, then put all instant and sorcery cards from among them into your hand.
-        this.getSpellCard().getSpellAbility().addEffect(new GleamofDdeathEffect());
+        this.getSpellCard().getSpellAbility().addEffect(new GleamofDeathEffect());
 
         this.finalizeAdventure();
     }
@@ -131,20 +131,20 @@ class EquippedCreaturesPowerDynamicValue implements DynamicValue {
     }
 }
 
-class GleamofDdeathEffect extends OneShotEffect {
+class GleamofDeathEffect extends OneShotEffect {
 
-    GleamofDdeathEffect() {
+    GleamofDeathEffect() {
         super(Outcome.DrawCard);
         staticText = "Mill six cards, then put all instant and sorcery cards from among them into your hand";
     }
 
-    private GleamofDdeathEffect(final mage.cards.g.GleamofDdeathEffect effect) {
+    private GleamofDeathEffect(final mage.cards.g.GleamofDeathEffect effect) {
         super(effect);
     }
 
     @Override
-    public mage.cards.g.GleamofDdeathEffect copy() {
-        return new mage.cards.g.GleamofDdeathEffect(this);
+    public mage.cards.g.GleamofDeathEffect copy() {
+        return new mage.cards.g.GleamofDeathEffect(this);
     }
 
     @Override

--- a/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
+++ b/Mage.Sets/src/mage/cards/g/GlamdringFoeHammer.java
@@ -68,7 +68,7 @@ class GlamdringFoeHammerEffect extends CostModificationEffectImpl {
         staticText = "Instant and sorcery spells you cast cost {X} less to cast, where X is equipped creature’s power";
     }
 
-    private GlamdringFoeHammerEffect(final mage.cards.g.GlamdringFoeHammerEffect effect) {
+    private GlamdringFoeHammerEffect(final GlamdringFoeHammerEffect effect) {
         super(effect);
     }
 
@@ -87,8 +87,8 @@ class GlamdringFoeHammerEffect extends CostModificationEffectImpl {
     }
 
     @Override
-    public mage.cards.g.GlamdringFoeHammerEffect copy() {
-        return new mage.cards.g.GlamdringFoeHammerEffect(this);
+    public GlamdringFoeHammerEffect copy() {
+        return new GlamdringFoeHammerEffect(this);
     }
 
     public static Hint getHint() {
@@ -116,8 +116,8 @@ class EquippedCreaturesPowerDynamicValue implements DynamicValue {
     }
 
     @Override
-    public mage.cards.g.EquippedCreaturesPowerDynamicValue copy() {
-        return new mage.cards.g.EquippedCreaturesPowerDynamicValue();
+    public EquippedCreaturesPowerDynamicValue copy() {
+        return new EquippedCreaturesPowerDynamicValue();
     }
 
     @Override
@@ -138,13 +138,13 @@ class GleamofDeathEffect extends OneShotEffect {
         staticText = "Mill six cards, then put all instant and sorcery cards from among them into your hand";
     }
 
-    private GleamofDeathEffect(final mage.cards.g.GleamofDeathEffect effect) {
+    private GleamofDeathEffect(final GleamofDeathEffect effect) {
         super(effect);
     }
 
     @Override
-    public mage.cards.g.GleamofDeathEffect copy() {
-        return new mage.cards.g.GleamofDeathEffect(this);
+    public GleamofDeathEffect copy() {
+        return new GleamofDeathEffect(this);
     }
 
     @Override

--- a/Mage.Sets/src/mage/sets/TheHobbit.java
+++ b/Mage.Sets/src/mage/sets/TheHobbit.java
@@ -110,6 +110,8 @@ public final class TheHobbit extends ExpansionSet {
         cards.add(new SetCardInfo("Gleaming Splendor", 275, Rarity.MYTHIC, mage.cards.g.GleamingSplendor.class));
         cards.add(new SetCardInfo("Gigantic Big Bear", 126, Rarity.RARE, mage.cards.g.GiganticBigBear.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Gigantic Big Bear", 307, Rarity.RARE, mage.cards.g.GiganticBigBear.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Glamdring, Foe-hammer", 174, Rarity.RARE, mage.cards.g.GlamdringFoeHammer.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Glamdring, Foe-hammer", 204, Rarity.RARE, mage.cards.g.GlamdringFoeHammer.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Gloin the Mighty", 227, Rarity.UNCOMMON, mage.cards.g.GloinTheMighty.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Gloin the Mighty", 263, Rarity.UNCOMMON, mage.cards.g.GloinTheMighty.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Gloin the Mighty", 99, Rarity.UNCOMMON, mage.cards.g.GloinTheMighty.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
Implement [[Glamdring, Foe-hammer]].

"Mill X. Put all _ cards" could be considered for creating a generic variant with filters.
I've found 4 other on Scryfall. Although they are quite different.
[[Beluna Grandsquall]]
[[Tazri, Stalwart Survivor]]
[[Cantankerous Keepers]]
[[Greensleeves]]

EquippedCreaturesPowerDynamicValue maybe also.
I did not find any other cards using the value this way. Others use it as part for an activated ability granted to the creature.