### PR TITLE
[dev] Run CI when moving a PR from Draft to Ready for review

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master", "main" ]
   pull_request:
     branches: [ "master", "main" ]
+    types: ["opened", "ready_for_review", "reopened", "synchronize"]
   schedule:
     - cron: '0 1 * * *'
 


### PR DESCRIPTION
> By default, a workflow only runs when a pull_request_target event's activity type is opened, synchronize, or reopened.

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request

When updating a draft PR to ready for review, to avoid having to force a rebase and push of a new commit (a `synchronize` event trigger), having CI just re-fire would save this juggling. 

Use-case would be items where a PR isn't ready to run due to MtgJSON dumps being outdated, and wanting to just re-run later once they're updated.