### PR TITLE
[HOB] Implement Bifur, Melodic Rider & share implementation for trigger doublers

### DIFF
--- a/Mage.Sets/src/mage/cards/a/AnnieJoinsUp.java
+++ b/Mage.Sets/src/mage/cards/a/AnnieJoinsUp.java
@@ -3,18 +3,15 @@ package mage.cards.a;
 import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.DamageTargetEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterPermanent;
+import mage.filter.StaticFilters;
 import mage.filter.common.FilterCreatureOrPlaneswalkerPermanent;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
 import mage.target.TargetPermanent;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -41,7 +38,7 @@ public final class AnnieJoinsUp extends CardImpl {
         this.addAbility(ability);
 
         // If a triggered ability of a legendary creature you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new AnnieJoinsUpEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(StaticFilters.FILTER_CONTROLLED_CREATURE_LEGENDARY)));
     }
 
     private AnnieJoinsUp(final AnnieJoinsUp card) {
@@ -51,43 +48,5 @@ public final class AnnieJoinsUp extends CardImpl {
     @Override
     public AnnieJoinsUp copy() {
         return new AnnieJoinsUp(this);
-    }
-}
-
-class AnnieJoinsUpEffect extends ReplacementEffectImpl {
-
-    AnnieJoinsUpEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if a triggered ability of a legendary creature you control triggers, " +
-                "that ability triggers an additional time";
-    }
-
-    private AnnieJoinsUpEffect(final AnnieJoinsUpEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public AnnieJoinsUpEffect copy() {
-        return new AnnieJoinsUpEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-                && permanent.isControlledBy(source.getControllerId())
-                && permanent.isLegendary(game)
-                && permanent.isCreature(game);
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/b/BifurMelodicRider.java
+++ b/Mage.Sets/src/mage/cards/b/BifurMelodicRider.java
@@ -1,0 +1,55 @@
+package mage.cards.b;
+
+import mage.MageInt;
+import mage.abilities.Ability;
+import mage.abilities.common.EntersBattlefieldOrAttacksSourceTriggeredAbility;
+import mage.abilities.common.SimpleStaticAbility;
+import mage.abilities.condition.common.EnduringStoryCondition;
+import mage.abilities.effects.common.counter.AddCountersTargetEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
+import mage.abilities.keyword.StoriedAbility;
+import mage.cards.CardImpl;
+import mage.cards.CardSetInfo;
+import mage.constants.CardType;
+import mage.constants.SubType;
+import mage.constants.SuperType;
+import mage.counters.CounterType;
+import mage.filter.common.FilterControlledPermanent;
+import mage.target.common.TargetCreaturePermanent;
+
+import java.util.UUID;
+
+public final class BifurMelodicRider extends CardImpl {
+
+    private final static FilterControlledPermanent filter = new FilterControlledPermanent(SubType.DWARF);
+
+    public BifurMelodicRider(UUID ownerId, CardSetInfo setInfo) {
+        super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{4}{R/W}{R/W}");
+
+        this.supertype.add(SuperType.LEGENDARY);
+        this.subtype.add(SubType.DWARF);
+        this.subtype.add(SubType.BARD);
+        this.power = new MageInt(4);
+        this.toughness = new MageInt(5);
+
+        // Storied
+        this.addAbility(new StoriedAbility());
+
+        // Whenever Bifur enters or attacks, put a +1/+1 counter on target creature.
+        final Ability ability = new EntersBattlefieldOrAttacksSourceTriggeredAbility(new AddCountersTargetEffect(CounterType.P1P1.createInstance()));
+        ability.addTarget(new TargetCreaturePermanent());
+        this.addAbility(ability);
+
+        // As long as you have an enduring story, if a triggered ability of a Dwarf you control triggers, that ability triggers an additional time.
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter, EnduringStoryCondition.instance)).addHint(EnduringStoryCondition.getHint()));
+    }
+
+    private BifurMelodicRider(final BifurMelodicRider card) {
+        super(card);
+    }
+
+    @Override
+    public BifurMelodicRider copy() {
+        return new BifurMelodicRider(this);
+    }
+}

--- a/Mage.Sets/src/mage/cards/c/ChiefOfTheWilds.java
+++ b/Mage.Sets/src/mage/cards/c/ChiefOfTheWilds.java
@@ -2,27 +2,22 @@ package mage.cards.c;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.constants.CardType;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.counters.CounterType;
 import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
 import mage.filter.predicate.mageobject.AnotherPredicate;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
