### PR TITLE
Show prepared spells in separate exile zones

### DIFF
--- a/Mage/src/main/java/mage/game/GameState.java
+++ b/Mage/src/main/java/mage/game/GameState.java
@@ -1176,6 +1176,19 @@ public class GameState implements Serializable, Copyable<GameState> {
         }
     }
 
+    private void addCardToExile(Card card, String exileZoneName) {
+        setZone(card.getId(), Zone.EXILED);
+
+        if (card.getId().equals(card.getMainCard().getId())) {
+            getExile().createZone(card.getId(), exileZoneName).add(card);
+        }
+
+        // add card specific abilities to game
+        for (Ability ability : card.getInitAbilities()) {
+            addAbility(ability, null, card);
+        }
+    }
+
     /**
      * Used for adding abilities that exist permanent on cards/permanents and
      * are not only gained for a certain time (e.g. until end of turn).
@@ -1634,17 +1647,13 @@ public class GameState implements Serializable, Copyable<GameState> {
      * Registers a standalone copy built from one part of a multipart card.
      * The supplied copy already contains the characteristics that become normal.
      */
-    public Card addCardPartCopyToZone(Card partToCopy, Card copiedCard, UUID newController,
-                                      Zone destinationZone) {
-        if (destinationZone == null) {
-            throw new IllegalArgumentException("Destination zone cannot be null");
-        }
+    public Card addCardPartCopyToExileZone(Card owningCard, Card partToCopy, Card copiedCard, UUID newController) {
         if (!copiedCard.getId().equals(copiedCard.getMainCard().getId())) {
             throw new IllegalArgumentException("The promoted copy must be a standalone card");
         }
         prepareCardForCopy(partToCopy, copiedCard, newController);
         copiedCards.put(copiedCard.getId(), copiedCard);
-        addCard(copiedCard, destinationZone);
+        addCardToExile(copiedCard, "Prepared by " + owningCard.getIdName());
         this.setValue(COPIED_CARD_KEY + copiedCard.getId(), copiedCard.copy());
         return copiedCard;
     }

--- a/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
+++ b/Mage/src/main/java/mage/game/permanent/PermanentImpl.java
@@ -44,7 +44,6 @@ import org.apache.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author BetaSteward_at_googlemail.com
@@ -1974,8 +1973,8 @@ public abstract class PermanentImpl extends CardImpl implements Permanent {
             return;
         }
         Card copy = prepareCard.createPreparedSpellCopy(getId());
-        game.getState().addCardPartCopyToZone(
-                prepareCard.getSpellCard(), copy, getControllerId(), Zone.EXILED
+        game.getState().addCardPartCopyToExileZone(
+                this, prepareCard.getSpellCard(), copy, getControllerId()
         );
         preparedSpellCopyId = copy.getId();
         game.getState().keepCardCopyWhileSourceExists(copy.getId(), getId());


### PR DESCRIPTION
Significant UX improvement for the prepared mechanic. Before this PR, all spell copies created by cards with prepared would go to the generic exile zone, along with exiled cards which aren't associated with any other cards (such as those exiled by Swords to Plowshares). This made it hard to tell which cards were prepared in exile (aside from the fact that they have no image), and **especially** hard to track which prepared spell belongs to which creature. See below.

<details><summary>Before this PR</summary>

<img width="1180" height="1149" alt="image" src="https://github.com/user-attachments/assets/a8168b59-9646-457b-b98b-cf22b354ef55" />

</details>

With the changes in this PR, all prepared spells go into unique exile zones with the name (and ID) of the creature that prepared it. These unique zones automatically clean themselves up when the owning card leaves the battlefield, or when the spell is cast. See below.

<details><summary>After this PR</summary>

<img width="1270" height="1155" alt="image" src="https://github.com/user-attachments/assets/29b0435e-8d21-46ff-ab92-ab9018e0d71e" />

</details>