### PR TITLE
Duel Commander: only one commander can be cast 

### DIFF
--- a/Mage.Server.Plugins/Mage.Game.CommanderDuel/src/mage/game/CommanderDuelMatch.java
+++ b/Mage.Server.Plugins/Mage.Game.CommanderDuel/src/mage/game/CommanderDuelMatch.java
@@ -18,9 +18,11 @@ public class CommanderDuelMatch extends MatchImpl {
         int startLife = 40;
         // Don't like it to compare but seems like it's complicated to do it in another way
         boolean checkCommanderDamage = true;
+        boolean castOnlyOneCommanderPerGame = false;
         if (options.getDeckType().equals("Variant Magic - Duel Commander")) {
             startLife = 20;   // Starting with the Commander 2016 update (on November 11th, 2016), Duel Commander will be played with 20 life points instead of 30.
             checkCommanderDamage = false; // since nov 16 duel commander uses no longer commander damage rule
+            castOnlyOneCommanderPerGame = true; // duel commander allows to cast only one commander from the command zone per game
         }
         if (options.getDeckType().equals("Variant Magic - MTGO 1v1 Commander")) {
             startLife = 30;
@@ -36,6 +38,7 @@ public class CommanderDuelMatch extends MatchImpl {
                 mulligan, startLife, startHandSize
         );
         game.setCheckCommanderDamage(checkCommanderDamage);
+        game.setCastOnlyOneCommanderPerGame(castOnlyOneCommanderPerGame);
         game.setStartMessage(this.createGameStartMessage());
         initGame(game);
         games.add(game);

--- a/Mage.Tests/src/test/java/org/mage/test/commander/duel/DuelCommanderOneCommanderCastTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/commander/duel/DuelCommanderOneCommanderCastTest.java
@@ -1,0 +1,100 @@
+package org.mage.test.commander.duel;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.game.GameCommanderImpl;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestCommanderDuelBase;
+
+/**
+ * Duel Commander: a player can cast only one of their commanders from the command zone each game
+ * (the first one cast). Casting the other one from any other zone is still allowed.
+ */
+public class DuelCommanderOneCommanderCastTest extends CardTestCommanderDuelBase {
+
+    private void enableDuelCommanderRule() {
+        ((GameCommanderImpl) currentGame).setCastOnlyOneCommanderPerGame(true);
+    }
+
+    private void prepareCommandersAndLands() {
+        // Partner (You can have two commanders if both have partner.)
+        addCard(Zone.COMMAND, playerA, "Thrasios, Triton Hero"); // Creature {G}{U} 1/3
+        addCard(Zone.COMMAND, playerA, "Ishai, Ojutai Dragonspeaker"); // Creature {2}{W}{U} 1/1
+        addCard(Zone.COMMAND, playerB, "Daxos of Meletis");
+
+        addCard(Zone.BATTLEFIELD, playerA, "Forest", 3);
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 4);
+        addCard(Zone.BATTLEFIELD, playerA, "Plains", 3);
+    }
+
+    @Test
+    public void testCanCastAnyCommanderAtFirst() {
+        prepareCommandersAndLands();
+        enableDuelCommanderRule();
+
+        checkPlayableAbility("first is playable", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Thrasios", true);
+        checkPlayableAbility("second is playable", 1, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Ishai", true);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+    }
+
+    @Test
+    public void testCantCastSecondCommander() {
+        prepareCommandersAndLands();
+        enableDuelCommanderRule();
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Thrasios, Triton Hero");
+        checkPlayableAbility("second is locked", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Cast Ishai", false);
+        checkPlayableAbility("still locked next turn", 3, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Ishai", false);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Thrasios, Triton Hero", 1);
+        assertCommandZoneCount(playerA, "Ishai, Ojutai Dragonspeaker", 1);
+    }
+
+    @Test
+    public void testCanRecastFirstCommander() {
+        prepareCommandersAndLands();
+        enableDuelCommanderRule();
+
+        addCard(Zone.BATTLEFIELD, playerB, "Mountain", 1);
+        addCard(Zone.HAND, playerB, "Lightning Bolt", 1);
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Thrasios, Triton Hero");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Lightning Bolt", "Thrasios, Triton Hero");
+        setChoice(playerA, true); // move commander to command zone
+
+        // commander tax makes it {2}{G}{U} now
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Thrasios, Triton Hero");
+        checkPlayableAbility("second is still locked", 3, PhaseStep.POSTCOMBAT_MAIN, playerA, "Cast Ishai", false);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Thrasios, Triton Hero", 1);
+        assertCommandZoneCount(playerA, "Ishai, Ojutai Dragonspeaker", 1);
+    }
+
+    @Test
+    public void testNormalCommanderCanCastBothPartners() {
+        prepareCommandersAndLands();
+        // no Duel Commander rule here, both commanders can be cast
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Thrasios, Triton Hero");
+        castSpell(3, PhaseStep.PRECOMBAT_MAIN, playerA, "Ishai, Ojutai Dragonspeaker");
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.END_TURN);
+        execute();
+
+        assertPermanentCount(playerA, "Thrasios, Triton Hero", 1);
+        assertPermanentCount(playerA, "Ishai, Ojutai Dragonspeaker", 1);
+    }
+}

--- a/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/CastOnlyOneCommanderPerGameEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/ruleModifying/CastOnlyOneCommanderPerGameEffect.java
@@ -1,0 +1,68 @@
+package mage.abilities.effects.common.ruleModifying;
+
+import mage.abilities.Ability;
+import mage.abilities.effects.ContinuousRuleModifyingEffectImpl;
+import mage.cards.Card;
+import mage.constants.Duration;
+import mage.constants.Outcome;
+import mage.constants.Zone;
+import mage.game.Game;
+import mage.game.events.GameEvent;
+import mage.watchers.common.CommanderPlaysCountWatcher;
+
+/**
+ * Duel Commander format rule: a player may cast only one of their commanders from the command zone
+ * each game (the first one cast, the choice isn't announced before). Only casting from the command
+ * zone is restricted, so the other commander can still be cast from another zone (Command Beacon,
+ * Road of Return, Netherborn Altar, ...).
+ * <p>
+ * One effect is created per commander, see GameCommanderImpl.initCommanderEffects
+ */
+public class CastOnlyOneCommanderPerGameEffect extends ContinuousRuleModifyingEffectImpl {
+
+    private final Card commander;
+
+    public CastOnlyOneCommanderPerGameEffect(Card commander) {
+        super(Duration.EndOfGame, Outcome.Detriment, true, true);
+        this.commander = commander;
+    }
+
+    protected CastOnlyOneCommanderPerGameEffect(final CastOnlyOneCommanderPerGameEffect effect) {
+        super(effect);
+        this.commander = effect.commander;
+    }
+
+    @Override
+    public CastOnlyOneCommanderPerGameEffect copy() {
+        return new CastOnlyOneCommanderPerGameEffect(this);
+    }
+
+    @Override
+    public String getInfoMessage(Ability source, GameEvent event, Game game) {
+        return "You can cast only one of your commanders from the command zone each game ("
+                + commander.getName() + ").";
+    }
+
+    @Override
+    public boolean checksEventType(GameEvent event, Game game) {
+        return event.getType() == GameEvent.EventType.CAST_SPELL;
+    }
+
+    @Override
+    public boolean applies(GameEvent event, Ability source, Game game) {
+        if (event.getZone() != Zone.COMMAND || !commander.isOwnedBy(event.getPlayerId())) {
+            return false;
+        }
+        Card cardToCheck = game.getCard(event.getSourceId()); // split/mdf cards support
+        if (cardToCheck == null || !commander.getId().equals(cardToCheck.getMainCard().getId())) {
+            return false;
+        }
+        CommanderPlaysCountWatcher watcher = game.getState().getWatcher(CommanderPlaysCountWatcher.class);
+        if (watcher == null) {
+            return false;
+        }
+        // another commander of that player was already played from the command zone
+        // (recasting the same commander is fine)
+        return watcher.getPlayerCount(event.getPlayerId()) > watcher.getPlaysCount(commander.getId());
+    }
+}

--- a/Mage/src/main/java/mage/game/GameCommanderImpl.java
+++ b/Mage/src/main/java/mage/game/GameCommanderImpl.java
@@ -7,6 +7,7 @@ import mage.abilities.common.SimpleStaticAbility;
 import mage.abilities.effects.common.InfoEffect;
 import mage.abilities.effects.common.continuous.CommanderReplacementEffect;
 import mage.abilities.effects.common.cost.CommanderCostModification;
+import mage.abilities.effects.common.ruleModifying.CastOnlyOneCommanderPerGameEffect;
 import mage.abilities.keyword.CompanionAbility;
 import mage.cards.Card;
 import mage.choices.ChoiceColor;
@@ -24,6 +25,9 @@ public abstract class GameCommanderImpl extends GameImpl {
 
     // private final Map<UUID, Cards> mulliganedCards = new HashMap<>();
     protected boolean checkCommanderDamage = true;
+
+    // Duel Commander: a player can cast only one of their commanders from the command zone each game
+    protected boolean castOnlyOneCommanderPerGame = false;
 
     // old commander's versions (before 2017) restrict return from hand or library to command zone
     protected boolean alsoHand = true;    // replace commander going to hand
@@ -43,6 +47,7 @@ public abstract class GameCommanderImpl extends GameImpl {
         this.alsoLibrary = game.alsoLibrary;
         this.startingPlayerSkipsDraw = game.startingPlayerSkipsDraw;
         this.checkCommanderDamage = game.checkCommanderDamage;
+        this.castOnlyOneCommanderPerGame = game.castOnlyOneCommanderPerGame;
     }
 
     private void handlePipers(Player player, Set<Card> commanders) {
@@ -158,6 +163,9 @@ public abstract class GameCommanderImpl extends GameImpl {
         // all commander effects must be independent from sourceId or controllerId
         commanderAbility.addEffect(new CommanderReplacementEffect(commander.getId(), alsoHand, alsoLibrary, false, "Commander"));
         commanderAbility.addEffect(new CommanderCostModification(commander));
+        if (castOnlyOneCommanderPerGame) {
+            commanderAbility.addEffect(new CastOnlyOneCommanderPerGameEffect(commander));
+        }
     }
 
     //20130711
@@ -283,6 +291,14 @@ public abstract class GameCommanderImpl extends GameImpl {
 
     public void setCheckCommanderDamage(boolean checkCommanderDamage) {
         this.checkCommanderDamage = checkCommanderDamage;
+    }
+
+    public boolean isCastOnlyOneCommanderPerGame() {
+        return castOnlyOneCommanderPerGame;
+    }
+
+    public void setCastOnlyOneCommanderPerGame(boolean castOnlyOneCommanderPerGame) {
+        this.castOnlyOneCommanderPerGame = castOnlyOneCommanderPerGame;
     }
 
     public void addCommander(Card card, Player player) {


### PR DESCRIPTION
You can only play one of the commanders from command zone if you have multiple commanders there (partner)

Implemented as a rule modifying effect added per commander when the new  `GameCommanderImpl.castOnlyOneCommanderPerGame` flag is on, which CommanderDuelMatch enables for the "Variant Magic - Duel Commander" deck type (same place as the 20 starting life and the disabled commander damage).

Rule from https://www.duelcommander.org/rules/quickrules:

With Two Commanders: You have 98 cards in your library instead of 99. Both commanders start in the command zone. Your color identity is the combination of both commanders' color identities. **However, you can only cast one commander directly from the command zone per game!**


Fixes first part of https://github.com/magefree/mage/issues/12483
