### PR TITLE
Added puts/removes counters log messages for all actions

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AcademyElite.java
+++ b/Mage.Sets/src/mage/cards/a/AcademyElite.java
@@ -36,7 +36,7 @@ public final class AcademyElite extends CardImpl {
         // Academy Elite enters the battlefield with X +1/+1 counters on it, where X is the number of instant and
         // sorcery cards in all graveyards.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(),
-                new CardsInAllGraveyardsCount(new FilterInstantOrSorceryCard()), false),
+                new CardsInAllGraveyardsCount(new FilterInstantOrSorceryCard())),
                 "with X +1/+1 counters on it, where X is the number of instant and sorcery cards in all graveyards"));
 
         // {2}{U}, Remove a +1/+1 counter from Academy Elite: Draw a card, then discard a card.

--- a/Mage.Sets/src/mage/cards/a/AceFearlessRebel.java
+++ b/Mage.Sets/src/mage/cards/a/AceFearlessRebel.java
@@ -44,7 +44,7 @@ public final class AceFearlessRebel extends CardImpl {
 
         // Nitro-9 -- Whenever Ace, Fearless Rebel attacks, you may sacrifice an artifact. When you do, put a +1/+1 counter on Ace, Fearless Rebel, then it fights up to one target creature defending player controls.
         ReflexiveTriggeredAbility ability = new ReflexiveTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), false), false
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false
         );
         ability.addEffect(new FightTargetSourceEffect()
                 .setText(", then it fights up to one target creature defending player controls"));

--- a/Mage.Sets/src/mage/cards/a/AdaptiveShimmerer.java
+++ b/Mage.Sets/src/mage/cards/a/AdaptiveShimmerer.java
@@ -29,8 +29,7 @@ public final class AdaptiveShimmerer extends CardImpl {
 
         // Adaptive Shimmerer enters the battlefield with three +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(3), true
-        ), "with three +1/+1 counters on it"));
+                CounterType.P1P1.createInstance(3)), "with three +1/+1 counters on it"));
     }
 
     private AdaptiveShimmerer(final AdaptiveShimmerer card) {

--- a/Mage.Sets/src/mage/cards/a/AetherVial.java
+++ b/Mage.Sets/src/mage/cards/a/AetherVial.java
@@ -33,7 +33,7 @@ public final class AetherVial extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
 
         // At the beginning of your upkeep, you may put a charge counter on Aether Vial.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true), true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), true));
         // {tap}: You may put a creature card with converted mana cost equal to the number of charge counters on Aether Vial from your hand onto the battlefield.
         this.addAbility(new SimpleActivatedAbility(new AetherVialEffect(), new TapSourceCost()));
     }

--- a/Mage.Sets/src/mage/cards/a/AeveProgenitorOoze.java
+++ b/Mage.Sets/src/mage/cards/a/AeveProgenitorOoze.java
@@ -46,8 +46,7 @@ public final class AeveProgenitorOoze extends CardImpl {
 
         // Aeve enters the battlefield with a +1/+1 counter on it for each other Ooze you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), new PermanentsOnBattlefieldCount(filter), true
-        ), "with a +1/+1 counter on it for each other Ooze you control"
+                CounterType.P1P1.createInstance(), new PermanentsOnBattlefieldCount(filter)), "with a +1/+1 counter on it for each other Ooze you control"
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AinokWayfarer.java
+++ b/Mage.Sets/src/mage/cards/a/AinokWayfarer.java
@@ -29,7 +29,7 @@ public final class AinokWayfarer extends CardImpl {
         // When this creature enters, mill three cards. You may put a land card from among them into your hand. If you don't, put a +1/+1 counter on this creature.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new MillThenPutInHandEffect(
                 3, StaticFilters.FILTER_CARD_LAND_A,
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true)
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance())
         )));
     }
 

--- a/Mage.Sets/src/mage/cards/a/AkroanSkyguard.java
+++ b/Mage.Sets/src/mage/cards/a/AkroanSkyguard.java
@@ -29,7 +29,7 @@ public final class AkroanSkyguard extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // <i>Heroic</i> &mdash; Whenever you cast a spell that targets Akroan Skyguard, put a +1/+1 counter on Akroan Skyguard.
-        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true)));
+        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance())));
     }
 
     private AkroanSkyguard(final AkroanSkyguard card) {

--- a/Mage.Sets/src/mage/cards/a/AllHallowsEve.java
+++ b/Mage.Sets/src/mage/cards/a/AllHallowsEve.java
@@ -31,7 +31,7 @@ public final class AllHallowsEve extends CardImpl {
         // Exile All Hallow's Eve with two scream counters on it.
         this.getSpellAbility().addEffect(new ExileSpellEffect());
         this.getSpellAbility().addEffect(new AddCountersSourceEffect(
-                CounterType.SCREAM.createInstance(), StaticValue.get(2), true, true
+                CounterType.SCREAM.createInstance(), StaticValue.get(2), true
         ).setText("with two scream counters on it"));
 
         // At the beginning of your upkeep, if All Hallow's Eve is exiled with a scream counter on it, remove a scream counter from it.

--- a/Mage.Sets/src/mage/cards/a/AltarOfShadows.java
+++ b/Mage.Sets/src/mage/cards/a/AltarOfShadows.java
@@ -37,7 +37,7 @@ public final class AltarOfShadows extends CardImpl {
         // {7}, {tap}: Destroy target creature. Then put a charge counter on Altar of Shadows.
         Ability destroyAbility = new SimpleActivatedAbility(new DestroyTargetEffect(), new GenericManaCost(7));
         destroyAbility.addCost(new TapSourceCost());
-        destroyAbility.addEffect(new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true)
+        destroyAbility.addEffect(new AddCountersSourceEffect(CounterType.CHARGE.createInstance())
                 .concatBy("Then"));
         destroyAbility.addTarget(new TargetCreaturePermanent());
         this.addAbility(destroyAbility);

--- a/Mage.Sets/src/mage/cards/a/AmbitiousDragonborn.java
+++ b/Mage.Sets/src/mage/cards/a/AmbitiousDragonborn.java
@@ -41,8 +41,7 @@ public final class AmbitiousDragonborn extends CardImpl {
         // Ambitious Dragonborn enters the battlefield with X +1/+1 counters on it, where X is the greatest power among creatures you control and creature cards in your graveyard.
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
-                        CounterType.P1P1.createInstance(), AmbitiousDragonbornValue.instance, false
-                ), "with X +1/+1 counters on it, where X is the greatest power " +
+                        CounterType.P1P1.createInstance(), AmbitiousDragonbornValue.instance), "with X +1/+1 counters on it, where X is the greatest power " +
                 "among creatures you control and creature cards in your graveyard"
         ).addHint(hint));
     }

--- a/Mage.Sets/src/mage/cards/a/Anavolver.java
+++ b/Mage.Sets/src/mage/cards/a/Anavolver.java
@@ -41,7 +41,7 @@ public final class Anavolver extends CardImpl {
 
         // If Anavolver was kicked with its {1}{U} kicker, it enters with two +1/+1 counters on it and with flying.
         EntersBattlefieldAbility ability1 = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(2),false),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)),
                 new KickedCostCondition("{1}{U}"), "If {this} was kicked with its {1}{U} kicker, it enters with two +1/+1 counters on it and with flying.",
                 "{this} enters with two +1/+1 counters on it and with flying");
         ((EntersBattlefieldEffect)ability1.getEffects().get(0)).addEffect(new GainAbilitySourceEffect(FlyingAbility.getInstance(), Duration.WhileOnBattlefield));
@@ -49,7 +49,7 @@ public final class Anavolver extends CardImpl {
 
         // If Anavolver was kicked with its {B} kicker, it enters with a +1/+1 counter on it and with "Pay 3 life: Regenerate Anavolver."
         EntersBattlefieldAbility ability2 = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(1), false), new KickedCostCondition("{B}"),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), new KickedCostCondition("{B}"),
                 "If {this} was kicked with its {B} kicker, it enters with a +1/+1 counter on it and with \"Pay 3 life: Regenerate {this}.\"",
                 "{this} enters with a +1/+1 counter on it and with \"Pay 3 life: Regenerate {this}.\"");
         ((EntersBattlefieldEffect)ability2.getEffects().get(0)).addEffect(new GainAbilitySourceEffect(new SimpleActivatedAbility(new RegenerateSourceEffect(), new PayLifeCost(3)), Duration.WhileOnBattlefield));

--- a/Mage.Sets/src/mage/cards/a/AncientImperiosaur.java
+++ b/Mage.Sets/src/mage/cards/a/AncientImperiosaur.java
@@ -43,8 +43,7 @@ public final class AncientImperiosaur extends CardImpl {
 
         // Ancient Imperiosaur enters the battlefield with two +1/+1 counters on it for each creature that convoked it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), xValue, true
-        ), null, "{this} enters with two " +
+                CounterType.P1P1.createInstance(), xValue), null, "{this} enters with two " +
                 "+1/+1 counters on it for each creature that convoked it.", null));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ApexHawks.java
+++ b/Mage.Sets/src/mage/cards/a/ApexHawks.java
@@ -35,7 +35,7 @@ public final class ApexHawks extends CardImpl {
 
         // Apex Hawks enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance, true)
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance)
                 ,"with a +1/+1 counter on it for each time it was kicked"));
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcboundSlith.java
+++ b/Mage.Sets/src/mage/cards/a/ArcboundSlith.java
@@ -25,7 +25,7 @@ public final class ArcboundSlith extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Whenever Arcbound Slith deals combat damage to a player, put a +1/+1 counter on it.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true), false));
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false));
 
         // Modular 1
         this.addAbility(new ModularAbility(this, 1));

--- a/Mage.Sets/src/mage/cards/a/ArceeSharpshooter.java
+++ b/Mage.Sets/src/mage/cards/a/ArceeSharpshooter.java
@@ -84,8 +84,7 @@ class ArceeAcrobaticCoupeTriggeredAbility extends SpellCastControllerTriggeredAb
     ArceeAcrobaticCoupeTriggeredAbility() {
         super(new AddCountersSourceEffect(
                 CounterType.P1P1.createInstance(0),
-                SavedDamageValue.MANY, false
-        ), false);
+                SavedDamageValue.MANY), false);
         this.addEffect(new TransformSourceEffect());
     }
 

--- a/Mage.Sets/src/mage/cards/a/ArcheryTraining.java
+++ b/Mage.Sets/src/mage/cards/a/ArcheryTraining.java
@@ -43,8 +43,7 @@ public final class ArcheryTraining extends CardImpl {
 
         // At the beginning of your upkeep, you may put an arrow counter on Archery Training.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.ARROW.createInstance(), true
-        ), true));
+                CounterType.ARROW.createInstance()), true));
 
         // Enchanted creature has "{tap}: This creature deals X damage to target attacking or blocking creature, where X is the number of arrow counters on Archery Training."
         this.addAbility(new SimpleStaticAbility(new ArcheryTrainingEffect()));

--- a/Mage.Sets/src/mage/cards/a/AsForetold.java
+++ b/Mage.Sets/src/mage/cards/a/AsForetold.java
@@ -34,8 +34,7 @@ public final class AsForetold extends CardImpl {
                 new BeginningOfUpkeepTriggeredAbility(
                         new AddCountersSourceEffect(
                                 CounterType.TIME.createInstance(),
-                                StaticValue.get(1),
-                                true), false
+                                StaticValue.get(1)), false
                 ));
 
         // Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast with converted mana cost X or less, where X is the number of time counters on As Foretold.

--- a/Mage.Sets/src/mage/cards/a/AscendantAcolyte.java
+++ b/Mage.Sets/src/mage/cards/a/AscendantAcolyte.java
@@ -35,8 +35,7 @@ public final class AscendantAcolyte extends CardImpl {
 
         // Ascendant Acolyte enters the battlefield with a +1/+1 counter on it for each +1/+1 counter among other creatures you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), AscendantAcolyteValue.instance, true
-        ), "with a +1/+1 counter on it for each +1/+1 counter among other creatures you control").addHint(AscendantAcolyteValue.getHint()));
+                CounterType.P1P1.createInstance(), AscendantAcolyteValue.instance), "with a +1/+1 counter on it for each +1/+1 counter among other creatures you control").addHint(AscendantAcolyteValue.getHint()));
 
         // At the beginning of your upkeep, double the number of +1/+1 counters on Ascendant Acolyte.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/a/AsmiraHolyAvenger.java
+++ b/Mage.Sets/src/mage/cards/a/AsmiraHolyAvenger.java
@@ -37,7 +37,7 @@ public final class AsmiraHolyAvenger extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // At the beginning of each end step, put a +1/+1 counter on Asmira, Holy Avenger for each creature put into your graveyard from the battlefield this turn.
-        this.addAbility(new BeginningOfEndStepTriggeredAbility(TargetController.ANY, new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new AsmiraHolyAvengerDynamicValue(), true), false), new AsmiraHolyAvengerWatcher());
+        this.addAbility(new BeginningOfEndStepTriggeredAbility(TargetController.ANY, new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new AsmiraHolyAvengerDynamicValue()), false), new AsmiraHolyAvengerWatcher());
     }
 
     private AsmiraHolyAvenger(final AsmiraHolyAvenger card) {

--- a/Mage.Sets/src/mage/cards/a/AuntieBlyteBadInfluence.java
+++ b/Mage.Sets/src/mage/cards/a/AuntieBlyteBadInfluence.java
@@ -69,8 +69,7 @@ class AuntieBlyteBadInfluenceTriggeredAbility extends TriggeredAbilityImpl {
 
     AuntieBlyteBadInfluenceTriggeredAbility() {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), SavedDamageValue.MANY, false
-        ).setText("put that many +1/+1 counters on {this}"));
+                CounterType.P1P1.createInstance(0), SavedDamageValue.MANY).setText("put that many +1/+1 counters on {this}"));
         setTriggerPhrase("Whenever a source you control deals damage to you, ");
     }
 

--- a/Mage.Sets/src/mage/cards/a/AvatarOfTheResolute.java
+++ b/Mage.Sets/src/mage/cards/a/AvatarOfTheResolute.java
@@ -37,7 +37,7 @@ public final class AvatarOfTheResolute extends CardImpl {
         // Avatar of the Resolute enters the battlefield with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it.
         DynamicValue numberCounters = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_OTHER_CONTROLLED_CREATURE_P1P1);
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), numberCounters, true),
+                CounterType.P1P1.createInstance(0), numberCounters),
                 "with a +1/+1 counter on it for each other creature you control with a +1/+1 counter on it")
         );
         

--- a/Mage.Sets/src/mage/cards/b/BaneOfProgress.java
+++ b/Mage.Sets/src/mage/cards/b/BaneOfProgress.java
@@ -76,7 +76,7 @@ class BaneOfProgressEffect extends OneShotEffect {
             }
         }
         if (destroyedPermanents > 0) {
-            return new AddCountersSourceEffect(CounterType.P1P1.createInstance(destroyedPermanents),true).apply(game, source);
+            return new AddCountersSourceEffect(CounterType.P1P1.createInstance(destroyedPermanents)).apply(game, source);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/b/BioessenceHydra.java
+++ b/Mage.Sets/src/mage/cards/b/BioessenceHydra.java
@@ -39,8 +39,7 @@ public final class BioessenceHydra extends CardImpl {
 
         // Bioessence Hydra enters the battlefield with a +1/+1 counter on it for each loyalty counter on planeswalkers you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), BioessenceHydraDynamicValue.instance, true
-        ), "with a +1/+1 counter on it for each loyalty counter on planeswalkers you control."
+                CounterType.P1P1.createInstance(), BioessenceHydraDynamicValue.instance), "with a +1/+1 counter on it for each loyalty counter on planeswalkers you control."
         ));
 
         // Whenever one or more loyalty counters are put on planeswalkers you control, put that many +1/+1 counters on Bioessence Hydra.

--- a/Mage.Sets/src/mage/cards/b/BlastZone.java
+++ b/Mage.Sets/src/mage/cards/b/BlastZone.java
@@ -45,8 +45,7 @@ public final class BlastZone extends CardImpl {
 
         // {X}{X}, {T}: Put X charge counters on Blast Zone.
         Ability ability = new SimpleActivatedAbility(new AddCountersSourceEffect(
-                CounterType.CHARGE.createInstance(), GetXValue.instance, true
-        ), new ManaCostsImpl<>("{X}{X}"));
+                CounterType.CHARGE.createInstance(), GetXValue.instance), new ManaCostsImpl<>("{X}{X}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/b/BloodchiefAscension.java
+++ b/Mage.Sets/src/mage/cards/b/BloodchiefAscension.java
@@ -32,7 +32,7 @@ public final class BloodchiefAscension extends CardImpl {
 
         // At the beginning of each end step, if an opponent lost 2 or more life this turn, you may put a quest counter on Bloodchief Ascension. (Damage causes loss of life.)
         this.addAbility(new BeginningOfEndStepTriggeredAbility(
-                TargetController.ANY, new AddCountersSourceEffect(CounterType.QUEST.createInstance(1), false),
+                TargetController.ANY, new AddCountersSourceEffect(CounterType.QUEST.createInstance(1)),
                 true, new OpponentLostLifeCondition(ComparisonType.MORE_THAN, 1)
         ));
 

--- a/Mage.Sets/src/mage/cards/b/BloodcrazedHoplite.java
+++ b/Mage.Sets/src/mage/cards/b/BloodcrazedHoplite.java
@@ -36,7 +36,7 @@ public final class BloodcrazedHoplite extends CardImpl {
         this.toughness = new MageInt(1);
 
         // Heroic - Whenever you cast a spell that targets Bloodcrazed Hoplite, put a +1/+1 counter on it.
-        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), false))
+        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()))
                 .withRuleTextReplacement(true));
         // Whenever a +1/+1 counter is put on Bloodcrazed Hoplite, remove a +1/+1 counter from target creature an opponent controls.
         Ability ability = new BloodcrazedHopliteTriggeredAbility();

--- a/Mage.Sets/src/mage/cards/b/BloodcrazedPaladin.java
+++ b/Mage.Sets/src/mage/cards/b/BloodcrazedPaladin.java
@@ -33,8 +33,7 @@ public final class BloodcrazedPaladin extends CardImpl {
 
         // Bloodcrazed Paladin enters the battlefield with a +1/+1 counter on it for each creature that died this turn.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), CreaturesDiedThisTurnCount.instance, true
-        ).setText("with a +1/+1 counter on it for each creature that died this turn.")).addHint(CreaturesDiedThisTurnHint.instance));
+                CounterType.P1P1.createInstance(0), CreaturesDiedThisTurnCount.instance).setText("with a +1/+1 counter on it for each creature that died this turn.")).addHint(CreaturesDiedThisTurnHint.instance));
     }
 
     private BloodcrazedPaladin(final BloodcrazedPaladin card) {

--- a/Mage.Sets/src/mage/cards/b/BombSquad.java
+++ b/Mage.Sets/src/mage/cards/b/BombSquad.java
@@ -170,8 +170,6 @@ class BombSquadBeginningEffect extends OneShotEffect {
         }
         for (Permanent permanent : game.getBattlefield().getActivePermanents(filter, source.getControllerId(), game)) {
             permanent.addCounters(CounterType.FUSE.createInstance(), source.getControllerId(), source, game);
-
-            game.informPlayers(card.getName() + " puts a fuse counter on " + permanent.getName());
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/b/BoneDevourer.java
+++ b/Mage.Sets/src/mage/cards/b/BoneDevourer.java
@@ -43,8 +43,7 @@ public final class BoneDevourer extends CardImpl {
 
         // This creature enters with a number of +1/+1 counters on it equal to the number of creatures that died this turn.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), CreaturesDiedThisTurnCount.instance, false
-        ), "with a number of +1/+1 counters on it equal to the number of creatures that died this turn").addHint(CreaturesDiedThisTurnHint.instance));
+                CounterType.P1P1.createInstance(), CreaturesDiedThisTurnCount.instance), "with a number of +1/+1 counters on it equal to the number of creatures that died this turn").addHint(CreaturesDiedThisTurnHint.instance));
 
         // When this creature dies, you draw X cards and you lose X life, where X is the number of +1/+1 counters on it.
         Ability ability = new DiesSourceTriggeredAbility(new DrawCardSourceControllerEffect(xValue).setText("you draw X cards"));

--- a/Mage.Sets/src/mage/cards/b/BosssChauffeur.java
+++ b/Mage.Sets/src/mage/cards/b/BosssChauffeur.java
@@ -48,8 +48,7 @@ public final class BosssChauffeur extends CardImpl {
 
         // Boss's Chauffeur enters the battlefield with a number of +1/+1 counters on it equal to one plus the number of other creatures you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), xValue, false
-        ), "with a number of +1/+1 counters on it equal to " +
+                CounterType.P1P1.createInstance(), xValue), "with a number of +1/+1 counters on it equal to " +
                 "one plus the number of other creatures you control").addHint(hint));
 
         // Alliance — Whenever another creature you control enters, put a +1/+1 counter on Boss's Chauffeur.

--- a/Mage.Sets/src/mage/cards/b/BotanicalBrawler.java
+++ b/Mage.Sets/src/mage/cards/b/BotanicalBrawler.java
@@ -36,8 +36,7 @@ public final class BotanicalBrawler extends CardImpl {
 
         // Botanical Brawler enters the battlefield with two +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(2), true
-        ), "with two +1/+1 counters on it"));
+                CounterType.P1P1.createInstance(2)), "with two +1/+1 counters on it"));
 
         // Whenever one or more +1/+1 counters are put on another permanent you control, if it's the first time +1/+1 counters have been put on that permanent this turn, put a +1/+1 counter on Botanical Brawler.
         this.addAbility(new BotanicalBrawlerTriggeredAbility());

--- a/Mage.Sets/src/mage/cards/c/CallousSellSword.java
+++ b/Mage.Sets/src/mage/cards/c/CallousSellSword.java
@@ -47,8 +47,7 @@ public final class CallousSellSword extends AdventureCard {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(0),
-                        CreaturesYouControlDiedCount.instance, true
-                ).setText("with a +1/+1 counter on it for each creature that died under your control this turn.")
+                        CreaturesYouControlDiedCount.instance).setText("with a +1/+1 counter on it for each creature that died under your control this turn.")
         ).addHint(hint));
 
         // Burn Together

