### PR TITLE
Fix Replicate on Isochron Scepter copies

### DIFF
--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/IsochronScepterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/IsochronScepterTest.java
@@ -4,7 +4,9 @@ package org.mage.test.cards.copy;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
 import org.junit.Test;
+import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
+import org.mage.test.serverside.base.impl.CardTestPlayerAPIImpl.StackClause;
 
 /**
  * {@link mage.cards.i.IsochronScepter Isochron Scepter}
@@ -178,4 +180,75 @@ public class IsochronScepterTest extends CardTestPlayerBase {
         assertPermanentCount(playerB, "Silvercoat Lion", 0);
 
     }
+
+    /**
+     * https://github.com/magefree/mage/issues/13998
+     */
+    @Test
+    public void testCopyCardWithReplicate() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+        addCard(Zone.HAND, playerA, "Isochron Scepter");
+        addCard(Zone.HAND, playerA, "Consign to Memory");
+        addCard(Zone.HAND, playerB, "Ornithopter");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Isochron Scepter");
+        setChoice(playerA, true); // imprint
+        setChoice(playerA, "Consign to Memory");
+
+        castSpell(4, PhaseStep.PRECOMBAT_MAIN, playerB, "Ornithopter");
+        activateAbility(4, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}, {T}:",
+                TestPlayer.NO_TARGET, "Ornithopter", StackClause.WHILE_ON_STACK);
+        setChoice(playerA, true); // copy imprinted card
+        setChoice(playerA, true); // cast copy
+        setChoice(playerA, true); // pay replicate {1} once
+        setChoice(playerA, false); // stop paying replicate
+        addTarget(playerA, "Ornithopter");
+        setChoice(playerA, false); // keep replicate copy target
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.END_TURN);
+        execute();
+
+        assertTappedCount("Island", true, 3);
+        assertExileCount("Consign to Memory", 1);
+        assertGraveyardCount(playerB, "Ornithopter", 1);
+    }
+    /**
+     * https://github.com/magefree/mage/issues/13758
+     */
+    @Test
+    public void testCopyCardWithReplicateAgainstChalice() {
+        addCard(Zone.BATTLEFIELD, playerA, "Island", 3);
+        addCard(Zone.HAND, playerA, "Isochron Scepter");
+        addCard(Zone.HAND, playerA, "Consign to Memory");
+        addCard(Zone.BATTLEFIELD, playerB, "Wastes", 2);
+        addCard(Zone.HAND, playerB, "Chalice of the Void");
+        addCard(Zone.HAND, playerB, "Ornithopter");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Isochron Scepter");
+        setChoice(playerA, true); //imprint
+        setChoice(playerA, "Consign to Memory");
+
+        castSpell(2, PhaseStep.PRECOMBAT_MAIN, playerB, "Chalice of the Void");
+        setChoice(playerB, "X=1");
+
+        castSpell(4, PhaseStep.PRECOMBAT_MAIN, playerB, "Ornithopter");
+        activateAbility(4, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}, {T}:",
+                TestPlayer.NO_TARGET, "Ornithopter", StackClause.WHILE_ON_STACK);
+        setChoice(playerA, true); // copy imprinted card
+        setChoice(playerA, true); // cast copy
+        setChoice(playerA, true); // pay replicate {1} once
+        setChoice(playerA, false); // stop paying replicate
+        addTarget(playerA, "Ornithopter");
+        setChoice(playerA, false); // keep replicate copy target
+
+        setStrictChooseMode(true);
+        setStopAt(4, PhaseStep.END_TURN);
+        execute();
+
+        // Chalice counters cast copy, but not the Replicate copy because it wasn't cast
+        assertGraveyardCount(playerB, "Ornithopter", 1);
+        assertPermanentCount(playerB, "Ornithopter", 0);
+    }
+
 }

--- a/Mage.Tests/src/test/java/org/mage/test/cards/copy/IsochronScepterTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/copy/IsochronScepterTest.java
@@ -1,8 +1,11 @@
 
 package org.mage.test.cards.copy;
 
+import mage.abilities.keyword.ReplicateAbility;
 import mage.constants.PhaseStep;
 import mage.constants.Zone;
+import mage.game.stack.Spell;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mage.test.player.TestPlayer;
 import org.mage.test.serverside.base.CardTestPlayerBase;
