### PR TITLE
Fix Wickersmith's Tools creating untapped Scarecrow tokens

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WickersmithsTools.java
+++ b/Mage.Sets/src/mage/cards/w/WickersmithsTools.java
@@ -38,7 +38,7 @@ public final class WickersmithsTools extends CardImpl {
 
         // {5}, {T}, Sacrifice this artifact: Create X tapped 2/2 colorless Scarecrow artifact creature tokens, where X is the number of charge counters on this artifact.
         Ability ability = new SimpleActivatedAbility(new CreateTokenEffect(
-                new ScarecrowToken(), new CountersSourceCount(CounterType.CHARGE)
+                new ScarecrowToken(), new CountersSourceCount(CounterType.CHARGE), true, false
         ).setText("create X tapped 2/2 colorless Scarecrow artifact creature tokens, " +
                 "where X is the number of charge counters on {this}"), new ManaCostsImpl<>("{5}"));
         ability.addCost(new TapSourceCost());

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ecc/WickersmithsToolsTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ecc/WickersmithsToolsTest.java
@@ -1,0 +1,36 @@
+package org.mage.test.cards.single.ecc;
+
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import mage.counters.CounterType;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * @author MaxFreedomPollard
+ */
+public class WickersmithsToolsTest extends CardTestPlayerBase {
+
+    private static final String tools = "Wickersmith's Tools";
+
+    /**
+     * {5}, {T}, Sacrifice this artifact: Create X tapped 2/2 colorless Scarecrow artifact creature
+     * tokens, where X is the number of charge counters on this artifact.
+     */
+    @Test
+    public void testScarecrowTokensEnterTapped() {
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 5);
+        addCard(Zone.BATTLEFIELD, playerA, tools);
+
+        addCounters(1, PhaseStep.PRECOMBAT_MAIN, playerA, tools, CounterType.CHARGE, 3);
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{5}, {T}, Sacrifice");
+
+        setStrictChooseMode(true);
+        setStopAt(1, PhaseStep.BEGIN_COMBAT);
+        execute();
+
+        assertGraveyardCount(playerA, tools, 1);
+        assertPermanentCount(playerA, "Scarecrow Token", 3);
+        assertTappedCount("Scarecrow Token", true, 3);
+    }
+}


### PR DESCRIPTION
Wickersmith's Tools (ECC) reads "Create X tapped 2/2 colorless Scarecrow artifact creature tokens, where X is the number of charge counters on this artifact", but the tokens came in untapped.

Mage.Sets/src/mage/cards/w/WickersmithsTools.java line 40 built the effect as `new CreateTokenEffect(new ScarecrowToken(), new CountersSourceCount(CounterType.CHARGE))`. That two argument constructor delegates to `CreateTokenEffect(token, amount, false, false)`, so tapped is false. The card's printed text is hardcoded through `setText`, so the rules text kept promising tapped tokens while the effect produced untapped ones.

Fixed by passing tapped = true to the four argument constructor. The new test at Mage.Tests/src/test/java/org/mage/test/cards/single/ecc/WickersmithsToolsTest.java puts three charge counters on the artifact, activates the sacrifice ability, and asserts all three Scarecrow tokens are tapped.

On master `mvn test -pl Mage.Tests -Dtest=WickersmithsToolsTest` fails with `(Battlefield) 3 permanents (Scarecrow Token) are not tapped. expected:<3> but was:<0>`. With this change the same command reports `Tests run: 1, Failures: 0, Errors: 0, Skipped: 0`.