-import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldAllTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.counter.AddCountersSourceEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.abilities.keyword.MenaceAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
 
 /**
  *
@@ -34,6 +29,13 @@ public final class ChiefOfTheWilds extends CardImpl {
 
     static {
         filter.add(AnotherPredicate.instance);
+    }
+
+    private static final FilterPermanent filter2 = new FilterControlledPermanent("another Wolf or battle you control");
+
+    static {
+        filter2.add(AnotherPredicate.instance);
+        filter2.add(Predicates.or(SubType.WOLF.getPredicate(), CardType.BATTLE.getPredicate()));
     }
 
     public ChiefOfTheWilds(UUID ownerId, CardSetInfo setInfo) {
@@ -53,7 +55,7 @@ public final class ChiefOfTheWilds extends CardImpl {
         ));
 
         // If an ability of another Wolf or battle you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new ChiefOfTheWildsEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter2)));
     }
 
     private ChiefOfTheWilds(final ChiefOfTheWilds card) {
@@ -63,45 +65,5 @@ public final class ChiefOfTheWilds extends CardImpl {
     @Override
     public ChiefOfTheWilds copy() {
         return new ChiefOfTheWilds(this);
-    }
-}
-
-class ChiefOfTheWildsEffect extends ReplacementEffectImpl {
-
-    ChiefOfTheWildsEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if an ability of another Wolf or battle you control triggers, " +
-            "that ability triggers an additional time";
-    }
-
-    private ChiefOfTheWildsEffect(final ChiefOfTheWildsEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ChiefOfTheWildsEffect copy() {
-        return new ChiefOfTheWildsEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-            && permanent.isControlledBy(source.getControllerId())
-            && (
-                permanent.isBattle()
-                || (permanent.hasSubtype(SubType.WOLF, game) && !permanent.getId().equals(source.getSourceId()))
-            );
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/ClaraOswald.java
+++ b/Mage.Sets/src/mage/cards/c/ClaraOswald.java
@@ -1,18 +1,14 @@
 package mage.cards.c;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.CommanderChooseColorAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.abilities.keyword.DoctorsCompanionAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
+import mage.filter.common.FilterControlledPermanent;
 
 import java.util.UUID;
 
@@ -20,6 +16,8 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class ClaraOswald extends CardImpl {
+
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.DOCTOR);
 
     public ClaraOswald(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{6}");
@@ -34,7 +32,7 @@ public final class ClaraOswald extends CardImpl {
         this.addAbility(new CommanderChooseColorAbility().withFlavorWord("Impossible Girl"));
 
         // If a triggered ability of a Doctor you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new ClaraOswaldEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter)));
 
         // Doctor's companion
         this.addAbility(DoctorsCompanionAbility.getInstance());
@@ -47,42 +45,5 @@ public final class ClaraOswald extends CardImpl {
     @Override
     public ClaraOswald copy() {
         return new ClaraOswald(this);
-    }
-}
-
-class ClaraOswaldEffect extends ReplacementEffectImpl {
-
-    ClaraOswaldEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if a triggered ability of a Doctor you control triggers, " +
-                "that ability triggers an additional time";
-    }
-
-    private ClaraOswaldEffect(final ClaraOswaldEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public ClaraOswaldEffect copy() {
-        return new ClaraOswaldEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-                && permanent.isControlledBy(source.getControllerId())
-                && permanent.hasSubtype(SubType.DOCTOR, game);
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/c/CloudMidgarMercenary.java
+++ b/Mage.Sets/src/mage/cards/c/CloudMidgarMercenary.java
@@ -1,22 +1,19 @@
 package mage.cards.c;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.EntersBattlefieldTriggeredAbility;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.condition.common.EquippedSourceCondition;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.abilities.effects.common.search.SearchLibraryPutInHandEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterCard;
-import mage.filter.predicate.permanent.EquippedPredicate;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.events.NumberOfTriggersEvent;
-import mage.game.permanent.Permanent;
+import mage.filter.FilterPermanent;
+import mage.filter.FilterPermanentThisOrAnother;
+import mage.filter.predicate.permanent.AttachedToSourcePredicate;
 import mage.target.common.TargetCardInLibrary;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -26,10 +23,16 @@ import java.util.UUID;
 public final class CloudMidgarMercenary extends CardImpl {
 
     private static final FilterCard filter = new FilterCard("an Equipment card");
-
     static {
         filter.add(SubType.EQUIPMENT.getPredicate());
     }
+
+    private static final FilterPermanent subfilter = new FilterPermanent(SubType.EQUIPMENT, "an equipment attached to it");
+    static {
+        subfilter.add(AttachedToSourcePredicate.instance);
+    }
+
+    private static final FilterPermanentThisOrAnother filter2 = new FilterPermanentThisOrAnother(subfilter, false, "{this} or an equipment attached to it");
 
     public CloudMidgarMercenary(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{W}{W}");
@@ -47,7 +50,7 @@ public final class CloudMidgarMercenary extends CardImpl {
         ));
 
         // As long as Cloud is equipped, if an ability of Cloud or an Equipment attached to it triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new CloudMidgarMercenaryEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter2, EquippedSourceCondition.instance)).addHint(EquippedSourceCondition.getHint()));
     }
 
     private CloudMidgarMercenary(final CloudMidgarMercenary card) {
@@ -57,52 +60,5 @@ public final class CloudMidgarMercenary extends CardImpl {
     @Override
     public CloudMidgarMercenary copy() {
         return new CloudMidgarMercenary(this);
-    }
-}
-
-class CloudMidgarMercenaryEffect extends ReplacementEffectImpl {
-
-    CloudMidgarMercenaryEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "as long as {this} is equipped, if an ability of {this} " +
-                "or an Equipment attached to it triggers, that ability triggers an additional time";
-    }
-
-    private CloudMidgarMercenaryEffect(final CloudMidgarMercenaryEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public CloudMidgarMercenaryEffect copy() {
-        return new CloudMidgarMercenaryEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent sourcePermanent = source.getSourcePermanentIfItStillExists(game);
-        if (sourcePermanent == null || !EquippedPredicate.instance.apply(sourcePermanent, game)) {
-            return false;
-        }
-        NumberOfTriggersEvent numberOfTriggersEvent = (NumberOfTriggersEvent) event;
-        GameEvent sourceEvent = numberOfTriggersEvent.getSourceEvent();
-        if (sourceEvent == null) {
-            return false;
-        }
-        Permanent permanent = game.getPermanent(((NumberOfTriggersEvent) event).getSourceId());
-        return permanent != null
-                && (permanent.equals(sourcePermanent)
-                || (permanent.hasSubtype(SubType.EQUIPMENT, game)
-                && sourcePermanent.getAttachments().contains(permanent.getId())));
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/d/DelneyStreetwiseLookout.java
+++ b/Mage.Sets/src/mage/cards/d/DelneyStreetwiseLookout.java
@@ -1,18 +1,14 @@
 package mage.cards.d;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.combat.CantBeBlockedByCreaturesAllEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.common.FilterCreaturePermanent;
 import mage.filter.predicate.mageobject.PowerPredicate;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
 
 import java.util.UUID;
 
@@ -44,7 +40,7 @@ public final class DelneyStreetwiseLookout extends CardImpl {
         )));
 
         // If an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new DelneyStreetwiseLookoutEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filterSmall)));
     }
 
     private DelneyStreetwiseLookout(final DelneyStreetwiseLookout card) {
@@ -54,42 +50,5 @@ public final class DelneyStreetwiseLookout extends CardImpl {
     @Override
     public DelneyStreetwiseLookout copy() {
         return new DelneyStreetwiseLookout(this);
-    }
-}
-
-class DelneyStreetwiseLookoutEffect extends ReplacementEffectImpl {
-
-    DelneyStreetwiseLookoutEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if an ability of a creature you control with power 2 or less triggers, that ability triggers an additional time";
-    }
-
-    private DelneyStreetwiseLookoutEffect(final DelneyStreetwiseLookoutEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public DelneyStreetwiseLookoutEffect copy() {
-        return new DelneyStreetwiseLookoutEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-                && permanent.isCreature(game)
-                && permanent.isControlledBy(source.getControllerId())
-                && permanent.getPower().getValue() <= 2;
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(event.getAmount() + 1);
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/e/EchoesOfEternity.java
+++ b/Mage.Sets/src/mage/cards/e/EchoesOfEternity.java
@@ -1,20 +1,16 @@
 package mage.cards.e;
 
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.SpellCastControllerTriggeredAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.CopyTargetStackObjectEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
 import mage.filter.FilterSpell;
+import mage.filter.common.FilterSpellOrPermanent;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 import mage.filter.predicate.mageobject.ColorlessPredicate;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.game.stack.Spell;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -29,13 +25,23 @@ public final class EchoesOfEternity extends CardImpl {
         filter.add(ColorlessPredicate.instance);
     }
 
+    private static final FilterSpellOrPermanent filter2 = new FilterSpellOrPermanent("a colorless spell you control or another colorless permanent you control");
+
+    static {
+        filter2.getSpellFilter().add(TargetController.YOU.getControllerPredicate());
+        filter2.getSpellFilter().add(ColorlessPredicate.instance);
+        filter2.getPermanentFilter().add(TargetController.YOU.getControllerPredicate());
+        filter2.getPermanentFilter().add(ColorlessPredicate.instance);
+        filter2.getPermanentFilter().add(AnotherPredicate.instance);
+    }
+
     public EchoesOfEternity(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.KINDRED, CardType.ENCHANTMENT}, "{3}{C}{C}{C}");
 
         this.subtype.add(SubType.ELDRAZI);
 
         // If a triggered ability of a colorless spell you control or another colorless permanent you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new EchoesOfEternityEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter2)));
 
         // Whenever you cast a colorless spell, copy it. You may choose new targets for the copy.
         this.addAbility(new SpellCastControllerTriggeredAbility(new CopyTargetStackObjectEffect(
@@ -50,48 +56,5 @@ public final class EchoesOfEternity extends CardImpl {
     @Override
     public EchoesOfEternity copy() {
         return new EchoesOfEternity(this);
-    }
-}
-
-class EchoesOfEternityEffect extends ReplacementEffectImpl {
-
-    EchoesOfEternityEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if a triggered ability of a colorless spell you control or another " +
-                "colorless permanent you control triggers, that ability triggers an additional time";
-    }
-
-    private EchoesOfEternityEffect(final EchoesOfEternityEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public EchoesOfEternityEffect copy() {
-        return new EchoesOfEternityEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        if (!source.isControlledBy(event.getPlayerId())) {
-            return false;
-        }
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        if (permanent != null && permanent.getColor(game).isColorless()
-                && !permanent.getId().equals(source.getSourceId())) {
-            return true;
-        }
-        Spell spell = game.getSpell(event.getSourceId());
-        return spell != null && spell.getColor(game).isColorless();
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/h/HarmonicProdigy.java
+++ b/Mage.Sets/src/mage/cards/h/HarmonicProdigy.java
@@ -1,20 +1,17 @@
 package mage.cards.h;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.abilities.keyword.ProwessAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
+import mage.filter.FilterPermanent;
+import mage.filter.common.FilterControlledPermanent;
+import mage.filter.predicate.Predicates;
+import mage.filter.predicate.mageobject.AnotherPredicate;
 
 import java.util.UUID;
 
@@ -22,6 +19,12 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class HarmonicProdigy extends CardImpl {
+
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent("a Shaman or another Wizard you control");
+
+    static {
+        filter.add(Predicates.or(SubType.SHAMAN.getPredicate(), Predicates.and(new FilterPermanent(SubType.WIZARD).add(AnotherPredicate.instance).getPredicates())));
+    }
 
     public HarmonicProdigy(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{R}");
@@ -35,7 +38,7 @@ public final class HarmonicProdigy extends CardImpl {
         this.addAbility(new ProwessAbility());
 
         // If an ability of a Shaman or another Wizard you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new HarmonicProdigyEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter)));
     }
 
     private HarmonicProdigy(final HarmonicProdigy card) {
@@ -45,44 +48,5 @@ public final class HarmonicProdigy extends CardImpl {
     @Override
     public HarmonicProdigy copy() {
         return new HarmonicProdigy(this);
-    }
-}
-
-class HarmonicProdigyEffect extends ReplacementEffectImpl {
-
-    HarmonicProdigyEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if an ability of a Shaman or another Wizard you control triggers, " +
-                "that ability triggers an additional time";
-    }
-
-    private HarmonicProdigyEffect(final HarmonicProdigyEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public HarmonicProdigyEffect copy() {
-        return new HarmonicProdigyEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-                && permanent.isControlledBy(source.getControllerId())
-                && (permanent.hasSubtype(SubType.SHAMAN, game)
-                || (permanent.hasSubtype(SubType.WIZARD, game)
-                && !permanent.getId().equals(source.getSourceId())));
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/k/KataraTheFearless.java
+++ b/Mage.Sets/src/mage/cards/k/KataraTheFearless.java
@@ -1,15 +1,12 @@
 package mage.cards.k;
 
 import mage.MageInt;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
+import mage.filter.common.FilterControlledPermanent;
 
 import java.util.UUID;
 
@@ -17,6 +14,8 @@ import java.util.UUID;
  * @author TheElk801
  */
 public final class KataraTheFearless extends CardImpl {
+
+    private final static FilterControlledPermanent filter = new FilterControlledPermanent(SubType.ALLY);
 
     public KataraTheFearless(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{G}{W}{U}");
@@ -29,7 +28,7 @@ public final class KataraTheFearless extends CardImpl {
         this.toughness = new MageInt(3);
 
         // If a triggered ability of an Ally you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new KataraTheFearlessEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter)));
     }
 
     private KataraTheFearless(final KataraTheFearless card) {
@@ -39,41 +38,5 @@ public final class KataraTheFearless extends CardImpl {
     @Override
     public KataraTheFearless copy() {
         return new KataraTheFearless(this);
-    }
-}
-
-class KataraTheFearlessEffect extends ReplacementEffectImpl {
-
-    KataraTheFearlessEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if a triggered ability of an Ally you control triggers, that ability triggers an additional time";
-    }
-
-    private KataraTheFearlessEffect(final KataraTheFearlessEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public KataraTheFearlessEffect copy() {
-        return new KataraTheFearlessEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-                && permanent.isControlledBy(source.getControllerId())
-                && permanent.hasSubtype(SubType.ALLY, game);
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(event.getAmount() + 1);
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/m/MirrorRoomFracturedRealm.java
+++ b/Mage.Sets/src/mage/cards/m/MirrorRoomFracturedRealm.java
@@ -3,18 +3,13 @@ package mage.cards.m;
 import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.common.UnlockThisDoorTriggeredAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.CreateTokenCopyTargetEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.cards.CardSetInfo;
 import mage.cards.RoomCard;
-import mage.constants.Duration;
-import mage.constants.Outcome;
 import mage.constants.SubType;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
+import mage.filter.StaticFilters;
 import mage.target.common.TargetControlledCreaturePermanent;
-import mage.util.CardUtil;
 
 import java.util.UUID;
 
@@ -40,7 +35,7 @@ public final class MirrorRoomFracturedRealm extends RoomCard {
 
         // Fractured Realm
         // If a triggered ability of a permanent you control triggers, that ability triggers an additional time.
-        this.getRightHalfCard().addAbility(new SimpleStaticAbility(new FracturedRealmEffect()));
+        this.getRightHalfCard().addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(StaticFilters.FILTER_CONTROLLED_A_PERMANENT)));
     }
 
     private MirrorRoomFracturedRealm(final MirrorRoomFracturedRealm card) {
@@ -50,40 +45,5 @@ public final class MirrorRoomFracturedRealm extends RoomCard {
     @Override
     public MirrorRoomFracturedRealm copy() {
         return new MirrorRoomFracturedRealm(this);
-    }
-}
-
-class FracturedRealmEffect extends ReplacementEffectImpl {
-
-    FracturedRealmEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if a triggered ability of a permanent you control triggers, " +
-                "that ability triggers an additional time";
-    }
-
-    private FracturedRealmEffect(final FracturedRealmEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public FracturedRealmEffect copy() {
-        return new FracturedRealmEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null && permanent.isControlledBy(source.getControllerId());
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/r/RoamingThrone.java
+++ b/Mage.Sets/src/mage/cards/r/RoamingThrone.java
@@ -5,21 +5,17 @@ import mage.abilities.Ability;
 import mage.abilities.common.AsEntersBattlefieldAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.ChooseCreatureTypeEffect;
 import mage.abilities.effects.common.continuous.AddChosenSubtypeEffect;
 import mage.abilities.effects.common.enterAttribute.EnterAttributeAddChosenSubtypeEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.abilities.keyword.WardAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.*;
-import mage.filter.FilterPermanent;
 import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
+import mage.filter.predicate.mageobject.ChosenSubtypePredicate;
 
 import java.util.UUID;
 
@@ -27,6 +23,13 @@ import java.util.UUID;
  * @author Susucr
  */
 public final class RoamingThrone extends CardImpl {
+
+    private static final FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent("another creature you control of the chosen type");
+
+    static {
+        filter.add(AnotherPredicate.instance);
+        filter.add(ChosenSubtypePredicate.TRUE);
+    }
 
     public RoamingThrone(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.ARTIFACT, CardType.CREATURE}, "{4}");
@@ -47,7 +50,7 @@ public final class RoamingThrone extends CardImpl {
         this.addAbility(new SimpleStaticAbility(new AddChosenSubtypeEffect()));
 
         // If a triggered ability of another creature you control of the chosen type triggers, it triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new RoamingThroneReplacementEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter)));
     }
 
     private RoamingThrone(final RoamingThrone card) {
@@ -57,51 +60,5 @@ public final class RoamingThrone extends CardImpl {
     @Override
     public RoamingThrone copy() {
         return new RoamingThrone(this);
-    }
-}
-
-class RoamingThroneReplacementEffect extends ReplacementEffectImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
-    RoamingThroneReplacementEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "If a triggered ability of another creature you control of the chosen type triggers, "
-                + "it triggers an additional time";
-    }
-
-    private RoamingThroneReplacementEffect(final RoamingThroneReplacementEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public RoamingThroneReplacementEffect copy() {
-        return new RoamingThroneReplacementEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        if (!source.isControlledBy(event.getPlayerId())) {
-            return false;
-        }
-        Permanent permanentSource = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanentSource != null
-                && filter.match(permanentSource, source.getControllerId(), source, game)
-                && permanentSource.hasSubtype(ChooseCreatureTypeEffect.getChosenCreatureType(source.getSourceId(), game), game);
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/s/SplinterRadicalRat.java
+++ b/Mage.Sets/src/mage/cards/s/SplinterRadicalRat.java
@@ -6,20 +6,17 @@ import mage.abilities.Ability;
 import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.costs.mana.ManaCostsImpl;
-import mage.abilities.effects.ReplacementEffectImpl;
 import mage.abilities.effects.common.combat.CantBeBlockedTargetEffect;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.constants.SubType;
 import mage.constants.SuperType;
 import mage.filter.FilterPermanent;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
+import mage.filter.common.FilterControlledCreaturePermanent;
 import mage.target.TargetPermanent;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
 import mage.constants.Duration;
-import mage.constants.Outcome;
 
 /**
  *
@@ -28,6 +25,8 @@ import mage.constants.Outcome;
 public final class SplinterRadicalRat extends CardImpl {
 
     private static final FilterPermanent filter = new FilterPermanent(SubType.NINJA, "Ninja");
+
+    private static final FilterPermanent filter2 = new FilterControlledCreaturePermanent(SubType.NINJA);
 
     public SplinterRadicalRat(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{1}{W/B}{W/B}");
@@ -40,7 +39,7 @@ public final class SplinterRadicalRat extends CardImpl {
         this.toughness = new MageInt(4);
 
         // If any ability of a Ninja creature you control triggers, that ability triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new SplinterRadicalRatEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter2)));
 
         // {1}{U}: Target Ninja can't be blocked this turn.
         Ability ability = new SimpleActivatedAbility(new CantBeBlockedTargetEffect(Duration.EndOfTurn), new ManaCostsImpl<>("{1}{U}"));
@@ -55,42 +54,5 @@ public final class SplinterRadicalRat extends CardImpl {
     @Override
     public SplinterRadicalRat copy() {
         return new SplinterRadicalRat(this);
-    }
-}
-
-class SplinterRadicalRatEffect extends ReplacementEffectImpl {
-
-    SplinterRadicalRatEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "if an ability of a Ninja creature you control triggers, that ability triggers an additional time";
-    }
-
-    private SplinterRadicalRatEffect(final SplinterRadicalRatEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public SplinterRadicalRatEffect copy() {
-        return new SplinterRadicalRatEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        Permanent permanent = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanent != null
-                && permanent.isControlledBy(source.getControllerId())
-                && permanent.isCreature(game)
-                && permanent.hasSubtype(SubType.NINJA, game);
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(event.getAmount() + 1);
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/cards/t/TwinflameTravelers.java
+++ b/Mage.Sets/src/mage/cards/t/TwinflameTravelers.java
@@ -3,28 +3,26 @@ package mage.cards.t;
 import java.util.UUID;
 import mage.MageInt;
 import mage.constants.SubType;
-import mage.filter.FilterPermanent;
-import mage.filter.common.FilterControlledCreaturePermanent;
+import mage.filter.common.FilterControlledPermanent;
 import mage.filter.predicate.mageobject.AnotherPredicate;
-import mage.game.Game;
-import mage.game.events.GameEvent;
-import mage.game.permanent.Permanent;
-import mage.util.CardUtil;
-import mage.abilities.Ability;
 import mage.abilities.common.SimpleStaticAbility;
-import mage.abilities.effects.ReplacementEffectImpl;
+import mage.abilities.effects.common.replacement.AdditionalTriggerObjectReplacementEffect;
 import mage.abilities.keyword.FlyingAbility;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Duration;
-import mage.constants.Outcome;
 
 /**
  *
  * @author muz
  */
 public final class TwinflameTravelers extends CardImpl {
+
+    private static final FilterControlledPermanent filter = new FilterControlledPermanent(SubType.ELEMENTAL, "another Elemental you control");
+
+    static {
+        filter.add(AnotherPredicate.instance);
+    }
 
     public TwinflameTravelers(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.CREATURE}, "{2}{U}{R}");
@@ -38,7 +36,7 @@ public final class TwinflameTravelers extends CardImpl {
         this.addAbility(FlyingAbility.getInstance());
 
         // If a triggered ability of another Elemental you control triggers, it triggers an additional time.
-        this.addAbility(new SimpleStaticAbility(new TwinflameTravelersReplacementEffect()));
+        this.addAbility(new SimpleStaticAbility(new AdditionalTriggerObjectReplacementEffect(filter)));
     }
 
     private TwinflameTravelers(final TwinflameTravelers card) {
@@ -48,51 +46,5 @@ public final class TwinflameTravelers extends CardImpl {
     @Override
     public TwinflameTravelers copy() {
         return new TwinflameTravelers(this);
-    }
-}
-
-class TwinflameTravelersReplacementEffect extends ReplacementEffectImpl {
-
-    private static final FilterPermanent filter = new FilterControlledCreaturePermanent();
-
-    static {
-        filter.add(AnotherPredicate.instance);
-    }
-
-    TwinflameTravelersReplacementEffect() {
-        super(Duration.WhileOnBattlefield, Outcome.Benefit);
-        staticText = "If a triggered ability of another Elemental you control triggers, "
-                + "it triggers an additional time";
-    }
-
-    private TwinflameTravelersReplacementEffect(final TwinflameTravelersReplacementEffect effect) {
-        super(effect);
-    }
-
-    @Override
-    public TwinflameTravelersReplacementEffect copy() {
-        return new TwinflameTravelersReplacementEffect(this);
-    }
-
-    @Override
-    public boolean checksEventType(GameEvent event, Game game) {
-        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
-    }
-
-    @Override
-    public boolean applies(GameEvent event, Ability source, Game game) {
-        if (!source.isControlledBy(event.getPlayerId())) {
-            return false;
-        }
-        Permanent permanentSource = game.getPermanentOrLKIBattlefield(event.getSourceId());
-        return permanentSource != null
-                && filter.match(permanentSource, source.getControllerId(), source, game)
-                && permanentSource.hasSubtype(SubType.ELEMENTAL, game);
-    }
-
-    @Override
-    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
-        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
-        return false;
     }
 }

--- a/Mage.Sets/src/mage/sets/TheHobbit.java
+++ b/Mage.Sets/src/mage/sets/TheHobbit.java
@@ -45,6 +45,7 @@ public final class TheHobbit extends ExpansionSet {
         cards.add(new SetCardInfo("Beorn the Fierce", 266, Rarity.MYTHIC, mage.cards.b.BeornTheFierce.class, NON_FULL_USE_VARIOUS));
         cards.add(new SetCardInfo("Beorn's Hospitality", 120, Rarity.UNCOMMON, mage.cards.b.BeornsHospitality.class));
         cards.add(new SetCardInfo("Beorn, Reluctant Host", 118, Rarity.COMMON, mage.cards.b.BeornReluctantHost.class));
+        cards.add(new SetCardInfo("Bifur, Melodic Rider", 147, Rarity.UNCOMMON, mage.cards.b.BifurMelodicRider.class));
         cards.add(new SetCardInfo("Bilbo Baggins, Burglar", 34, Rarity.COMMON, mage.cards.b.BilboBagginsBurglar.class));
         cards.add(new SetCardInfo("Bilbo's Deadly Slice", 62, Rarity.COMMON, mage.cards.b.BilbosDeadlySlice.class));
         cards.add(new SetCardInfo("Bilbo's Gambit", 285, Rarity.RARE, mage.cards.b.BilbosGambit.class, NON_FULL_USE_VARIOUS));

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/fin/CloudMidgarMercenaryTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/fin/CloudMidgarMercenaryTest.java
@@ -1,0 +1,64 @@
+package org.mage.test.cards.single.fin;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.permanent.Permanent;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class CloudMidgarMercenaryTest extends CardTestPlayerBase {
+
+    @Test
+    public void testEquippedTriggers() {
+        addCard(Zone.BATTLEFIELD, playerA, "Cloud, Midgar Mercenary");
+        addCard(Zone.BATTLEFIELD, playerA, "Sword of Forge and Frontier");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip", "Cloud, Midgar Mercenary");
+        attack(1, playerA, "Cloud, Midgar Mercenary");
+        setChoice(playerA, "Whenever");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertExileCount(playerA, 4);
+    }
+
+    @Test
+    public void testGainsTriggers() {
+        addCard(Zone.BATTLEFIELD, playerA, "Cloud, Midgar Mercenary");
+        addCard(Zone.BATTLEFIELD, playerA, "Power Fist");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 2);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Equip", "Cloud, Midgar Mercenary");
+        attack(1, playerA, "Cloud, Midgar Mercenary");
+        setChoice(playerA, "Whenever");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Cloud, Midgar Mercenary", 6, 5);
+    }
+
+    @Test
+    public void testNotEquipped() {
+        addCard(Zone.BATTLEFIELD, playerA, "Cloud, Midgar Mercenary");
+        addCard(Zone.HAND, playerA, "Invocation of Saint Traft");
+        addCard(Zone.BATTLEFIELD, playerA, "Plains");
+        addCard(Zone.BATTLEFIELD, playerA, "Island");
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Invocation of Saint Traft", "Cloud, Midgar Mercenary");
+        attack(1, playerA, "Cloud, Midgar Mercenary");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.DECLARE_BLOCKERS);
+        execute();
+
+        assertPermanentCount(playerA, "Angel Token", 1);
+    }
+
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/triggers/TriggersAnAdditionalTimeTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/triggers/TriggersAnAdditionalTimeTest.java
@@ -1,0 +1,42 @@
+package org.mage.test.cards.triggers;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class TriggersAnAdditionalTimeTest extends CardTestPlayerBase {
+
+    @Test
+    public void testTriggerMultiplier() {
+        addCard(Zone.BATTLEFIELD, playerA, "Annie Joins Up");
+        addCard(Zone.BATTLEFIELD, playerA, "Alesha, Who Laughs at Fate");
+
+        attack(1, playerA, "Alesha, Who Laughs at Fate");
+        setChoice(playerA, "Whenever");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPowerToughness(playerA, "Alesha, Who Laughs at Fate", 4, 4);
+    }
+
+    @Test
+    public void testCastTrigger() {
+        addCard(Zone.BATTLEFIELD, playerA, "Wastes", 8);
+        addCard(Zone.BATTLEFIELD, playerA, "Echoes of Eternity");
+        addCard(Zone.HAND, playerA, "Breaker of Creation");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Breaker of Creation");
+        setChoice(playerA, "Whenever you cast");
+        setChoice(playerA, "When you cast this spell");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.POSTCOMBAT_MAIN);
+        execute();
+
+        assertPermanentCount(playerA, "Breaker of Creation", 2);
+        assertLife(playerA, 20 + 9 + 9);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/condition/common/EnduringStoryCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/EnduringStoryCondition.java
@@ -3,6 +3,8 @@ package mage.abilities.condition.common;
 
 import mage.abilities.Ability;
 import mage.abilities.condition.Condition;
+import mage.abilities.hint.Hint;
+import mage.abilities.hint.common.EnduringStoryHint;
 import mage.designations.DesignationType;
 import mage.game.Game;
 
@@ -13,6 +15,10 @@ import mage.game.Game;
 public enum EnduringStoryCondition implements Condition {
 
     instance;
+
+    public static Hint getHint() {
+        return EnduringStoryHint.instance;
+    }
 
     @Override
     public boolean apply(Game game, Ability source) {

--- a/Mage/src/main/java/mage/abilities/condition/common/EquippedSourceCondition.java
+++ b/Mage/src/main/java/mage/abilities/condition/common/EquippedSourceCondition.java
@@ -3,6 +3,8 @@ package mage.abilities.condition.common;
 
 import mage.abilities.Ability;
 import mage.abilities.condition.Condition;
+import mage.abilities.hint.ConditionHint;
+import mage.abilities.hint.Hint;
 import mage.game.Game;
 import mage.game.permanent.Permanent;
 
@@ -16,11 +18,16 @@ import mage.constants.SubType;
  */
 public enum EquippedSourceCondition implements Condition {
 
-   instance;
+    instance;
+    private static Hint hint = new ConditionHint(instance);
+
+    public static Hint getHint() {
+        return hint;
+    }
 
     @Override
     public boolean apply(Game game, Ability source) {
-        Permanent permanent = game.getPermanent(source.getSourceId());
+        Permanent permanent = source.getSourcePermanentIfItStillExists(game);
         if (permanent != null) {
             for (UUID uuid : permanent.getAttachments()) {
                 Permanent attached = game.getPermanent(uuid);

--- a/Mage/src/main/java/mage/abilities/effects/common/replacement/AdditionalTriggerObjectReplacementEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/replacement/AdditionalTriggerObjectReplacementEffect.java
@@ -1,0 +1,62 @@
+package mage.abilities.effects.common.replacement;
+
+import mage.MageObject;
+import mage.abilities.Ability;
+import mage.abilities.condition.Condition;
+import mage.abilities.effects.ReplacementEffectImpl;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.filter.FilterInPlay;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.game.events.NumberOfTriggersEvent;
+import mage.util.CardUtil;
+
+public class AdditionalTriggerObjectReplacementEffect extends ReplacementEffectImpl {
+
+    private final FilterInPlay filter;
+    private final Condition condition;
+
+    public AdditionalTriggerObjectReplacementEffect(FilterInPlay filter) {
+        this(filter, null);
+    }
+
+    public AdditionalTriggerObjectReplacementEffect(FilterInPlay filter, Condition condition) {
+        super(Duration.WhileOnBattlefield, Outcome.Benefit);
+        this.filter = filter;
+        this.condition = condition;
+        this.staticText = (condition == null ? "" : ("as long as " + condition.toString() + ", ")) +
+            "if a triggered ability of " + filter.getMessage() + " triggers, that ability triggers an additional time.";
+    }
+
+    protected AdditionalTriggerObjectReplacementEffect(final AdditionalTriggerObjectReplacementEffect effect) {
+        super(effect);
+        this.filter = effect.filter;
+        this.condition = effect.condition;
+    }
+
+    @Override
+    public AdditionalTriggerObjectReplacementEffect copy() {
+        return new AdditionalTriggerObjectReplacementEffect(this);
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.NUMBER_OF_TRIGGERS;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (this.condition == null || this.condition.apply(game, source)) {
+            final MageObject object = game.getObject(((NumberOfTriggersEvent)event).getSourceId());
+            return this.filter.checkObjectClass(object) && this.filter.match(object, source.getControllerId(), source, game);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean replaceEvent(GameEvent event, Ability source, Game game) {
+        event.setAmount(CardUtil.overflowInc(event.getAmount(), 1));
+        return false;
+    }
+}


### PR DESCRIPTION
Provides a shared implementation using filters for cards that make triggered abilities trigger an additional time.

Consolidated cards:
* Annie Joins Up
* Chief of the Wilds
* Clara Oswald
* Cloud, Midgar Mercenary
* Delney, Streetwise Lookout
* Echoes of Eternity
* Harmonic Prodigy
* Katara, the Fearless
* Mirror Room // Fractured Realm
* Roaming Throne
* Splinter, Radical Rat
* Twinflame Travelers


Linked to https://github.com/magefree/mage/issues/14857