@@ -249,6 +252,109 @@ public class IsochronScepterTest extends CardTestPlayerBase {
         // Chalice counters cast copy, but not the Replicate copy because it wasn't cast
         assertGraveyardCount(playerB, "Ornithopter", 1);
         assertPermanentCount(playerB, "Ornithopter", 0);
+    }
+
+    @Test
+    public void testCopiedCardWithTwoGrantedReplicateAbilities() {
+        addCard(Zone.BATTLEFIELD, playerA, "Swamp", 10);
+        addCard(Zone.BATTLEFIELD, playerA, "Hatchery Sliver", 2);
+        addCard(Zone.BATTLEFIELD, playerB, "Autochthon Wurm"); // 9/14 survives all four resolutions
+        addCard(Zone.HAND, playerA, "Isochron Scepter");
+        addCard(Zone.HAND, playerA, "Nameless Inversion");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Isochron Scepter");
+        setChoice(playerA, true);
+        setChoice(playerA, "Nameless Inversion");
+
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{2}, {T}:");
+        setChoice(playerA, true); // copy the imprinted card
+        setChoice(playerA, true); // cast it
+        setChoice(playerA, true); // first replicate: twice
+        setChoice(playerA, true);
+        setChoice(playerA, false);
+        setChoice(playerA, true); // second replicate: once
+        setChoice(playerA, false);
+        addTarget(playerA, "Autochthon Wurm");
+        setChoice(playerA, "Replicate"); // order the two triggers
+        setChoice(playerA, false); // retain target for all three copies
+        setChoice(playerA, false);
+        setChoice(playerA, false);
+
+        waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN, playerA, true); // Scepter ability
+        checkStackSize("spell and two replicate triggers", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, 3);
+        checkStackObject("two distinct replicate triggers", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Replicate", 2);
+        runCode("two independently paid replicate abilities", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, (info, player, game) -> {
+            Spell spell = (Spell) game.getStack().stream().filter(Spell.class::isInstance).findFirst().get();
+            Assert.assertEquals(2, spell.getCard().getAbilities(game).stream()
+                    .filter(ReplicateAbility.class::isInstance).count());
+        });
+        waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN);
+        checkPT("four Nameless Inversion resolutions", 1, PhaseStep.POSTCOMBAT_MAIN,
+                playerB, "Autochthon Wurm", 21, 2);
+
+        activateAbility(3, PhaseStep.PRECOMBAT_MAIN, playerA, "{2}, {T}:");
+        setChoice(playerA, true);
+        setChoice(playerA, true);
+        setChoice(playerA, false); // decline both replicate costs on the new casting
+        setChoice(playerA, false);
+        addTarget(playerA, "Autochthon Wurm");
+        waitStackResolved(3, PhaseStep.PRECOMBAT_MAIN, playerA, true);
+        checkStackSize("second casting has no replicate triggers", 3, PhaseStep.PRECOMBAT_MAIN, playerA, 1);
+        checkStackObject("only the cast card copy", 3, PhaseStep.PRECOMBAT_MAIN, playerA, "Cast Nameless Inversion", 1);
+        waitStackResolved(3, PhaseStep.PRECOMBAT_MAIN);
+
+        setStrictChooseMode(true);
+        setStopAt(3, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertPowerToughness(playerB, "Autochthon Wurm", 12, 11);
+        assertExileCount("Nameless Inversion", 1);
+        assertPermanentCount(playerA, "Hatchery Sliver", 2);
+    }
+
+    @Test
+    public void testSimultaneousCardCopiesKeepReplicatePaymentsIndependent() {
+        addCard(Zone.BATTLEFIELD, playerA, "Volcanic Island", 12);
+        addCard(Zone.HAND, playerA, "Isochron Scepter");
+        addCard(Zone.HAND, playerA, "Pyromatics");
+        addCard(Zone.HAND, playerA, "Dramatic Reversal");
+
+        castSpell(1, PhaseStep.PRECOMBAT_MAIN, playerA, "Isochron Scepter");
+        setChoice(playerA, true);
+        setChoice(playerA, "Pyromatics");
+
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{2}, {T}:");
+        setChoice(playerA, true); // copy the imprinted card
+        setChoice(playerA, true); // cast the first copy
+        setChoice(playerA, true); // replicate twice
+        setChoice(playerA, true);
+        setChoice(playerA, false);
+        addTarget(playerA, playerB);
+        waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN, playerA, true);
+        checkStackSize("first casting and its replicate trigger", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, 2);
+
+        // Cast another copy of the same card while the first copy's trigger is pending.
+        castSpell(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Dramatic Reversal", TestPlayer.NO_TARGET, "Replicate");
+        waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN, playerA, true);
+        activateAbility(1, PhaseStep.POSTCOMBAT_MAIN, playerA, "{2}, {T}:",
+                TestPlayer.NO_TARGET, "Replicate", StackClause.WHILE_ON_STACK);
+        setChoice(playerA, true);
+        setChoice(playerA, true); // cast the second copy
+        setChoice(playerA, false); // no replicate for this casting
+        addTarget(playerA, playerA); // different target exposes copies of the wrong spell
+        waitStackResolved(1, PhaseStep.POSTCOMBAT_MAIN, playerA, true);
+        checkStackSize("two cast copies and only the first replicate trigger", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, 3);
+        checkStackObject("second casting does not reuse the first payment", 1, PhaseStep.POSTCOMBAT_MAIN, playerA, "Replicate", 1);
+        setChoice(playerA, false); // retain the first spell's target for both replicate copies
+        setChoice(playerA, false);
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.END_TURN);
+        execute();
+
+        assertLife(playerA, 19); // second casting: one resolution
+        assertLife(playerB, 17); // first casting: original plus two replicate copies
+        assertExileCount("Pyromatics", 1);
     }
 
 }