--- a/Mage.Sets/src/mage/cards/c/CattiBrieOfMithralHall.java
+++ b/Mage.Sets/src/mage/cards/c/CattiBrieOfMithralHall.java
@@ -55,7 +55,7 @@ public final class CattiBrieOfMithralHall extends CardImpl {
         // Whenever Catti-brie of Mithral Hall attacks, put a +1/+1 counter on it for each Equipment attached to it.
         EquipmentAttachedCount amount = new EquipmentAttachedCount();
         this.addAbility(new AttacksTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), amount, false).setText("put a +1/+1 counter on it for each Equipment attached to it")));
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), amount).setText("put a +1/+1 counter on it for each Equipment attached to it")));
 
         // {1}, Remove all +1/+1 counters from Catti-brie: It deals X damage to target attacking or blocking creature an opponent controls, where X is the number of counters removed this way.
         Ability damageAbility = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/c/CentaurVinecrasher.java
+++ b/Mage.Sets/src/mage/cards/c/CentaurVinecrasher.java
@@ -38,7 +38,7 @@ public final class CentaurVinecrasher extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Centaur Vinecrasher enters the battlefield with a number of +1/+1 counters on it equal to the number of land cards in all graveyards.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new CardsInAllGraveyardsCount(new FilterLandCard()), true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new CardsInAllGraveyardsCount(new FilterLandCard()));
         effect.setText("with a number of +1/+1 counters on it equal to the number of land cards in all graveyards");
         this.addAbility(new EntersBattlefieldAbility(effect));
         // Whenever a land card is put into a graveyard from anywhere, you may pay {G}{G}. If you do, return Centaur Vinecrasher from your graveyard to your hand.

--- a/Mage.Sets/src/mage/cards/c/CephalidVandal.java
+++ b/Mage.Sets/src/mage/cards/c/CephalidVandal.java
@@ -33,7 +33,7 @@ public final class CephalidVandal extends CardImpl {
 
         // At the beginning of your upkeep, put a shred counter on Cephalid Vandal. Then put the top card of your library into your graveyard for each shred counter on Cephalid Vandal.
         Effect effect = new CephalidVandalEffect();
-        Ability ability = new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.SHRED.createInstance(), false));
+        Ability ability = new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.SHRED.createInstance()));
         ability.addEffect(effect);
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/Cetavolver.java
+++ b/Mage.Sets/src/mage/cards/c/Cetavolver.java
@@ -39,7 +39,7 @@ public final class Cetavolver extends CardImpl {
 
         // If Cetavolver was kicked with its {1}{R} kicker, it enters with two +1/+1 counters on it and with first strike.
         EntersBattlefieldAbility ability1 = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(2),false),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)),
                 new KickedCostCondition("{1}{R}"), "If {this} was kicked with its {1}{R} kicker, it enters with two +1/+1 counters on it and with first strike.",
                 "{this} enters with two +1/+1 counters on it and with first strike");
         ((EntersBattlefieldEffect)ability1.getEffects().get(0)).addEffect(new GainAbilitySourceEffect(FirstStrikeAbility.getInstance(), Duration.WhileOnBattlefield));
@@ -47,7 +47,7 @@ public final class Cetavolver extends CardImpl {
 
         // If Cetavolver was kicked with its {G} kicker, it enters with a +1/+1 counter on it and with trample.
         EntersBattlefieldAbility ability2 = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(1),false), new KickedCostCondition("{G}"),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), new KickedCostCondition("{G}"),
                 "If {this} was kicked with its {G} kicker, it enters with a +1/+1 counter on it and with trample.",
                 "{this} enters with a +1/+1 counter on it and with trample");
         ((EntersBattlefieldEffect)ability2.getEffects().get(0)).addEffect(new GainAbilitySourceEffect(TrampleAbility.getInstance(), Duration.WhileOnBattlefield));

--- a/Mage.Sets/src/mage/cards/c/CetiEel.java
+++ b/Mage.Sets/src/mage/cards/c/CetiEel.java
@@ -44,8 +44,7 @@ public final class CetiEel extends CardImpl {
         // When this creature enters, mill two cards, then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard.
         Ability ability = new EntersBattlefieldTriggeredAbility(new MillCardsControllerEffect(2));
         ability.addEffect(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), xValue, false
-        ).setText(", then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard"));
+                CounterType.P1P1.createInstance(), xValue).setText(", then put a +1/+1 counter on this creature for each artifact and/or creature card in your graveyard"));
 
         this.addAbility(ability.addHint(hint));
     }

--- a/Mage.Sets/src/mage/cards/c/Chainbreaker.java
+++ b/Mage.Sets/src/mage/cards/c/Chainbreaker.java
@@ -30,8 +30,7 @@ public final class Chainbreaker extends CardImpl {
 
         // Chainbreaker enters the battlefield with two -1/-1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.M1M1.createInstance(2), false
-        ), "with two -1/-1 counters on it"));
+                CounterType.M1M1.createInstance(2)), "with two -1/-1 counters on it"));
 
         // {3}, {tap}: Remove a -1/-1 counter from target creature.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/c/ChamberSentry.java
+++ b/Mage.Sets/src/mage/cards/c/ChamberSentry.java
@@ -42,7 +42,7 @@ public final class ChamberSentry extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Chamber Sentry enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()),
                 "with a +1/+1 counter on it for each color of mana spent to cast it"));
 
         // {X}, {T}, Remove X +1/+1 counters from Chamber Sentry: It deals X damage to any target.

--- a/Mage.Sets/src/mage/cards/c/ChokingMiasma.java
+++ b/Mage.Sets/src/mage/cards/c/ChokingMiasma.java
@@ -2,7 +2,6 @@ package mage.cards.c;
 
 import java.util.UUID;
 
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.condition.common.KickedCondition;
 import mage.abilities.effects.OneShotEffect;
@@ -84,18 +83,6 @@ class ChokingMiasmaEffect extends OneShotEffect {
             return false;
         }
         permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
-        if (!game.isSimulation()) {
-            StringBuilder sb = new StringBuilder();
-            MageObject sourceObject = game.getObject(source);
-            if (sourceObject != null) {
-                sb.append(sourceObject.getLogName());
-                sb.append(": ");
-            }
-            sb.append(controller.getLogName());
-            sb.append(" put a +1/+1 counter on ");
-            sb.append(permanent.getLogName());
-            game.informPlayers(sb.toString());
-        }
         return true;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
+++ b/Mage.Sets/src/mage/cards/c/ChorusOfTheConclave.java
@@ -147,7 +147,6 @@ class ChorusOfTheConclaveReplacementEffect2 extends ReplacementEffectImpl {
             int xValue = spellX.get(key);
             if (xValue > 0) {
                 creature.addCounters(CounterType.P1P1.createInstance(xValue), source.getControllerId(), source, game, event.getAppliedEffects());
-                game.informPlayers(sourceObject.getLogName() + ": " + creature.getLogName() + " enters the battlefield with " + xValue + " +1/+1 counter" + (xValue > 1 ? "s" : "") + " on it");
             }
             spellX.remove(key);
         }

--- a/Mage.Sets/src/mage/cards/c/ClayChampion.java
+++ b/Mage.Sets/src/mage/cards/c/ClayChampion.java
@@ -35,7 +35,7 @@ public final class ClayChampion extends CardImpl {
 
         // Clay Champion enters the battlefield with three +1/+1 counters on it for each {G}{G} spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), xValue, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), xValue),
                 null, null, "with three +1/+1 counters on it for each {G}{G} spent to cast it"
         ));
 

--- a/Mage.Sets/src/mage/cards/c/ClockworkHydra.java
+++ b/Mage.Sets/src/mage/cards/c/ClockworkHydra.java
@@ -44,7 +44,7 @@ public final class ClockworkHydra extends CardImpl {
 
         // {tap}: Put a +1/+1 counter on Clockwork Hydra.
         this.addAbility(new SimpleActivatedAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true), new TapSourceCost()
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance()), new TapSourceCost()
         ));
     }
 

--- a/Mage.Sets/src/mage/cards/c/CoalitionRelic.java
+++ b/Mage.Sets/src/mage/cards/c/CoalitionRelic.java
@@ -32,7 +32,7 @@ public final class CoalitionRelic extends CardImpl {
         // {tap}: Add one mana of any color.
         this.addAbility(new AnyColorManaAbility());
         // {tap}: Put a charge counter on Coalition Relic.
-        this.addAbility(new SimpleActivatedAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true), new TapSourceCost()));
+        this.addAbility(new SimpleActivatedAbility(new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new TapSourceCost()));
         // At the beginning of your precombat main phase, remove all charge counters from Coalition Relic. Add one mana of any color for each charge counter removed this way.
         this.addAbility(new BeginningOfFirstMainTriggeredAbility(new CoalitionRelicEffect()));
     }

--- a/Mage.Sets/src/mage/cards/c/ConclaveSledgeCaptain.java
+++ b/Mage.Sets/src/mage/cards/c/ConclaveSledgeCaptain.java
@@ -49,8 +49,7 @@ public final class ConclaveSledgeCaptain extends CardImpl {
         Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(),
-                        SavedDamageValue.MANY, false
-                ).setText("put that many +1/+1 counters on it"), false
+                        SavedDamageValue.MANY).setText("put that many +1/+1 counters on it"), false
         ).setTriggerPhrase("Whenever this creature deals combat damage to a player, ");
         backupAbility1.addAbility(ability);
         backupAbility2.addAbility(ability, true);

--- a/Mage.Sets/src/mage/cards/c/CopperLeafAngel.java
+++ b/Mage.Sets/src/mage/cards/c/CopperLeafAngel.java
@@ -34,7 +34,7 @@ public final class CopperLeafAngel extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // {tap}, Sacrifice X lands: Put X +1/+1 counters on Copper-Leaf Angel.
-        Ability ability = new SimpleActivatedAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), GetXValue.instance, false), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), GetXValue.instance), new TapSourceCost());
         ability.addCost(new SacrificeXTargetCost(new FilterControlledLandPermanent("lands")));
         this.addAbility(ability);
     }

--- a/Mage.Sets/src/mage/cards/c/CoralReef.java
+++ b/Mage.Sets/src/mage/cards/c/CoralReef.java
@@ -48,7 +48,7 @@ public final class CoralReef extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(effect));
 
         // Sacrifice an Island: Put two polyp counters on Coral Reef.
-        effect = new AddCountersSourceEffect(CounterType.POLYP.createInstance(2), true);
+        effect = new AddCountersSourceEffect(CounterType.POLYP.createInstance(2));
         effect.setText("Put two polyp counters on {this}");
         this.addAbility(new SimpleActivatedAbility(effect,
                 new SacrificeTargetCost(islandFilter)));

--- a/Mage.Sets/src/mage/cards/c/CrescendoOfWar.java
+++ b/Mage.Sets/src/mage/cards/c/CrescendoOfWar.java
@@ -28,7 +28,7 @@ public final class CrescendoOfWar extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{3}{W}");
 
         // At the beginning of each upkeep, put a strife counter on Crescendo of War.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(TargetController.ANY, new AddCountersSourceEffect(CounterType.STRIFE.createInstance(1), true), false));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(TargetController.ANY, new AddCountersSourceEffect(CounterType.STRIFE.createInstance(1)), false));
 
         // Attacking creatures get +1/+0 for each strife counter on Crescendo of War.
         this.addAbility(new SimpleStaticAbility(new BoostAllEffect(xValue, StaticValue.get(0),

--- a/Mage.Sets/src/mage/cards/c/CrovaxTheCursed.java
+++ b/Mage.Sets/src/mage/cards/c/CrovaxTheCursed.java
@@ -82,12 +82,10 @@ class CrovaxTheCursedEffect extends OneShotEffect {
                 if (new SacrificeControllerEffect(StaticFilters.FILTER_PERMANENT_CREATURES, 1, "").apply(game, source)) {
                     if (sourceObject != null) {
                         sourceObject.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                        game.informPlayers(controller.getLogName() + " puts a +1/+1 counter on " + sourceObject.getName());
                     }
                 }
             } else if (sourceObject != null && sourceObject.getCounters(game).containsKey(CounterType.P1P1)) {
                 sourceObject.removeCounters(CounterType.P1P1.getName(), 1, source, game);
-                game.informPlayers(controller.getLogName() + " removes a +1/+1 counter from " + sourceObject.getName());
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/c/CrowdControlWarden.java
+++ b/Mage.Sets/src/mage/cards/c/CrowdControlWarden.java
@@ -104,7 +104,7 @@ class CrowdControlWardenReplacementEffect extends ReplacementEffectImpl {
 
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), xValue, false)
+        new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), xValue)
                 .apply(game, source);
         return false;
     }

--- a/Mage.Sets/src/mage/cards/c/CrystallineCrawler.java
+++ b/Mage.Sets/src/mage/cards/c/CrystallineCrawler.java
@@ -32,7 +32,7 @@ public final class CrystallineCrawler extends CardImpl {
 
         // Converge - Crystalline Crawler enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
         this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 

--- a/Mage.Sets/src/mage/cards/c/CurseOfTheCabal.java
+++ b/Mage.Sets/src/mage/cards/c/CurseOfTheCabal.java
@@ -103,7 +103,7 @@ class CurseOfTheCabalSacrificeEffect extends OneShotEffect {
 class CurseOfTheCabalTriggeredAbilityConditionalDelay extends AddCountersSourceEffect {
 
     public CurseOfTheCabalTriggeredAbilityConditionalDelay() {
-        super(CounterType.TIME.createInstance(), StaticValue.get(2), false, true);
+        super(CounterType.TIME.createInstance(), StaticValue.get(2), true);
         staticText = "that player may sacrifice a permanent of their choice. If the player does, put two time counters on this card";
     }
 

--- a/Mage.Sets/src/mage/cards/c/CustodiSoulbinders.java
+++ b/Mage.Sets/src/mage/cards/c/CustodiSoulbinders.java
@@ -43,8 +43,7 @@ public final class CustodiSoulbinders extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(),
-                        new PermanentsOnBattlefieldCount(filter),
-                        false),
+                        new PermanentsOnBattlefieldCount(filter)),
                 "with X +1/+1 counters on it, where X is the number of other creatures on the battlefield"));
 
 

--- a/Mage.Sets/src/mage/cards/d/DakkonShadowSlayer.java
+++ b/Mage.Sets/src/mage/cards/d/DakkonShadowSlayer.java
@@ -33,8 +33,7 @@ public final class DakkonShadowSlayer extends CardImpl {
         // Dakkon, Shadow Slayer enters the battlefield with a number of loyalty counters on him equal to the number of lands you control.
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
-                        CounterType.LOYALTY.createInstance(0), LandsYouControlCount.instance, true
-                ), "with a number of loyalty counters on him equal to the number of lands you control"
+                        CounterType.LOYALTY.createInstance(0), LandsYouControlCount.instance), "with a number of loyalty counters on him equal to the number of lands you control"
         ).addHint(LandsYouControlHint.instance));
 
         // +1: Surveil 2.

--- a/Mage.Sets/src/mage/cards/d/DawnOfANewAge.java
+++ b/Mage.Sets/src/mage/cards/d/DawnOfANewAge.java
@@ -31,7 +31,7 @@ public final class DawnOfANewAge extends CardImpl {
         // Dawn of a New Age enters the battlefield with a hope counter on it for each creature you control.
         DynamicValue numberCounters = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_PERMANENT_CREATURE_CONTROLLED);
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.HOPE.createInstance(0), numberCounters, true),
+                CounterType.HOPE.createInstance(0), numberCounters),
                 "with a hope counter on it for each creature you control")
         );
 

--- a/Mage.Sets/src/mage/cards/d/Degavolver.java
+++ b/Mage.Sets/src/mage/cards/d/Degavolver.java
@@ -41,7 +41,7 @@ public final class Degavolver extends CardImpl {
 
         // If Degavolver was kicked with its {1}{B} kicker, it enters with two +1/+1 counters on it and with "Pay 3 life: Regenerate Degavolver."
         EntersBattlefieldAbility ability1 = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), false),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)),
                 new KickedCostCondition("{1}{B}"), "If {this} was kicked with its {1}{B} kicker, it enters with two +1/+1 counters on it and with \"Pay 3 life: Regenerate this creature.\"",
                 "{this} enters with two +1/+1 counters on it and with \"Pay 3 life: Regenerate this creature.\"");
         ((EntersBattlefieldEffect)ability1.getEffects().get(0)).addEffect(new GainAbilitySourceEffect(new SimpleActivatedAbility(new RegenerateSourceEffect(), new PayLifeCost(3)), Duration.WhileOnBattlefield));
@@ -49,7 +49,7 @@ public final class Degavolver extends CardImpl {
 
         // If Degavolver was kicked with its {R} kicker, it enters with a +1/+1 counter on it and with first strike.
         EntersBattlefieldAbility ability2 = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(1), false), new KickedCostCondition("{R}"),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)), new KickedCostCondition("{R}"),
                 "If {this} was kicked with its {R} kicker, it enters with a +1/+1 counter on it and with first strike.",
                 "{this} enters with a +1/+1 counter on it and with first strike");
         ((EntersBattlefieldEffect)ability2.getEffects().get(0)).addEffect(new GainAbilitySourceEffect(FirstStrikeAbility.getInstance(), Duration.WhileOnBattlefield));

--- a/Mage.Sets/src/mage/cards/d/DelayingShield.java
+++ b/Mage.Sets/src/mage/cards/d/DelayingShield.java
@@ -61,7 +61,7 @@ class DelayingShieldReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         DamageEvent damageEvent = (DamageEvent) event;
-        new AddCountersSourceEffect(CounterType.DELAY.createInstance(damageEvent.getAmount()), true).apply(game, source);
+        new AddCountersSourceEffect(CounterType.DELAY.createInstance(damageEvent.getAmount())).apply(game, source);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/d/DescendantOfMasumaro.java
+++ b/Mage.Sets/src/mage/cards/d/DescendantOfMasumaro.java
@@ -75,7 +75,6 @@ class DescendantOfMasumaroEffect extends OneShotEffect {
             Player targetOpponent = game.getPlayer(getTargetPointer().getFirst(game, source));
             if (targetOpponent != null && !targetOpponent.getHand().isEmpty()) {
                 sourcePermanent.removeCounters(CounterType.P1P1.getName(), targetOpponent.getHand().size(), source, game);
-                game.informPlayers(controller.getLogName() + " removes " + targetOpponent.getHand().size() + " +1/+1 counters from " + sourcePermanent.getLogName());
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/d/DescendantOfMasumaro.java
+++ b/Mage.Sets/src/mage/cards/d/DescendantOfMasumaro.java
@@ -70,7 +70,7 @@ class DescendantOfMasumaroEffect extends OneShotEffect {
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (controller != null && sourcePermanent != null) {
             if (!controller.getHand().isEmpty()) {
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(controller.getHand().size()), true).apply(game, source);
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(controller.getHand().size())).apply(game, source);
             }
             Player targetOpponent = game.getPlayer(getTargetPointer().getFirst(game, source));
             if (targetOpponent != null && !targetOpponent.getHand().isEmpty()) {

--- a/Mage.Sets/src/mage/cards/d/DiscordantDirge.java
+++ b/Mage.Sets/src/mage/cards/d/DiscordantDirge.java
@@ -30,7 +30,7 @@ public final class DiscordantDirge extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Discordant Dirge.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // {B}, Sacrifice Discordant Dirge: Look at target opponent's hand and choose up to X cards from it, where X is the number of verse counters on Discordant Dirge. That player discards those cards.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/d/DrakeHatcher.java
+++ b/Mage.Sets/src/mage/cards/d/DrakeHatcher.java
@@ -44,8 +44,7 @@ public final class DrakeHatcher extends CardImpl {
         Ability ability = new DealsCombatDamageToAPlayerTriggeredAbility(
                 new AddCountersSourceEffect(
                         CounterType.INCUBATION.createInstance(),
-                        SavedDamageValue.MANY, false
-                ).setText("put that many incubation counters on it"), false
+                        SavedDamageValue.MANY).setText("put that many incubation counters on it"), false
         ).setTriggerPhrase("Whenever this creature deals combat damage to a player, ");
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/d/DrakestownForgotten.java
+++ b/Mage.Sets/src/mage/cards/d/DrakestownForgotten.java
@@ -36,8 +36,7 @@ public final class DrakestownForgotten extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(),
-                        new CardsInAllGraveyardsCount(StaticFilters.FILTER_CARD_CREATURE),
-                        false),
+                        new CardsInAllGraveyardsCount(StaticFilters.FILTER_CARD_CREATURE)),
                 "with X +1/+1 counters on it, where X is the number of creature cards in all graveyards"));
 
         // {2}{B}, Remove a +1/+1 counter from Drakestown Forgotten: Target creature gets -1/-1 until end of turn.

--- a/Mage.Sets/src/mage/cards/d/DralnusPet.java
+++ b/Mage.Sets/src/mage/cards/d/DralnusPet.java
@@ -99,7 +99,7 @@ class DralnusPetEffect extends OneShotEffect {
                         cmc = ((DiscardCardCost) cost).getCards().get(0).getManaValue();
                     }
                     if (cmc > 0) {
-                        return new AddCountersSourceEffect(CounterType.P1P1.createInstance(cmc), true).apply(game, source);
+                        return new AddCountersSourceEffect(CounterType.P1P1.createInstance(cmc)).apply(game, source);
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/d/DyadrineSynthesisAmalgam.java
+++ b/Mage.Sets/src/mage/cards/d/DyadrineSynthesisAmalgam.java
@@ -47,8 +47,7 @@ public final class DyadrineSynthesisAmalgam extends CardImpl {
 
         // Dyadrine enters with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), ManaSpentToCastCount.instance, true
-        ), "with a number of +1/+1 counters on it equal to the amount of mana spent to cast it"));
+                CounterType.P1P1.createInstance(), ManaSpentToCastCount.instance), "with a number of +1/+1 counters on it equal to the amount of mana spent to cast it"));
 
         // Whenever you attack, you may remove a +1/+1 counter from each of two creatures you control. If you do, draw a card and create a 2/2 colorless Robot artifact creature token.
         this.addAbility(new AttacksWithCreaturesTriggeredAbility(new DoIfCostPaid(

--- a/Mage.Sets/src/mage/cards/e/EmblazonedGolem.java
+++ b/Mage.Sets/src/mage/cards/e/EmblazonedGolem.java
@@ -46,7 +46,7 @@ public final class EmblazonedGolem extends CardImpl {
         
         // If Emblazoned Golem was kicked, it enters with X +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(),
-                EmblazonedGolemKickerValue.instance, false),
+                EmblazonedGolemKickerValue.instance),
                 KickedCondition.ONCE, "If {this} was kicked, it enters with X +1/+1 counters on it.", ""));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EmbodimentOfAgonies.java
