### PR TITLE
[TLA] Implement Secret of Bloodbending

### DIFF
--- a/Mage.Sets/src/mage/cards/s/SecretOfBloodbending.java
+++ b/Mage.Sets/src/mage/cards/s/SecretOfBloodbending.java
@@ -12,7 +12,6 @@ import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.game.Game;
 import mage.game.turn.CombatPhase;
-import mage.game.turn.Phase;
 import mage.game.turn.TurnMod;
 import mage.players.Player;
 import mage.target.common.TargetOpponent;
@@ -20,7 +19,7 @@ import mage.target.common.TargetOpponent;
 import java.util.UUID;
 
 /**
- * @author TheElk801
+ * @author miesma
  */
 public final class SecretOfBloodbending extends CardImpl {
 

--- a/Mage.Sets/src/mage/cards/s/SecretOfBloodbending.java
+++ b/Mage.Sets/src/mage/cards/s/SecretOfBloodbending.java
@@ -1,0 +1,126 @@
+package mage.cards.s;
+
+import mage.abilities.Ability;
+import mage.abilities.condition.common.WaterbendedCondition;
+import mage.abilities.effects.Effect;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.*;
+import mage.abilities.effects.common.turn.ControlTargetPlayerNextTurnEffect;
+import mage.abilities.keyword.WaterbendAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.game.Game;
+import mage.game.turn.CombatPhase;
+import mage.game.turn.Phase;
+import mage.game.turn.TurnMod;
+import mage.players.Player;
+import mage.target.common.TargetOpponent;
+
+import java.util.UUID;
+
+/**
+ * @author TheElk801
+ */
+public final class SecretOfBloodbending extends CardImpl {
+
+    public SecretOfBloodbending(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.SORCERY}, "{U}{U}{U}{U}");
+
+        this.subtype.add(SubType.LESSON);
+
+        // As an additional cost to cast this spell, you may waterbend {10}.
+        this.addAbility(new WaterbendAbility(10));
+
+        // You control target opponent during their next combat phase.
+        // If this spell’s additional cost was paid, you control that player during their next turn instead.
+        this.getSpellAbility().addEffect(new SecretOfBloodbendingEffect());
+        this.getSpellAbility().addTarget(new TargetOpponent());
+
+        // Exile Secret of Bloodbending.
+        this.getSpellAbility().addEffect(new ExileSpellEffect().concatBy("<br>"));
+    }
+
+    private SecretOfBloodbending(final SecretOfBloodbending card) {
+        super(card);
+    }
+
+    @Override
+    public SecretOfBloodbending copy() {
+        return new SecretOfBloodbending(this);
+    }
+}
+
+class SecretOfBloodbendingEffect extends OneShotEffect {
+
+    SecretOfBloodbendingEffect() {
+        super(Outcome.GainControl);
+        staticText = "You control target opponent during their next combat phase. " +
+                "If this spell's additional cost was paid, you control that player during their next turn instead";
+    }
+
+    private SecretOfBloodbendingEffect(final SecretOfBloodbendingEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public SecretOfBloodbendingEffect copy() {
+        return new SecretOfBloodbendingEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player targetPlayer = game.getPlayer(source.getFirstTarget());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (targetPlayer == null || controller == null) {
+            return false;
+        }
+        if (WaterbendedCondition.instance.apply(game, source)) {
+            game.informPlayers(controller.getLogName() + " will take control of "
+                    + targetPlayer.getLogName() + "'s next turn");
+            Effect controlPlayerEffect = new ControlTargetPlayerNextTurnEffect();
+            controlPlayerEffect.apply(game, source);
+        } else {
+            game.informPlayers(controller.getLogName() + " will take control of "
+                    + targetPlayer.getLogName() + "'s next combat");
+            Effect controlCombatEffect = new ControlPlayerCombatEffect();
+            controlCombatEffect.apply(game, source);
+        }
+
+
+        return true;
+    }
+}
+
+class ControlPlayerCombatEffect extends OneShotEffect {
+
+    public ControlPlayerCombatEffect() {
+        super(Outcome.Benefit);
+        staticText = "You control target opponent during their next combat phase";
+    }
+
+    protected ControlPlayerCombatEffect(final ControlPlayerCombatEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public ControlPlayerCombatEffect copy() {
+        return new ControlPlayerCombatEffect(this);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player targetPlayer = game.getPlayer(source.getFirstTarget());
+        Player controller = game.getPlayer(source.getControllerId());
+        if (targetPlayer == null || controller == null) {
+            return false;
+        }
+        // Possible generalization for any phase
+        TurnMod combat = new TurnMod(targetPlayer.getId())
+                .withPhaseController(new CombatPhase(), controller.getId());
+        game.getState().getTurnMods().add(combat);
+        return true;
+    }
+}
+
+

--- a/Mage.Sets/src/mage/sets/AvatarTheLastAirbender.java
+++ b/Mage.Sets/src/mage/sets/AvatarTheLastAirbender.java
@@ -298,6 +298,8 @@ public final class AvatarTheLastAirbender extends ExpansionSet {
         cards.add(new SetCardInfo("Sandbender Scavengers", 239, Rarity.RARE, mage.cards.s.SandbenderScavengers.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Sandbender Scavengers", 382, Rarity.RARE, mage.cards.s.SandbenderScavengers.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Sandbenders' Storm", 34, Rarity.COMMON, mage.cards.s.SandbendersStorm.class));
+        cards.add(new SetCardInfo("Secret of Bloodbending", 69, Rarity.MYTHIC, mage.cards.s.SecretOfBloodbending.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Secret of Bloodbending", 337, Rarity.MYTHIC, mage.cards.s.SecretOfBloodbending.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Secret Tunnel", 278, Rarity.RARE, mage.cards.s.SecretTunnel.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Secret Tunnel", 392, Rarity.RARE, mage.cards.s.SecretTunnel.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Seismic Sense", 195, Rarity.UNCOMMON, mage.cards.s.SeismicSense.class));

--- a/Mage/src/main/java/mage/game/turn/Turn.java
+++ b/Mage/src/main/java/mage/game/turn/Turn.java
@@ -105,6 +105,8 @@ public class Turn implements Serializable {
 
         // turn control must be called after potential turn skip due 720.1.
         checkTurnIsControlledByOtherPlayer(game, activePlayer.getId());
+        // Remember if whole turn is under opponents control
+        boolean opponentInFullControl = !activePlayer.isGameUnderControl();
 
         game.getPlayer(activePlayer.getId()).beginTurn(game);
         GameEvent event = new GameEvent(GameEvent.EventType.BEGIN_TURN, null, null, activePlayer.getId());
@@ -126,6 +128,11 @@ public class Turn implements Serializable {
                         skipPhaseMod.getInfo()
                 ));
                 continue;
+            }
+            // If no opponent has taken full control check individual phases
+            // To not remove control over turn with checkCurrentPhaseIsControlledByOtherPlayer
+            if (!opponentInFullControl) {
+                checkCurrentPhaseIsControlledByOtherPlayer(game, activePlayer.getId(), currentPhase);
             }
 
             game.fireEvent(new PhaseChangedEvent(activePlayer.getId(), null));
@@ -246,6 +253,30 @@ public class Turn implements Serializable {
             // game logs added in child's call (controlPlayersTurn)
             game.getPlayer(newControllerMod.getNewControllerId()).controlPlayersTurn(game, activePlayerId, newControllerMod.getInfo());
         }
+    }
+
+    private void checkCurrentPhaseIsControlledByOtherPlayer(Game game, UUID activePlayerId, Phase currentPhase) {
+
+        // remove old under control
+        game.getPlayers().values().forEach(player -> {
+            if (player.isInGame() && !player.isGameUnderControl()) {
+                Player controllingPlayer = game.getPlayer(player.getTurnControlledBy());
+                if (player != controllingPlayer && controllingPlayer != null) {
+                    game.informPlayers(controllingPlayer.getLogName() + " lost control over " + player.getLogName());
+                }
+                player.setGameUnderYourControl(game, true);
+            }
+        });
+
+        // add new under control
+        TurnMod newControllerMod = game.getState().getTurnMods().useNextNewPhaseController(activePlayerId, currentPhase);
+        if (newControllerMod != null
+                && !newControllerMod.getControlledPhase().equals(activePlayerId)
+                && newControllerMod.getControlledPhase().getType().equals(currentPhase.getType())) {
+            // game logs added in child's call (controlPlayersTurn)
+            game.getPlayer(newControllerMod.getPhaseController()).controlPlayersTurn(game, activePlayerId, newControllerMod.getInfo());
+        }
+
     }
 
     private void resetCounts() {

--- a/Mage/src/main/java/mage/game/turn/Turn.java
+++ b/Mage/src/main/java/mage/game/turn/Turn.java
@@ -332,7 +332,7 @@ public class Turn implements Serializable {
             currentPhase = phase;
             // Remove Phase control and check if a new one exists
             // In theorie there could be an instant speed Secrets of Bloodbending
-            if (phaseControl) {
+            if (phaseControl || game.getPlayer(activePlayerId).isGameUnderControl()) {
                 checkCurrentPhaseIsControlledByOtherPlayer(game, activePlayerId, currentPhase);
             }
             game.fireEvent(new PhaseChangedEvent(activePlayerId, extraPhaseMod));

--- a/Mage/src/main/java/mage/game/turn/Turn.java
+++ b/Mage/src/main/java/mage/game/turn/Turn.java
@@ -30,6 +30,7 @@ public class Turn implements Serializable {
     private UUID activePlayerId;
     private final List<Phase> phases = new ArrayList<>();
     private boolean declareAttackersStepStarted = false;
+    private boolean phaseControl = false;
     private boolean endTurn; // indicates that an end turn effect has resolved.
 
     public Turn() {
@@ -131,6 +132,7 @@ public class Turn implements Serializable {
             }
             // If no opponent has taken full control check individual phases
             // To not remove control over turn with checkCurrentPhaseIsControlledByOtherPlayer
+            // Check after skip phase because of 723.1b
             if (!opponentInFullControl) {
                 checkCurrentPhaseIsControlledByOtherPlayer(game, activePlayer.getId(), currentPhase);
             }
@@ -264,6 +266,7 @@ public class Turn implements Serializable {
                 if (player != controllingPlayer && controllingPlayer != null) {
                     game.informPlayers(controllingPlayer.getLogName() + " lost control over " + player.getLogName());
                 }
+                this.phaseControl = false;
                 player.setGameUnderYourControl(game, true);
             }
         });
@@ -274,6 +277,7 @@ public class Turn implements Serializable {
                 && !newControllerMod.getControlledPhase().equals(activePlayerId)
                 && newControllerMod.getControlledPhase().getType().equals(currentPhase.getType())) {
             // game logs added in child's call (controlPlayersTurn)
+            this.phaseControl = true;
             game.getPlayer(newControllerMod.getPhaseController()).controlPlayersTurn(game, activePlayerId, newControllerMod.getInfo());
         }
 
@@ -326,6 +330,11 @@ public class Turn implements Serializable {
                 phase.keepOnlyStep(skipAllButExtraStep);
             }
             currentPhase = phase;
+            // Remove Phase control and check if a new one exists
+            // In theorie there could be an instant speed Secrets of Bloodbending
+            if (phaseControl) {
+                checkCurrentPhaseIsControlledByOtherPlayer(game, activePlayerId, currentPhase);
+            }
             game.fireEvent(new PhaseChangedEvent(activePlayerId, extraPhaseMod));
             Player activePlayer = game.getPlayer(activePlayerId);
             if (activePlayer != null) {

--- a/Mage/src/main/java/mage/game/turn/Turn.java
+++ b/Mage/src/main/java/mage/game/turn/Turn.java
@@ -226,13 +226,13 @@ public class Turn implements Serializable {
     }
 
     private void checkTurnIsControlledByOtherPlayer(Game game, UUID activePlayerId) {
-        // 720.1.
+        // 723.1.
         // Some cards allow a player to control another player during that player’s next turn.
         // This effect applies to the next turn that the affected player actually takes.
         // The affected player is controlled during the entire turn; the effect doesn’t end until
         // the beginning of the next turn.
         //
-        // 720.1b
+        // 723.1b
         // If a turn is skipped, any pending player-controlling effects wait until the player who would be
         // affected actually takes a turn.
 

--- a/Mage/src/main/java/mage/game/turn/TurnMod.java
+++ b/Mage/src/main/java/mage/game/turn/TurnMod.java
@@ -46,6 +46,9 @@ public class TurnMod implements Serializable, Copyable<TurnMod> {
     private TurnPhase afterPhase;
     private PhaseStep afterStep;
 
+    private Phase controlledPhase;
+    private UUID phaseController;
+
     private boolean locked = false; // locked for modification, used for wrong code usage protection
     private String tag; // for inner usage like enable/disable mod in effects
     private String info; // for GUI usage like additional info in logs
@@ -146,6 +149,18 @@ public class TurnMod implements Serializable, Copyable<TurnMod> {
         return this;
     }
 
+    public TurnMod withPhaseController(Phase controlledPhase, UUID newControllerId) {
+        return withPhaseController(controlledPhase, newControllerId, null);
+    }
+
+    public TurnMod withPhaseController(Phase controlledPhase, UUID newControllerId, TurnMod nextSubsequentTurnMod) {
+        this.controlledPhase = controlledPhase;
+        this.phaseController = newControllerId;
+        this.subsequentTurnMod = nextSubsequentTurnMod;
+        lock();
+        return this;
+    }
+
     public TurnMod withSkipStep(PhaseStep skipStep) {
         this.skipStep = skipStep;
         lock();
@@ -221,9 +236,11 @@ public class TurnMod implements Serializable, Copyable<TurnMod> {
         return afterStep;
     }
 
-    public UUID getNewControllerId() {
-        return newControllerId;
-    }
+    public UUID getNewControllerId() {return newControllerId;}
+
+    public UUID getPhaseController() { return phaseController;}
+
+    public Phase getControlledPhase() { return controlledPhase;}
 
     public UUID getId() {
         return id;

--- a/Mage/src/main/java/mage/game/turn/TurnMods.java
+++ b/Mage/src/main/java/mage/game/turn/TurnMods.java
@@ -72,21 +72,46 @@ public class TurnMods extends ArrayList<TurnMod> implements Serializable, Copyab
 
         TurnMod lastNewControllerMod = null;
 
-        // find last/actual mod
-        ListIterator<TurnMod> it = this.listIterator(this.size());
-        while (it.hasPrevious()) {
-            TurnMod turnMod = it.previous();
-            if (turnMod.getNewControllerId() != null && turnMod.getPlayerId().equals(playerId)) {
+        // find last/actual mod full or partial control (end of the list)
+        ListIterator<TurnMod> it = this.listIterator();
+        while (it.hasNext()) {
+            TurnMod turnMod = it.next();
+            if ((turnMod.getNewControllerId() != null && turnMod.getPlayerId().equals(playerId))
+              || (turnMod.getPhaseController() != null && turnMod.getPlayerId().equals(playerId))) {
                 lastNewControllerMod = turnMod;
                 it.remove();
             }
         }
 
-        // delete all other outdated mods
-        it = this.listIterator(this.size());
-        while (it.hasPrevious()) {
-            TurnMod turnMod = it.previous();
-            if (turnMod.getNewControllerId() != null && turnMod.getPlayerId().equals(playerId)) {
+        // add subsequent turn mod to execute after current
+        if (lastNewControllerMod != null && lastNewControllerMod.getSubsequentTurnMod() != null) {
+            this.add(lastNewControllerMod.getSubsequentTurnMod());
+        }
+
+        if (lastNewControllerMod != null && lastNewControllerMod.getNewControllerId() != null) {
+            // Opponent has taken control over the full turn
+            return lastNewControllerMod;
+        } else if (lastNewControllerMod != null) {
+            // Keep Partial Turn Mod if it was the last/actual mod
+            this.add(lastNewControllerMod);
+            return null;
+        }
+        return lastNewControllerMod;
+    }
+
+    public TurnMod useNextNewPhaseController(UUID playerId, Phase controlledPhase) {
+
+        TurnMod lastNewControllerMod = null;
+
+        // useNextNewController has already filtered down to the correct last control mod
+        // find the correct phase for the partial turn mod
+        ListIterator<TurnMod> it = this.listIterator();
+        while (it.hasNext()) {
+            TurnMod turnMod = it.next();
+            if (turnMod.getPhaseController() != null
+                    && turnMod.getPlayerId().equals(playerId)
+                    && turnMod.getControlledPhase().getType().equals(controlledPhase.getType())) {
+                lastNewControllerMod = turnMod;
                 it.remove();
             }
         }

--- a/Mage/src/main/java/mage/game/turn/TurnMods.java
+++ b/Mage/src/main/java/mage/game/turn/TurnMods.java
@@ -62,11 +62,11 @@ public class TurnMods extends ArrayList<TurnMod> implements Serializable, Copyab
     }
 
     public TurnMod useNextNewController(UUID playerId) {
-        // 720.1a
+        // 723.1a.
         // Multiple player-controlling effects that affect the same player overwrite each other.
         // The last one to be created is the one that works.
         //
-        // 720.1b
+        // 723.1b.
         // If a turn is skipped, any pending player-controlling effects wait until the player
         // who would be affected actually takes a turn.
 

--- a/Mage/src/main/java/mage/game/turn/TurnMods.java
+++ b/Mage/src/main/java/mage/game/turn/TurnMods.java
@@ -103,8 +103,8 @@ public class TurnMods extends ArrayList<TurnMod> implements Serializable, Copyab
 
         TurnMod lastNewControllerMod = null;
 
-        // useNextNewController has already filtered down to the correct last control mod
         // find the correct phase for the partial turn mod
+        // instant speed could have added new ones after useNextNewController
         ListIterator<TurnMod> it = this.listIterator();
         while (it.hasNext()) {
             TurnMod turnMod = it.next();


### PR DESCRIPTION
Implement Secret of Bloodbending for [TLA](https://github.com/magefree/mage/issues/13773)

Updated TurnMods to be able to take control of a singular Phase of another player's turn.

Fixed player controlling effects to actually follow rule [723.1](https://yawgatog.com/resources/magic-rules/#R7231a) and select the last one created to take effect. And removed double removing of TurnMods.

Taking control of a players Phase seems to be treated as an control over turn effect pertaining rule 723.1 as the gatherer rulings
for Secret of Bloodbending contain said rule. Therefore the following should apply:

Activating and resolving Mindslaver (or similar effects) and afterwards resolving Secrets of Bloodbending without the additional
waterbending targeting the same opponent results in only the Secrets of Bloodbending effect to affect that opponents next turn giving control over the combat phase.

Resolving Secrets of Bloodbending without the additional cost and afterwards activating and resolving Mindslaver (or similar effects)  targeting the same opponent results in only the Mindslaver effect to affect that opponents next turn giving control over the entire turn.

I've found not specific ruling but as Secret of Bloodbending specifically states "next combat" creating extra combat phases won't
be controlled by an opponent just the first the relevant player enters.

I've tried to cover for an theoretical instant speed Secret of Bloodbending as with extra phases the "next combat" could be after the current combat or Main2 created by an effect.

