### PR TITLE
[Bugfix][ECL] Makes flame-chain mauler menace last until end of turn

### DIFF
--- a/Mage.Sets/src/mage/cards/f/FlameChainMauler.java
+++ b/Mage.Sets/src/mage/cards/f/FlameChainMauler.java
@@ -33,7 +33,7 @@ public final class FlameChainMauler extends CardImpl {
                 new BoostSourceEffect(1, 0, Duration.EndOfTurn).setText("{this} gets +1/+0"), 
                 new ManaCostsImpl<>("{1}{R}")
         );
-        ability.addEffect(new GainAbilitySourceEffect(new MenaceAbility()).setText("and gains menace until end of turn"));
+        ability.addEffect(new GainAbilitySourceEffect(new MenaceAbility(), Duration.EndOfTurn).setText("and gains menace until end of turn"));
         this.addAbility(ability);
     }
 

--- a/Mage.Tests/src/test/java/org/mage/test/cards/single/ecl/FlameChainMaulerTest.java
+++ b/Mage.Tests/src/test/java/org/mage/test/cards/single/ecl/FlameChainMaulerTest.java
@@ -1,0 +1,38 @@
+package org.mage.test.cards.single.ecl;
+
+import mage.abilities.keyword.MenaceAbility;
+import mage.constants.PhaseStep;
+import mage.constants.Zone;
+import org.junit.Test;
+import org.mage.test.serverside.base.CardTestPlayerBase;
+
+/**
+ * {@link mage.cards.f.FlameChainMauler Flame-Chain Mauler} {1}{R}
+ * Creature — Elemental Warrior 2/2
+ * {1}{R}: This creature gets +1/+0 and gains menace until end of turn.
+ */
+public class FlameChainMaulerTest extends CardTestPlayerBase {
+
+    private static final String mauler = "Flame-Chain Mauler";
+
+    @Test
+    public void test_PumpAndMenaceEndAtEndOfTurn() {
+        setStrictChooseMode(true);
+
+        addCard(Zone.BATTLEFIELD, playerA, "Mountain", 3);
+        addCard(Zone.BATTLEFIELD, playerA, mauler);
+
+        activateAbility(1, PhaseStep.PRECOMBAT_MAIN, playerA, "{1}{R}: {this} gets +1/+0");
+
+        checkPT("pumped", 1, PhaseStep.END_TURN, playerA, mauler, 3, 2);
+        checkAbility("has menace while pumped", 1, PhaseStep.END_TURN, playerA, mauler, MenaceAbility.class, true);
+
+        setStopAt(2, PhaseStep.PRECOMBAT_MAIN);
+        execute();
+
+        // Both the +1/+0 and the menace grant are "until end of turn", so both
+        // must be gone on the following turn.
+        assertPowerToughness(playerA, mauler, 2, 2);
+        assertAbility(playerA, mauler, new MenaceAbility(), false);
+    }
+}


### PR DESCRIPTION
The flame-chain maulers pump effect is until end-of-turn, but currently only the power pump is implemented as an end of turn effect, the menace ability is granted so it persists across turn end.

This change makes the menace ability only last until end of turn.