### PR TITLE
Add Alchemy: Wilds of Eldraine set

### DIFF
--- a/Mage.Sets/src/mage/sets/AlchemyWildsOfEldraine.java
+++ b/Mage.Sets/src/mage/sets/AlchemyWildsOfEldraine.java
@@ -1,0 +1,26 @@
+package mage.sets;
+
+import mage.cards.ExpansionSet;
+import mage.constants.Rarity;
+import mage.constants.SetType;
+
+/**
+ * @author muz
+ */
+public final class AlchemyWildsOfEldraine extends ExpansionSet {
+
+    private static final AlchemyWildsOfEldraine instance = new AlchemyWildsOfEldraine();
+
+    public static AlchemyWildsOfEldraine getInstance() {
+        return instance;
+    }
+
+    private AlchemyWildsOfEldraine() {
+        super("Alchemy: Wilds of Eldraine", "YWOE", ExpansionSet.buildDate(2023, 10, 10), SetType.MAGIC_ARENA);
+        this.blockName = "Alchemy";
+        this.hasBoosters = false;
+        this.hasBasicLands = false;
+
+        cards.add(new SetCardInfo("Overcooked", 11, Rarity.MYTHIC, mage.cards.o.Overcooked.class));
+    }
+}

--- a/Utils/mtg-sets-data.txt
+++ b/Utils/mtg-sets-data.txt
@@ -6,6 +6,7 @@ Alara Reborn|ARB|
 Alchemy: Dominaria|YDMU|
 Alchemy: Innistrad|Y22|
 Alchemy: Secrets of Strixhaven|YSOS|
+Alchemy: Wilds of Eldraine|YWOE|
 Alliances|ALL|
 Amonkhet|AKH|
 Anthologies|ATH|


### PR DESCRIPTION
Linked to https://github.com/magefree/mage/issues/16000

Also adds the original printing of Overcooked, which was reprinted in MBC