### PR TITLE
[TRK] Text fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CetiEel.java
+++ b/Mage.Sets/src/mage/cards/c/CetiEel.java
@@ -45,7 +45,7 @@ public final class CetiEel extends CardImpl {
         Ability ability = new EntersBattlefieldTriggeredAbility(new MillCardsControllerEffect(2));
         ability.addEffect(new AddCountersSourceEffect(
                 CounterType.P1P1.createInstance(), xValue, false
-        ).setText("then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard"));
+        ).setText(", then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard"));
 
         this.addAbility(ability.addHint(hint));
     }

--- a/Mage.Sets/src/mage/cards/d/DisruptorPistol.java
+++ b/Mage.Sets/src/mage/cards/d/DisruptorPistol.java
@@ -23,7 +23,7 @@ public final class DisruptorPistol extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // {4}, {T}, Sacrifice this artifact: It deals 5 damage to target creature.
-        Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(5), new ManaCostsImpl<>("{4}"));
+        Ability ability = new SimpleActivatedAbility(new DamageTargetEffect(5, "This artifact"), new ManaCostsImpl<>("{4}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addTarget(new TargetCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/v/VGerTheIntruder.java
+++ b/Mage.Sets/src/mage/cards/v/VGerTheIntruder.java
@@ -43,7 +43,10 @@ public final class VGerTheIntruder extends CardImpl {
         ability.addEffect(new DrawCardSourceControllerEffect(1).concatBy(", then"));
 
         // * Creatures your opponents control get -1/-0 until your next turn.
-        ability.addMode(new Mode(new BoostOpponentsEffect(-1, 0, Duration.UntilYourNextTurn)));
+        ability.addMode(new Mode(
+            new BoostOpponentsEffect(-1, 0, Duration.UntilYourNextTurn)
+                .setText("creatures your opponents control get -1/-0 until your next turn")
+        ));
         this.addAbility(ability);
     }
 


### PR DESCRIPTION
Minor text fixes;

 * Missing comma on Ceti Eel when chaining effect text
 * Disruptor Pistol text references itself as `This artifact` instead of default `It`
 * `BoostOpponentsEffect` only generates "until end of turn" duration text if Duration.EndOfTurn is passed in. For other durations it generates an empty string.