### PR TITLE
[Bugfix] [ECL] Dose of dawnglow blight only applied in opponent main phase

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DoseOfDawnglow.java
+++ b/Mage.Sets/src/mage/cards/d/DoseOfDawnglow.java
@@ -1,5 +1,7 @@
 package mage.cards.d;
 
+import mage.abilities.condition.Condition;
+import mage.abilities.condition.InvertCondition;
 import mage.abilities.condition.common.IsMainPhaseCondition;
 import mage.abilities.decorator.ConditionalOneShotEffect;
 import mage.abilities.effects.common.ReturnFromGraveyardToBattlefieldTargetEffect;
@@ -17,6 +19,9 @@ import java.util.UUID;
  */
 public final class DoseOfDawnglow extends CardImpl {
 
+    private static final Condition NOT_YOUR_MAIN_PHASE =
+            new InvertCondition(IsMainPhaseCondition.YOURS, "it isn't your main phase");
+
     public DoseOfDawnglow(UUID ownerId, CardSetInfo setInfo) {
         super(ownerId, setInfo, new CardType[]{CardType.INSTANT}, "{4}{B}");
 
@@ -24,7 +29,7 @@ public final class DoseOfDawnglow extends CardImpl {
         this.getSpellAbility().addEffect(new ReturnFromGraveyardToBattlefieldTargetEffect());
         this.getSpellAbility().addTarget(new TargetCardInYourGraveyard(StaticFilters.FILTER_CARD_CREATURE_YOUR_GRAVEYARD));
         this.getSpellAbility().addEffect(new ConditionalOneShotEffect(
-                new BlightControllerEffect(2), IsMainPhaseCondition.NOT_YOURS
+                new BlightControllerEffect(2), NOT_YOUR_MAIN_PHASE
         ).concatBy("Then"));
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ecl/DoseOfDawnglowTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ecl/DoseOfDawnglowTest.java
@@ -1,0 +1,71 @@
+package org.mage.test.cards.single.ecl;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * {@link mage.cards.d.DoseOfDawnglow Dose of Dawnglow} {4}{B}
+ * Instant
+ * Return target creature card from your graveyard to the battlefield. Then if it isn't your main phase, blight 2.
+ */
+public class DoseOfDawnglowTest extends CardTestPlayerBase {
+
+    private static final String dose = "Dose of Dawnglow";
+    private static final String bears = "Grizzly Bears"; // the reanimation target.
+    private static final String giant = "Hill Giant";   // 3/3 creature to survive blight 2.
+
+    @Test
+    public void test_BlightOutsideMainPhase() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.HAND, playerA, dose);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+        addCard(Zone.GRAVEYARD, playerA, bears);          // to reanimate
+        addCard(Zone.BATTLEFIELD, playerA, giant);        // to blight
+
+        castSpell(1, PhaseStep.UPKEEP, playerA, dose, bears);
+        setChoice(playerA, giant);                       // blight target (a choose, not a target)
+
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        // The reanimated creature returned to the battlefield.
+        assertPermanentCount(playerA, bears, 1);
+        assertGraveyardCount(playerA, bears, 0);
+
+        // The blight put two -1/-1 counters on the chosen creature (3/3 -> 1/1).
+        assertPermanentCount(playerA, giant, 1);
+        assertCounterCount(playerA, giant, CounterType.M1M1, 2);
+        assertPowerToughness(playerA, giant, 1, 1);
+    }
+
+    /**
+     * Cast during your own main phase. The spell returns the creature but does
+     * NOT blight (it IS your main phase), so no counters are placed.
+     */
+    @Test
+    public void test_NoBlightDuringMainPhase() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.HAND, playerA, dose);
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 5);
+        addCard(Zone.GRAVEYARD, playerA, bears);          // to reanimate
+        addCard(Zone.BATTLEFIELD, playerA, giant);        // to not blight
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, dose, bears);
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        // The reanimated creature returned to the battlefield.
+        assertPermanentCount(playerA, bears, 1);
+        assertGraveyardCount(playerA, bears, 0);
+        
+        // No blight during the main phase: no counters on the creature.
+        assertCounterCount(playerA, giant, CounterType.M1M1, 0);
+        assertPowerToughness(playerA, giant, 3, 3);
+    }
+}


### PR DESCRIPTION
The condition `IsMainPhaseCondition.NOT_YOURS` identifies exactly opponent main phases, but the Dose of dawnglow's additional blight price should apply in all phases except your main phases. So the current implementation doesn't apply the cost in any combat upkeep draw ect phases.

I arguably think `IsMainPhaseCondition.NOT_YOURS` does what it says on the tin and therefor I have fixed it in the card implementation by negating `IsMainPhaseCondition.YOURS`. After this there is no usages of `IsMainPhaseCondition.NOT_YOURS` but i chose to leave it in to keep PR minimal.

`test_BlightOutsideMainPhase` fails with current implementation
`test_NoBlightDuringMainPhase` passes with current implementation