--- a/Mage/src/main/java/mage/abilities/effects/common/continuous/EachSpellYouCastHasReplicateEffect.java
+++ b/Mage/src/main/java/mage/abilities/effects/common/continuous/EachSpellYouCastHasReplicateEffect.java
@@ -64,9 +64,10 @@ public class EachSpellYouCastHasReplicateEffect extends ContinuousEffectImpl {
 
         boolean applied = false;
 
+        // Copies of cards can be cast (Isochron Scepter); copies of spells are not cast
         for (StackObject stackObject : game.getStack()) {
             if (!(stackObject instanceof Spell)
-                    || stackObject.isCopy()
+                    || (stackObject.isCopy() && stackObject.getCopyFrom() instanceof Spell)
                     || !stackObject.isControlledBy(source.getControllerId())
                     || (fixedNewCost == null && stackObject.getManaCost().isEmpty())) { // If the spell has no mana cost, it cannot be played by this ability unless an fixed alternative cost (e.g. such as from Threefold Signal) is specified.
                 continue;
@@ -75,7 +76,7 @@ public class EachSpellYouCastHasReplicateEffect extends ContinuousEffectImpl {
             if (filter.match(stackObject, game)) {
                 Cost cost = fixedNewCost != null ? fixedNewCost.copy() : spell.getSpellAbility().getManaCosts().copy();
                 ReplicateAbility replicateAbility = replicateAbilities.computeIfAbsent(spell.getId(), k -> new ReplicateAbility(cost));
-                game.getState().addOtherAbility(spell.getCard(), replicateAbility, false); // Do not copy because paid and # of activations state is handled in the baility
+                game.getState().addOtherAbility(spell.getCard(), replicateAbility, false);
                 applied = true;
             }
         }

--- a/Mage/src/main/java/mage/abilities/keyword/ReplicateAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ReplicateAbility.java
@@ -29,6 +29,7 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
     private static final String reminderTextMana = "When you cast this spell, "
             + "copy it for each time you paid its replicate cost."
             + " You may choose new targets for the copies.";
+    private final UUID replicateId;
     protected OptionalAdditionalCost additionalCost;
 
     public ReplicateAbility(String manaString) {
@@ -37,20 +38,26 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
 
     public ReplicateAbility(Cost cost) {
         super(Zone.STACK, null);
+        this.replicateId = UUID.randomUUID();
         this.additionalCost = new OptionalAdditionalCostImpl(keywordText, reminderTextMana, cost);
         this.additionalCost.setRepeatable(true);
         setRuleAtTheTop(true);
-        addSubAbility(new ReplicateTriggeredAbility(this.getId()));
+        addSubAbility(new ReplicateTriggeredAbility(this.replicateId));
     }
 
     protected ReplicateAbility(final ReplicateAbility ability) {
         super(ability);
-        additionalCost = ability.additionalCost;
+        this.replicateId = ability.replicateId;
+        additionalCost = ability.additionalCost.copy();
     }
 
     @Override
     public ReplicateAbility copy() {
         return new ReplicateAbility(this);
+    }
+
+    UUID getReplicateId() {
+        return replicateId;
     }
 
     @Override
@@ -169,7 +176,9 @@ class ReplicateTriggeredAbility extends TriggeredAbilityImpl {
             return false;
         }
         for (Ability ability : card.getAbilities(game)) {
-            if (!(ability instanceof ReplicateAbility) || !ability.isActivated() || ability.getId() != replicateId) {
+            if (!(ability instanceof ReplicateAbility)
+                    || !ability.isActivated()
+                    || !((ReplicateAbility) ability).getReplicateId().equals(replicateId)) {
                 continue;
             }
             for (Effect effect : this.getEffects()) {

--- a/Mage/src/main/java/mage/abilities/keyword/ReplicateAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ReplicateAbility.java
@@ -29,6 +29,12 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
     private static final String reminderTextMana = "When you cast this spell, "
             + "copy it for each time you paid its replicate cost."
             + " You may choose new targets for the copies.";
+    /**
+     * link each replicate trigger to its own paid cost (multiple Hatchery Sliver grants must stay independent).
+     * originalId survives AbilityImpl.newId(), but copying a card with Isochron Scepter calls CardImpl.assignNewId() -> newOriginalId(), 
+     * replacing both IDs without updating the trigger's stored link.
+     * keep this separate key unchanged in both copy constructors so the copied cost and trigger still match.
+     */
     private final UUID replicateId;
     protected OptionalAdditionalCost additionalCost;
 
@@ -48,6 +54,10 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
     protected ReplicateAbility(final ReplicateAbility ability) {
         super(ability);
         this.replicateId = ability.replicateId;
+        /**
+         * copy the activation flag and payment count, but do not share their mutable cost object.
+         * otherwise resetting replicate on a copied card/spell would also reset the original's payments.
+         */
         additionalCost = ability.additionalCost.copy();
     }
 
@@ -175,6 +185,10 @@ class ReplicateTriggeredAbility extends TriggeredAbilityImpl {
         if (card == null) {
             return false;
         }
+        /**
+         * original and copied cards share the link key, so search only the spell that caused this trigger.
+         * within that spell, match the specific replicate instance: another grant may have a different payment count.
+         */
         for (Ability ability : card.getAbilities(game)) {
             if (!(ability instanceof ReplicateAbility)
                     || !ability.isActivated()

--- a/Mage/src/main/java/mage/abilities/keyword/ReplicateAbility.java
+++ b/Mage/src/main/java/mage/abilities/keyword/ReplicateAbility.java
@@ -16,9 +16,9 @@ import mage.game.events.GameEvent;
 import mage.game.stack.Spell;
 import mage.game.stack.StackObject;
 import mage.players.Player;
+import mage.util.CardUtil;
 
 import java.util.Iterator;
-import java.util.UUID;
 
 /**
  * @author LevelX2
@@ -29,13 +29,8 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
     private static final String reminderTextMana = "When you cast this spell, "
             + "copy it for each time you paid its replicate cost."
             + " You may choose new targets for the copies.";
-    /**
-     * link each replicate trigger to its own paid cost (multiple Hatchery Sliver grants must stay independent).
-     * originalId survives AbilityImpl.newId(), but copying a card with Isochron Scepter calls CardImpl.assignNewId() -> newOriginalId(), 
-     * replacing both IDs without updating the trigger's stored link.
-     * keep this separate key unchanged in both copy constructors so the copied cost and trigger still match.
-     */
-    private final UUID replicateId;
+    // Distinguish multiple replicate instances; the tag's value belongs to the cast spell
+    private final String activationKey;
     protected OptionalAdditionalCost additionalCost;
 
     public ReplicateAbility(String manaString) {
@@ -44,30 +39,22 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
 
     public ReplicateAbility(Cost cost) {
         super(Zone.STACK, null);
-        this.replicateId = UUID.randomUUID();
+        this.activationKey = "replicateActivation|" + getOriginalId();
         this.additionalCost = new OptionalAdditionalCostImpl(keywordText, reminderTextMana, cost);
         this.additionalCost.setRepeatable(true);
         setRuleAtTheTop(true);
-        addSubAbility(new ReplicateTriggeredAbility(this.replicateId));
+        addSubAbility(new ReplicateTriggeredAbility(activationKey));
     }
 
     protected ReplicateAbility(final ReplicateAbility ability) {
         super(ability);
-        this.replicateId = ability.replicateId;
-        /**
-         * copy the activation flag and payment count, but do not share their mutable cost object.
-         * otherwise resetting replicate on a copied card/spell would also reset the original's payments.
-         */
+        this.activationKey = ability.activationKey;
         additionalCost = ability.additionalCost.copy();
     }
 
     @Override
     public ReplicateAbility copy() {
         return new ReplicateAbility(this);
-    }
-
-    UUID getReplicateId() {
-        return replicateId;
     }
 
     @Override
@@ -130,6 +117,7 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
                 }
             }
         }
+        ability.setCostsTag(activationKey, getActivateCount());
     }
 
     @Override
@@ -145,21 +133,22 @@ public class ReplicateAbility extends StaticAbility implements OptionalAdditiona
     public String getReminderText() {
         return additionalCost == null ? "" : additionalCost.getReminderText();
     }
+
 }
 
 class ReplicateTriggeredAbility extends TriggeredAbilityImpl {
 
-    private UUID replicateId; // need to correspond only to own replicate ability, not any other instances of replicate ability
+    private final String activationKey;
 
-    public ReplicateTriggeredAbility(UUID replicateId) {
+    ReplicateTriggeredAbility(String activationKey) {
         super(Zone.STACK, new ReplicateCopyEffect());
-        this.replicateId = replicateId;
-        this.setRuleVisible(false);
+        this.activationKey = activationKey;
+        setRuleVisible(false);
     }
 
     private ReplicateTriggeredAbility(final ReplicateTriggeredAbility ability) {
         super(ability);
-        this.replicateId = ability.replicateId;
+        this.activationKey = ability.activationKey;
     }
 
     @Override
@@ -181,27 +170,16 @@ class ReplicateTriggeredAbility extends TriggeredAbilityImpl {
         if (!(spell instanceof Spell)) {
             return false;
         }
-        Card card = ((Spell) spell).getCard();
-        if (card == null) {
+        int replicateCount = CardUtil.getSourceCostsTag(game, this,
+                activationKey, 0);
+        if (replicateCount == 0) {
             return false;
         }
-        /**
-         * original and copied cards share the link key, so search only the spell that caused this trigger.
-         * within that spell, match the specific replicate instance: another grant may have a different payment count.
-         */
-        for (Ability ability : card.getAbilities(game)) {
-            if (!(ability instanceof ReplicateAbility)
-                    || !ability.isActivated()
-                    || !((ReplicateAbility) ability).getReplicateId().equals(replicateId)) {
-                continue;
-            }
-            for (Effect effect : this.getEffects()) {
-                effect.setValue("ReplicateSpell", spell);
-                effect.setValue("ReplicateCount", ((ReplicateAbility) ability).getActivateCount());
-            }
-            return true;
+        for (Effect effect : getEffects()) {
+            effect.setValue("ReplicateSpell", spell);
+            effect.setValue("ReplicateCount", replicateCount);
         }
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Preserve the link between Replicate additional cost and triggered ability when a card is copied.

fixes #13998 and #13758

`originalId` survives `newId()`, but Scepter copies cards through
`assignNewId()` → `newOriginalId()`, replacing both IDs and leaving the trigger’s
stored reference stale. The custom ref survives copying and keeps each trigger
linked to its own paid cost, preserving the multiple-replicate fix from #10694.
Cost state is also copied independently so resets cannot affect the original.

Verified both cases: using `originalId` fails both Scepter regressions; removing
the per-instance link produces three Metallic Slivers instead of four in the
Hatchery Sliver regression. With the custom ref, all 23 enabled tests pass.

Code comments explain the workaround locally.