+++ b/Mage.Sets/src/mage/cards/e/EmbodimentOfAgonies.java
@@ -38,8 +38,7 @@ public final class EmbodimentOfAgonies extends CardImpl {
 
         // Embodiment of Agonies enters the battlefield with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), EmbodimentOfAgoniesValue.instance, false
-        ), "with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard"));
+                CounterType.P1P1.createInstance(), EmbodimentOfAgoniesValue.instance), "with a +1/+1 counter on it for each different mana cost among nonland cards in your graveyard"));
     }
 
     private EmbodimentOfAgonies(final EmbodimentOfAgonies card) {

--- a/Mage.Sets/src/mage/cards/e/EmeriaCaptain.java
+++ b/Mage.Sets/src/mage/cards/e/EmeriaCaptain.java
@@ -35,8 +35,7 @@ public final class EmeriaCaptain extends CardImpl {
 
         // When Emeria Captain enters the battlefield, put a +1/+1 counter on it for each creature in your party.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), PartyCount.instance, false
-        ).setText("put a +1/+1 counter on it for each creature in your party. " + PartyCount.getReminder())));
+                CounterType.P1P1.createInstance(), PartyCount.instance).setText("put a +1/+1 counter on it for each creature in your party. " + PartyCount.getReminder())));
     }
 
     private EmeriaCaptain(final EmeriaCaptain card) {

--- a/Mage.Sets/src/mage/cards/e/EnclaveElite.java
+++ b/Mage.Sets/src/mage/cards/e/EnclaveElite.java
@@ -36,7 +36,7 @@ public final class EnclaveElite extends CardImpl {
 
         // Enclave Elite enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance),
                 "with a +1/+1 counter on it for each time it was kicked"));
     }
 

--- a/Mage.Sets/src/mage/cards/e/EnergyVortex.java
+++ b/Mage.Sets/src/mage/cards/e/EnergyVortex.java
@@ -53,8 +53,7 @@ public final class EnergyVortex extends CardImpl {
         this.addAbility(new ActivateIfConditionActivatedAbility(
                 new AddCountersSourceEffect(
                         CounterType.VORTEX.createInstance(),
-                        GetXValue.instance, true
-                ), new ManaCostsImpl<>("{X}"),
+                        GetXValue.instance), new ManaCostsImpl<>("{X}"),
                 IsStepCondition.getMyUpkeep()
         ));
     }

--- a/Mage.Sets/src/mage/cards/e/EntrailsFeaster.java
+++ b/Mage.Sets/src/mage/cards/e/EntrailsFeaster.java
@@ -75,7 +75,6 @@ class EntrailsFeasterEffect extends OneShotEffect {
                         controller.moveCardsToExile(cardChosen, source, game, true, null, "");
                         if (sourceObject != null) {
                             sourceObject.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                            game.informPlayers(controller.getLogName() + " puts a +1/+1 counter on " + sourceObject.getLogName());
                         }
                     }
                 } else if (sourceObject != null) {

--- a/Mage.Sets/src/mage/cards/e/EomerKingOfRohan.java
+++ b/Mage.Sets/src/mage/cards/e/EomerKingOfRohan.java
@@ -55,9 +55,7 @@ public final class EomerKingOfRohan extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(),
-                        new PermanentsOnBattlefieldCount(filter),
-                        true
-                ), "with a +1/+1 counter on it for each other Human you control"
+                        new PermanentsOnBattlefieldCount(filter)), "with a +1/+1 counter on it for each other Human you control"
         ));
 
         // When Eomer enters the battlefield, target player becomes the monarch. Eomer deals damage equal to its power to any target.

--- a/Mage.Sets/src/mage/cards/e/EverflowingChalice.java
+++ b/Mage.Sets/src/mage/cards/e/EverflowingChalice.java
@@ -33,7 +33,7 @@ public final class EverflowingChalice extends CardImpl {
 
         // Everflowing Chalice enters the battlefield with a charge counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.CHARGE.createInstance(0), MultikickerCount.instance, true),
+                new AddCountersSourceEffect(CounterType.CHARGE.createInstance(0), MultikickerCount.instance),
                 "with a charge counter on it for each time it was kicked"));
 
         // {T}: Add {C} for each charge counter on Everflowing Chalice.

--- a/Mage.Sets/src/mage/cards/e/EvolutionVat.java
+++ b/Mage.Sets/src/mage/cards/e/EvolutionVat.java
@@ -35,7 +35,7 @@ public final class EvolutionVat extends CardImpl {
         Effect effect = new AddCountersTargetEffect(CounterType.P1P1.createInstance());
         effect.setText("and put a +1/+1 counter on it");
         ability.addEffect(effect);
-        effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(), new CountersSourceCount(CounterType.P1P1), false);
+        effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(), new CountersSourceCount(CounterType.P1P1));
         effect.setText("Double the number of +1/+1 counters on this creature");
         Ability gainedAbility = new SimpleActivatedAbility(effect, new ManaCostsImpl<>("{2}{G}{U}"));
         ability.addEffect(new GainAbilityTargetEffect(gainedAbility, Duration.EndOfTurn,

--- a/Mage.Sets/src/mage/cards/f/FesteringWound.java
+++ b/Mage.Sets/src/mage/cards/f/FesteringWound.java
@@ -35,7 +35,7 @@ public final class FesteringWound extends CardImpl {
         this.addAbility(ability);
 
         // At the beginning of your upkeep, you may put an infection counter on Festering Wound.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.INFECTION.createInstance(), true), true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.INFECTION.createInstance()), true));
         // At the beginning of the upkeep of enchanted creature's controller, Festering Wound deals X damage to that player, where X is the number of infection counters on Festering Wound.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(TargetController.CONTROLLER_ATTACHED_TO, new FesteringWoundEffect(), false));
     }

--- a/Mage.Sets/src/mage/cards/f/FirebenderAscension.java
+++ b/Mage.Sets/src/mage/cards/f/FirebenderAscension.java
@@ -59,7 +59,7 @@ class FirebenderAscensionTriggeredAbility extends TriggeredAbilityImpl {
     private static final Condition condition = new SourceHasCounterCondition(CounterType.QUEST, 4);
 
     FirebenderAscensionTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.QUEST.createInstance(), true), false);
+        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.QUEST.createInstance()), false);
         addEffect(new ConditionalOneShotEffect(new OptionalOneShotEffect(new CopyStackObjectEffect()), condition,
                 "Then if it has four or more quest counters on it, you may copy that ability. You may choose new targets for the copy."));
         setTriggerPhrase("Whenever a creature you control attacking causes a triggered ability of that creature to trigger, ");

--- a/Mage.Sets/src/mage/cards/f/FlametongueYearling.java
+++ b/Mage.Sets/src/mage/cards/f/FlametongueYearling.java
@@ -35,8 +35,7 @@ public final class FlametongueYearling extends CardImpl {
 
         // Flametongue Yearling enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), MultikickerCount.instance, true
-        ), "with a +1/+1 counter on it for each time it was kicked"));
+                CounterType.P1P1.createInstance(0), MultikickerCount.instance), "with a +1/+1 counter on it for each time it was kicked"));
 
         // When Flametongue Yearling enters the battlefield, it deals damage equal to its power to target creature.
         Ability ability = new EntersBattlefieldTriggeredAbility(new DamageTargetEffect(SourcePermanentPowerValue.NOT_NEGATIVE)

--- a/Mage.Sets/src/mage/cards/f/ForceBubble.java
+++ b/Mage.Sets/src/mage/cards/f/ForceBubble.java
@@ -66,7 +66,7 @@ class ForceBubbleReplacementEffect extends ReplacementEffectImpl {
     @Override
     public boolean replaceEvent(GameEvent event, Ability source, Game game) {
         DamageEvent damageEvent = (DamageEvent) event;
-        new AddCountersSourceEffect(CounterType.DEPLETION.createInstance(damageEvent.getAmount()), true).apply(game, source);
+        new AddCountersSourceEffect(CounterType.DEPLETION.createInstance(damageEvent.getAmount())).apply(game, source);
         return true;
     }
 

--- a/Mage.Sets/src/mage/cards/g/GatekeeperGargoyle.java
+++ b/Mage.Sets/src/mage/cards/g/GatekeeperGargoyle.java
@@ -33,8 +33,7 @@ public final class GatekeeperGargoyle extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(),
-                        GateYouControlCount.instance, true
-                ), "with a +1/+1 counter on it for each Gate you control"
+                        GateYouControlCount.instance), "with a +1/+1 counter on it for each Gate you control"
         ).addHint(GatesYouControlHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GeometricNexus.java
+++ b/Mage.Sets/src/mage/cards/g/GeometricNexus.java
@@ -33,8 +33,7 @@ public final class GeometricNexus extends CardImpl {
         this.addAbility(new SpellCastAllTriggeredAbility(
                 new AddCountersSourceEffect(
                         CounterType.CHARGE.createInstance(0),
-                        GeometricNexusMVValue.instance, false
-                ).setText("put a number of charge counters on {this} equal to that spell's mana value"),
+                        GeometricNexusMVValue.instance).setText("put a number of charge counters on {this} equal to that spell's mana value"),
                 StaticFilters.FILTER_SPELL_AN_INSTANT_OR_SORCERY, false
         ));
 

--- a/Mage.Sets/src/mage/cards/g/GideonChampionOfJustice.java
+++ b/Mage.Sets/src/mage/cards/g/GideonChampionOfJustice.java
@@ -41,7 +41,7 @@ public final class GideonChampionOfJustice extends CardImpl {
 
         // +1: Put a loyalty counter on Gideon, Champion of Justice for each creature target opponent controls.
         LoyaltyAbility ability1 = new LoyaltyAbility(
-            new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(0), new PermanentsTargetOpponentControlsCount(new FilterCreaturePermanent()), true), 1);
+            new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(0), new PermanentsTargetOpponentControlsCount(new FilterCreaturePermanent())), 1);
         ability1.addTarget(new TargetOpponent());
         this.addAbility(ability1);
 

--- a/Mage.Sets/src/mage/cards/g/GlintingCreeper.java
+++ b/Mage.Sets/src/mage/cards/g/GlintingCreeper.java
@@ -31,8 +31,7 @@ public final class GlintingCreeper extends CardImpl {
 
         // Converge — Glinting Creeper enters the battlefield with two +1/+1 counters on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), xValue, true
-        ), null, "<i>Converge</i> &mdash; {this} enters " +
+                CounterType.P1P1.createInstance(), xValue), null, "<i>Converge</i> &mdash; {this} enters " +
                 "with two +1/+1 counters on it for each color of mana spent to cast it.", null));
         this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 

--- a/Mage.Sets/src/mage/cards/g/GluttonousHellkite.java
+++ b/Mage.Sets/src/mage/cards/g/GluttonousHellkite.java
@@ -39,7 +39,7 @@ public final class GluttonousHellkite extends CardImpl {
         // When you cast this spell, each player sacrifices X creatures. Gluttonous Hellkite enters the battlefield with two +1/+1 counters on it for each creature sacrificed this way.
         this.addAbility(new CastSourceTriggeredAbility(new SacrificeAllEffect(GetXValue.instance, StaticFilters.FILTER_PERMANENT_CREATURES)));
         Ability ability = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), GluttonousHellkiteDynamicValue.instance, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), GluttonousHellkiteDynamicValue.instance),
                 "with two +1/+1 counters on it for each creature sacrificed this way");
         ability.addHint(new ValueHint("Will get +1/+1 counters on ETB", GluttonousHellkiteDynamicValue.instance));
         //ability.setRuleVisible(false);

--- a/Mage.Sets/src/mage/cards/g/GnarlidPack.java
+++ b/Mage.Sets/src/mage/cards/g/GnarlidPack.java
@@ -31,7 +31,7 @@ public final class GnarlidPack extends CardImpl {
 
         // Gnarlid Pack enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance),
                 "with a +1/+1 counter on it for each time it was kicked"));
     }
 

--- a/Mage.Sets/src/mage/cards/g/GoldberryRiverDaughter.java
+++ b/Mage.Sets/src/mage/cards/g/GoldberryRiverDaughter.java
@@ -167,12 +167,6 @@ class GoldberryRiverDaughterToEffect extends OneShotEffect {
                         source,
                         game);
                 fromPermanent.removeCounters(counterName, amount, source, game);
-                game.informPlayers(
-                        controller.getLogName() + "moved " +
-                                amount + " " +
-                                counterName + " counter" + (amount > 1 ? "s" : "") +
-                                " from " + fromPermanent.getLogName() +
-                                "to " + toPermanent.getLogName() + ".");
             }
         }
 

--- a/Mage.Sets/src/mage/cards/g/GolgariRaiders.java
+++ b/Mage.Sets/src/mage/cards/g/GolgariRaiders.java
@@ -38,8 +38,7 @@ public final class GolgariRaiders extends CardImpl {
                         CounterType.P1P1.createInstance(0),
                         new CardsInControllerGraveyardCount(
                                 StaticFilters.FILTER_CARD_CREATURE
-                        ), true
-                ), null, AbilityWord.UNDERGROWTH.formatWord() + "{this} enters " +
+                        )), null, AbilityWord.UNDERGROWTH.formatWord() + "{this} enters " +
                 "with a +1/+1 counter on it for each creature card in your graveyard.", null
         );
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/g/GrizzlyGhoul.java
+++ b/Mage.Sets/src/mage/cards/g/GrizzlyGhoul.java
@@ -33,8 +33,7 @@ public final class GrizzlyGhoul extends CardImpl {
 
         // Grizzly Ghoul enters the battlefield with a +1/+1 counter on it for each creature that died this turn.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), CreaturesDiedThisTurnCount.instance, true
-        ).setText("with a +1/+1 counter on it for each creature that died this turn.")).addHint(CreaturesDiedThisTurnHint.instance));
+                CounterType.P1P1.createInstance(0), CreaturesDiedThisTurnCount.instance).setText("with a +1/+1 counter on it for each creature that died this turn.")).addHint(CreaturesDiedThisTurnHint.instance));
     }
 
     private GrizzlyGhoul(final GrizzlyGhoul card) {

--- a/Mage.Sets/src/mage/cards/g/GyrusWakerOfCorpses.java
+++ b/Mage.Sets/src/mage/cards/g/GyrusWakerOfCorpses.java
@@ -48,7 +48,7 @@ public final class GyrusWakerOfCorpses extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Gyrus, Walker of Corpses enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), ManaSpentToCastCount.instance, true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), ManaSpentToCastCount.instance);
         effect.setText("with a number of +1/+1 counters on it equal to the amount of mana spent to cast it");
         this.addAbility(new EntersBattlefieldAbility(effect));
 

--- a/Mage.Sets/src/mage/cards/h/HamletVanguard.java
+++ b/Mage.Sets/src/mage/cards/h/HamletVanguard.java
@@ -51,8 +51,7 @@ public final class HamletVanguard extends CardImpl {
 
         // Hamlet Vanguard enters the battlefield with two +1/+1 counters on it for each other nontoken Human you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), xValue, false
-        ), "with two +1/+1 counters on it for each other nontoken Human you control").addHint(hint));
+                CounterType.P1P1.createInstance(0), xValue), "with two +1/+1 counters on it for each other nontoken Human you control").addHint(hint));
     }
 
     private HamletVanguard(final HamletVanguard card) {

--- a/Mage.Sets/src/mage/cards/h/Heartmender.java
+++ b/Mage.Sets/src/mage/cards/h/Heartmender.java
@@ -72,8 +72,6 @@ class HeartmenderEffect extends OneShotEffect {
             if (creature != null
                     && creature.getCounters(game).getCount(counter.getName()) >= counter.getCount()) {
                 creature.removeCounters(counter.getName(), counter.getCount(), source, game);
-                game.informPlayers("Removed " + counter.getCount() + ' ' + counter.getName() +
-                        " counter from " + creature.getName());
                 applied = true;
             }
         }

--- a/Mage.Sets/src/mage/cards/h/HeliodsPunishment.java
+++ b/Mage.Sets/src/mage/cards/h/HeliodsPunishment.java
@@ -117,9 +117,6 @@ class HeliodsPunishmentEffect extends OneShotEffect {
         if (sourceEnchantment != null) {
             if (sourceEnchantment.getCounters(game).getCount(CounterType.TASK) > 0) {
                 sourceEnchantment.removeCounters(CounterType.TASK.createInstance(1), source, game);
-                if (!game.isSimulation()) {
-                    game.informPlayers("Removed a task counter from " + sourceEnchantment.getLogName());
-                }
             }
             if (sourceEnchantment.getCounters(game).getCount(CounterType.TASK) == 0) {
                 sourceEnchantment.destroy(source, game, false);

--- a/Mage.Sets/src/mage/cards/h/HelixPinnacle.java
+++ b/Mage.Sets/src/mage/cards/h/HelixPinnacle.java
@@ -32,8 +32,7 @@ public final class HelixPinnacle extends CardImpl {
 
         // {X}: Put X tower counters on Helix Pinnacle.
         this.addAbility(new SimpleActivatedAbility(new AddCountersSourceEffect(
-                CounterType.TOWER.createInstance(), GetXValue.instance, true
-        ), new ManaCostsImpl<>("{X}")));
+                CounterType.TOWER.createInstance(), GetXValue.instance), new ManaCostsImpl<>("{X}")));
 
         // At the beginning of your upkeep, if there are 100 or more tower counters on Helix Pinnacle, you win the game.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(new WinGameSourceControllerEffect()).withInterveningIf(condition));

--- a/Mage.Sets/src/mage/cards/h/HeroOfLeinaTower.java
+++ b/Mage.Sets/src/mage/cards/h/HeroOfLeinaTower.java
@@ -75,7 +75,7 @@ class HeroOfLeinaTowerEffect extends OneShotEffect {
             if (cost.pay(source, game, source, source.getControllerId(), false, null)) {
                 Permanent sourcePermanent = game.getPermanent(source.getSourceId());
                 if (sourcePermanent != null) {
-                    return new AddCountersSourceEffect(CounterType.P1P1.createInstance(costX), true).apply(game, source);
+                    return new AddCountersSourceEffect(CounterType.P1P1.createInstance(costX)).apply(game, source);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/h/HeroesBane.java
+++ b/Mage.Sets/src/mage/cards/h/HeroesBane.java
@@ -31,10 +31,10 @@ public final class HeroesBane extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Heroe's Bane enters the battlefield with four +1/+1 counters on it.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(4), true), 
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(4)), 
                 "with four +1/+1 counters on it"));
         // {2}{G}{G}: Put X +1/+1 counters on Heroe's Bane, where X is its power.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), SourcePermanentPowerValue.NOT_NEGATIVE, true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), SourcePermanentPowerValue.NOT_NEGATIVE);
         effect.setText("Put X +1/+1 counters on {this}, where X is its power");
         this.addAbility(new SimpleActivatedAbility(effect, new ManaCostsImpl<>("{2}{G}{G}")));
     }

--- a/Mage.Sets/src/mage/cards/h/Hexavus.java
+++ b/Mage.Sets/src/mage/cards/h/Hexavus.java
@@ -39,8 +39,7 @@ public final class Hexavus extends CardImpl {
 
         // Hexavus enters the battlefield with six +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(6), true
-        ), "with six +1/+1 counters on it"));
+                CounterType.P1P1.createInstance(6)), "with six +1/+1 counters on it"));
 
         // {1}, Remove a +1/+1 counter from Hexavus: Put a flying counter on another target creature.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/h/HuatliRadiantChampion.java
+++ b/Mage.Sets/src/mage/cards/h/HuatliRadiantChampion.java
@@ -33,7 +33,7 @@ public final class HuatliRadiantChampion extends CardImpl {
 
         // +1: Put a loyalty counter on Huatli, Radiant Champion for each creature you control.
         this.addAbility(new LoyaltyAbility(new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(0),
-                new PermanentsOnBattlefieldCount(StaticFilters.FILTER_PERMANENT_CREATURE_CONTROLLED), true), 1));
+                new PermanentsOnBattlefieldCount(StaticFilters.FILTER_PERMANENT_CREATURE_CONTROLLED)), 1));
 
         // -1: Target creature gets +X/+X until end of turn, where X is the number of creatures you control.
         PermanentsOnBattlefieldCount amount = new PermanentsOnBattlefieldCount(StaticFilters.FILTER_PERMANENT_CREATURE_CONTROLLED);

--- a/Mage.Sets/src/mage/cards/i/IceCauldron.java
+++ b/Mage.Sets/src/mage/cards/i/IceCauldron.java
@@ -47,7 +47,7 @@ public final class IceCauldron extends CardImpl {
         Ability ability = new ActivateIfConditionActivatedAbility(
                 new IceCauldronExileEffect(), new ManaCostsImpl<>("{X}"), condition
         );
-        ability.addEffect(new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.CHARGE.createInstance()));
         ability.addEffect(new IceCauldronNoteManaEffect());
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/i/IgnitionTeam.java
+++ b/Mage.Sets/src/mage/cards/i/IgnitionTeam.java
@@ -41,7 +41,7 @@ public final class IgnitionTeam extends CardImpl {
         // Ignition Team enters the battlefield with X +1/+1 counters on it, where X is the number of tapped lands on the battlefield.
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(CounterType.P1P1.createInstance(0),
-                new TappedLandsCount(), true), 
+                new TappedLandsCount()), 
                 "with X +1/+1 counters on it, where X is the number of tapped lands on the battlefield."));
         
         // {2}{R}, Remove a +1/+1 counter from Ignition Team: Target land becomes a 4/4 red Elemental creature until end of turn. It's still a land.

