### PR TITLE
Implement mana ability rules update from CR 20260807

### DIFF
--- a/Mage.Sets/src/mage/cards/c/CharmedPendant.java
+++ b/Mage.Sets/src/mage/cards/c/CharmedPendant.java
@@ -2,13 +2,12 @@ package mage.cards.c;
 
 import mage.Mana;
 import mage.abilities.Ability;
+import mage.abilities.ActivatedAbilityImpl;
 import mage.abilities.costs.Cost;
 import mage.abilities.costs.common.MillCardsCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.*;
 import mage.abilities.effects.mana.ManaEffect;
-import mage.abilities.effects.mana.BasicManaEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
 import mage.abilities.mana.ManaOptions;
 import mage.cards.Card;
 import mage.cards.CardImpl;
@@ -47,17 +46,11 @@ public final class CharmedPendant extends CardImpl {
     }
 }
 
-class CharmedPendantAbility extends ActivatedManaAbilityImpl {
+class CharmedPendantAbility extends ActivatedAbilityImpl {
 
     public CharmedPendantAbility() {
         super(Zone.BATTLEFIELD, new CharmedPendantManaEffect(), new TapSourceCost());
         this.addCost(new MillCardsCost());
-        this.setUndoPossible(false); // Otherwise you could return the card from graveyard
-    }
-
-    public CharmedPendantAbility(Zone zone, Mana mana, Cost cost) {
-        super(zone, new BasicManaEffect(mana), cost);
-
     }
 
     private CharmedPendantAbility(final CharmedPendantAbility ability) {

--- a/Mage.Sets/src/mage/cards/c/ChromaticSphere.java
+++ b/Mage.Sets/src/mage/cards/c/ChromaticSphere.java
@@ -2,12 +2,12 @@
 package mage.cards.c;
 
 import java.util.UUID;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.GenericManaCost;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.AnyColorManaAbility;
+import mage.abilities.effects.mana.AddManaOfAnyColorEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -22,11 +22,10 @@ public final class ChromaticSphere extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
         
         // {1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color. Draw a card.
-        ActivatedManaAbilityImpl ability = new AnyColorManaAbility(new GenericManaCost(1));
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new AddManaOfAnyColorEffect(1), new GenericManaCost(1));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addEffect(new DrawCardSourceControllerEffect(1));
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DarkwaterEgg.java
+++ b/Mage.Sets/src/mage/cards/d/DarkwaterEgg.java
@@ -3,16 +3,15 @@ package mage.cards.d;
 
 import java.util.UUID;
 import mage.Mana;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.SimpleManaAbility;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 
 /**
  *
@@ -24,11 +23,10 @@ public final class DarkwaterEgg extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
 
         // {2}, {tap}, Sacrifice Darkwater Egg: Add {U}{B}. Draw a card.
-        ActivatedManaAbilityImpl ability = new SimpleManaAbility(Zone.BATTLEFIELD, new Mana(0, 1, 1, 0, 0, 0, 0, 0), new ManaCostsImpl<>("{2}"));
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(new Mana(0, 1, 1, 0, 0, 0, 0, 0)), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addEffect(new DrawCardSourceControllerEffect(1));
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/d/DerangedAssistant.java
+++ b/Mage.Sets/src/mage/cards/d/DerangedAssistant.java
@@ -2,8 +2,11 @@ package mage.cards.d;
 
 import java.util.UUID;
 import mage.MageInt;
+import mage.Mana;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.MillCardsCost;
-import mage.abilities.mana.ColorlessManaAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -24,9 +27,8 @@ public final class DerangedAssistant extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {T}, Mill a card: Add {C}.
-        ColorlessManaAbility ability = new ColorlessManaAbility();
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(Mana.ColorlessMana(1)), new TapSourceCost());
         ability.addCost(new MillCardsCost());
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/Millikin.java
+++ b/Mage.Sets/src/mage/cards/m/Millikin.java
@@ -2,9 +2,12 @@
 package mage.cards.m;
 
 import java.util.UUID;
+import mage.Mana;
 import mage.MageInt;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.MillCardsCost;
-import mage.abilities.mana.ColorlessManaAbility;
+import mage.abilities.costs.common.TapSourceCost;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
@@ -23,9 +26,8 @@ public final class Millikin extends CardImpl {
         this.toughness = new MageInt(1);
 
         // {tap}, Put the top card of your library into your graveyard: Add {C}.
-        ColorlessManaAbility ability = new ColorlessManaAbility();
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(Mana.ColorlessMana(1)), new TapSourceCost());
         ability.addCost(new MillCardsCost());
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/m/MossfireEgg.java
+++ b/Mage.Sets/src/mage/cards/m/MossfireEgg.java
@@ -3,16 +3,15 @@ package mage.cards.m;
 
 import java.util.UUID;
 import mage.Mana;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.SimpleManaAbility;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 
 /**
  *
@@ -24,11 +23,10 @@ public final class MossfireEgg extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
 
         // {2}, {tap}, Sacrifice Mossfire Egg: Add {R}{G}. Draw a card.
-        ActivatedManaAbilityImpl ability = new SimpleManaAbility(Zone.BATTLEFIELD, new Mana(0, 0, 0, 1, 1, 0, 0, 0), new ManaCostsImpl<>("{2}"));
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(new Mana(0, 0, 0, 1, 1, 0, 0, 0)), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addEffect(new DrawCardSourceControllerEffect(1));
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SelvalaExplorerReturned.java
+++ b/Mage.Sets/src/mage/cards/s/SelvalaExplorerReturned.java
@@ -1,20 +1,16 @@
 package mage.cards.s;
 
 import mage.MageInt;
-import mage.MageObject;
 import mage.Mana;
 import mage.abilities.Ability;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.dynamicvalue.common.ParleyCount;
 import mage.abilities.effects.Effect;
 import mage.abilities.effects.common.DrawCardAllEffect;
 import mage.abilities.effects.mana.ManaEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.SimpleManaAbility;
-import mage.cards.Card;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
-import mage.cards.CardsImpl;
 import mage.constants.*;
 import mage.game.Game;
 import mage.players.Player;
@@ -37,8 +33,7 @@ public final class SelvalaExplorerReturned extends CardImpl {
         this.toughness = new MageInt(4);
 
         // Parley - {T}: Each player reveals the top card of their library. For each nonland card revealed this way, add {G} and you gain 1 life. Then each player draws a card.
-        ActivatedManaAbilityImpl manaAbility = new SimpleManaAbility(Zone.BATTLEFIELD, new SelvalaExplorerReturnedEffect(), new TapSourceCost());
-        manaAbility.setUndoPossible(false);
+        final SimpleActivatedAbility manaAbility = new SimpleActivatedAbility(new SelvalaExplorerReturnedEffect(), new TapSourceCost());
         manaAbility.setAbilityWord(AbilityWord.PARLEY);
         Effect effect = new DrawCardAllEffect(1);
         effect.setText("Then each player draws a card");

--- a/Mage.Sets/src/mage/cards/s/ShadowbloodEgg.java
+++ b/Mage.Sets/src/mage/cards/s/ShadowbloodEgg.java
@@ -3,16 +3,15 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.Mana;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.SimpleManaAbility;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 
 /**
  *
@@ -24,11 +23,10 @@ public final class ShadowbloodEgg extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
 
         // {2}, {tap}, Sacrifice Shadowblood Egg: Add {B}{R}. Draw a card.
-        ActivatedManaAbilityImpl ability = new SimpleManaAbility(Zone.BATTLEFIELD, new Mana(0, 0, 1, 1, 0, 0, 0, 0), new ManaCostsImpl<>("{2}"));
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(new Mana(0, 0, 1, 1, 0, 0, 0, 0)), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addEffect(new DrawCardSourceControllerEffect(1));
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SkycloudEgg.java
+++ b/Mage.Sets/src/mage/cards/s/SkycloudEgg.java
@@ -3,16 +3,15 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.Mana;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.SimpleManaAbility;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 
 /**
  *
@@ -24,11 +23,10 @@ public final class SkycloudEgg extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
 
         // {2}, {tap}, Sacrifice Skycloud Egg: Add {W}{U}. Draw a card.
-        ActivatedManaAbilityImpl ability = new SimpleManaAbility(Zone.BATTLEFIELD, new Mana(1, 1, 0, 0, 0, 0, 0, 0), new ManaCostsImpl<>("{2}"));
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(new Mana(1, 1, 0, 0, 0, 0, 0, 0)), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addEffect(new DrawCardSourceControllerEffect(1));
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Sets/src/mage/cards/s/SungrassEgg.java
+++ b/Mage.Sets/src/mage/cards/s/SungrassEgg.java
@@ -3,16 +3,15 @@ package mage.cards.s;
 
 import java.util.UUID;
 import mage.Mana;
+import mage.abilities.common.SimpleActivatedAbility;
 import mage.abilities.costs.common.SacrificeSourceCost;
 import mage.abilities.costs.common.TapSourceCost;
 import mage.abilities.costs.mana.ManaCostsImpl;
 import mage.abilities.effects.common.DrawCardSourceControllerEffect;
-import mage.abilities.mana.ActivatedManaAbilityImpl;
-import mage.abilities.mana.SimpleManaAbility;
+import mage.abilities.effects.mana.BasicManaEffect;
 import mage.cards.CardImpl;
 import mage.cards.CardSetInfo;
 import mage.constants.CardType;
-import mage.constants.Zone;
 
 /**
  *
@@ -24,11 +23,10 @@ public final class SungrassEgg extends CardImpl {
         super(ownerId,setInfo,new CardType[]{CardType.ARTIFACT},"{1}");
 
         // {2}, {tap}, Sacrifice Sungrass Egg: Add {G}{W}. Draw a card.
-        ActivatedManaAbilityImpl ability = new SimpleManaAbility(Zone.BATTLEFIELD, new Mana(1, 0, 0, 0, 1, 0, 0, 0), new ManaCostsImpl<>("{2}"));
+        final SimpleActivatedAbility ability = new SimpleActivatedAbility(new BasicManaEffect(new Mana(1, 0, 0, 0, 1, 0, 0, 0)), new ManaCostsImpl<>("{2}"));
         ability.addCost(new TapSourceCost());
         ability.addCost(new SacrificeSourceCost());
         ability.addEffect(new DrawCardSourceControllerEffect(1));
-        ability.setUndoPossible(false);
         this.addAbility(ability);
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ParleyTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/abilities/keywords/ParleyTest.java
@@ -51,7 +51,7 @@ public class ParleyTest extends CardTestPlayerBase {
 
         castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Selvala, Explorer Returned");
 
-        activateManaAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "<i>Parley");
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "<i>Parley");
 
         setStopAt(3, PhaseStep.END_TURN);
         execute();

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ody/MillikinTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ody/MillikinTest.java
@@ -1,0 +1,33 @@
+package org.mage.test.cards.single.ody;
+
+import mage.constants.ManaType;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class MillikinTest extends CardTestPlayerBase {
+
+    @Test
+    public void testNonManaAbilityMana() {
+        // Since CR 20260807, Millikin's ability is not a mana ability
+        // Ensure that it can be stifled
+        // https://github.com/magefree/mage/pull/16054
+
+        addCard(Zone.BATTLEFIELD, playerA, "Millikin");
+        addCard(Zone.HAND, playerB, "Stifle");
+        addCard(Zone.BATTLEFIELD, playerB, "Island");
+        addCard(Zone.BATTLEFIELD, playerA, "Upwelling");
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{T}");
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerB, "Stifle");
+        addTarget(playerB, "stack ability");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        assertManaPool(playerA, ManaType.COLORLESS, 0);
+        assertGraveyardCount(playerA, 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/utils/ManaOptionsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/utils/ManaOptionsTest.java
@@ -78,12 +78,12 @@ public class ManaOptionsTest extends CardTestPlayerBase {
         assertManaOptions("{U}{U}{U}", manaOptions);
     }
 
-    // Chromatic Sphere
-    // {1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color. Draw a card.
+    // Arcum's Astrolabe
+    // {1}, {T}: Add one mana of any color.
     @Test
-    public void testChromaticSphere() {
+    public void testArcumsAstrolabe() {
         addCard(Zone.BATTLEFIELD, playerA, "Plains", 2);
-        addCard(Zone.BATTLEFIELD, playerA, "Chromatic Sphere", 2);
+        addCard(Zone.BATTLEFIELD, playerA, "Arcum's Astrolabe", 2);
 
         setStopAt(1, PhaseStep.UPKEEP);
         execute();
@@ -328,8 +328,8 @@ public class ManaOptionsTest extends CardTestPlayerBase {
         // {1}, {T}, Sacrifice Chromatic Star: Add one mana of any color.
         // When Chromatic Star is put into a graveyard from the battlefield, draw a card.
         addCard(Zone.BATTLEFIELD, playerA, "Chromatic Star", 1);
-        // {1}, {T}, Sacrifice Chromatic Sphere: Add one mana of any color. Draw a card.
-        addCard(Zone.BATTLEFIELD, playerA, "Chromatic Sphere", 1);
+        // {1}, {T}: Add one mana of any color.
+        addCard(Zone.BATTLEFIELD, playerA, "Arcum's Astrolabe", 1);
         // {T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.
         addCard(Zone.BATTLEFIELD, playerA, "Urza's Tower", 1);
         // {T}: Add {C}.


### PR DESCRIPTION
Affected cards:

* Charmed Pendant
* Chromatic Sphere
* Darkwater Egg
* Deranged Assistant
* Millikin
* Mossfire Egg
* Selvala, Explorer Returned
* Shadowblood Egg
* Skycloud Egg
* Sungrass Egg

I used Arcum's Astrolabe as a replacement card for tests covering mana filtering.

Fixes https://github.com/magefree/mage/issues/15876