### PR TITLE
[fix] Introduce Heartwood as a SubType and set it on Heartwood tokens

### DIFF
--- a/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
+++ b/Mage.Client/src/main/java/org/mage/plugins/card/dl/sources/ScryfallImageSupportTokens.java
@@ -3049,6 +3049,7 @@ public class ScryfallImageSupportTokens {
             put("HOB/Wolf", "https://api.scryfall.com/cards/thob/9?format=image");
 
             // FRA
+            put("FRA/Heartwood", "https://api.scryfall.com/cards/tfra/11?format=image");
             put("FRA/Illusion", "https://api.scryfall.com/cards/tfra/4?format=image");
 
             // TRK

--- a/Mage/src/main/java/mage/constants/SubType.java
+++ b/Mage/src/main/java/mage/constants/SubType.java
@@ -66,6 +66,7 @@ public enum SubType {
     FOOD("Food", SubTypeSet.ArtifactType),
     FORTIFICATION("Fortification", SubTypeSet.ArtifactType),
     GOLD("Gold", SubTypeSet.ArtifactType),
+    HEARTWOOD("Heartwood", SubTypeSet.ArtifactType),
     INCUBATOR("Incubator", SubTypeSet.ArtifactType),
     INFINITY("Infinity", SubTypeSet.ArtifactType),
     JUNK("Junk", SubTypeSet.ArtifactType),

--- a/Mage/src/main/java/mage/game/permanent/token/HeartwoodToken.java
+++ b/Mage/src/main/java/mage/game/permanent/token/HeartwoodToken.java
@@ -3,6 +3,7 @@ package mage.game.permanent.token;
 import mage.abilities.mana.GreenManaAbility;
 import mage.abilities.mana.RedManaAbility;
 import mage.constants.CardType;
+import mage.constants.SubType;
 
 /**
  * @author muz
@@ -12,6 +13,7 @@ public final class HeartwoodToken extends TokenImpl {
     public HeartwoodToken() {
         super("Heartwood Token", "Heartwood token");
         cardType.add(CardType.ARTIFACT);
+        subtype.add(SubType.HEARTWOOD);
         color.setRed(true);
         color.setGreen(true);
 

--- a/Mage/src/main/resources/tokens-database.txt
+++ b/Mage/src/main/resources/tokens-database.txt
@@ -3085,6 +3085,7 @@
 |TOK:HOB|Wolf||WolfToken|
 
 # FRA
+|TOK:FRA|Heartwood||HeartwoodToken|
 |TOK:FRA|Illusion||Illusion11Token|
 
 # TRK


### PR DESCRIPTION
Not on Scryfall yet, but spoiled art shows we have a new Artifact SubType

<img width="400" height="559" alt="image" src="https://github.com/user-attachments/assets/1afa1ef0-3d8d-41c0-93ba-a1243775fa24" />