--- a/Mage.Sets/src/mage/cards/i/Incendiary.java
+++ b/Mage.Sets/src/mage/cards/i/Incendiary.java
@@ -43,7 +43,7 @@ public final class Incendiary extends CardImpl {
 
         // At the beginning of your upkeep, you may put a fuse counter on Incendiary.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.FUSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.FUSE.createInstance()), true));
 
         // When enchanted creature dies, Incendiary deals X damage to any target, where X is the number of fuse counters on Incendiary.
         Effect effect = new DamageTargetEffect(new CountersSourceCount(CounterType.FUSE)).setText(rule);

--- a/Mage.Sets/src/mage/cards/i/InfernoProject.java
+++ b/Mage.Sets/src/mage/cards/i/InfernoProject.java
@@ -42,8 +42,7 @@ public final class InfernoProject extends CardImpl {
 
         // Inferno Project enters the battlefield with X +1/+1 counters on it, where X is the total mana value of instant and sorcery cards in your graveyard.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), InfernoProjectValue.instance, false
-        ), "with X +1/+1 counters on it, where X is the total mana value " +
+                CounterType.P1P1.createInstance(0), InfernoProjectValue.instance), "with X +1/+1 counters on it, where X is the total mana value " +
                 "of instant and sorcery cards in your graveyard").addHint(hint));
     }
 

--- a/Mage.Sets/src/mage/cards/i/InvestigatorsJournal.java
+++ b/Mage.Sets/src/mage/cards/i/InvestigatorsJournal.java
@@ -35,7 +35,7 @@ public final class InvestigatorsJournal extends CardImpl {
 
         // Investigator's Journal enters the battlefield with a number of suspect counters on it equal to the greatest number of creatures a player controls.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.SUSPECT.createInstance(), InvestigatorsJournalValue.instance, false),
+                new AddCountersSourceEffect(CounterType.SUSPECT.createInstance(), InvestigatorsJournalValue.instance),
                 "with a number of suspect counters on it equal to the greatest number of creatures a player controls"
         ));
 

--- a/Mage.Sets/src/mage/cards/i/IroncladRevolutionary.java
+++ b/Mage.Sets/src/mage/cards/i/IroncladRevolutionary.java
@@ -33,7 +33,7 @@ public final class IroncladRevolutionary extends CardImpl {
         this.toughness = new MageInt(4);
 
         // When Ironclad Revolutionary enters the battlefield, you may sacrifice an artifact. If you do, put two +1/+1 counters on Ironclad Revolutionary and each opponent loses 2 life.
-        DoIfCostPaid doEffect = new DoIfCostPaid(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true),
+        DoIfCostPaid doEffect = new DoIfCostPaid(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)),
                 new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_ARTIFACT));
         Effect effect = new LoseLifeOpponentsEffect(2);
         effect.setText("and each opponent loses 2 life");

--- a/Mage.Sets/src/mage/cards/j/JeskaThriceReborn.java
+++ b/Mage.Sets/src/mage/cards/j/JeskaThriceReborn.java
@@ -42,8 +42,7 @@ public final class JeskaThriceReborn extends CardImpl {
 
         // Jeska, Thrice Reborn enters the battlefield with a loyalty counter on it for each time you've cast a commander from the command zone this game.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.LOYALTY.createInstance(0), JeskaThriceRebornValue.instance, false
-        ), "with a loyalty counter on her for each time " +
+                CounterType.LOYALTY.createInstance(0), JeskaThriceRebornValue.instance), "with a loyalty counter on her for each time " +
                 "you've cast a commander from the command zone this game"
         ).addHint(JeskaThriceRebornValue.getHint()));
 

--- a/Mage.Sets/src/mage/cards/j/JeweledAmulet.java
+++ b/Mage.Sets/src/mage/cards/j/JeweledAmulet.java
@@ -38,7 +38,7 @@ public final class JeweledAmulet extends CardImpl {
 
         // {1}, {tap}: Put a charge counter on Jeweled Amulet. Note the type of mana spent to pay this activation cost. Activate this ability only if there are no charge counters on Jeweled Amulet.
         Ability ability = new ActivateIfConditionActivatedAbility(
-                new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true), new GenericManaCost(1), condition
+                new AddCountersSourceEffect(CounterType.CHARGE.createInstance()), new GenericManaCost(1), condition
         );
         ability.addEffect(new JeweledAmuletAddCounterEffect());
         ability.addCost(new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/j/JinxedChoker.java
+++ b/Mage.Sets/src/mage/cards/j/JinxedChoker.java
@@ -103,7 +103,7 @@ class JinxedChokerCounterEffect extends OneShotEffect {
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (controller != null && sourcePermanent != null) {
             if (!sourcePermanent.getCounters(game).containsKey(CounterType.CHARGE) || controller.chooseUse(outcome, "Put a charge counter on? (No removes one)", source, game)) {
-                return new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true).apply(game, source);
+                return new AddCountersSourceEffect(CounterType.CHARGE.createInstance()).apply(game, source);
             } else {
                 return new RemoveCounterSourceEffect(CounterType.CHARGE.createInstance()).apply(game, source);
             }

--- a/Mage.Sets/src/mage/cards/j/JoragaWarcaller.java
+++ b/Mage.Sets/src/mage/cards/j/JoragaWarcaller.java
@@ -49,7 +49,7 @@ public final class JoragaWarcaller extends CardImpl {
         
         // Joraga Warcaller enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance),
                 "with a +1/+1 counter on it for each time it was kicked"));
 
         

--- a/Mage.Sets/src/mage/cards/j/JovenAndChandler.java
+++ b/Mage.Sets/src/mage/cards/j/JovenAndChandler.java
@@ -44,7 +44,7 @@ public final class JovenAndChandler extends CardImpl {
 
         // Whenever an artifact is put into a graveyard from the battlefield, put a number of +1/+1 counters equal to that artifact's mana value on Joven and Chandler.
         this.addAbility(new PutIntoGraveFromBattlefieldAllTriggeredAbility(
-            new AddCountersSourceEffect(CounterType.P1P1.createInstance(), artifactManaValue, false)
+            new AddCountersSourceEffect(CounterType.P1P1.createInstance(), artifactManaValue)
                 .setText("put a number of +1/+1 counters equal to that artifact's mana value on {this}"),
             false, StaticFilters.FILTER_PERMANENT_ARTIFACT_AN, false
         ));

--- a/Mage.Sets/src/mage/cards/k/KalonianHydra.java
+++ b/Mage.Sets/src/mage/cards/k/KalonianHydra.java
@@ -32,8 +32,7 @@ public final class KalonianHydra extends CardImpl {
 
         // Kalonian Hydra enters the battlefield with four +1/+1 counters on it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(4), true
-        ), "with four +1/+1 counters on it"));
+                CounterType.P1P1.createInstance(4)), "with four +1/+1 counters on it"));
 
         // Whenever Kalonian Hydra attacks, double the number of +1/+1 counters on each creature you control.
         this.addAbility(new AttacksTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/k/KangeeAerieKeeper.java
+++ b/Mage.Sets/src/mage/cards/k/KangeeAerieKeeper.java
@@ -54,8 +54,7 @@ public final class KangeeAerieKeeper extends CardImpl {
 
         // When Kangee, Aerie Keeper enters the battlefield, if it was kicked, put X feather counters on it.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.FEATHER.createInstance(), GetXValue.instance, true
-        )).withInterveningIf(KickedCondition.ONCE).withRuleTextReplacement(true));
+                CounterType.FEATHER.createInstance(), GetXValue.instance)).withInterveningIf(KickedCondition.ONCE).withRuleTextReplacement(true));
 
         // Other Bird creatures get +1/+1 for each feather counter on Kangee, Aerie Keeper.
         this.addAbility(new SimpleStaticAbility(new BoostAllEffect(

--- a/Mage.Sets/src/mage/cards/k/KhabalGhoul.java
+++ b/Mage.Sets/src/mage/cards/k/KhabalGhoul.java
@@ -28,7 +28,7 @@ public final class KhabalGhoul extends CardImpl {
 
         // At the beginning of each end step, put a +1/+1 counter on Khabal Ghoul for each creature that died this turn.
         this.addAbility(new BeginningOfEndStepTriggeredAbility(TargetController.ANY, new AddCountersSourceEffect(CounterType.P1P1.createInstance(),
-            CreaturesDiedThisTurnCount.instance, true), false).addHint(CreaturesDiedThisTurnHint.instance));
+            CreaturesDiedThisTurnCount.instance), false).addHint(CreaturesDiedThisTurnHint.instance));
     }
 
     private KhabalGhoul(final KhabalGhoul card) {

--- a/Mage.Sets/src/mage/cards/k/KinsbaileBorderguard.java
+++ b/Mage.Sets/src/mage/cards/k/KinsbaileBorderguard.java
@@ -42,7 +42,7 @@ public final class KinsbaileBorderguard extends CardImpl {
 
         // Kinsbaile Borderguard enters the battlefield with a +1/+1 counter on it for each other Kithkin you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(0),
-                new PermanentsOnBattlefieldCount(filter), true), "with a +1/+1 counter on it for each other Kithkin you control"));
+                new PermanentsOnBattlefieldCount(filter)), "with a +1/+1 counter on it for each other Kithkin you control"));
         // When Kinsbaile Borderguard dies, create a 1/1 white Kithkin Soldier creature token for each counter on it.
         this.addAbility(new DiesSourceTriggeredAbility(new CreateTokenEffect(new KithkinSoldierToken(), new AllCountersCount())));
     }

--- a/Mage.Sets/src/mage/cards/k/KorvoldGleefulGlutton.java
+++ b/Mage.Sets/src/mage/cards/k/KorvoldGleefulGlutton.java
@@ -63,7 +63,7 @@ public final class KorvoldGleefulGlutton extends CardImpl {
 
         // Whenever Korvold deals combat damage to a player, put X +1/+1 counters on Korvold and draw X cards, where X is the number of permanent types among cards in your graveyard.
         Ability combatDamageAbility = new DealsCombatDamageToAPlayerTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), PermanentTypesInGraveyardCount.instance, true)
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), PermanentTypesInGraveyardCount.instance)
                         .setText("put X +1/+1 counters on {this}"),
                 false
         ).withRuleTextReplacement(false);

--- a/Mage.Sets/src/mage/cards/k/KurbisHarvestCelebrant.java
+++ b/Mage.Sets/src/mage/cards/k/KurbisHarvestCelebrant.java
@@ -45,8 +45,7 @@ public final class KurbisHarvestCelebrant extends CardImpl {
 
         // Kurbis, Harvest Celebrant enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), ManaSpentToCastCount.instance, true
-        ), "with a number of +1/+1 counters on it equal to the amount of mana spent to cast it"));
+                CounterType.P1P1.createInstance(), ManaSpentToCastCount.instance), "with a number of +1/+1 counters on it equal to the amount of mana spent to cast it"));
 
         // Remove a +1/+1 counter from Kurbis: Prevent all damage that would be dealt this turn to another target creature with a +1/+1 counter on it.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/k/KutzilsFlanker.java
+++ b/Mage.Sets/src/mage/cards/k/KutzilsFlanker.java
@@ -43,7 +43,7 @@ public final class KutzilsFlanker extends CardImpl {
         // When Kutzil's Flanker enters the battlefield, choose one --
         // * Put a +1/+1 counter on Kutzil's Flanker for each creature that left the battlefield under your control this turn.
         Ability ability = new EntersBattlefieldTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), KutzilsFlankerValue.instance, true)
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), KutzilsFlankerValue.instance)
                         .setText("put a +1/+1 counter on {this} for each creature that left the battlefield under your control this turn")
         );
         ability.addHint(KutzilsFlankerValue.getHint());

--- a/Mage.Sets/src/mage/cards/l/LegacysAllure.java
+++ b/Mage.Sets/src/mage/cards/l/LegacysAllure.java
@@ -30,7 +30,7 @@ public final class LegacysAllure extends CardImpl {
 
         // At the beginning of your upkeep, you may put a treasure counter on Legacy's Allure.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.TREASURE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.TREASURE.createInstance()), true));
 
         // Sacrifice Legacy's Allure: Gain control of target creature with power less than or equal to the number of treasure counters on Legacy's Allure.
         Ability ability = new SimpleActivatedAbility(new GainControlTargetEffect(Duration.EndOfGame, true), new SacrificeSourceCost());

--- a/Mage.Sets/src/mage/cards/l/LethalSting.java
+++ b/Mage.Sets/src/mage/cards/l/LethalSting.java
@@ -74,7 +74,6 @@ class LethalStingCost extends CostImpl {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
                 permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
-                game.informPlayers(controller.getLogName() + " puts a -1/-1 counter on " + permanent.getLogName());
                 this.paid = true;
             }
 

--- a/Mage.Sets/src/mage/cards/l/LightningCoils.java
+++ b/Mage.Sets/src/mage/cards/l/LightningCoils.java
@@ -30,7 +30,7 @@ public final class LightningCoils extends CardImpl {
         // Whenever a nontoken creature you control dies, put a charge counter on Lightning Coils.
         this.addAbility(
                 new DiesCreatureTriggeredAbility(
-                        new AddCountersSourceEffect(CounterType.CHARGE.createInstance(), true),
+                        new AddCountersSourceEffect(CounterType.CHARGE.createInstance()),
                         false, StaticFilters.FILTER_CONTROLLED_CREATURE_NON_TOKEN));
 
         // At the beginning of your upkeep, if Lightning Coils has five or more charge counters on it, remove all of them from it  and put that many 3/1 red Elemental creature tokens with haste onto the battlefield. Exile them at the beginning of the next end step.

--- a/Mage.Sets/src/mage/cards/l/LotusBlossom.java
+++ b/Mage.Sets/src/mage/cards/l/LotusBlossom.java
@@ -24,7 +24,7 @@ public final class LotusBlossom extends CardImpl {
 
 
         // At the beginning of your upkeep, you may put a petal counter on Lotus Blossom.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.PETAL.createInstance(), true), true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.PETAL.createInstance()), true));
         // {tap}, Sacrifice Lotus Blossom: Add X mana of any one color, where X is the number of petal counters on Lotus Blossom.
         DynamicManaAbility ability = new DynamicManaAbility(new Mana(0, 0, 0, 0, 0, 0, 1, 0), new CountersSourceCount(CounterType.PETAL), new TapSourceCost(),
                 "Add X mana of any one color, where X is the number of petal counters on {this}", true);

--- a/Mage.Sets/src/mage/cards/l/LuxknightBreacher.java
+++ b/Mage.Sets/src/mage/cards/l/LuxknightBreacher.java
@@ -35,8 +35,7 @@ public final class LuxknightBreacher extends CardImpl {
 
         // This creature enters with a +1/+1 counter on it for each other creature and/or artifact you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), xValue, true
-        ), "with a +1/+1 counter on it for each other creature and/or artifact you control").addHint(hint));
+                CounterType.P1P1.createInstance(0), xValue), "with a +1/+1 counter on it for each other creature and/or artifact you control").addHint(hint));
     }
 
     private LuxknightBreacher(final LuxknightBreacher card) {

--- a/Mage.Sets/src/mage/cards/m/MagmaMine.java
+++ b/Mage.Sets/src/mage/cards/m/MagmaMine.java
@@ -28,7 +28,7 @@ public final class MagmaMine extends CardImpl {
 
         // {4}: Put a pressure counter on Magma Mine.
         this.addAbility(new SimpleActivatedAbility(
-                new AddCountersSourceEffect(CounterType.PRESSURE.createInstance(), true), 
+                new AddCountersSourceEffect(CounterType.PRESSURE.createInstance()), 
                 new GenericManaCost(4)));
         
         // {tap}, Sacrifice Magma Mine: Magma Mine deals damage equal to the number of pressure counters on it to any target.

--- a/Mage.Sets/src/mage/cards/m/MarathWillOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/m/MarathWillOfTheWild.java
@@ -50,7 +50,7 @@ public final class MarathWillOfTheWild extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Marath, Will of the Wild enters the battlefield with a number of +1/+1 counters on it equal to the amount of mana spent to cast it.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), ManaSpentToCastCount.instance, true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), ManaSpentToCastCount.instance);
         effect.setText("with a number of +1/+1 counters on it equal to the amount of mana spent to cast it");
         this.addAbility(new EntersBattlefieldAbility(effect));
 

--- a/Mage.Sets/src/mage/cards/m/MidsummerRevel.java
+++ b/Mage.Sets/src/mage/cards/m/MidsummerRevel.java
@@ -28,7 +28,7 @@ public final class MidsummerRevel extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Midsummer Revel.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
         // {G}, Sacrifice Midsummer Revel: create X 3/3 green Beast creature tokens, where X is the number of verse counters on Midsummer Revel.
         Ability ability = new SimpleActivatedAbility(new CreateTokenEffect(new BeastToken(),
             new CountersSourceCount(CounterType.VERSE)), new ManaCostsImpl<>("{G}"));

--- a/Mage.Sets/src/mage/cards/m/MoldgrafMillipede.java
+++ b/Mage.Sets/src/mage/cards/m/MoldgrafMillipede.java
@@ -30,7 +30,7 @@ public final class MoldgrafMillipede extends CardImpl {
 
         // When Moldgraf Millipede enters the battlefield, mill three cards, then put a +1/+1 counter on Moldgraf Millipede for each creature card in your graveyard.
         Ability ability = new EntersBattlefieldTriggeredAbility(new MillCardsControllerEffect(3));
-        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE), false).concatBy(", then"));
+        ability.addEffect(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE)).concatBy(", then"));
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Momentum.java
+++ b/Mage.Sets/src/mage/cards/m/Momentum.java
@@ -39,7 +39,7 @@ public final class Momentum extends CardImpl {
         this.addAbility(ability);
 
         // At the beginning of your upkeep, you may put a growth counter on Momentum.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.GROWTH.createInstance(), true), true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.GROWTH.createInstance()), true));
 
         // Enchanted creature gets +1/+1 for each growth counter on Momentum.
         this.addAbility(new SimpleStaticAbility(new BoostEnchantedEffect(new CountersSourceCount(CounterType.GROWTH), new CountersSourceCount(CounterType.GROWTH))));

--- a/Mage.Sets/src/mage/cards/m/MoritteOfTheFrost.java
+++ b/Mage.Sets/src/mage/cards/m/MoritteOfTheFrost.java
@@ -69,7 +69,7 @@ class MoritteOfTheFrostCopyApplier extends CopyApplier {
         if (!isCopyOfCopy(source, blueprint, copyToObjectId) && blueprint.isCreature(game)) {
             blueprint.getAbilities().add(new ChangelingAbility());
             blueprint.getAbilities().add(new EntersBattlefieldAbility(
-                    new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), false)
+                    new AddCountersSourceEffect(CounterType.P1P1.createInstance(2))
             ));
         }
         return true;

--- a/Mage.Sets/src/mage/cards/m/MurktideRegent.java
+++ b/Mage.Sets/src/mage/cards/m/MurktideRegent.java
@@ -44,7 +44,7 @@ public final class MurktideRegent extends CardImpl {
 
         // Murktide Regent enters the battlefield with a +1/+1 counter on it for each instant and sorcery card exiled with it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), MurktideRegentValue.instance, false),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), MurktideRegentValue.instance),
                 "with a +1/+1 counter on it for each instant and sorcery card exiled with it"
         ));
 

--- a/Mage.Sets/src/mage/cards/m/MutatedCultist.java
+++ b/Mage.Sets/src/mage/cards/m/MutatedCultist.java
@@ -94,7 +94,7 @@ class MutatedCultistEffect extends OneShotEffect {
             countersRemoved = targetPermanent.removeAllCounters(source, game);
         }
         if (countersRemoved > 0) {
-            game.informPlayers("Removed " + countersRemoved);
+
             game.addEffect(new MutatedCultistSpellsCostReductionEffect(countersRemoved).setDuration(Duration.OneUse), source);
             return true;
         }

--- a/Mage.Sets/src/mage/cards/m/MyriadConstruct.java
+++ b/Mage.Sets/src/mage/cards/m/MyriadConstruct.java
@@ -53,7 +53,7 @@ public final class MyriadConstruct extends CardImpl {
 
         // If Myriad Construct was kicked, it enters with a +1/+1 counter on it for each nonbasic land your opponents control.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), xValue, false),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), xValue),
                 KickedCondition.ONCE, "If {this} was kicked, it enters " +
                 "with a +1/+1 counter on it for each nonbasic land your opponents control.", ""
         ));

--- a/Mage.Sets/src/mage/cards/n/NaturesBlessing.java
+++ b/Mage.Sets/src/mage/cards/n/NaturesBlessing.java
@@ -103,7 +103,6 @@ class NaturesBlessingEffect extends OneShotEffect {
                 game.addEffect(new GainAbilityTargetEffect(gainedAbility, Duration.Custom), source);
             } else {
                 targetPermanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                game.informPlayers(controller.getLogName() + " puts a +1/+1 counter on " + targetPermanent.getLogName());
             }
             return true;
         }

--- a/Mage.Sets/src/mage/cards/n/Necropolis.java
+++ b/Mage.Sets/src/mage/cards/n/Necropolis.java
@@ -38,7 +38,7 @@ public final class Necropolis extends CardImpl {
 
         // Exile a creature card from your graveyard: Put X +0/+1 counters on Necropolis, where X is the exiled card's converted mana cost.
         this.addAbility(new SimpleActivatedAbility(
-                new AddCountersSourceEffect(CounterType.P0P1.createInstance(0), new NecropolisValue(), true).setText("Put X +0/+1 counters on {this}, where X is the exiled card's mana value"),
+                new AddCountersSourceEffect(CounterType.P0P1.createInstance(0), new NecropolisValue()).setText("Put X +0/+1 counters on {this}, where X is the exiled card's mana value"),
                 new ExileFromGraveCost(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_A))));
     }
 

