### PR TITLE
[MSH] Text fixes

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CloakAndDaggerEntwined.java
+++ b/Mage.Sets/src/mage/cards/c/CloakAndDaggerEntwined.java
@@ -57,7 +57,7 @@ public final class CloakAndDaggerEntwined extends CardImpl {
         this.addAbility(LifelinkAbility.getInstance());
 
         // When Cloak and Dagger enter, choose target opponent and up to one target creature they control. They reveal their hand. You may exile a nonland card from their hand or the chosen creature until Cloak and Dagger leave the battlefield.
-        Ability ability = new EntersBattlefieldTriggeredAbility(new CloakAndDaggerEntwinedEffect());
+        Ability ability = new EntersBattlefieldTriggeredAbility(new CloakAndDaggerEntwinedEffect()).setTriggerPhrase("When {this} enter, ");
         ability.addTarget(new TargetOpponent());
         ability.addTarget(new TargetPermanent(0, 1, filter));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/ReptilDinomorpher.java
+++ b/Mage.Sets/src/mage/cards/r/ReptilDinomorpher.java
@@ -32,12 +32,12 @@ public final class ReptilDinomorpher extends CardImpl {
         this.power = new MageInt(1);
         this.toughness = new MageInt(2);
 
-        // Brontosaurus -- {3}: Until end of turn, Reptil becomes a Dinosaur Hero with base power and toughness 3/5 and gains vigilance and reach.
+        // Brontosaurus -- {3}: Until end of turn, Reptil becomes a Dinosaur Hero with base power and toughness 3/5 and gains reach and vigilance.
         this.addAbility(new SimpleActivatedAbility(
             new BecomesCreatureSourceEffect(
-                new CreatureToken(3, 5, "Dinosaur Hero with base power and toughness 3/5 and gains vigilance and reach", SubType.DINOSAUR, SubType.HERO)
-                    .withAbility(VigilanceAbility.getInstance())
-                    .withAbility(ReachAbility.getInstance()),
+                new CreatureToken(3, 5, "Dinosaur Hero with base power and toughness 3/5 and gains reach and vigilance", SubType.DINOSAUR, SubType.HERO)
+                    .withAbility(ReachAbility.getInstance())
+                    .withAbility(VigilanceAbility.getInstance()),
                 null, Duration.EndOfTurn
             ).withDurationRuleAtStart(true),
             new ManaCostsImpl<>("{3}")


### PR DESCRIPTION
* Cloak and Dagger Entwined uses `enter` instead of `enters`
* Reptil got errata'd in Oracle to sort gained abilities alphabetically, regardless of what was originally printed on the card