### PR TITLE
[Bugfix][ECL]Fix typo in optional pay 'or pay 1'

### DIFF
--- a/Mage.Sets/src/mage/cards/w/WildUnraveling.java
+++ b/Mage.Sets/src/mage/cards/w/WildUnraveling.java
@@ -21,7 +21,7 @@ public final class WildUnraveling extends CardImpl {
 
         // As an additional cost to cast this spell, blight 2 or pay {1}.
         this.getSpellAbility().addCost(new OrCost(
-                "blight 2 or pay {1}", new BlightCost(2), new GenericManaCost(2)
+                "blight 2 or pay {1}", new BlightCost(2), new GenericManaCost(1)
         ));
 
         // Counter target spell.


### PR DESCRIPTION
The text on the card is:
_As an additional cost to cast this spell, blight 2 or pay {1}._ 
https://scryfall.com/card/ecl/84/wild-unraveling

This fixes a typo in the implementation to allow you to pay {1} rather then {2}.