--- a/Mage.Sets/src/mage/cards/n/NovijenHeartOfProgress.java
+++ b/Mage.Sets/src/mage/cards/n/NovijenHeartOfProgress.java
@@ -72,7 +72,6 @@ class NovijenHeartOfProgressEffect extends OneShotEffect {
             for (Permanent permanent : game.getBattlefield().getActivePermanents(StaticFilters.FILTER_PERMANENT_CREATURE, source.getControllerId(), game)) {
                 if (permanent.getTurnsOnBattlefield() == 0) {
                     permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                    game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts a +1/+1 counter on " + permanent.getLogName());
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
+++ b/Mage.Sets/src/mage/cards/p/PatronOfTheVein.java
@@ -157,7 +157,6 @@ class PatronOfTheVeinExileCreatureEffect extends OneShotEffect {
 
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents(filter, controller.getId(), game)) {
             permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-            game.informPlayers(sourceObject.getName() + ": Put a +1/+1 counter on " + permanent.getLogName());
         }
         return true;
 

--- a/Mage.Sets/src/mage/cards/p/PhantomNantuko.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomNantuko.java
@@ -34,7 +34,7 @@ public final class PhantomNantuko extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Phantom Nantuko enters the battlefield with two +1/+1 counters on it.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true), "with two +1/+1 counters on it"));
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2)), "with two +1/+1 counters on it"));
         // If damage would be dealt to Phantom Nantuko, prevent that damage. Remove a +1/+1 counter from Phantom Nantuko.
         this.addAbility(new SimpleStaticAbility(
                 new PreventDamageAndRemoveCountersEffect(false, false, false).withPhantomText()

--- a/Mage.Sets/src/mage/cards/p/PhantomNishoba.java
+++ b/Mage.Sets/src/mage/cards/p/PhantomNishoba.java
@@ -34,7 +34,7 @@ public final class PhantomNishoba extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
 
         // Phantom Nishoba enters the battlefield with seven +1/+1 counters on it.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(7), true), "with seven +1/+1 counters on it"));
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(7)), "with seven +1/+1 counters on it"));
 
         // Whenever Phantom Nishoba deals damage, you gain that much life.
         this.addAbility(new DealsDamageSourceTriggeredAbility(new GainLifeEffect(SavedDamageValue.MUCH)));

--- a/Mage.Sets/src/mage/cards/p/PheresBandThunderhoof.java
+++ b/Mage.Sets/src/mage/cards/p/PheresBandThunderhoof.java
@@ -26,7 +26,7 @@ public final class PheresBandThunderhoof extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Heroic - Whenever you cast a spell that targets Pheres-Band Thunderhood, put two +1/+1 counters on Pheres-Band Thunderhoof.
-        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true)));
+        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2))));
     }
 
     private PheresBandThunderhoof(final PheresBandThunderhoof card) {

--- a/Mage.Sets/src/mage/cards/p/PlagueBoiler.java
+++ b/Mage.Sets/src/mage/cards/p/PlagueBoiler.java
@@ -73,7 +73,7 @@ class PlagueBoilerEffect extends OneShotEffect {
         Permanent sourcePermanent = game.getPermanent(source.getSourceId());
         if (controller != null && sourcePermanent != null) {
             if (!sourcePermanent.getCounters(game).containsKey(CounterType.PLAGUE) || controller.chooseUse(outcome, "Put a plague counter on? (No removes one)", source, game)) {
-                return new AddCountersSourceEffect(CounterType.PLAGUE.createInstance(), true).apply(game, source);
+                return new AddCountersSourceEffect(CounterType.PLAGUE.createInstance()).apply(game, source);
             } else {
                 return new RemoveCounterSourceEffect(CounterType.PLAGUE.createInstance()).apply(game, source);
             }

--- a/Mage.Sets/src/mage/cards/p/PowderKeg.java
+++ b/Mage.Sets/src/mage/cards/p/PowderKeg.java
@@ -38,7 +38,7 @@ public final class PowderKeg extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT}, "{2}");
 
         // At the beginning of your upkeep, you may put a fuse counter on Powder Keg.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.FUSE.createInstance(), true), true));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.FUSE.createInstance()), true));
 
         // {T}, Sacrifice Powder Keg: Destroy each artifact and creature with converted mana cost equal to the number of fuse counters on Powder Keg.
         Ability ability = new SimpleActivatedAbility(new DestroyAllEffect(filter), new TapSourceCost());

--- a/Mage.Sets/src/mage/cards/p/PowerFist.java
+++ b/Mage.Sets/src/mage/cards/p/PowerFist.java
@@ -29,8 +29,7 @@ public final class PowerFist extends CardImpl {
         Ability ability = new SimpleStaticAbility(new GainAbilityAttachedEffect(TrampleAbility.getInstance(), AttachmentType.EQUIPMENT));
         ability.addEffect(new GainAbilityAttachedEffect(
                 new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(
-                        CounterType.P1P1.createInstance(), SavedDamageValue.MANY, false
-                ).setText("put that many +1/+1 counters on it"), false, true), AttachmentType.EQUIPMENT
+                        CounterType.P1P1.createInstance(), SavedDamageValue.MANY).setText("put that many +1/+1 counters on it"), false, true), AttachmentType.EQUIPMENT
         ).setText("and \"Whenever this creature deals combat damage to a player, put that many +1/+1 counters on it.\""));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/p/PrimalInstinct.java
+++ b/Mage.Sets/src/mage/cards/p/PrimalInstinct.java
@@ -57,7 +57,6 @@ class PrimalInstictEffect extends OneShotEffect {
             if (target != null) {
                 target.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
                 int addCounterCount = target.getCounters(game).getCount(CounterType.P1P1);
-                game.informPlayers("Counters " + addCounterCount);
                 target.addCounters(CounterType.P1P1.createInstance(addCounterCount), source.getControllerId(), source, game);
                 return true;
             }

--- a/Mage.Sets/src/mage/cards/p/PrimeSpeakerZegana.java
+++ b/Mage.Sets/src/mage/cards/p/PrimeSpeakerZegana.java
@@ -34,9 +34,7 @@ public final class PrimeSpeakerZegana extends CardImpl {
         //Prime Speaker Zegana enters the battlefield with X +1/+1 counters on it, where X is the greatest power among other creatures you control.
         Effect effect = new AddCountersSourceEffect(
                 CounterType.P1P1.createInstance(0),
-                GreatestAmongPermanentsValue.POWER_OTHER_CONTROLLED_CREATURES,
-                true
-        );
+                GreatestAmongPermanentsValue.POWER_OTHER_CONTROLLED_CREATURES);
         effect.setText("with X +1/+1 counters on it, where X is the greatest power among other creatures you control.");
         this.addAbility(new EntersBattlefieldAbility(effect).addHint(GreatestAmongPermanentsValue.POWER_OTHER_CONTROLLED_CREATURES.getHint()));
         //When Prime Speaker Zegana enters the battlefield, draw cards equal to its power.

--- a/Mage.Sets/src/mage/cards/p/PrismArray.java
+++ b/Mage.Sets/src/mage/cards/p/PrismArray.java
@@ -28,7 +28,7 @@ public final class PrismArray extends CardImpl {
 
         // <i>Converge</i> &mdash; Prism Array enters the battlefield with a crystal counter on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.CRYSTAL.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
+                new AddCountersSourceEffect(CounterType.CRYSTAL.createInstance(), ColorsOfManaSpentToCastCount.getInstance()),
                 null, "<i>Converge</i> &mdash; {this} enters with a crystal counter on it for each color of mana spent to cast it.", null));
         this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 

--- a/Mage.Sets/src/mage/cards/p/PrivateResearch.java
+++ b/Mage.Sets/src/mage/cards/p/PrivateResearch.java
@@ -40,7 +40,7 @@ public final class PrivateResearch extends CardImpl {
 
         // At the beginning of your upkeep, you may put a page counter on Private Research.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.PAGE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.PAGE.createInstance()), true));
 
         // When enchanted creature dies, draw a card for each page counter on Private Research.
         this.addAbility(new DiesAttachedTriggeredAbility(new DrawCardSourceControllerEffect(new CountersSourceCount(CounterType.PAGE)).setText(rule), "enchanted creature"));

--- a/Mage.Sets/src/mage/cards/p/PyromancerAscension.java
+++ b/Mage.Sets/src/mage/cards/p/PyromancerAscension.java
@@ -47,7 +47,7 @@ public final class PyromancerAscension extends CardImpl {
 class PyromancerAscensionQuestTriggeredAbility extends TriggeredAbilityImpl {
 
     PyromancerAscensionQuestTriggeredAbility() {
-        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.QUEST.createInstance(), true), true);
+        super(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.QUEST.createInstance()), true);
     }
 
     private PyromancerAscensionQuestTriggeredAbility(final PyromancerAscensionQuestTriggeredAbility ability) {

--- a/Mage.Sets/src/mage/cards/q/QuagVampires.java
+++ b/Mage.Sets/src/mage/cards/q/QuagVampires.java
@@ -36,7 +36,7 @@ public final class QuagVampires extends CardImpl {
 
         // Quag Vampires enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance),
                 "with a +1/+1 counter on it for each time it was kicked"));
     }
 

--- a/Mage.Sets/src/mage/cards/q/QuestForTheNihilStone.java
+++ b/Mage.Sets/src/mage/cards/q/QuestForTheNihilStone.java
@@ -29,7 +29,7 @@ public final class QuestForTheNihilStone extends CardImpl {
         super(ownerId, setInfo, new CardType[]{CardType.ENCHANTMENT}, "{B}");
 
         // Whenever an opponent discards a card, you may put a quest counter on Quest for the Nihil Stone.
-        this.addAbility(new DiscardsACardOpponentTriggeredAbility(new AddCountersSourceEffect(CounterType.QUEST.createInstance(), true), true));
+        this.addAbility(new DiscardsACardOpponentTriggeredAbility(new AddCountersSourceEffect(CounterType.QUEST.createInstance()), true));
 
         // At the beginning of each opponent's upkeep, if that player has no cards in hand and Quest for the Nihil Stone has two or more quest counters on it, you may have that player lose 5 life.
         this.addAbility(new QuestForTheNihilStoneTriggeredAbility());

--- a/Mage.Sets/src/mage/cards/r/RalMonsoonMage.java
+++ b/Mage.Sets/src/mage/cards/r/RalMonsoonMage.java
@@ -80,8 +80,7 @@ public final class RalMonsoonMage extends TransformingDoubleFacedCard {
 
         // Ral, Leyline Prodigy enters the battlefield with an additional loyalty counter on him for each instant and sorcery spell you've cast this turn.
         this.getRightHalfCard().addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(), InstantAndSorceryCastThisTurn.YOU,
-                        false)
+                new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(), InstantAndSorceryCastThisTurn.YOU)
                         .setText("with an additional loyalty counter on him for each instant and sorcery spell you've cast this turn"))
                 .addHint(InstantAndSorceryCastThisTurn.YOU.getHint())
         );

--- a/Mage.Sets/src/mage/cards/r/RampagingAetherhood.java
+++ b/Mage.Sets/src/mage/cards/r/RampagingAetherhood.java
@@ -87,7 +87,7 @@ class RampagingAetherhoodEffect extends OneShotEffect {
                 int energyToPay = controller.getAmount(1, totalEnergy, "Pay one or more {E}", source, game);
                 Cost cost = new PayEnergyCost(energyToPay);
                 if (cost.pay(source, game, source, controller.getId(), true)) {
-                    new AddCountersSourceEffect(CounterType.P1P1.createInstance(energyToPay), true).apply(game, source);
+                    new AddCountersSourceEffect(CounterType.P1P1.createInstance(energyToPay)).apply(game, source);
                     return true;
                 }
             }

--- a/Mage.Sets/src/mage/cards/r/RasputinTheOneiromancer.java
+++ b/Mage.Sets/src/mage/cards/r/RasputinTheOneiromancer.java
@@ -44,8 +44,7 @@ public final class RasputinTheOneiromancer extends CardImpl {
         // When Rasputin, the Oneiromancer enters the battlefield, put a dream counter on it for each
         // opponent you have. Each opponent creates a 1/1 red Goblin creature token.
         Ability ability = new EntersBattlefieldTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.DREAM.createInstance(), OpponentsCount.instance, false
-        ).setText("put a dream counter on it for each opponent you have."));
+                CounterType.DREAM.createInstance(), OpponentsCount.instance).setText("put a dream counter on it for each opponent you have."));
         ability.addEffect(new CreateTokenAllEffect(new GoblinToken(), TargetController.OPPONENT));
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/r/RealmSeekers.java
+++ b/Mage.Sets/src/mage/cards/r/RealmSeekers.java
@@ -37,8 +37,7 @@ public final class RealmSeekers extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(), 
-                        CardsInAllHandsCount.instance,
-                        false), 
+                        CardsInAllHandsCount.instance), 
                 "with X +1/+1 counters on it, where X is the total number of cards in all players' hands"));
         
         // {2}{G}, Remove a +1/+1 counter from Realm Seekers: Search your library for a land card, reveal it, put it into your hand, then shuffle your library.

--- a/Mage.Sets/src/mage/cards/r/Recantation.java
+++ b/Mage.Sets/src/mage/cards/r/Recantation.java
@@ -31,7 +31,7 @@ public final class Recantation extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Recantation.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // {U}, Sacrifice Recantation: Return up to X target permanents to their owners' hands, where X is the number of verse counters on Recantation.
         Effect effect = new ReturnToHandTargetEffect();

--- a/Mage.Sets/src/mage/cards/r/ResourcefulDefense.java
+++ b/Mage.Sets/src/mage/cards/r/ResourcefulDefense.java
@@ -123,12 +123,6 @@ class ResourcefulDefenseMoveCounterEffect extends OneShotEffect {
 
                 toPermanent.addCounters(CounterType.findByName(counterName).createInstance(amount), source, game);
                 fromPermanent.removeCounters(counterName, amount, source, game);
-                game.informPlayers(
-                        controller.getLogName() + "moved " +
-                                amount + " " +
-                                counterName + " counter" + (amount > 1 ? "s" : "") +
-                                " from " + fromPermanent.getLogName() +
-                                "to " + toPermanent.getLogName() + ".");
             }
         }
 

--- a/Mage.Sets/src/mage/cards/r/ResplendentMarshal.java
+++ b/Mage.Sets/src/mage/cards/r/ResplendentMarshal.java
@@ -97,10 +97,6 @@ class ResplendentMarshalEffect extends OneShotEffect {
                     StaticFilters.FILTER_CONTROLLED_ANOTHER_CREATURE, source.getControllerId(), source, game)) {
                 if (permanent.shareCreatureTypes(game, exiledCard)) {
                     permanent.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game);
-                    if (!game.isSimulation()) {
-                        game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName()
-                                + " puts a +1/+1 counter on " + permanent.getLogName());
-                    }
                 }
             }
             return true;

--- a/Mage.Sets/src/mage/cards/r/RetaliatorGriffin.java
+++ b/Mage.Sets/src/mage/cards/r/RetaliatorGriffin.java
@@ -29,8 +29,7 @@ public final class RetaliatorGriffin extends CardImpl {
 
         // Whenever a source an opponent controls deals damage to you, you may put that many +1/+1 counters on Retaliator Griffin.
         this.addAbility(new SourceDealsDamageToYouTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), SavedDamageValue.MANY, true
-        ), true));
+                CounterType.P1P1.createInstance(), SavedDamageValue.MANY), true));
     }
 
     private RetaliatorGriffin(final RetaliatorGriffin card) {

--- a/Mage.Sets/src/mage/cards/r/ReverentHunter.java
+++ b/Mage.Sets/src/mage/cards/r/ReverentHunter.java
@@ -27,8 +27,7 @@ public final class ReverentHunter extends CardImpl {
 
         // When Reverent Hunter enters the battlefield, put a number of +1/+1 counters on it equal to your devotion to green.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), DevotionCount.G, true
-        )).addHint(DevotionCount.G.getHint()));
+                CounterType.P1P1.createInstance(0), DevotionCount.G)).addHint(DevotionCount.G.getHint()));
     }
 
     private ReverentHunter(final ReverentHunter card) {

--- a/Mage.Sets/src/mage/cards/r/RhizomeLurcher.java
+++ b/Mage.Sets/src/mage/cards/r/RhizomeLurcher.java
@@ -33,8 +33,7 @@ public final class RhizomeLurcher extends CardImpl {
                         CounterType.P1P1.createInstance(0),
                         new CardsInControllerGraveyardCount(
                                 StaticFilters.FILTER_CARD_CREATURE
-                        ), true
-                ), null, "<i>Undergrowth</i> &mdash; {this} enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.",
+                        )), null, "<i>Undergrowth</i> &mdash; {this} enters with a number of +1/+1 counters on it equal to the number of creature cards in your graveyard.",
                 null
         );
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/r/RhythmOfTheWild.java
+++ b/Mage.Sets/src/mage/cards/r/RhythmOfTheWild.java
@@ -105,7 +105,6 @@ class RhythmOfTheWildEffect extends ReplacementEffectImpl {
                 outcome, "Have " + creature.getLogName() + " enter the battlefield with a +1/+1 counter on it or with haste?",
                 null, "+1/+1 counter", "Haste", source, game
         )) {
-            game.informPlayers(player.getLogName() + " choose to put a +1/+1 counter on " + creature.getName());
             creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         } else {
             ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/r/RiggingRunner.java
+++ b/Mage.Sets/src/mage/cards/r/RiggingRunner.java
@@ -33,7 +33,7 @@ public final class RiggingRunner extends CardImpl {
         this.addAbility(FirstStrikeAbility.getInstance());
 
         // Raid — Rigging Runner enters the battlefield with a +1/+1 counter on it if you attacked this turn.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1), false),
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)),
                         RaidCondition.instance,
                         "{this} enters with a +1/+1 counter on it if you attacked this turn.",
                         "{this} enters with a +1/+1 counter")

--- a/Mage.Sets/src/mage/cards/r/RogueSkycaptain.java
+++ b/Mage.Sets/src/mage/cards/r/RogueSkycaptain.java
@@ -77,7 +77,7 @@ class RogueSkycaptainEffect extends OneShotEffect {
         Player controller = game.getPlayer(source.getControllerId());
         Permanent permanent = game.getPermanentOrLKIBattlefield(source.getSourceId());
         if (controller != null && permanent != null) {
-            new AddCountersSourceEffect(CounterType.WAGE.createInstance(), true).apply(game, source);
+            new AddCountersSourceEffect(CounterType.WAGE.createInstance()).apply(game, source);
             Cost cost = ManaUtil.createManaCost(2 * permanent.getCounters(game).getCount(CounterType.WAGE), false);
             if (!cost.pay(source, game, source, controller.getId(), false)) {
                 new RemoveAllCountersSourceEffect(CounterType.WAGE).apply(game, source);

--- a/Mage.Sets/src/mage/cards/r/RoseTyler.java
+++ b/Mage.Sets/src/mage/cards/r/RoseTyler.java
@@ -43,8 +43,7 @@ public final class RoseTyler extends CardImpl {
 
         // Bad Wolf -- Whenever Rose Tyler attacks, put a time counter on it for each suspended card you own and each other permanent you control with a time counter on it.
         this.addAbility(new AttacksTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.TIME.createInstance(), RoseTylerValue.instance, true
-        )).addHint(RoseTylerValue.getHint()).withFlavorWord("Bad Wolf"));
+                CounterType.TIME.createInstance(), RoseTylerValue.instance)).addHint(RoseTylerValue.getHint()).withFlavorWord("Bad Wolf"));
 
         // Doctor's companion
         this.addAbility(DoctorsCompanionAbility.getInstance());

--- a/Mage.Sets/src/mage/cards/r/RubblebeltRaiders.java
+++ b/Mage.Sets/src/mage/cards/r/RubblebeltRaiders.java
@@ -28,7 +28,7 @@ public final class RubblebeltRaiders extends CardImpl {
 
         // Whenever Rubblebelt Raiders attacks, put a +1/+1 counter on it for each attacking creature you control.
         this.addAbility(new AttacksTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new AttackingCreatureCount("attacking creature you control"), true),false));
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new AttackingCreatureCount("attacking creature you control")),false));
     }
 
     private RubblebeltRaiders(final RubblebeltRaiders card) {

--- a/Mage.Sets/src/mage/cards/r/RumblingCrescendo.java
+++ b/Mage.Sets/src/mage/cards/r/RumblingCrescendo.java
@@ -37,7 +37,7 @@ public final class RumblingCrescendo extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Rumbling Crescendo.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // {R}, Sacrifice Rumbling Crescendo: Destroy up to X target lands, where X is the number of verse counters on Rumbling Crescendo.        
         Effect effect = new DestroyTargetEffect(true);

--- a/Mage.Sets/src/mage/cards/s/SautekhImmortal.java
+++ b/Mage.Sets/src/mage/cards/s/SautekhImmortal.java
@@ -34,8 +34,7 @@ public final class SautekhImmortal extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(0),
-                        CreaturesDiedThisTurnCount.instance, true
-                ).setText("with a +1/+1 counter on it for each creature that died this turn.")
+                        CreaturesDiedThisTurnCount.instance).setText("with a +1/+1 counter on it for each creature that died this turn.")
         ).withFlavorWord("Elite Troops").addHint(CreaturesDiedThisTurnHint.instance));
     }
 

--- a/Mage.Sets/src/mage/cards/s/ScarletSpiderBenReilly.java
+++ b/Mage.Sets/src/mage/cards/s/ScarletSpiderBenReilly.java
@@ -48,7 +48,7 @@ public final class ScarletSpiderBenReilly extends CardImpl {
         String ruleText = CardUtil.italicizeWithEmDash("Sensational Save") + "If {this} was cast using web-slinging, " +
                 "he enters with X +1/+1 counters on him, where X is the mana value of the returned creature.";
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(),
-                ScarletSpiderBenReillyValue.instance, false),
+                ScarletSpiderBenReillyValue.instance),
                 WebSlingingCondition.THIS, ruleText, ""));
     }
 

