### PR TITLE
[fix] U.S.S. Enterprise-D, Galaxy-Class should match on Charge counters for trigger

### DIFF
--- a/Mage.Sets/src/mage/cards/u/USSEnterpriseDGalaxyClass.java
+++ b/Mage.Sets/src/mage/cards/u/USSEnterpriseDGalaxyClass.java
@@ -1,8 +1,11 @@
 package mage.cards.u;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import mage.constants.SubType;
 import mage.constants.SuperType;
+import mage.constants.WatcherScope;
 import mage.constants.Zone;
 import mage.abilities.keyword.StationAbility;
 import mage.abilities.effects.common.ExileTopXMayPlayUntilEffect;
@@ -11,8 +14,9 @@ import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.events.GameEvent;
 import mage.game.permanent.Permanent;
-import mage.watchers.common.BoostCountersAddedFirstTimeWatcher;
+import mage.watchers.Watcher;
 import mage.abilities.keyword.StationLevelAbility;
+import mage.MageObjectReference;
 import mage.abilities.TriggeredAbilityImpl;
 import mage.abilities.keyword.FlyingAbility;
 import mage.abilities.keyword.VigilanceAbility;
@@ -63,7 +67,7 @@ class USSEnterpriseDGalaxyClassTriggeredAbility extends TriggeredAbilityImpl {
     USSEnterpriseDGalaxyClassTriggeredAbility() {
         super(Zone.BATTLEFIELD, new ExileTopXMayPlayUntilEffect(1, Duration.EndOfTurn));
         this.setTriggerPhrase("Whenever one or more charge counters are put on {this} for the first time each turn, ");
-        this.addWatcher(new BoostCountersAddedFirstTimeWatcher());
+        this.addWatcher(new ChargeCountersAddedFirstTimeWatcher());
     }
 
     private USSEnterpriseDGalaxyClassTriggeredAbility(final USSEnterpriseDGalaxyClassTriggeredAbility ability) {
@@ -86,6 +90,47 @@ class USSEnterpriseDGalaxyClassTriggeredAbility extends TriggeredAbilityImpl {
         return permanent != null
                 && this.getSourceId().equals(event.getTargetId())
                 && event.getData().equals(CounterType.CHARGE.getName())
-                && BoostCountersAddedFirstTimeWatcher.checkEvent(event, permanent, game, 0);
+                && ChargeCountersAddedFirstTimeWatcher.checkEvent(event, permanent, game, 0);
+    }
+}
+
+class ChargeCountersAddedFirstTimeWatcher extends Watcher {
+
+    private final Map<MageObjectReference, UUID> map = new HashMap<>();
+
+    public ChargeCountersAddedFirstTimeWatcher() {
+        super(WatcherScope.GAME);
+    }
+
+    @Override
+    public void watch(GameEvent event, Game game) {
+        if (event.getType() != GameEvent.EventType.COUNTERS_ADDED) {
+            return;
+        }
+        Permanent permanent = game.getPermanent(event.getTargetId());
+        int offset = 0;
+        if (permanent == null) {
+            permanent = game.getPermanentEntering(event.getTargetId());
+            offset++;
+        }
+        if (permanent != null && event.getData().equals(CounterType.CHARGE.getName())) {
+            map.putIfAbsent(new MageObjectReference(permanent, game, offset), event.getId());
+        }
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        map.clear();
+    }
+
+    public static boolean checkEvent(GameEvent event, Permanent permanent, Game game, int offset) {
+        return event
+                .getId()
+                .equals(game
+                        .getState()
+                        .getWatcher(ChargeCountersAddedFirstTimeWatcher.class)
+                        .map
+                        .getOrDefault(new MageObjectReference(permanent, game, offset), null));
     }
 }


### PR DESCRIPTION
Reported via discord 

<img width="497" height="89" alt="Screenshot 2026-08-15 at 09 49 33" src="https://github.com/user-attachments/assets/851b1d52-b8d7-4544-8b27-4762f6fba04a" />

It was using `BoostCountersAddedFirstTimeWatcher` previously, which would check for `CounterType.P1P1` specifically. We do have a `CountersAddedFirstTimeWatcher` which matches on _any_ counter which is also wrong. 

This looks like the only card that cares about Charge counters for now. 

Will follow up with a more long term issue to look into having a generic approach where the counter type can either be omitted for any, or specified and we can pass in P1P1 or CHARGE as an argument and have cards use this common class.