### PR TITLE
Fix NPE when creature type choice is missing #14392

### DIFF
--- a/Mage.Sets/src/mage/cards/d/DistantMelody.java
+++ b/Mage.Sets/src/mage/cards/d/DistantMelody.java
@@ -59,12 +59,19 @@ class DistantMelodyEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        Choice typeChoice = new ChoiceCreatureType(game, source);
-        if (controller != null && controller.choose(Outcome.BoostCreature, typeChoice, game)) {
-            FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
-            filter.add(SubType.byDescription(typeChoice.getChoiceKey()).getPredicate());
-            return new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filter)).apply(game, source);
+        if (controller == null) {
+            return false;
         }
-        return false;
+        Choice typeChoice = new ChoiceCreatureType(game, source);
+        if (!controller.choose(Outcome.BoostCreature, typeChoice, game)) {
+            return false;
+        }
+        SubType subType = SubType.byDescription(typeChoice.getChoiceKey());
+        if (subType == null) {
+            return false;
+        }
+        FilterControlledCreaturePermanent filter = new FilterControlledCreaturePermanent();
+        filter.add(subType.getPredicate());
+        return new DrawCardSourceControllerEffect(new PermanentsOnBattlefieldCount(filter)).apply(game, source);
     }
 }

--- a/Mage.Sets/src/mage/cards/k/KindredDominance.java
+++ b/Mage.Sets/src/mage/cards/k/KindredDominance.java
@@ -59,13 +59,20 @@ class KindredDominanceEffect extends OneShotEffect {
     @Override
     public boolean apply(Game game, Ability source) {
         Player controller = game.getPlayer(source.getControllerId());
-        Choice typeChoice = new ChoiceCreatureType(game, source);
-        if (controller != null && controller.choose(outcome, typeChoice, game)) {
-            game.informPlayers(controller.getLogName() + " has chosen " + typeChoice.getChoiceKey());
-            FilterCreaturePermanent filter = new FilterCreaturePermanent("All creatures not of the chosen type");
-            filter.add(Predicates.not(SubType.byDescription(typeChoice.getChoiceKey()).getPredicate()));
-            return new DestroyAllEffect(filter).apply(game, source);
+        if (controller == null) {
+            return false;
         }
-        return false;
+        Choice typeChoice = new ChoiceCreatureType(game, source);
+        if (!controller.choose(outcome, typeChoice, game)) {
+            return false;
+        }
+        SubType subType = SubType.byDescription(typeChoice.getChoiceKey());
+        if (subType == null) {
+            return false;
+        }
+        game.informPlayers(controller.getLogName() + " has chosen " + typeChoice.getChoiceKey());
+        FilterCreaturePermanent filter = new FilterCreaturePermanent("All creatures not of the chosen type");
+        filter.add(Predicates.not(subType.getPredicate()));
+        return new DestroyAllEffect(filter).apply(game, source);
     }
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/c17/KindredDominanceTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/c17/KindredDominanceTest.java
@@ -1,0 +1,37 @@
+package org.mage.test.cards.single.c17;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class KindredDominanceTest extends CardTestPlayerBase {
+
+    private static final String dominance = "Kindred Dominance";
+    private static final String elf = "Cylian Elf";
+    private static final String lion = "Silvercoat Lion";
+
+    /**
+     * #14392 — NPE when SubType.byDescription(choiceKey) is null.
+     */
+    @Test
+    public void testDestroysCreaturesNotOfChosenType() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 7);
+        addCard(Zone.BATTLEFIELD, playerA, elf);
+        addCard(Zone.BATTLEFIELD, playerA, lion);
+        addCard(Zone.HAND, playerA, dominance);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, dominance);
+        setChoice(playerA, "Elf");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, dominance, 1);
+        assertPermanentCount(playerA, elf, 1);
+        assertPermanentCount(playerA, lion, 0);
+        assertGraveyardCount(playerA, lion, 1);
+    }
+}

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/lrw/DistantMelodyTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/lrw/DistantMelodyTest.java
@@ -1,0 +1,37 @@
+package org.mage.test.cards.single.lrw;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+public class DistantMelodyTest extends CardTestPlayerBase {
+
+    private static final String melody = "Distant Melody";
+    private static final String elf = "Cylian Elf";
+    private static final String lion = "Silvercoat Lion";
+
+    /**
+     * #14392 — NPE when SubType.byDescription(choiceKey) is null.
+     */
+    @Test
+    public void testDrawsForChosenCreatureType() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, elf, 2);
+        addCard(Zone.BATTLEFIELD, playerA, lion);
+        addCard(Zone.HAND, playerA, melody);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, melody);
+        setChoice(playerA, "Elf");
+
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, melody, 1);
+        assertHandCount(playerA, 2);
+        assertPermanentCount(playerA, elf, 2);
+        assertPermanentCount(playerA, lion, 1);
+    }
+}


### PR DESCRIPTION
Fixes #14392

Distant Melody and Kindred Dominance both did
`SubType.byDescription(choiceKey).getPredicate()` after the type dialog.
If the choice key is missing, `byDescription` returns null and that NPE's.

I added a null check in both cards, same pattern as Bloodline Shaman.
Also added tests for the happy path (choose Elf).