--- a/Mage.Sets/src/mage/cards/s/ScarscaleRitual.java
+++ b/Mage.Sets/src/mage/cards/s/ScarscaleRitual.java
@@ -73,7 +73,6 @@ class ScarscaleRitualCost extends CostImpl {
             Permanent permanent = game.getPermanent(target.getFirstTarget());
             if (permanent != null) {
                 permanent.addCounters(CounterType.M1M1.createInstance(), controllerId, ability, game);
-                game.informPlayers(controller.getLogName() + " puts a -1/-1 counter on " + permanent.getLogName());
                 this.paid = true;
             }
 

--- a/Mage.Sets/src/mage/cards/s/ScavengingGhoul.java
+++ b/Mage.Sets/src/mage/cards/s/ScavengingGhoul.java
@@ -32,7 +32,7 @@ public final class ScavengingGhoul extends CardImpl {
 
         // At the beginning of each end step, put a corpse counter on Scavenging Ghoul for each creature that died this turn.
         this.addAbility(new BeginningOfEndStepTriggeredAbility(TargetController.ANY, new AddCountersSourceEffect(CounterType.CORPSE.createInstance(),
-            CreaturesDiedThisTurnCount.instance, true), false).addHint(CreaturesDiedThisTurnHint.instance));
+            CreaturesDiedThisTurnCount.instance), false).addHint(CreaturesDiedThisTurnHint.instance));
         // Remove a corpse counter from Scavenging Ghoul: Regenerate Scavenging Ghoul.
         this.addAbility(new SimpleActivatedAbility(new RegenerateSourceEffect(),
             new RemoveCountersSourceCost(CounterType.CORPSE.createInstance())));

--- a/Mage.Sets/src/mage/cards/s/ScourgeOfSkolaVale.java
+++ b/Mage.Sets/src/mage/cards/s/ScourgeOfSkolaVale.java
@@ -41,7 +41,7 @@ public final class ScourgeOfSkolaVale extends CardImpl {
         // Trample
         this.addAbility(TrampleAbility.getInstance());
         // Scourge of Skola Vale enters the battlefield with two +1/+1 counters on it.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(2));
         effect.setText("with two +1/+1 counters on it");
         this.addAbility(new EntersBattlefieldAbility(effect));
         // {T}, Sacrifice another creature: Put a number of +1/+1 counters on Scourge of Skola Vale equal to the sacrificed creature's toughness.
@@ -83,7 +83,7 @@ class ScourgeOfSkolaValeEffect extends OneShotEffect {
                 int amount = ((SacrificeTargetCost) cost).getPermanents().get(0).getToughness().getValue();
                 Player player = game.getPlayer(source.getControllerId());
                 if (amount > 0 && player != null) {
-                    return new AddCountersSourceEffect(CounterType.P1P1.createInstance(amount), true).apply(game, source);
+                    return new AddCountersSourceEffect(CounterType.P1P1.createInstance(amount)).apply(game, source);
                 }
             }
         }

--- a/Mage.Sets/src/mage/cards/s/SerrasHymn.java
+++ b/Mage.Sets/src/mage/cards/s/SerrasHymn.java
@@ -28,7 +28,7 @@ public final class SerrasHymn extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Serra's Hymn.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // Sacrifice Serra's Hymn: Prevent the next X damage that would be dealt this turn to any number of targets, divided as you choose, where X is the number of verse counters on Serra's Hymn.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/s/SerrasLiturgy.java
+++ b/Mage.Sets/src/mage/cards/s/SerrasLiturgy.java
@@ -41,7 +41,7 @@ public final class SerrasLiturgy extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Serra's Liturgy.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // {W}, Sacrifice Serra's Liturgy: Destroy up to X target artifacts and/or enchantments, where X is the number of verse counters on Serra's Liturgy.
         Effect effect = new DestroyTargetEffect(true);

--- a/Mage.Sets/src/mage/cards/s/SerratedBiskelion.java
+++ b/Mage.Sets/src/mage/cards/s/SerratedBiskelion.java
@@ -30,7 +30,7 @@ public final class SerratedBiskelion extends CardImpl {
         this.toughness = new MageInt(2);
 
         // {tap}: Put a -1/-1 counter on Serrated Biskelion and a -1/-1 counter on target creature.
-        Ability ability = new SimpleActivatedAbility(new AddCountersSourceEffect(CounterType.M1M1.createInstance(), true), new TapSourceCost());
+        Ability ability = new SimpleActivatedAbility(new AddCountersSourceEffect(CounterType.M1M1.createInstance()), new TapSourceCost());
         ability.addEffect(new AddCountersTargetEffect(CounterType.M1M1.createInstance()).setText("and a -1/-1 counter on target creature"));
         ability.addTarget(new TargetCreaturePermanent());
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SetessanOathsworn.java
+++ b/Mage.Sets/src/mage/cards/s/SetessanOathsworn.java
@@ -26,7 +26,7 @@ public final class SetessanOathsworn extends CardImpl {
         this.toughness = new MageInt(1);
 
         // <i>Heroic</i> &mdash; Whenever you cast a spell that targets Setessan Oathsworn, put two +1/+1 counters on Setessan Oathsworn.
-        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true)));
+        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(2))));
     }
 
     private SetessanOathsworn(final SetessanOathsworn card) {

--- a/Mage.Sets/src/mage/cards/s/SheriffOfSafePassage.java
+++ b/Mage.Sets/src/mage/cards/s/SheriffOfSafePassage.java
@@ -40,8 +40,7 @@ public final class SheriffOfSafePassage extends CardImpl {
                 new EntersBattlefieldAbility(
                         new AddCountersSourceEffect(
                                 CounterType.P1P1.createInstance(),
-                                xValue, false
-                        ),
+                                xValue),
                         "with a +1/+1 counter on it plus an additional +1/+1 counter on it for each other creature you control"
                 ).addHint(hint)
         );

--- a/Mage.Sets/src/mage/cards/s/SkitterOfLizards.java
+++ b/Mage.Sets/src/mage/cards/s/SkitterOfLizards.java
@@ -35,7 +35,7 @@ public final class SkitterOfLizards extends CardImpl {
 
         // Skitter of Lizards enters the battlefield with a +1/+1 counter on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), MultikickerCount.instance),
                 "with a +1/+1 counter on it for each time it was kicked"));
 
     }

--- a/Mage.Sets/src/mage/cards/s/SkyriderElf.java
+++ b/Mage.Sets/src/mage/cards/s/SkyriderElf.java
@@ -32,7 +32,7 @@ public final class SkyriderElf extends CardImpl {
 
         // <i>Converge</i>-Skyrider Elf enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
         this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 

--- a/Mage.Sets/src/mage/cards/s/SlumberingTrudge.java
+++ b/Mage.Sets/src/mage/cards/s/SlumberingTrudge.java
@@ -39,7 +39,7 @@ public final class SlumberingTrudge extends CardImpl {
 
         // This creature enters with a number of stun counters on it equal to three minus X. If X is 2 or less, it enters tapped.
         Ability ability = new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.STUN.createInstance(), xValue, false),
+                new AddCountersSourceEffect(CounterType.STUN.createInstance(), xValue),
                 "with a number of stun counters on it equal to three minus X.");
         ability.addEffect(new ConditionalOneShotEffect(new TapSourceEffect(true), condition, null));
         this.addAbility(ability);

--- a/Mage.Sets/src/mage/cards/s/SparkDouble.java
+++ b/Mage.Sets/src/mage/cards/s/SparkDouble.java
@@ -93,7 +93,7 @@ class SparkDoubleCopyApplier extends CopyApplier {
             // enters with an additional +1/+1 counter on it if it’s a creature
             if (blueprint.isCreature(game)) {
                 blueprint.getAbilities().add(new EntersBattlefieldAbility(
-                        new AddCountersSourceEffect(CounterType.P1P1.createInstance(), false)
+                        new AddCountersSourceEffect(CounterType.P1P1.createInstance())
                                 .setText("with an additional +1/+1 counter on it")
                 ));
             }
@@ -101,7 +101,7 @@ class SparkDoubleCopyApplier extends CopyApplier {
             // enters with an additional loyalty counter on it if it’s a planeswalker
             if (blueprint.isPlaneswalker(game)) {
                 blueprint.getAbilities().add(new EntersBattlefieldAbility(
-                        new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(), false)
+                        new AddCountersSourceEffect(CounterType.LOYALTY.createInstance())
                                 .setText("with an additional loyalty counter on it")
                 ));
             }

--- a/Mage.Sets/src/mage/cards/s/SpiderPunk.java
+++ b/Mage.Sets/src/mage/cards/s/SpiderPunk.java
@@ -141,7 +141,6 @@ class SpiderPunkRiotETBEffect extends ReplacementEffectImpl {
                 outcome, "Have " + creature.getLogName() + " enter the battlefield with a +1/+1 counter on it or with haste?",
                 null, "+1/+1 counter", "Haste", source, game
         )) {
-            game.informPlayers(player.getLogName() + " choose to put a +1/+1 counter on " + creature.getName());
             creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         } else {
             ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/s/Spiritmonger.java
+++ b/Mage.Sets/src/mage/cards/s/Spiritmonger.java
@@ -31,7 +31,7 @@ public final class Spiritmonger extends CardImpl {
         this.toughness = new MageInt(6);
 
         // Whenever Spiritmonger deals damage to a creature, put a +1/+1 counter on Spiritmonger.
-        this.addAbility(new DealsDamageToACreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true), false, false, false));
+        this.addAbility(new DealsDamageToACreatureTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance()), false, false, false));
         // {B}: Regenerate Spiritmonger.
         this.addAbility(new SimpleActivatedAbility(new RegenerateSourceEffect(), new ManaCostsImpl<>("{B}")));
         // {G}: Spiritmonger becomes the color of your choice until end of turn.

--- a/Mage.Sets/src/mage/cards/s/SpringmantleCleric.java
+++ b/Mage.Sets/src/mage/cards/s/SpringmantleCleric.java
@@ -27,8 +27,7 @@ public final class SpringmantleCleric extends CardImpl {
 
         // Springmantle Cleric enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true
-        ), "with a +1/+1 counter on it for each color of mana spent to cast it."));
+                CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()), "with a +1/+1 counter on it for each color of mana spent to cast it."));
     }
 
     private SpringmantleCleric(final SpringmantleCleric card) {

--- a/Mage.Sets/src/mage/cards/s/SquadCaptain.java
+++ b/Mage.Sets/src/mage/cards/s/SquadCaptain.java
@@ -36,8 +36,7 @@ public final class SquadCaptain extends CardImpl {
 
         // Squad Captain enters the battlefield with a +1/+1 counter on it for each other creature you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), xValue, false
-        ).setText("with a +1/+1 counter on it for each other creature you control")));
+                CounterType.P1P1.createInstance(), xValue).setText("with a +1/+1 counter on it for each other creature you control")));
     }
 
     private SquadCaptain(final SquadCaptain card) {

--- a/Mage.Sets/src/mage/cards/s/StagBeetle.java
+++ b/Mage.Sets/src/mage/cards/s/StagBeetle.java
@@ -34,7 +34,7 @@ public final class StagBeetle extends CardImpl {
 
         // Stag Beetle enters the battlefield with X +1/+1 counters on it, where X is the number of other creatures on the battlefield.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(),
-            new PermanentsOnBattlefieldCount(filter), false),
+            new PermanentsOnBattlefieldCount(filter)),
             "with X +1/+1 counters on it, where X is the number of other creatures on the battlefield"));
     }
 

--- a/Mage.Sets/src/mage/cards/s/StormEntity.java
+++ b/Mage.Sets/src/mage/cards/s/StormEntity.java
@@ -35,8 +35,7 @@ public final class StormEntity extends CardImpl {
         this.addAbility(new EntersBattlefieldAbility(
                 new AddCountersSourceEffect(
                         CounterType.P1P1.createInstance(),
-                        new OtherSpellsCastThisTurnCount(),
-                        true),
+                        new OtherSpellsCastThisTurnCount()),
                 "with a +1/+1 counter on it for each other spell cast this turn"));
     }
 

--- a/Mage.Sets/src/mage/cards/s/StormFleetAerialist.java
+++ b/Mage.Sets/src/mage/cards/s/StormFleetAerialist.java
@@ -33,7 +33,7 @@ public final class StormFleetAerialist extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // Raid - Storm Fleet Aerialist enters the battlefield with a +1/+1 counter on it if you attacked this turn.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1), false),
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)),
                         RaidCondition.instance,
                         "{this} enters with a +1/+1 counter on it if you attacked this turn.",
                         "{this} enters with a +1/+1 counter")

--- a/Mage.Sets/src/mage/cards/s/SwarmOfBloodflies.java
+++ b/Mage.Sets/src/mage/cards/s/SwarmOfBloodflies.java
@@ -30,7 +30,7 @@ public final class SwarmOfBloodflies extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Swarm of Bloodflies enters the battlefield with two +1/+1 counters on it.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(2), true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(2));
         effect.setText("with two +1/+1 counters on it");
         this.addAbility(new EntersBattlefieldAbility(effect));
         // Whenever another creature dies, put a +1/+1 counter on Swarm of Bloodflies

--- a/Mage.Sets/src/mage/cards/t/TajuruStalwart.java
+++ b/Mage.Sets/src/mage/cards/t/TajuruStalwart.java
@@ -28,7 +28,7 @@ public final class TajuruStalwart extends CardImpl {
 
         // <i>Converge</i> &mdash; Tajuru Stalwart enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
         this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
 

--- a/Mage.Sets/src/mage/cards/t/TayamLuminousEnigma.java
+++ b/Mage.Sets/src/mage/cards/t/TayamLuminousEnigma.java
@@ -124,12 +124,6 @@ class TayamLuminousEnigmaCost extends RemoveCounterCost {
                         if (counterName != null) {
                             permanent.removeCounters(counterName, 1, source, game);
                             target.clearChosen();
-                            if (!game.isSimulation()) {
-                                game.informPlayers(new StringBuilder(controller.getLogName())
-                                        .append(" removes a ")
-                                        .append(counterName).append(" counter from ")
-                                        .append(permanent.getName()).toString());
-                            }
                             countersRemoved++;
                             if (countersRemoved == countersToRemove) {
                                 paid = true;

--- a/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
+++ b/Mage.Sets/src/mage/cards/t/TemptWithGlory.java
@@ -69,7 +69,6 @@ class TemptWithGloryEffect extends OneShotEffect {
                     if (opponent.chooseUse(outcome, "Put a +1/+1 counter on each creature you control?", source, game)) {
                         opponentsAddedCounters++;
                         addCounterToEachCreature(playerId, counter, source, game);
-                        game.informPlayers(opponent.getLogName() + " added a +1/+1 counter on each of its creatures");
                     }
                 }
             }

--- a/Mage.Sets/src/mage/cards/t/TenaciousTosk.java
+++ b/Mage.Sets/src/mage/cards/t/TenaciousTosk.java
@@ -30,7 +30,7 @@ public final class TenaciousTosk extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new CantBeBlockedByMoreThanOneSourceEffect()));
 
         // Whenever this creature deals combat damage to a player, put a +1/+1 counter on it.
-        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true)));
+        this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance())));
     }
 
     private TenaciousTosk(final TenaciousTosk card) {

--- a/Mage.Sets/src/mage/cards/t/TheAesirEscapeValhalla.java
+++ b/Mage.Sets/src/mage/cards/t/TheAesirEscapeValhalla.java
@@ -131,8 +131,6 @@ class TheAesirEscapeValhallaTwoEffect extends OneShotEffect {
         Permanent permanent = game.getPermanent(uuid);
         if (permanent != null) {
             permanent.addCounters(CounterType.P1P1.createInstance(mv), source.getControllerId(), source, game);
-            game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
-                    + mv + " +1/+1 counters on " + permanent.getLogName());
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/t/TheSwarmlord.java
+++ b/Mage.Sets/src/mage/cards/t/TheSwarmlord.java
@@ -43,7 +43,7 @@ public final class TheSwarmlord extends CardImpl {
 
         // Rapid Regeneration -- The Swarmlord enters the battlefield with two +1/+1 counters on it for each time you've cast your commander from the command zone this game.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), xValue, true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), xValue),
                 "with two +1/+1 counters on it for each time you've cast your commander from the command zone this game"
         ).addHint(CommanderCastCountValue.getHint()).withFlavorWord("Rapid Regeneration"));
 

--- a/Mage.Sets/src/mage/cards/t/ThopterSquadron.java
+++ b/Mage.Sets/src/mage/cards/t/ThopterSquadron.java
@@ -54,7 +54,7 @@ public final class ThopterSquadron extends CardImpl {
         this.addAbility(firstAbility);
 
         // {1}, Sacrifice another Thopter: Put a +1/+1 counter on Thopter Squadron. Activate this secondAbility only any time you could cast a sorcery.
-        Ability secondAbility = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true), new ManaCostsImpl<>("{1}"));
+        Ability secondAbility = new ActivateAsSorceryActivatedAbility(Zone.BATTLEFIELD, new AddCountersSourceEffect(CounterType.P1P1.createInstance()), new ManaCostsImpl<>("{1}"));
         secondAbility.addCost(new SacrificeTargetCost(filter));
         this.addAbility(secondAbility);
     }

--- a/Mage.Sets/src/mage/cards/t/ThoughtSponge.java
+++ b/Mage.Sets/src/mage/cards/t/ThoughtSponge.java
@@ -37,8 +37,7 @@ public final class ThoughtSponge extends CardImpl {
 
         // Thought Sponge enters the battlefield with a number of +1/+1 counters on it equal to the greatest number of cards an opponent has drawn this turn.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), ThoughtSpongeValue.instance, false
-        ), "with a number of +1/+1 counters on it equal to " +
+                CounterType.P1P1.createInstance(), ThoughtSpongeValue.instance), "with a number of +1/+1 counters on it equal to " +
                 "the greatest number of cards an opponent has drawn this turn"
         ));
 

--- a/Mage.Sets/src/mage/cards/t/Tidewalker.java
+++ b/Mage.Sets/src/mage/cards/t/Tidewalker.java
@@ -36,7 +36,7 @@ public final class Tidewalker extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Tidewalker enters the battlefield with a time counter on it for each Island you control.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.TIME.createInstance(0), new PermanentsOnBattlefieldCount(filter), true), "with a time counter on it for each Island you control"));
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.TIME.createInstance(0), new PermanentsOnBattlefieldCount(filter)), "with a time counter on it for each Island you control"));
 
         // Vanishing
         this.addAbility(new VanishingAbility(0));

--- a/Mage.Sets/src/mage/cards/t/TimeBomb.java
+++ b/Mage.Sets/src/mage/cards/t/TimeBomb.java
@@ -29,7 +29,7 @@ public final class TimeBomb extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{4}");
 
         // At the beginning of your upkeep, put a time counter on Time Bomb.
-        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.TIME.createInstance(), true)));
+        this.addAbility(new BeginningOfUpkeepTriggeredAbility(new AddCountersSourceEffect(CounterType.TIME.createInstance())));
 
         // {1}, {tap}, Sacrifice Time Bomb: Time Bomb deals damage equal to the number of time counters on it to each creature and each player.
         Effect effect = new DamageEverythingEffect(new CountersSourceCount(CounterType.TIME), new FilterCreaturePermanent());

--- a/Mage.Sets/src/mage/cards/t/TorchSong.java
+++ b/Mage.Sets/src/mage/cards/t/TorchSong.java
@@ -28,7 +28,7 @@ public final class TorchSong extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Torch Song.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // {2}{R}, Sacrifice Torch Song: Torch Song deals X damage to any target, where X is the number of verse counters on Torch Song.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/t/ToweringTitan.java
+++ b/Mage.Sets/src/mage/cards/t/ToweringTitan.java
@@ -49,8 +49,7 @@ public final class ToweringTitan extends CardImpl {
 
         // Towering Titan enters the battlefield with X +1/+1 counters on it, where X is the total toughness of other creatures you control.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), ToweringTitanCount.instance, false
-        ), "with X +1/+1 counters on it, where X is the total toughness of other creatures you control"));
+                CounterType.P1P1.createInstance(), ToweringTitanCount.instance), "with X +1/+1 counters on it, where X is the total toughness of other creatures you control"));
 
         // Sacrifice a creature with defender: All creatures gain trample until end of turn.
         this.addAbility(new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/t/TyvarTheBellicose.java
+++ b/Mage.Sets/src/mage/cards/t/TyvarTheBellicose.java
@@ -71,8 +71,7 @@ class TyvarTheBellicoseTriggeredAbility extends TriggeredAbilityImpl {
 
     TyvarTheBellicoseTriggeredAbility() {
         super(Zone.BATTLEFIELD, new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), SavedDamageValue.MANY, false
-        ));
+                CounterType.P1P1.createInstance(0), SavedDamageValue.MANY));
         this.setTriggersLimitEachTurn(1);
     }
 

--- a/Mage.Sets/src/mage/cards/u/UlamogTheDefiler.java
+++ b/Mage.Sets/src/mage/cards/u/UlamogTheDefiler.java
@@ -55,8 +55,7 @@ public final class UlamogTheDefiler extends CardImpl {
         this.addAbility(
                 new EntersBattlefieldAbility(
                         new AddCountersSourceEffect(
-                                CounterType.P1P1.createInstance(), UlamogTheDefilerValue.instance, false
-                        ), "with a number of +1/+1 counters on it equal to " +
+                                CounterType.P1P1.createInstance(), UlamogTheDefilerValue.instance), "with a number of +1/+1 counters on it equal to " +
                         "the greatest mana value among cards in exile"
                 ).addHint(UlamogTheDefilerValue.hint)
         );

