### PR TITLE
[MSH] Implement Taskmaster, Mercenary Mimic

### DIFF
--- a/Mage.Sets/src/mage/cards/t/TaskmasterMercenaryMimic.java
+++ b/Mage.Sets/src/mage/cards/t/TaskmasterMercenaryMimic.java
@@ -92,13 +92,13 @@ class TaskmasterMercenaryMimicCopyEffect extends OneShotEffect {
         UUID targetID = source.getFirstTarget();
         if (player != null && targetID != null) {
             Zone zone = game.getState().getZone(targetID);
-            if (zone.match(Zone.BATTLEFIELD)) {
+            if (zone != null && zone.match(Zone.BATTLEFIELD)) {
                 // Copy from Permanent (not card)
                 CopyPermanentEffect copyPermanentEffect = new CopyPermanentEffect(
                         new FilterCreaturePermanent(), new TaskmasterMercenaryMimicCopyApplier(), true
                 ).setDuration(Duration.UntilYourNextTurn);
                 copyPermanentEffect.apply(game, source);
-            } else if (zone.match(Zone.GRAVEYARD)) {
+            } else if (zone != null && zone.match(Zone.GRAVEYARD)) {
                 // Copy from Card
                 Card copyFromCard = game.getCard(targetID);
                 if (copyFromCard != null) {

--- a/Mage.Sets/src/mage/cards/t/TaskmasterMercenaryMimic.java
+++ b/Mage.Sets/src/mage/cards/t/TaskmasterMercenaryMimic.java
@@ -1,0 +1,123 @@
+package mage.cards.t;
+
+import mage.MageInt;
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.effects.OneShotEffect;
+import mage.abilities.effects.common.CopyEffect;
+import mage.abilities.effects.common.CopyPermanentEffect;
+import mage.abilities.triggers.BeginningOfFirstMainTriggeredAbility;
+import mage.cards.Card;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.*;
+import mage.filter.StaticFilters;
+import mage.filter.common.FilterCreaturePermanent;
+import mage.game.Game;
+import mage.game.permanent.Permanent;
+import mage.game.permanent.PermanentCard;
+import mage.players.Player;
+import mage.target.common.TargetCardInGraveyardBattlefieldOrStack;
+import mage.util.functions.CopyApplier;
+
+import java.util.*;
+
+/**
+ * @author miesma
+ */
+public final class TaskmasterMercenaryMimic extends CardImpl {
+
+    public TaskmasterMercenaryMimic(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{B}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.HUMAN);
+        this.subtype.add(SubType.MERCENARY);
+        this.subtype.add(SubType.VILLAIN);
+        this.power = new MageInt(3);
+        this.toughness = new MageInt(5);
+
+        // Photographic Reflexes
+        // At the beginning of your first main phase, until your next turn,
+        // Taskmaster becomes a copy of up to one target creature on the battlefield or creature card in a graveyard,
+        // except his name is Taskmaster, Mercenary Mimic and he’s a legendary Human Mercenary Villain creature.
+        Ability ability = new BeginningOfFirstMainTriggeredAbility(new TaskmasterMercenaryMimicCopyEffect(),false)
+                .withFlavorWord("Photographic Reflexes");
+        ability.addTarget(new TargetCardInGraveyardBattlefieldOrStack(0,1,
+                StaticFilters.FILTER_CARD_CREATURE,StaticFilters.FILTER_PERMANENT_CREATURE));
+        this.addAbility(ability);
+
+
+    }
+
+    private TaskmasterMercenaryMimic(final TaskmasterMercenaryMimic card) {
+        super(card);
+    }
+
+    @Override
+    public TaskmasterMercenaryMimic copy() {
+        return new TaskmasterMercenaryMimic(this);
+    }
+}
+
+class TaskmasterMercenaryMimicCopyApplier extends CopyApplier {
+
+    @Override
+    public boolean apply(Game game, MageObject blueprint, Ability source, UUID copyToObjectId) {
+        blueprint.setName("Taskmaster, Mercenary Mimic");
+        blueprint.removeAllCreatureTypes();
+        blueprint.addSuperType(SuperType.LEGENDARY);
+        blueprint.addSubType(SubType.HUMAN);
+        blueprint.addSubType(SubType.MERCENARY);
+        blueprint.addSubType(SubType.VILLAIN);
+        return true;
+    }
+}
+
+class TaskmasterMercenaryMimicCopyEffect extends OneShotEffect {
+
+    TaskmasterMercenaryMimicCopyEffect() {
+        super(Outcome.Copy);
+        this.staticText = "until your next turn, {this} becomes a copy of of up to one target creature on the battlefield or creature card in a graveyard, "
+                + "except his name is Taskmaster, Mercenary Mimic, and he's a legendary Human Mercenary Villain creature";
+    }
+
+    private TaskmasterMercenaryMimicCopyEffect(final TaskmasterMercenaryMimicCopyEffect effect) {
+        super(effect);
+    }
+
+    @Override
+    public boolean apply(Game game, Ability source) {
+        Player player = game.getPlayer(source.getControllerId());
+        UUID targetID = source.getFirstTarget();
+        if (player != null && targetID != null) {
+            Zone zone = game.getState().getZone(targetID);
+            if (zone.match(Zone.BATTLEFIELD)) {
+                // Copy from Permanent (not card)
+                CopyPermanentEffect copyPermanentEffect = new CopyPermanentEffect(
+                        new FilterCreaturePermanent(), new TaskmasterMercenaryMimicCopyApplier(), true
+                ).setDuration(Duration.UntilYourNextTurn);
+                copyPermanentEffect.apply(game, source);
+            } else if (zone.match(Zone.GRAVEYARD)) {
+                // Copy from Card
+                Card copyFromCard = game.getCard(targetID);
+                if (copyFromCard != null) {
+                    Permanent newBluePrint = new PermanentCard(copyFromCard, source.getControllerId(), game);
+                    newBluePrint.assignNewId();
+                    TaskmasterMercenaryMimicCopyApplier applier = new TaskmasterMercenaryMimicCopyApplier();
+                    applier.apply(game, newBluePrint, source, source.getSourceId());
+                    CopyEffect copyEffect = new CopyEffect(Duration.UntilYourNextTurn, newBluePrint, source.getSourceId());
+                    game.addEffect(copyEffect, source);
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public TaskmasterMercenaryMimicCopyEffect copy() {
+        return new TaskmasterMercenaryMimicCopyEffect(this);
+    }
+}

--- a/Mage.Sets/src/mage/sets/MarvelSuperHeroes.java
+++ b/Mage.Sets/src/mage/sets/MarvelSuperHeroes.java
@@ -348,6 +348,8 @@ public final class MarvelSuperHeroes extends ExpansionSet {
         cards.add(new SetCardInfo("Swordsman, Sharp Scoundrel", 116, Rarity.UNCOMMON, mage.cards.s.SwordsmanSharpScoundrel.class));
         cards.add(new SetCardInfo("Take Up the Shield", 348, Rarity.COMMON, mage.cards.t.TakeUpTheShield.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Take Up the Shield", 39, Rarity.COMMON, mage.cards.t.TakeUpTheShield.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Taskmaster, Mercenary Mimic", 232, Rarity.RARE, mage.cards.t.TaskmasterMercenaryMimic.class, NON_FULL_USE_VARIOUS));
+        cards.add(new SetCardInfo("Taskmaster, Mercenary Mimic", 425, Rarity.RARE, mage.cards.t.TaskmasterMercenaryMimic.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Team Tactics", 155, Rarity.UNCOMMON, mage.cards.t.TeamTactics.class));
         cards.add(new SetCardInfo("Thanos, the Mad Titan", 233, Rarity.MYTHIC, mage.cards.t.ThanosTheMadTitan.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Thanos, the Mad Titan", 376, Rarity.MYTHIC, mage.cards.t.ThanosTheMadTitan.class, NON_FULL_USE_VARIOUS));


### PR DESCRIPTION
Implement Taskmaster, Mercenary Mimic for [MSH](https://github.com/magefree/mage/issues/14118)

The highlight on possible target seems only to work in one zone (objects added from the first zone checked).