### PR TITLE
Fix Ultron, Artificial Malevolence not creating token copy

### DIFF
--- a/Mage.Sets/src/mage/cards/u/UltronArtificialMalevolence.java
+++ b/Mage.Sets/src/mage/cards/u/UltronArtificialMalevolence.java
@@ -95,9 +95,17 @@ class UltronArtificialMaleveolenceEffect extends OneShotEffect {
                 effect.withAdditionalSubType(SubType.VILLAIN);
                 effect.setPower(2);
                 effect.setToughness(2);
+
+                // THE FIX: Tell the copy effect what to copy!
+                effect.setTargetPointer(this.getTargetPointer());
+
                 return effect.apply(game, source);
             } else {
                 CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(source.getControllerId());
+
+                // THE FIX: Tell the copy effect what to copy!
+                effect.setTargetPointer(this.getTargetPointer());
+
                 return effect.apply(game, source);
             }
         }

--- a/Mage.Sets/src/mage/cards/u/UltronArtificialMalevolence.java
+++ b/Mage.Sets/src/mage/cards/u/UltronArtificialMalevolence.java
@@ -101,10 +101,7 @@ class UltronArtificialMaleveolenceEffect extends OneShotEffect {
                 return effect.apply(game, source);
             } else {
                 CreateTokenCopyTargetEffect effect = new CreateTokenCopyTargetEffect(source.getControllerId());
-
-                // THE FIX: Tell the copy effect what to copy!
                 effect.setTargetPointer(this.getTargetPointer());
-
                 return effect.apply(game, source);
             }
         }

--- a/Mage.Sets/src/mage/cards/u/UltronArtificialMalevolence.java
+++ b/Mage.Sets/src/mage/cards/u/UltronArtificialMalevolence.java
@@ -96,7 +96,6 @@ class UltronArtificialMaleveolenceEffect extends OneShotEffect {
                 effect.setPower(2);
                 effect.setToughness(2);
 
-                // THE FIX: Tell the copy effect what to copy!
                 effect.setTargetPointer(this.getTargetPointer());
 
                 return effect.apply(game, source);


### PR DESCRIPTION
### Summary of Changes
Fixes an issue where [[Ultron, Artificial Malevolence]] would prompt and pay the mana cost, but fail to create a token copy on the battlefield.

### Cause & Fix
The `UltronArtificialMaleveolenceEffect` instantiated a new `CreateTokenCopyTargetEffect` without passing down the target pointer, causing the inner effect to resolve against a null target. Added `effect.setTargetPointer(this.getTargetPointer())` to both creature and non-creature branches.

### Testing
- Tested locally in client against an AI opponent with cheat commands.
- Verified casting an artifact (e.g. Commander's Plate) with Ultron in play creates the 2/2 Robot Villain creature token copy upon paying {2}.