--- a/Mage.Sets/src/mage/cards/u/UncivilUnrest.java
+++ b/Mage.Sets/src/mage/cards/u/UncivilUnrest.java
@@ -93,7 +93,6 @@ class UncivilUnrestRiotEffect extends ReplacementEffectImpl {
                 outcome, "Have " + creature.getLogName() + " enter the battlefield with a +1/+1 counter on it or with haste?",
                 null, "+1/+1 counter", "Haste", source, game
         )) {
-            game.informPlayers(player.getLogName() + " choose to put a +1/+1 counter on " + creature.getName());
             creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
         } else {
             ContinuousEffect effect = new GainAbilityTargetEffect(HasteAbility.getInstance(), Duration.Custom);

--- a/Mage.Sets/src/mage/cards/u/UndercoverOperative.java
+++ b/Mage.Sets/src/mage/cards/u/UndercoverOperative.java
@@ -59,7 +59,7 @@ class UndercoverOperativeApplier extends CopyApplier {
         if (!isCopyOfCopy(source, blueprint, copyToObjectId)
                 && ((Permanent) blueprint).isControlledBy(source.getControllerId())) {
             blueprint.getAbilities().add(new EntersBattlefieldAbility(
-                    new AddCountersSourceEffect(CounterType.SHIELD.createInstance(), false)
+                    new AddCountersSourceEffect(CounterType.SHIELD.createInstance())
                             .setText("with a shield counter on it")
             ));
         }

--- a/Mage.Sets/src/mage/cards/u/UndergrowthScavenger.java
+++ b/Mage.Sets/src/mage/cards/u/UndergrowthScavenger.java
@@ -28,7 +28,7 @@ public final class UndergrowthScavenger extends CardImpl {
         this.toughness = new MageInt(0);
 
         // Undergrowth Scavenger enters the battlefield with a number of +1/+1 counters on it equal to the number of creature cards in all graveyards.
-        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new CardsInAllGraveyardsCount(StaticFilters.FILTER_CARD_CREATURE), true);
+        Effect effect = new AddCountersSourceEffect(CounterType.P1P1.createInstance(0), new CardsInAllGraveyardsCount(StaticFilters.FILTER_CARD_CREATURE));
         effect.setText("with a number of +1/+1 counters on it equal to the number of creature cards in all graveyards");
         this.addAbility(new EntersBattlefieldAbility(effect));
     }

--- a/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
+++ b/Mage.Sets/src/mage/cards/u/UrzaAcademyHeadmaster.java
@@ -176,7 +176,7 @@ class UrzaAcademyHeadmasterRandomEffect extends OneShotEffect {
                                 break;
                             case 9: // GIDEON CHAMPION OF JUSTICE 1
                                 sb.append("Put a loyalty counter on Urza for each creature target opponent controls.");
-                                effects.add(new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(0), new PermanentsTargetOpponentControlsCount(new FilterCreaturePermanent()), true));
+                                effects.add(new AddCountersSourceEffect(CounterType.LOYALTY.createInstance(0), new PermanentsTargetOpponentControlsCount(new FilterCreaturePermanent())));
                                 target = new TargetOpponent();
                                 break;
                             case 10: // JACE ARCHITECT OF THOUGHT 1

--- a/Mage.Sets/src/mage/cards/v/VentifactBottle.java
+++ b/Mage.Sets/src/mage/cards/v/VentifactBottle.java
@@ -34,8 +34,7 @@ public final class VentifactBottle extends CardImpl {
 
         // {X}{1}, {tap}: Put X charge counters on Ventifact Bottle. Activate this ability only any time you could cast a sorcery.
         Ability ability = new ActivateAsSorceryActivatedAbility(new AddCountersSourceEffect(
-                CounterType.CHARGE.createInstance(), GetXValue.instance, true
-        ), new ManaCostsImpl<>("{X}{1}"));
+                CounterType.CHARGE.createInstance(), GetXValue.instance), new ManaCostsImpl<>("{X}{1}"));
         ability.addCost(new TapSourceCost());
         this.addAbility(ability);
 

--- a/Mage.Sets/src/mage/cards/v/VerazolTheSplitCurrent.java
+++ b/Mage.Sets/src/mage/cards/v/VerazolTheSplitCurrent.java
@@ -34,8 +34,7 @@ public final class VerazolTheSplitCurrent extends CardImpl {
 
         // Verazol, the Split Current enters the battlefield with a +1/+1 counter on it for each mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(), ManaSpentToCastCount.instance, true
-        ), "with a +1/+1 counter on it for each mana spent to cast it"));
+                CounterType.P1P1.createInstance(), ManaSpentToCastCount.instance), "with a +1/+1 counter on it for each mana spent to cast it"));
 
         // Whenever you cast a kicked spell, you may remove two +1/+1 counters from Verazol, the Split Current. If you do, copy that spell. You may choose new targets for that copy.
         this.addAbility(new SpellCastControllerTriggeredAbility(

--- a/Mage.Sets/src/mage/cards/v/VexingPuzzlebox.java
+++ b/Mage.Sets/src/mage/cards/v/VexingPuzzlebox.java
@@ -31,8 +31,7 @@ public final class VexingPuzzlebox extends CardImpl {
 
         // Whenever you roll one or more dice, put a number of charge counters on Vexing Puzzlebox equal to the result.
         this.addAbility(new OneOrMoreDiceRolledTriggeredAbility(new AddCountersSourceEffect(
-                CounterType.CHARGE.createInstance(), VexingPuzzleboxValue.instance, true
-        ).setText("put a number of charge counters on {this} equal to the result")));
+                CounterType.CHARGE.createInstance(), VexingPuzzleboxValue.instance).setText("put a number of charge counters on {this} equal to the result")));
 
         // {T}: Add one mana of any color. Roll a d20.
         AnyColorManaAbility manaAbility = new AnyColorManaAbility();

--- a/Mage.Sets/src/mage/cards/v/VileRequiem.java
+++ b/Mage.Sets/src/mage/cards/v/VileRequiem.java
@@ -41,7 +41,7 @@ public final class VileRequiem extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on Vile Requiem.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // {1}{B}, Sacrifice Vile Requiem: Destroy up to X target nonblack creatures, where X is the number of verse counters on Vile Requiem. They can't be regenerated.
         Effect effect = new DestroyTargetEffect(true);

--- a/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
+++ b/Mage.Sets/src/mage/cards/v/VishKalBloodArbiter.java
@@ -49,8 +49,7 @@ public final class VishKalBloodArbiter extends CardImpl {
         // Sacrifice a creature: Put X +1/+1 counters on Vish Kal, Blood Arbiter, where X is the sacrificed creature's power.
         this.addAbility(new SimpleActivatedAbility(
                 new AddCountersSourceEffect(
-                        CounterType.P1P1.createInstance(), SacrificeCostCreaturesPower.instance, true
-                ).setText("put X +1/+1 counters on {this}, where X is the sacrificed creature's power"),
+                        CounterType.P1P1.createInstance(), SacrificeCostCreaturesPower.instance).setText("put X +1/+1 counters on {this}, where X is the sacrificed creature's power"),
                 new SacrificeTargetCost(StaticFilters.FILTER_PERMANENT_CREATURE)
         ));
 

--- a/Mage.Sets/src/mage/cards/v/VodalianMindsinger.java
+++ b/Mage.Sets/src/mage/cards/v/VodalianMindsinger.java
@@ -55,8 +55,7 @@ public final class VodalianMindsinger extends CardImpl {
 
         // Vodalian Mindsinger enters the battlefield with two +1/+1 counters on it for each time it was kicked.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), xValue, true
-        ), "with two +1/+1 counters on it for each time it was kicked"));
+                CounterType.P1P1.createInstance(0), xValue), "with two +1/+1 counters on it for each time it was kicked"));
 
         // When Vodalian Mindsinger enters the battlefield, gain control of target creature with power less than Vodalian Mindsinger's power for as long as you control Vodalian Mindsinger.
         Ability ability = new EntersBattlefieldTriggeredAbility(new GainControlTargetEffect(Duration.WhileControlled));

--- a/Mage.Sets/src/mage/cards/v/VoraciousWurm.java
+++ b/Mage.Sets/src/mage/cards/v/VoraciousWurm.java
@@ -27,8 +27,7 @@ public final class VoraciousWurm extends CardImpl {
 
         // Voracious Wurm enters the battlefield with X +1/+1 counters on it, where X is the amount of life you've gained this turn.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), ControllerGainedLifeCount.instance, true
-        ), "with X +1/+1 counters on it, where X is the amount of life you've gained this turn")
+                CounterType.P1P1.createInstance(0), ControllerGainedLifeCount.instance), "with X +1/+1 counters on it, where X is the amount of life you've gained this turn")
                 .addHint(ControllerGainedLifeCount.getHint()), new PlayerGainedLifeWatcher());
     }
 

--- a/Mage.Sets/src/mage/cards/v/VoroshTheHunter.java
+++ b/Mage.Sets/src/mage/cards/v/VoroshTheHunter.java
@@ -33,7 +33,7 @@ public final class VoroshTheHunter extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
         // Whenever Vorosh, the Hunter deals combat damage to a player, you may pay {2}{G}. If you do, put six +1/+1 counters on Vorosh.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new DoIfCostPaid(new AddCountersSourceEffect(CounterType.P1P1.createInstance(6), true), new ManaCostsImpl<>("{2}{G}")), false));
+                new DoIfCostPaid(new AddCountersSourceEffect(CounterType.P1P1.createInstance(6)), new ManaCostsImpl<>("{2}{G}")), false));
     }
 
     private VoroshTheHunter(final VoroshTheHunter card) {

--- a/Mage.Sets/src/mage/cards/w/WarDance.java
+++ b/Mage.Sets/src/mage/cards/w/WarDance.java
@@ -28,7 +28,7 @@ public final class WarDance extends CardImpl {
 
         // At the beginning of your upkeep, you may put a verse counter on War Dance.
         this.addAbility(new BeginningOfUpkeepTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.VERSE.createInstance(), true), true));
+                new AddCountersSourceEffect(CounterType.VERSE.createInstance()), true));
 
         // Sacrifice War Dance: Target creature gets +X/+X until end of turn, where X is the number of verse counters on War Dance.
         Ability ability = new SimpleActivatedAbility(

--- a/Mage.Sets/src/mage/cards/w/WarNameAspirant.java
+++ b/Mage.Sets/src/mage/cards/w/WarNameAspirant.java
@@ -37,7 +37,7 @@ public final class WarNameAspirant extends CardImpl {
         this.toughness = new MageInt(1);
 
         // <i>Raid</i> &mdash; War-Name Aspirant enters the battlefield with a +1/+1 counter on it if you attacked this turn.
-        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1), false),
+        this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(1)),
                         RaidCondition.instance,
                         "{this} enters with a +1/+1 counter on it if you attacked this turn.",
                         "{this} enters with a +1/+1 counter")

--- a/Mage.Sets/src/mage/cards/w/WarWingSiren.java
+++ b/Mage.Sets/src/mage/cards/w/WarWingSiren.java
@@ -29,7 +29,7 @@ public final class WarWingSiren extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Heroic — Whenever you cast a spell that targets War-Wing Siren, put a +1/+1 counter on War-Wing Siren.
-        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), false)));
+        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance())));
     }
 
     private WarWingSiren(final WarWingSiren card) {

--- a/Mage.Sets/src/mage/cards/w/WestgateRegent.java
+++ b/Mage.Sets/src/mage/cards/w/WestgateRegent.java
@@ -35,7 +35,7 @@ public final class WestgateRegent extends CardImpl {
 
         // Whenever Westgate Regent deals combat damage to a player, put that many +1/+1 counters on it.
         this.addAbility(new DealsCombatDamageToAPlayerTriggeredAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), SavedDamageValue.MANY, false)
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), SavedDamageValue.MANY)
                         .setText("put that many +1/+1 counters on it"), false, true
         ));
     }

--- a/Mage.Sets/src/mage/cards/w/WhiptongueHydra.java
+++ b/Mage.Sets/src/mage/cards/w/WhiptongueHydra.java
@@ -82,8 +82,7 @@ class WhiptongueHydraEffect extends OneShotEffect {
         if (destroyedPermanents > 0) {
             game.processAction();
             new AddCountersSourceEffect(
-                    CounterType.P1P1.createInstance(destroyedPermanents), true
-            ).apply(game, source);
+                    CounterType.P1P1.createInstance(destroyedPermanents)).apply(game, source);
         }
         return true;
     }

--- a/Mage.Sets/src/mage/cards/w/WickerWarcrawler.java
+++ b/Mage.Sets/src/mage/cards/w/WickerWarcrawler.java
@@ -27,7 +27,7 @@ public final class WickerWarcrawler extends CardImpl {
         // Whenever Wicker Warcrawler attacks or blocks, put a -1/-1 counter on it at end of combat.
         this.addAbility(new AttacksOrBlocksTriggeredAbility(
                 new CreateDelayedTriggeredAbilityEffect(new AtTheEndOfCombatDelayedTriggeredAbility(
-                        new AddCountersSourceEffect(CounterType.M1M1.createInstance(), true)
+                        new AddCountersSourceEffect(CounterType.M1M1.createInstance())
                 ), false).setText("put a -1/-1 counter on it at end of combat"), false
         ).setTriggerPhrase("Whenever {this} attacks or blocks, "));
     }

--- a/Mage.Sets/src/mage/cards/w/WingsteedRider.java
+++ b/Mage.Sets/src/mage/cards/w/WingsteedRider.java
@@ -29,7 +29,7 @@ public final class WingsteedRider extends CardImpl {
         // Flying
         this.addAbility(FlyingAbility.getInstance());
         // Heroic - Whenever you cast a spell that targets Wingsteed Rider, put a +1/+1 counter on Wingsteed Rider.
-        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance(), true)));
+        this.addAbility(new HeroicAbility(new AddCountersSourceEffect(CounterType.P1P1.createInstance())));
     }
 
     private WingsteedRider(final WingsteedRider card) {

--- a/Mage.Sets/src/mage/cards/w/WishingWell.java
+++ b/Mage.Sets/src/mage/cards/w/WishingWell.java
@@ -69,7 +69,7 @@ class WishingWellEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
 
-        if (!new AddCountersSourceEffect(CounterType.COIN.createInstance(), true).apply(game, source)) {
+        if (!new AddCountersSourceEffect(CounterType.COIN.createInstance()).apply(game, source)) {
             return false;
         }
 

--- a/Mage.Sets/src/mage/cards/w/WoodlandWanderer.java
+++ b/Mage.Sets/src/mage/cards/w/WoodlandWanderer.java
@@ -32,7 +32,7 @@ public final class WoodlandWanderer extends CardImpl {
         this.addAbility(TrampleAbility.getInstance());
         // <i>Converge</i> &mdash; Woodland Wanderer enters the battlefield with a +1/+1 counter on it for each color of mana spent to cast it.
         this.addAbility(new EntersBattlefieldAbility(
-                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance(), true),
+                new AddCountersSourceEffect(CounterType.P1P1.createInstance(), ColorsOfManaSpentToCastCount.getInstance()),
                 null, "<i>Converge</i> &mdash; {this} enters with a +1/+1 counter on it for each color of mana spent to cast it.", null));
         this.getSpellAbility().addHint(ColorsOfManaSpentToCastCount.getHint());
     }

--- a/Mage.Sets/src/mage/cards/z/ZarOjanenScionOfEfrava.java
+++ b/Mage.Sets/src/mage/cards/z/ZarOjanenScionOfEfrava.java
@@ -2,7 +2,6 @@ package mage.cards.z;
 
 import java.util.UUID;
 import mage.MageInt;
-import mage.MageObject;
 import mage.abilities.Ability;
 import mage.abilities.common.BecomesTappedSourceTriggeredAbility;
 import mage.abilities.dynamicvalue.common.DomainValue;
@@ -14,7 +13,6 @@ import mage.cards.CardSetInfo;
 import mage.counters.CounterType;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
-import mage.players.Player;
 
 /**
  *
@@ -63,27 +61,10 @@ class ZarOjanenScionOfEfravaEffect extends OneShotEffect {
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Player controller = game.getPlayer(source.getControllerId());
-        MageObject sourceObject = game.getObject(source);
-        StringBuilder sb = new StringBuilder();
-        if (sourceObject != null) {
-            sb.append(sourceObject.getLogName());
-            sb.append(": ");
-        }
-        if (controller != null) {
-            sb.append(controller.getLogName());
-        } else {
-            sb.append("controller");
-        }
-        sb.append(" puts a +1/+1 counter on ");
-        String prefix = sb.toString();
         int basicLandTypes = DomainValue.REGULAR.calculate(game, source, this);
         for (Permanent permanent : game.getBattlefield().getAllActivePermanents(source.getControllerId())) {
             if (permanent.isCreature(game) && permanent.getToughness().getValue() < basicLandTypes) {
                 permanent.addCounters(CounterType.P1P1.createInstance(), source, game);
-                if (!game.isSimulation()) {
-                    game.informPlayers(prefix + permanent.getLogName());
-                }
             }
         }
         return true;

--- a/Mage.Sets/src/mage/cards/z/ZombieMob.java
+++ b/Mage.Sets/src/mage/cards/z/ZombieMob.java
@@ -32,8 +32,7 @@ public final class ZombieMob extends CardImpl {
 
         // Zombie Mob enters the battlefield with a +1/+1 counter on it for each creature card in your graveyard.
         this.addAbility(new EntersBattlefieldAbility(new AddCountersSourceEffect(
-                CounterType.P1P1.createInstance(0), new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE), false
-        ), "with a +1/+1 counter on it for each creature card in your graveyard"));
+                CounterType.P1P1.createInstance(0), new CardsInControllerGraveyardCount(StaticFilters.FILTER_CARD_CREATURE)), "with a +1/+1 counter on it for each creature card in your graveyard"));
 
         // When Zombie Mob enters the battlefield, exile all creature cards from your graveyard.
         this.addAbility(new EntersBattlefieldTriggeredAbility(new ZombieMobExileEffect()));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/rtr/KarlovOfTheGhostCouncilTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/rtr/KarlovOfTheGhostCouncilTest.java
@@ -1,0 +1,33 @@
+package org.mage.test.cards.single.rtr;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author JayDi85
+ */
+public class KarlovOfTheGhostCouncilTest extends CardTestPlayerBase {
+
+    @Test
+    public void test_GainLifeAddsCounters() {
+        // Whenever you gain life, put two +1/+1 counters on Karlov of the Ghost Council.
+        addCard(Zone.BATTLEFIELD, playerA, "Karlov of the Ghost Council"); // 2/2
+
+        // Chaplain's Blessing -- You gain 5 life.
+        addCard(Zone.HAND, playerA, "Chaplain's Blessing"); // {W}
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Chaplain's Blessing");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 25); // 20 starting + 5
+
+        // boost +2/+2 from x2 counters
+        assertPowerToughness(playerA, "Karlov of the Ghost Council", 2 + 2, 2 + 2);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/costs/common/RemoveCounterCost.java
+++ b/Mage/src/main/java/mage/abilities/costs/common/RemoveCounterCost.java
@@ -141,12 +141,6 @@ public class RemoveCounterCost extends CostImpl {
                 }
                 targetObject.removeCounters(counterName, numberOfCountersSelected, source, game);
                 countersRemoved += numberOfCountersSelected;
-                if (!game.isSimulation()) {
-                    game.informPlayers(controller.getLogName() +
-                            " removes " + (numberOfCountersSelected == 1 ? "a" : numberOfCountersSelected) + ' ' +
-                            counterName + (numberOfCountersSelected == 1 ? " counter from " : " counters from ") +
-                            targetObject.getName());
-                }
                 if (countersRemoved == countersToRemove) {
                     this.paid = true;
                     break;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersAllEffect.java
@@ -64,9 +64,6 @@ public class AddCountersAllEffect extends OneShotEffect {
                 Counter newCounterForPermanent = newCounter.copy();
 
                 permanent.addCounters(newCounterForPermanent, source.getControllerId(), source, game);
-                game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
-                        + newCounterForPermanent.getCount() + ' ' + newCounterForPermanent.getName()
-                        + (newCounterForPermanent.getCount() == 1 ? " counter" : " counters") + " on " + permanent.getLogName());
 
                 result |= true;
             }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersPlayersEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersPlayersEffect.java
@@ -88,9 +88,6 @@ public class AddCountersPlayersEffect extends OneShotEffect {
             Player player = game.getPlayer(playerId);
             if (player != null) {
                 player.addCounters(newCounterForPlayer, source.getControllerId(), source, game);
-                game.informPlayers(player.getLogName() + " gets "
-                        + newCounterForPlayer.getCount() + ' ' + newCounterForPlayer.getName() + " counters"
-                        + CardUtil.getSourceLogName(game, source));
             }
         }
         return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
@@ -23,37 +23,26 @@ import java.util.UUID;
 public class AddCountersSourceEffect extends OneShotEffect {
 
     private Counter counter;
-    private boolean informPlayers;
     private DynamicValue amount;
     private boolean putOnCard;
 
     public AddCountersSourceEffect(Counter counter) {
-        this(counter, false);
-    }
-
-    public AddCountersSourceEffect(Counter counter, boolean informPlayers) {
-        this(counter, StaticValue.get(0), informPlayers);
+        this(counter, StaticValue.get(0));
     }
 
     public AddCountersSourceEffect(Counter counter, DynamicValue amount) {
-        this(counter, amount, true);
-    }
-
-    public AddCountersSourceEffect(Counter counter, DynamicValue amount, boolean informPlayers) {
-        this(counter, amount, informPlayers, false);
+        this(counter, amount, false);
     }
 
     /**
      * @param counter
-     * @param amount        this amount will be added to the counter instances
-     * @param informPlayers
-     * @param putOnCard     - counters have to be put on a card instead of a
-     *                      permanent
+     * @param amount    this amount will be added to the counter instances
+     * @param putOnCard - counters have to be put on a card instead of a
+     *                  permanent
      */
-    public AddCountersSourceEffect(Counter counter, DynamicValue amount, boolean informPlayers, boolean putOnCard) {
+    public AddCountersSourceEffect(Counter counter, DynamicValue amount, boolean putOnCard) {
         super(Outcome.Benefit);
         this.counter = counter.copy();
-        this.informPlayers = informPlayers;
         this.amount = amount;
         this.putOnCard = putOnCard;
         staticText = CardUtil.getAddRemoveCountersText(amount, counter, "{this}", true);
@@ -64,7 +53,6 @@ public class AddCountersSourceEffect extends OneShotEffect {
         if (effect.counter != null) {
             this.counter = effect.counter.copy();
         }
-        this.informPlayers = effect.informPlayers;
         this.amount = effect.amount;
         this.putOnCard = effect.putOnCard;
     }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersSourceEffect.java
@@ -94,12 +94,6 @@ public class AddCountersSourceEffect extends OneShotEffect {
             newCounter.add(countersToAdd);
             List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
             card.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects);
-            if (informPlayers && !game.isSimulation()) {
-                Player player = game.getPlayer(source.getControllerId());
-                if (player != null) {
-                    game.informPlayers(player.getLogName() + " puts " + newCounter.getCount() + ' ' + newCounter.getName() + " counter on " + card.getLogName());
-                }
-            }
             return true;
         } else {
             Permanent permanent = game.getPermanent(source.getSourceId());
@@ -119,16 +113,8 @@ public class AddCountersSourceEffect extends OneShotEffect {
                         countersToAdd--;
                     }
                     newCounter.add(countersToAdd);
-                    int before = permanent.getCounters(game).getCount(newCounter.getName());
                     List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects");
                     permanent.addCounters(newCounter, source.getControllerId(), source, game, appliedEffects); // if used from a replacement effect, the basic event determines if an effect was already applied to an event
-                    if (informPlayers && !game.isSimulation()) {
-                        int amountAdded = permanent.getCounters(game).getCount(newCounter.getName()) - before;
-                        Player player = game.getPlayer(source.getControllerId());
-                        if (player != null) {
-                            game.informPlayers(player.getLogName() + " puts " + amountAdded + ' ' + newCounter.getName() + " counter on " + permanent.getLogName());
-                        }
-                    }
                 }
             }
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/AddCountersTargetEffect.java
@@ -80,18 +80,12 @@ public class AddCountersTargetEffect extends OneShotEffect {
                 if (permanent != null) {
                     permanent.addCounters(newCounterForTarget, source.getControllerId(), source, game);
                     affectedTargets++;
-                    game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
-                            + newCounterForTarget.getCount() + ' ' + newCounterForTarget.getName() + " counters on " + permanent.getLogName());
                 } else if (player != null) {
                     player.addCounters(newCounterForTarget, source.getControllerId(), source, game);
                     affectedTargets++;
-                    game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
-                            + newCounterForTarget.getCount() + ' ' + newCounterForTarget.getName() + " counters on " + player.getLogName());
                 } else if (card != null) {
                     card.addCounters(newCounterForTarget, source.getControllerId(), source, game);
                     affectedTargets++;
-                    game.informPlayers(sourceObject.getLogName() + ": " + controller.getLogName() + " puts "
-                            + newCounterForTarget.getCount() + ' ' + newCounterForTarget.getName() + " counters on " + card.getLogName());
                 }
             }
             return affectedTargets > 0;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/ProliferateEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/ProliferateEffect.java
@@ -66,9 +66,7 @@ public class ProliferateEffect extends OneShotEffect {
                 if (permanent != null) {
                     for (Counter counter : permanent.getCounters(game).values()) {
                         Counter newCounter = CounterType.findByName(counter.getName()).createInstance();
-                        if (permanent.addCounters(newCounter, source.getControllerId(), source, game)) {
-                            game.informPlayers(permanent.getName() + " had " + newCounter.getDescription() + " added to it.");
-                        }
+                        permanent.addCounters(newCounter, source.getControllerId(), source, game);
                     }
                     continue;
                 }
@@ -79,9 +77,7 @@ public class ProliferateEffect extends OneShotEffect {
                 for (Counter counter : player.getCountersAsCopy().values()) {
                     // TODO: this does not work with ability counters that are not explicitly in CounterType. Like the Hexproof from XXX counters from Indominus Rex, Alpha
                     Counter newCounter = CounterType.findByName(counter.getName()).createInstance();
-                    if (player.addCounters(newCounter, source.getControllerId(), source, game)) {
-                        game.informPlayers(player.getLogName() + " had " + newCounter.getDescription() + " added to them.");
-                    }
+                    player.addCounters(newCounter, source.getControllerId(), source, game);
                 }
             }
             game.fireEvent(GameEvent.getEvent(

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/RemoveCounterSourceEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/RemoveCounterSourceEffect.java
@@ -33,7 +33,6 @@ public class RemoveCounterSourceEffect extends OneShotEffect {
             int toRemove = Math.min(counter.getCount(), permanent.getCounters(game).getCount(counter.getName()));
             if (toRemove > 0) {
                 permanent.removeCounters(counter.getName(), toRemove, source, game);
-                game.informPlayers("Removed " + toRemove + ' ' + counter.getName() + " counter from " + permanent.getLogName());
             }
             return true;
         }
@@ -42,9 +41,6 @@ public class RemoveCounterSourceEffect extends OneShotEffect {
             int toRemove = Math.min(counter.getCount(), card.getCounters(game).getCount(counter.getName()));
             if (toRemove > 0) {
                 card.removeCounters(counter.getName(), toRemove, source, game);
-                game.informPlayers("Removed " + toRemove + ' ' + counter.getName()
-                        + " counter from " + card.getLogName()
-                        + " (" + card.getCounters(game).getCount(counter.getName()) + " left)");
             }
             return true;
         }

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/RemoveCounterTargetEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/RemoveCounterTargetEffect.java
@@ -45,20 +45,11 @@ public class RemoveCounterTargetEffect extends OneShotEffect {
             Counter toRemove = (counter == null ? selectCounterType(game, source, p) : counter);
             if (toRemove != null && p.getCounters(game).getCount(toRemove.getName()) >= toRemove.getCount()) {
                 p.removeCounters(toRemove.getName(), toRemove.getCount(), source, game);
-                if (!game.isSimulation()) {
-                    game.informPlayers("Removed " + toRemove.getCount() + ' ' + toRemove.getName()
-                            + " counter from " + p.getName());
-                }
             }
         } else {
             Card c = game.getCard(getTargetPointer().getFirst(game, source));
             if (c != null && counter != null && c.getCounters(game).getCount(counter.getName()) >= counter.getCount()) {
                 c.removeCounters(counter.getName(), counter.getCount(), source, game);
-                if (!game.isSimulation()) {
-                    game.informPlayers(new StringBuilder("Removed ").append(counter.getCount()).append(' ').append(counter.getName())
-                            .append(" counter from ").append(c.getName())
-                            .append(" (").append(c.getCounters(game).getCount(counter.getName())).append(" left)").toString());
-                }
             }
         }
         return true;

--- a/Mage/src/main/java/mage/abilities/effects/common/counter/TimeTravelEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/counter/TimeTravelEffect.java
@@ -67,14 +67,12 @@ public class TimeTravelEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(chosen);
             if (permanent != null) {
                 permanent.addCounters(CounterType.TIME.createInstance(), source.getControllerId(), source, game);
-                game.informPlayers(permanent.getName() + " had a time counter added to it.");
                 filter.getPermanentFilter().add(Predicates.not(new CardIdPredicate(chosen)));
                 continue;
             }
             Card card = game.getCard(chosen);
             if (card != null) {
                 card.addCounters(CounterType.TIME.createInstance(), source.getControllerId(), source, game);
-                game.informPlayers(card.getName() + " had a time counter added to it.");
                 filter.getCardFilter().add(Predicates.not(new CardIdPredicate(chosen)));
             }
         }
@@ -87,13 +85,11 @@ public class TimeTravelEffect extends OneShotEffect {
             Permanent permanent = game.getPermanent(chosen);
             if (permanent != null) {
                 permanent.removeCounters(CounterType.TIME.createInstance(), source, game);
-                game.informPlayers(permanent.getName() + " had a time counter removed from it.");
                 continue;
             }
             Card card = game.getCard(chosen);
             if (card != null) {
                 card.removeCounters(CounterType.TIME.createInstance(), source, game);
-                game.informPlayers(card.getName() + " had a time counter removed from it.");
             }
         }
 

--- a/Mage/src/main/java/mage/abilities/effects/keyword/ShieldCounterEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/ShieldCounterEffect.java
@@ -36,9 +36,6 @@ public class ShieldCounterEffect extends ReplacementEffectImpl {
             return false;
         }
         permanent.removeCounters(CounterType.SHIELD.getName(), 1, source, game);
-        if (!game.isSimulation()) {
-            game.informPlayers("Removed a shield counter from " + permanent.getLogName());
-        }
         // Damage should be prevented rather than replacing the event.
         // Effects that say "damage can't be prevented" will have the creature both take the damage and remove a shield counter.
         if (event.getType() == GameEvent.EventType.DAMAGE_PERMANENT) {

--- a/Mage/src/main/java/mage/abilities/effects/keyword/StunCounterEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/keyword/StunCounterEffect.java
@@ -35,7 +35,6 @@ public class StunCounterEffect extends ReplacementEffectImpl {
             return false;
         }
         permanent.removeCounters(CounterType.STUN.getName(), 1, source, game);
-        game.informPlayers("Removed a stun counter from " + permanent.getLogName());
         return true;
     }
 

--- a/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/GraftAbility.java
@@ -146,9 +146,6 @@ class GraftDistributeCounterEffect extends OneShotEffect {
                 if (targetCreature != null) {
                     sourcePermanent.removeCounters(CounterType.P1P1.getName(), 1, source, game);
                     targetCreature.addCounters(CounterType.P1P1.createInstance(1), source.getControllerId(), source, game);
-                    if (!game.isSimulation()) {
-                        game.informPlayers("Moved one +1/+1 counter from " + sourcePermanent.getLogName() + " to " + targetCreature.getLogName());
-                    }
                     return true;
                 }
             }

--- a/Mage/src/main/java/mage/abilities/keyword/RenownAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RenownAbility.java
@@ -86,7 +86,7 @@ class BecomesRenownedSourceEffect extends OneShotEffect {
             if (renownValue == Integer.MAX_VALUE) {
                 renownValue = CardUtil.getSourceCostsTag(game, source, "X", 0);
             }
-            new AddCountersSourceEffect(CounterType.P1P1.createInstance(renownValue), true).apply(game, source);
+            new AddCountersSourceEffect(CounterType.P1P1.createInstance(renownValue)).apply(game, source);
             permanent.setRenowned(true);
             game.fireEvent(GameEvent.getEvent(GameEvent.EventType.BECOMES_RENOWNED, source.getSourceId(), source, source.getControllerId(), renownValue));
             return true;

--- a/Mage/src/main/java/mage/abilities/keyword/RepairAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RepairAbility.java
@@ -29,7 +29,7 @@ public class RepairAbility extends DiesSourceTriggeredAbility {
 
     public RepairAbility(int count) {
         super(new AddCountersSourceEffect(
-                CounterType.REPAIR.createInstance(), StaticValue.get(count), false, true));
+                CounterType.REPAIR.createInstance(), StaticValue.get(count), true));
         addSubAbility(new BeginningOfUpkeepTriggeredAbility(Zone.GRAVEYARD,
                 TargetController.YOU, new RemoveCounterSourceEffect(CounterType.REPAIR.createInstance()), false)
                 .setRuleVisible(false));

--- a/Mage/src/main/java/mage/abilities/keyword/RiotAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/RiotAbility.java
@@ -66,7 +66,6 @@ class RiotReplacementEffect extends ReplacementEffectImpl {
         Player controller = game.getPlayer(source.getControllerId());
         if (creature != null && controller != null) {
             if (controller.chooseUse(outcome, "Have " + creature.getLogName() + " enter the battlefield with a +1/+1 counter on it or with haste?", null, "+1/+1 counter", "Haste", source, game)) {
-                game.informPlayers(controller.getLogName() + " choose to put a +1/+1 counter on " + creature.getName());
                 creature.addCounters(CounterType.P1P1.createInstance(), source.getControllerId(), source, game, event.getAppliedEffects());
             } else {
                 game.addEffect(new GainAbilitySourceEffect(HasteAbility.getInstance(), Duration.Custom), source);

--- a/Mage/src/main/java/mage/abilities/keyword/SunburstAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/SunburstAbility.java
@@ -80,12 +80,6 @@ class SunburstEffect extends OneShotEffect {
                 }
                 List<UUID> appliedEffects = (ArrayList<UUID>) this.getValue("appliedEffects"); // the basic event is the EntersBattlefieldEvent, so use already applied replacement effects from that event
                 permanent.addCounters(counter, source.getControllerId(), source, game, appliedEffects);
-                if (!game.isSimulation()) {
-                    Player player = game.getPlayer(source.getControllerId());
-                    if (player != null) {
-                        game.informPlayers(player.getLogName() + " puts " + counter.getCount() + ' ' + counter.getName() + " counter on " + permanent.getName());
-                    }
-                }
             }
         }
         return true;

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -855,7 +855,7 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
             removedAmount++;
         }
 
-        CardUtil.informPlayersCountersChange(null, counterName, startAmount, Math.abs(startAmount - removedAmount), this, game, source);
+        CardUtil.informPlayersCountersChange(null, counterName, startAmount, startAmount - removedAmount, this, game, source);
         GameEvent event = new CountersRemovedEvent(counterName, this, source, removedAmount, isDamage);
         game.fireEvent(event);
         return removedAmount;

--- a/Mage/src/main/java/mage/cards/CardImpl.java
+++ b/Mage/src/main/java/mage/cards/CardImpl.java
@@ -783,10 +783,11 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                 amount = addingAllEvent.getAmount();
             }
             boolean isEffectFlag = addingAllEvent.getFlag();
-            int finalAmount = amount;
+            int startAmount = getCounters(game).getCount(counter.getName());
+            int addedAmount = amount;
             for (int i = 0; i < amount; i++) {
                 Counter eventCounter = counter.copy();
-                eventCounter.remove(eventCounter.getCount() - 1);
+                eventCounter.remove(eventCounter.getCount() - 1); // make 1 counter
                 GameEvent addingOneEvent = GameEvent.getEvent(GameEvent.EventType.ADD_COUNTER, objectId, source, playerAddingCounters, counter.getName(), 1);
                 addingOneEvent.setAppliedEffects(appliedEffects);
                 addingOneEvent.setFlag(isEffectFlag);
@@ -796,12 +797,13 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
                     addedOneEvent.setFlag(addingOneEvent.getFlag());
                     game.fireEvent(addedOneEvent);
                 } else {
-                    finalAmount--;
+                    addedAmount--;
                     returnCode = false; // restricted by ADD_COUNTER
                 }
             }
-            if (finalAmount > 0) {
-                GameEvent addedAllEvent = GameEvent.getEvent(GameEvent.EventType.COUNTERS_ADDED, objectId, source, playerAddingCounters, counter.getName(), amount);
+            if (addedAmount > 0) {
+                CardUtil.informPlayersCountersChange(playerAddingCounters, counter.getName(), startAmount, startAmount + addedAmount, this, game, source);
+                GameEvent addedAllEvent = GameEvent.getEvent(GameEvent.EventType.COUNTERS_ADDED, objectId, source, playerAddingCounters, counter.getName(), addedAmount);
                 addedAllEvent.setFlag(isEffectFlag);
                 game.fireEvent(addedAllEvent);
             } else {
@@ -834,7 +836,8 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
             return 0;
         }
 
-        int finalAmount = 0;
+        int startAmount = this.getCounters(game).getCount(counterName);
+        int removedAmount = 0;
         for (int i = 0; i < removeCountersEvent.getAmount(); i++) {
 
             GameEvent event = new RemoveCounterEvent(counterName, this, source, isDamage);
@@ -849,12 +852,13 @@ public abstract class CardImpl extends MageObjectImpl implements Card {
             event = new CounterRemovedEvent(counterName, this, source, isDamage);
             game.fireEvent(event);
 
-            finalAmount++;
+            removedAmount++;
         }
 
-        GameEvent event = new CountersRemovedEvent(counterName, this, source, finalAmount, isDamage);
+        CardUtil.informPlayersCountersChange(null, counterName, startAmount, Math.abs(startAmount - removedAmount), this, game, source);
+        GameEvent event = new CountersRemovedEvent(counterName, this, source, removedAmount, isDamage);
         game.fireEvent(event);
-        return finalAmount;
+        return removedAmount;
     }
 
     @Override

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2550,7 +2550,7 @@ public abstract class PlayerImpl implements Player, Serializable {
             removedAmount++;
         }
 
-        CardUtil.informPlayersCountersChange(null, counterName, startAmount, Math.abs(startAmount - removedAmount), this, game, source);
+        CardUtil.informPlayersCountersChange(null, counterName, startAmount, startAmount - removedAmount, this, game, source);
         GameEvent event = new CountersRemovedEvent(counterName, this, source, removedAmount, false);
         game.fireEvent(event);
     }

--- a/Mage/src/main/java/mage/players/PlayerImpl.java
+++ b/Mage/src/main/java/mage/players/PlayerImpl.java
@@ -2486,18 +2486,19 @@ public abstract class PlayerImpl implements Player, Serializable {
         );
         if (!game.replaceEvent(addingAllEvent)) {
             int amount = addingAllEvent.getAmount();
-            int finalAmount = amount;
+            int startAmount = this.counters.getCount(counter.getName());
+            int addedAmount = amount;
             boolean isEffectFlag = addingAllEvent.getFlag();
             for (int i = 0; i < amount; i++) {
                 Counter eventCounter = counter.copy();
-                eventCounter.remove(eventCounter.getCount() - 1);
+                eventCounter.remove(eventCounter.getCount() - 1); // make 1 counter
                 GameEvent addingOneEvent = GameEvent.getEvent(
                         GameEvent.EventType.ADD_COUNTER, playerId, source,
                         playerAddingCounters, counter.getName(), 1
                 );
                 addingOneEvent.setFlag(isEffectFlag);
                 if (!game.replaceEvent(addingOneEvent)) {
-                    counters.addCounter(eventCounter);
+                    this.counters.addCounter(eventCounter);
                     GameEvent addedOneEvent = GameEvent.getEvent(
                             GameEvent.EventType.COUNTER_ADDED, playerId, source,
                             playerAddingCounters, counter.getName(), 1
@@ -2505,14 +2506,15 @@ public abstract class PlayerImpl implements Player, Serializable {
                     addedOneEvent.setFlag(addingOneEvent.getFlag());
                     game.fireEvent(addedOneEvent);
                 } else {
-                    finalAmount--;
+                    addedAmount--;
                     returnCode = false;
                 }
             }
-            if (finalAmount > 0) {
+            if (addedAmount > 0) {
+                CardUtil.informPlayersCountersChange(playerAddingCounters, counter.getName(), startAmount, startAmount + addedAmount, this, game, source);
                 GameEvent addedAllEvent = GameEvent.getEvent(
                         GameEvent.EventType.COUNTERS_ADDED, playerId, source,
-                        playerAddingCounters, counter.getName(), amount
+                        playerAddingCounters, counter.getName(), addedAmount
                 );
                 addedAllEvent.setFlag(addingAllEvent.getFlag());
                 game.fireEvent(addedAllEvent);
@@ -2531,7 +2533,8 @@ public abstract class PlayerImpl implements Player, Serializable {
             return;
         }
 
-        int finalAmount = 0;
+        int startAmount = this.counters.getCount(counterName);
+        int removedAmount = 0;
         for (int i = 0; i < amount; i++) {
 
             GameEvent event = new RemoveCounterEvent(counterName, this, source, false);
@@ -2544,10 +2547,11 @@ public abstract class PlayerImpl implements Player, Serializable {
             }
             event = new CounterRemovedEvent(counterName, this, source, false);
             game.fireEvent(event);
-            finalAmount++;
+            removedAmount++;
         }
 
-        GameEvent event = new CountersRemovedEvent(counterName, this, source, finalAmount, false);
+        CardUtil.informPlayersCountersChange(null, counterName, startAmount, Math.abs(startAmount - removedAmount), this, game, source);
+        GameEvent event = new CountersRemovedEvent(counterName, this, source, removedAmount, false);
         game.fireEvent(event);
     }
 

--- a/Mage/src/main/java/mage/util/CardUtil.java
+++ b/Mage/src/main/java/mage/util/CardUtil.java
@@ -2561,4 +2561,48 @@ public final class CardUtil {
         return !ability.getEffects().isEmpty()
                 && ability.getEffects().stream().allMatch(InfoEffect.class::isInstance);
     }
+
+    public static void informPlayersCountersChange(UUID playerId, String counterName, int oldValue, int newValue, MageItem targetObject, Game game, Ability source) {
+        int change = Math.abs(newValue - oldValue);
+        if (change == 0) {
+            return;
+        }
+
+        String etbInfo = "";
+        if (targetObject instanceof Permanent && game.getPermanentEntering(targetObject.getId()) != null) {
+            etbInfo = " as it enters the battlefield";
+        }
+
+        boolean isRemoval = newValue < oldValue;
+
+        StringBuilder sb = new StringBuilder();
+        Player addingPlayer = game.getPlayer(playerId);
+        if (addingPlayer == null && source != null) {
+            addingPlayer = game.getPlayer(source.getControllerId());
+        }
+        if (addingPlayer != null) {
+            sb.append(addingPlayer.getLogName());
+        } else {
+            sb.append("Player");
+        }
+        sb.append(isRemoval ? " removes " : " puts ");
+        sb.append(change);
+        sb.append(' ');
+        sb.append(counterName);
+        sb.append(change == 1 ? " counter " : " counters ");
+        sb.append(isRemoval ? "from " : "on ");
+        if (targetObject instanceof Player) {
+            sb.append(((Player) targetObject).getLogName());
+        } else if (targetObject instanceof MageObject) {
+            sb.append(((MageObject) targetObject).getLogName());
+        } else {
+            sb.append("object");
+        }
+        sb.append(etbInfo);
+        sb.append(", remaining ");
+        sb.append(newValue);
+        sb.append(CardUtil.getSourceLogName(game, source, targetObject.getId()));
+
+        game.informPlayers(sb.toString());
+    }
 }


### PR DESCRIPTION
Now all counters generates standard and AI compatible logs with detail info about puts/removes counters, source of the event, etb hint and remaining amount. All other counters logs from custom effects were removed. Loyalty also generates counters logs. Must be fine and without new logs spamming.

Full fixes list:
- game: added counters puts/removes logs for any actions (close #9440, related to #9528);
- refactor: removed custom log messages about counters (due logs duplication)
- refactor: fixed wrong amount in COUNTERS_ADDED/COUNTERS_REMOVED (only code, no real bugs);
- refactor: cleanup AddCountersSourceEffect
- tests: added additional tests;
